### PR TITLE
fix: stabilize timestamp presenter test across timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.
+
 ## 0.2.1 - 2026-04-27
 
 ### Changed

--- a/src/lib/present.test.ts
+++ b/src/lib/present.test.ts
@@ -8,9 +8,8 @@ import {
 describe("present helpers", () => {
 	it("formats compact counts, short timestamps, and initials", () => {
 		expect(formatCompactNumber(12_300)).toBe("12K");
-		expect(formatShortTimestamp("2026-03-08T12:00:00.000Z")).toBe(
-			"Mar 8, 12:00 PM",
-		);
+		const localNoon = new Date(2026, 2, 8, 12, 0, 0).toISOString();
+		expect(formatShortTimestamp(localNoon)).toBe("Mar 8, 12:00 PM");
 		expect(getInitials("Sam Altman")).toBe("SA");
 		expect(getInitials("A")).toBe("A");
 		expect(getInitials(" Sam")).toBe("S");


### PR DESCRIPTION
## Problem

`formatShortTimestamp` intentionally formats timestamps in the local timezone, but the presenter test used a UTC-noon fixture and expected a local-noon string.

That made the test environment-dependent: it passed in UTC, but failed in other timezones such as `America/Los_Angeles` with `Mar 8, 5:00 AM` instead of `Mar 8, 12:00 PM`.

## What Changed

- Build the timestamp fixture as local noon with `new Date(2026, 2, 8, 12, 0, 0).toISOString()`.
- Keep the assertion focused on the formatted display string.
- Leave `formatShortTimestamp` behavior unchanged.

## Scope

- Test-only change.
- No runtime formatting behavior changed.
- No adjacent presenter or UI cleanup included.

## Verification

- `pnpm test`
- `pnpm check`
- `pnpm build`