### PR TITLE
feat: add x-web auto fallback for block actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.
 - Replace maintainer-local documentation links with repo-relative links and align the setup docs with the Node version file. Thanks @stainlu.
 - Resolve the `bird` transport from `PATH` before falling back to the local development checkout. Thanks @vyctorbrzezowski.
+- Use the existing Twitter web cookie fallback as the final `auto` transport for block and unblock actions. Thanks @pejmanjohn.
 
 ## 0.2.1 - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ pnpm cli unban @amelia --account acct_primary --transport bird --json
 Notes:
 
 - `ban` / `unban` accept `--transport auto|bird|xurl`
-- `auto` tries `bird` first, then falls back to `xurl` when bird fails
+- `auto` tries `bird` first, then falls back to `xurl`, then `x-web` cookie-backed block/unblock when both fail
 - forced `xurl` writes still verify through `bird status` before sqlite changes
 - Twitter still rejects pure OAuth2 block writes, so `auto` is the safe default for block/unblock
 - `blocks import` accepts newline-delimited blocklists with comments and markdown bullets

--- a/src/lib/actions-transport.test.ts
+++ b/src/lib/actions-transport.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
 	unblockUserViaXurl: vi.fn(),
 	muteUserViaXurl: vi.fn(),
 	unmuteUserViaXurl: vi.fn(),
+	blockUserViaXWeb: vi.fn(),
+	unblockUserViaXWeb: vi.fn(),
 	lookupAuthenticatedUser: vi.fn(),
 }));
 
@@ -30,6 +32,11 @@ vi.mock("./xurl", () => ({
 	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
 }));
 
+vi.mock("./x-web", () => ({
+	blockUserViaXWeb: mocks.blockUserViaXWeb,
+	unblockUserViaXWeb: mocks.unblockUserViaXWeb,
+}));
+
 describe("actions transport", () => {
 	beforeEach(() => {
 		delete process.env.BIRDCLAW_ACTIONS_TRANSPORT;
@@ -44,6 +51,8 @@ describe("actions transport", () => {
 		mocks.unblockUserViaXurl.mockReset();
 		mocks.muteUserViaXurl.mockReset();
 		mocks.unmuteUserViaXurl.mockReset();
+		mocks.blockUserViaXWeb.mockReset();
+		mocks.unblockUserViaXWeb.mockReset();
 		mocks.lookupAuthenticatedUser.mockReset();
 		mocks.lookupAuthenticatedUser.mockResolvedValue({ id: "1" });
 		mocks.blockUserViaBird.mockResolvedValue({
@@ -81,6 +90,14 @@ describe("actions transport", () => {
 		mocks.unmuteUserViaXurl.mockResolvedValue({
 			ok: true,
 			output: "xurl unmute ok",
+		});
+		mocks.blockUserViaXWeb.mockResolvedValue({
+			ok: true,
+			output: "x-web block ok",
+		});
+		mocks.unblockUserViaXWeb.mockResolvedValue({
+			ok: true,
+			output: "x-web unblock ok",
 		});
 	});
 
@@ -148,5 +165,57 @@ describe("actions transport", () => {
 			transport: "xurl",
 		});
 		expect(mocks.blockUserViaXurl).toHaveBeenCalledWith("1", "7");
+	});
+
+	it("falls back to x-web block when bird and xurl fail in auto mode", async () => {
+		mocks.blockUserViaBird.mockResolvedValue({
+			ok: false,
+			output: "bird unavailable",
+		});
+		mocks.blockUserViaXurl.mockResolvedValue({
+			ok: false,
+			output: "xurl rejected",
+			transport: "xurl",
+		});
+		const { runModerationAction } = await import("./actions-transport");
+		const result = await runModerationAction({
+			action: "block",
+			query: "7",
+			targetUserId: "7",
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			output:
+				"x-web block ok\nfalling back after bird: bird unavailable\nfalling back after xurl: xurl rejected",
+			transport: "x-web",
+		});
+		expect(mocks.blockUserViaXWeb).toHaveBeenCalledWith("7");
+	});
+
+	it("falls back to x-web unblock when bird and xurl fail in auto mode", async () => {
+		mocks.unblockUserViaBird.mockResolvedValue({
+			ok: false,
+			output: "bird unavailable",
+		});
+		mocks.unblockUserViaXurl.mockResolvedValue({
+			ok: false,
+			output: "xurl rejected",
+			transport: "xurl",
+		});
+		const { runModerationAction } = await import("./actions-transport");
+		const result = await runModerationAction({
+			action: "unblock",
+			query: "7",
+			targetUserId: "7",
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			output:
+				"x-web unblock ok\nfalling back after bird: bird unavailable\nfalling back after xurl: xurl rejected",
+			transport: "x-web",
+		});
+		expect(mocks.unblockUserViaXWeb).toHaveBeenCalledWith("7");
 	});
 });

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -9,7 +9,9 @@ import { type ActionsTransport, resolveActionsTransport } from "./config";
 import type {
 	ModerationAction,
 	ModerationActionTransportResult,
+	ModerationTransportKind,
 } from "./types";
+import { blockUserViaXWeb, unblockUserViaXWeb } from "./x-web";
 import {
 	blockUserViaXurl,
 	lookupAuthenticatedUser,
@@ -27,7 +29,7 @@ interface RunActionParams {
 	transport?: string;
 }
 
-function normalizeFailure(transport: "bird" | "xurl", output: string) {
+function normalizeFailure(transport: ModerationTransportKind, output: string) {
 	return `${transport}: ${output}`;
 }
 
@@ -133,6 +135,37 @@ async function runXurlAction(
 	};
 }
 
+async function runXWebAction(
+	action: ModerationAction,
+	targetUserId?: string,
+): Promise<ActionTransportResult> {
+	if (action !== "block" && action !== "unblock") {
+		return {
+			ok: false,
+			output: `x-web does not support ${action}`,
+			transport: "x-web",
+		};
+	}
+
+	if (!targetUserId) {
+		return {
+			ok: false,
+			output: "missing target user id for x-web transport",
+			transport: "x-web",
+		};
+	}
+
+	const result =
+		action === "block"
+			? await blockUserViaXWeb(targetUserId)
+			: await unblockUserViaXWeb(targetUserId);
+
+	return {
+		...result,
+		transport: "x-web",
+	};
+}
+
 export async function runModerationAction({
 	action,
 	query,
@@ -157,6 +190,30 @@ export async function runModerationAction({
 		return {
 			...xurlResult,
 			output: `${xurlResult.output}\nfalling back after ${normalizeFailure("bird", birdResult.output)}`,
+		};
+	}
+
+	if (action === "block" || action === "unblock") {
+		const xWebResult = await runXWebAction(action, targetUserId);
+		if (xWebResult.ok) {
+			return {
+				...xWebResult,
+				output: [
+					xWebResult.output,
+					`falling back after ${normalizeFailure("bird", birdResult.output)}`,
+					`falling back after ${normalizeFailure("xurl", xurlResult.output)}`,
+				].join("\n"),
+			};
+		}
+
+		return {
+			ok: false,
+			output: [
+				normalizeFailure("bird", birdResult.output),
+				normalizeFailure("xurl", xurlResult.output),
+				normalizeFailure("x-web", xWebResult.output),
+			].join("\n"),
+			transport: xWebResult.transport,
 		};
 	}
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,7 +171,7 @@ export interface TransportStatus {
 }
 
 export type ModerationAction = "block" | "unblock" | "mute" | "unmute";
-export type ModerationTransportKind = "bird" | "xurl";
+export type ModerationTransportKind = "bird" | "xurl" | "x-web";
 
 export interface ModerationActionTransportResult {
 	ok: boolean;


### PR DESCRIPTION
## Summary

Block and unblock actions in `auto` mode now have a final `x-web` fallback when both `bird` and `xurl` fail. This wires the existing cookie-backed web helpers into the moderation transport chain, matching the fallback behavior the README already described.

## Changes

- Extends `auto` block/unblock flow from `bird -> xurl` to `bird -> xurl -> x-web`.
- Keeps mute/unmute behavior unchanged because `x-web` only supports block/unblock today.
- Adds regression coverage for both block and unblock fallback behavior.
- Updates the README blocklist notes with the new transport chain.

## Testing

- `pnpm exec vitest run src/lib/actions-transport.test.ts`
- `TZ=UTC pnpm test`
- `pnpm check`
- `pnpm build`