### PR TITLE
fix: resolve bird command from PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.
 - Replace maintainer-local documentation links with repo-relative links and align the setup docs with the Node version file. Thanks @stainlu.
+- Resolve the `bird` transport from `PATH` before falling back to the local development checkout. Thanks @vyctorbrzezowski.
 
 ## 0.2.1 - 2026-04-27
 

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -196,6 +196,21 @@ describe("bird transport wrapper", () => {
 		);
 	});
 
+	it("explains how to configure bird when the binary is missing", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/missing/bird";
+		execFileAsyncMock.mockRejectedValue(
+			Object.assign(new Error("spawn /missing/bird ENOENT"), {
+				code: "ENOENT",
+			}),
+		);
+
+		const { listMentionsViaBird } = await import("./bird");
+
+		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
+			"bird CLI not found at /missing/bird",
+		);
+	});
+
 	it("tolerates bird json with raw newlines inside tweet text", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		execFileAsyncMock.mockResolvedValue({

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -10,6 +10,32 @@ import type {
 const execFileAsync = promisify(execFile);
 const BIRD_JSON_MAX_BUFFER_BYTES = 512 * 1024 * 1024;
 
+function formatBirdCommandError(error: unknown, birdCommand: string) {
+	if (
+		error instanceof Error &&
+		"code" in error &&
+		(error as { code?: unknown }).code === "ENOENT"
+	) {
+		return new Error(
+			`bird CLI not found at ${birdCommand}. Install @steipete/bird or set BIRDCLAW_BIRD_COMMAND / mentions.birdCommand to a valid bird binary.`,
+		);
+	}
+
+	return error;
+}
+
+async function runBirdJsonCommand(args: string[]) {
+	const birdCommand = getBirdCommand();
+	try {
+		const { stdout } = await execFileAsync(birdCommand, args, {
+			maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES,
+		});
+		return stdout;
+	} catch (error) {
+		throw formatBirdCommandError(error, birdCommand);
+	}
+}
+
 interface BirdTweetMedia {
 	type?: string;
 	url?: string;
@@ -224,12 +250,12 @@ export async function listMentionsViaBird({
 }: {
 	maxResults: number;
 }): Promise<XurlMentionsResponse> {
-	const birdCommand = getBirdCommand();
-	const { stdout } = await execFileAsync(
-		birdCommand,
-		["mentions", "-n", String(maxResults), "--json"],
-		{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES },
-	);
+	const stdout = await runBirdJsonCommand([
+		"mentions",
+		"-n",
+		String(maxResults),
+		"--json",
+	]);
 	const payload = parseBirdJson(stdout);
 
 	return normalizeBirdTweets(getBirdTweetItems(payload, "mentions"));
@@ -246,7 +272,6 @@ async function listTweetsViaBirdCommand({
 	all?: boolean;
 	maxPages?: number;
 }): Promise<XurlMentionsResponse> {
-	const birdCommand = getBirdCommand();
 	const args = [command, "-n", String(maxResults), "--json"];
 	if (all) {
 		args.push("--all");
@@ -254,9 +279,7 @@ async function listTweetsViaBirdCommand({
 	if (maxPages !== undefined) {
 		args.push("--max-pages", String(maxPages));
 	}
-	const { stdout } = await execFileAsync(birdCommand, args, {
-		maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES,
-	});
+	const stdout = await runBirdJsonCommand(args);
 	const payload = parseBirdJson(stdout);
 
 	return normalizeBirdTweets(getBirdTweetItems(payload, command));
@@ -301,12 +324,12 @@ export async function listDirectMessagesViaBird({
 }: {
 	maxResults: number;
 }): Promise<BirdDmsResponse> {
-	const birdCommand = getBirdCommand();
-	const { stdout } = await execFileAsync(
-		birdCommand,
-		["dms", "-n", String(maxResults), "--json"],
-		{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES },
-	);
+	const stdout = await runBirdJsonCommand([
+		"dms",
+		"-n",
+		String(maxResults),
+		"--json",
+	]);
 	const payload = parseBirdJson(stdout);
 	if (
 		!payload ||

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -14,9 +14,11 @@ import {
 } from "./config";
 
 const tempRoots: string[] = [];
+const originalPath = process.env.PATH;
 
 afterEach(() => {
 	resetBirdclawPathsForTests();
+	process.env.PATH = originalPath;
 	delete process.env.BIRDCLAW_HOME;
 	delete process.env.BIRDCLAW_CONFIG;
 	delete process.env.BIRDCLAW_ACTIONS_TRANSPORT;
@@ -81,6 +83,17 @@ describe("config", () => {
 		expect(resolveMentionsDataSource()).toBe("bird");
 		expect(resolveActionsTransport()).toBe("xurl");
 		expect(getBirdCommand()).toBe("/tmp/custom-bird");
+	});
+
+	it("resolves bird from PATH before falling back to the local dev path", () => {
+		const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-config-"));
+		tempRoots.push(tempRoot);
+		const birdPath = path.join(tempRoot, "bird");
+		writeFileSync(birdPath, "#!/bin/sh\n");
+		chmodSync(birdPath, 0o755);
+		process.env.PATH = tempRoot;
+
+		expect(getBirdCommand()).toBe(birdPath);
 	});
 
 	it("lets env override config for the datasource", () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+	accessSync,
+	constants,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -128,6 +134,28 @@ export function resolveActionsTransport(
 	return "auto";
 }
 
+function findCommandOnPath(command: string) {
+	const pathValue = process.env.PATH;
+	if (!pathValue) {
+		return undefined;
+	}
+
+	for (const directory of pathValue.split(path.delimiter)) {
+		if (!directory) {
+			continue;
+		}
+		const candidate = path.join(directory, command);
+		try {
+			accessSync(candidate, constants.X_OK);
+			return candidate;
+		} catch {
+			continue;
+		}
+	}
+
+	return undefined;
+}
+
 export function getBirdCommand() {
 	const envCommand = process.env.BIRDCLAW_BIRD_COMMAND?.trim();
 	if (envCommand) {
@@ -137,6 +165,11 @@ export function getBirdCommand() {
 	const configuredCommand = getBirdclawConfig().mentions?.birdCommand?.trim();
 	if (configuredCommand) {
 		return configuredCommand;
+	}
+
+	const pathCommand = findCommandOnPath("bird");
+	if (pathCommand) {
+		return pathCommand;
 	}
 
 	return path.join(os.homedir(), "Projects", "bird", "bird");


### PR DESCRIPTION
## Problem

Birdclaw already supports using `bird` as a live transport, but when no explicit `BIRDCLAW_BIRD_COMMAND` or `mentions.birdCommand` is configured it falls back to `~/Projects/bird/bird`.

That works for a local development checkout of `bird`, but misses the common install path where `bird` is available on `PATH` after `npm install -g @steipete/bird` or another package-manager install.

## Change

- Keep the existing precedence for `BIRDCLAW_BIRD_COMMAND` and `mentions.birdCommand`.
- Resolve `bird` from `PATH` before falling back to `~/Projects/bird/bird`.
- Wrap missing-binary `ENOENT` failures with an actionable message that points users to installing/configuring `bird`.
- Add regression coverage for PATH resolution and the missing-binary error.

## Testing

- `pnpm test src/lib/config.test.ts`
- `pnpm test src/lib/bird.test.ts`
- `pnpm run check`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
