### PR TITLE
fix: preserve rich bird collection data

### DIFF
--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -37,8 +37,29 @@ describe("bird transport wrapper", () => {
 						{
 							type: "photo",
 							url: "https://pbs.twimg.com/media/demo.jpg",
+							previewUrl: "https://pbs.twimg.com/media/demo.jpg:small",
+							width: 1200,
+							height: 800,
 						},
 					],
+					quotedTweet: {
+						id: "tweet_quote_1",
+						text: "quoted from bird",
+						createdAt: "Fri Mar 13 01:01:58 +0000 2026",
+						authorId: "43",
+						author: {
+							username: "amelia",
+							name: "Amelia",
+						},
+						media: [
+							{
+								type: "video",
+								url: "https://pbs.twimg.com/media/quote.jpg",
+								previewUrl: "https://pbs.twimg.com/media/quote.jpg:small",
+								videoUrl: "https://video.twimg.com/ext_tw_video/quote.mp4",
+							},
+						],
+					},
 				},
 			]),
 		});
@@ -73,6 +94,27 @@ describe("bird transport wrapper", () => {
 							}),
 						],
 					}),
+					media: [
+						{
+							url: "https://pbs.twimg.com/media/demo.jpg",
+							type: "image",
+							thumbnailUrl: "https://pbs.twimg.com/media/demo.jpg:small",
+							width: 1200,
+							height: 800,
+						},
+					],
+					quotedTweet: expect.objectContaining({
+						id: "tweet_quote_1",
+						author_id: "43",
+						text: "quoted from bird",
+						media: [
+							{
+								url: "https://video.twimg.com/ext_tw_video/quote.mp4",
+								type: "video",
+								thumbnailUrl: "https://pbs.twimg.com/media/quote.jpg:small",
+							},
+						],
+					}),
 				}),
 			],
 			includes: {
@@ -81,6 +123,11 @@ describe("bird transport wrapper", () => {
 						id: "42",
 						username: "sam",
 						name: "Sam",
+					},
+					{
+						id: "43",
+						username: "amelia",
+						name: "Amelia",
 					},
 				],
 			},
@@ -157,6 +204,12 @@ describe("bird transport wrapper", () => {
 						retweet_count: 5,
 						like_count: 6,
 					},
+					media: [
+						{
+							url: "https://pbs.twimg.com/media/other.jpg",
+							type: "image",
+						},
+					],
 				}),
 			],
 			includes: {

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { getBirdCommand } from "./config";
 import type {
+	TweetMediaItem,
 	XurlMentionData,
 	XurlMentionsResponse,
 	XurlMentionUser,
@@ -13,6 +14,10 @@ const BIRD_JSON_MAX_BUFFER_BYTES = 512 * 1024 * 1024;
 interface BirdTweetMedia {
 	type?: string;
 	url?: string;
+	previewUrl?: string;
+	width?: number;
+	height?: number;
+	videoUrl?: string;
 }
 
 interface BirdTweetAuthor {
@@ -32,6 +37,7 @@ interface BirdTweetItem {
 	author?: BirdTweetAuthor;
 	authorId?: string;
 	media?: BirdTweetMedia[];
+	quotedTweet?: BirdTweetItem;
 }
 
 export interface BirdDmUser {
@@ -175,35 +181,89 @@ function toMediaEntities(media: BirdTweetMedia[] | undefined) {
 	};
 }
 
+function toTimelineMediaType(type: string | undefined): TweetMediaItem["type"] {
+	if (type === "photo") return "image";
+	if (type === "video") return "video";
+	if (type === "animated_gif") return "gif";
+	return "unknown";
+}
+
+function toMediaItems(media: BirdTweetMedia[] | undefined) {
+	if (!Array.isArray(media) || media.length === 0) {
+		return undefined;
+	}
+
+	const items = media
+		.filter((item) => typeof item?.url === "string" && item.url.length > 0)
+		.map((item): TweetMediaItem => {
+			const type = toTimelineMediaType(item.type);
+			const sourceUrl = item.url as string;
+			const url =
+				type === "video" &&
+				typeof item.videoUrl === "string" &&
+				item.videoUrl.length > 0
+					? item.videoUrl
+					: sourceUrl;
+			const thumbnailUrl =
+				typeof item.previewUrl === "string" && item.previewUrl.length > 0
+					? item.previewUrl
+					: url !== sourceUrl
+						? sourceUrl
+						: undefined;
+
+			return {
+				url,
+				type,
+				...(thumbnailUrl ? { thumbnailUrl } : {}),
+				...(Number.isFinite(item.width) ? { width: Number(item.width) } : {}),
+				...(Number.isFinite(item.height)
+					? { height: Number(item.height) }
+					: {}),
+			};
+		});
+
+	return items.length > 0 ? items : undefined;
+}
+
+function normalizeBirdTweetItem(
+	item: BirdTweetItem,
+	users: Map<string, XurlMentionUser>,
+): XurlMentionData {
+	const authorId = String(item.authorId ?? item.author?.username ?? "unknown");
+	if (!users.has(authorId)) {
+		users.set(authorId, {
+			id: authorId,
+			username: item.author?.username ?? `user_${authorId}`,
+			name: item.author?.name ?? item.author?.username ?? `user_${authorId}`,
+		});
+	}
+
+	const media = toMediaItems(item.media);
+	const quotedTweet = item.quotedTweet
+		? normalizeBirdTweetItem(item.quotedTweet, users)
+		: undefined;
+
+	return {
+		id: item.id,
+		author_id: authorId,
+		text: item.text,
+		created_at: toIsoTimestamp(item.createdAt),
+		conversation_id: item.conversationId ?? item.id,
+		entities: toMediaEntities(item.media),
+		...(media ? { media } : {}),
+		...(quotedTweet ? { quotedTweet } : {}),
+		public_metrics: {
+			reply_count: Number(item.replyCount ?? 0),
+			retweet_count: Number(item.retweetCount ?? 0),
+			like_count: Number(item.likeCount ?? 0),
+		},
+		edit_history_tweet_ids: [item.id],
+	};
+}
+
 function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
 	const users = new Map<string, XurlMentionUser>();
-	const data = items.map((item): XurlMentionData => {
-		const authorId = String(
-			item.authorId ?? item.author?.username ?? "unknown",
-		);
-		if (!users.has(authorId)) {
-			users.set(authorId, {
-				id: authorId,
-				username: item.author?.username ?? `user_${authorId}`,
-				name: item.author?.name ?? item.author?.username ?? `user_${authorId}`,
-			});
-		}
-
-		return {
-			id: item.id,
-			author_id: authorId,
-			text: item.text,
-			created_at: toIsoTimestamp(item.createdAt),
-			conversation_id: item.conversationId ?? item.id,
-			entities: toMediaEntities(item.media),
-			public_metrics: {
-				reply_count: Number(item.replyCount ?? 0),
-				retweet_count: Number(item.retweetCount ?? 0),
-				like_count: Number(item.likeCount ?? 0),
-			},
-			edit_history_tweet_ids: [item.id],
-		};
-	});
+	const data = items.map((item) => normalizeBirdTweetItem(item, users));
 
 	return {
 		data,

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -103,11 +103,53 @@ describe("live timeline collection sync", () => {
 					author_id: "43",
 					text: "bird bookmark item",
 					created_at: "2026-04-26T13:43:34.000Z",
+					entities: {
+						urls: [
+							{
+								start: 0,
+								end: 18,
+								url: "https://t.co/site",
+								expanded_url: "https://example.com/post",
+								display_url: "example.com/post",
+							},
+							{
+								start: 19,
+								end: 23,
+								url: "https://t.co/media",
+								expanded_url: "https://pbs.twimg.com/media/bookmark.jpg",
+								display_url: "pbs.twimg.com/media/bookmark.jpg",
+								media_key: "bird_media_0",
+							},
+						],
+					},
+					media: [
+						{
+							url: "https://pbs.twimg.com/media/bookmark.jpg",
+							type: "image",
+							thumbnailUrl: "https://pbs.twimg.com/media/bookmark.jpg:small",
+						},
+					],
+					quotedTweet: {
+						id: "quoted_1",
+						author_id: "44",
+						text: "quoted context",
+						created_at: "2026-04-26T12:43:34.000Z",
+						public_metrics: { like_count: 3 },
+						media: [
+							{
+								url: "https://pbs.twimg.com/media/quoted.jpg",
+								type: "image",
+							},
+						],
+					},
 					public_metrics: { like_count: 7 },
 				},
 			],
 			includes: {
-				users: [{ id: "43", username: "amelia", name: "Amelia" }],
+				users: [
+					{ id: "43", username: "amelia", name: "Amelia" },
+					{ id: "44", username: "quoted_author", name: "Quoted Author" },
+				],
 			},
 			meta: { result_count: 1 },
 		});
@@ -134,10 +176,38 @@ describe("live timeline collection sync", () => {
 			all: true,
 			maxPages: 2,
 		});
+		expect(syncedBookmark?.entities.urls).toHaveLength(1);
 		expect(syncedBookmark).toMatchObject({
 			bookmarked: true,
 			liked: false,
 			author: { handle: "amelia" },
+			mediaCount: 1,
+			media: [
+				expect.objectContaining({
+					url: "https://pbs.twimg.com/media/bookmark.jpg",
+					type: "image",
+				}),
+			],
+			entities: {
+				urls: [
+					expect.objectContaining({
+						url: "https://t.co/site",
+						expandedUrl: "https://example.com/post",
+						displayUrl: "example.com/post",
+					}),
+				],
+			},
+			quotedTweet: expect.objectContaining({
+				id: "quoted_1",
+				text: "quoted context",
+				author: expect.objectContaining({ handle: "quoted_author" }),
+				media: [
+					expect.objectContaining({
+						url: "https://pbs.twimg.com/media/quoted.jpg",
+						type: "image",
+					}),
+				],
+			}),
 		});
 	});
 });

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -3,6 +3,8 @@ import { listBookmarkedTweetsViaBird, listLikedTweetsViaBird } from "./bird";
 import { getNativeDb } from "./db";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type {
+	TweetEntities,
+	TweetMediaItem,
 	XurlMentionData,
 	XurlMentionsResponse,
 	XurlMentionUser,
@@ -88,6 +90,10 @@ function resolveAccount(db: Database.Database, accountId?: string) {
 }
 
 function getMediaCount(tweet: XurlMentionData) {
+	if (Array.isArray(tweet.media) && tweet.media.length > 0) {
+		return tweet.media.length;
+	}
+
 	const urls = Array.isArray(tweet.entities?.urls) ? tweet.entities.urls : [];
 	return urls.filter(
 		(url) =>
@@ -95,6 +101,97 @@ function getMediaCount(tweet: XurlMentionData) {
 			typeof url === "object" &&
 			typeof (url as Record<string, unknown>).media_key === "string",
 	).length;
+}
+
+function toLocalEntities(tweet: XurlMentionData): TweetEntities {
+	const raw = tweet.entities;
+	if (!raw || typeof raw !== "object") {
+		return {};
+	}
+
+	const entities = raw as Record<string, unknown>;
+	const rawMentions = Array.isArray(entities.mentions) ? entities.mentions : [];
+	const hasStructuredMedia =
+		Array.isArray(tweet.media) && tweet.media.length > 0;
+	const rawUrls = Array.isArray(entities.urls)
+		? entities.urls.filter((url) => {
+				if (!hasStructuredMedia || !url || typeof url !== "object") {
+					return true;
+				}
+				return typeof (url as Record<string, unknown>).media_key !== "string";
+			})
+		: [];
+
+	return {
+		...(rawMentions.length
+			? {
+					mentions: rawMentions.map((mention) => {
+						const value =
+							mention && typeof mention === "object"
+								? (mention as Record<string, unknown>)
+								: {};
+						return {
+							username: String(value.username ?? ""),
+							id: typeof value.id === "string" ? String(value.id) : undefined,
+							start: Number(value.start ?? 0),
+							end: Number(value.end ?? 0),
+						};
+					}),
+				}
+			: {}),
+		...(rawUrls.length
+			? {
+					urls: rawUrls.map((url) => {
+						const value =
+							url && typeof url === "object"
+								? (url as Record<string, unknown>)
+								: {};
+						return {
+							url: String(value.url ?? ""),
+							expandedUrl: String(
+								value.expandedUrl ?? value.expanded_url ?? value.url ?? "",
+							),
+							displayUrl: String(
+								value.displayUrl ??
+									value.display_url ??
+									value.expanded_url ??
+									value.url ??
+									"",
+							),
+							start: Number(value.start ?? 0),
+							end: Number(value.end ?? 0),
+						};
+					}),
+				}
+			: {}),
+	};
+}
+
+function toLocalMediaItems(tweet: XurlMentionData): TweetMediaItem[] {
+	if (!Array.isArray(tweet.media)) {
+		return [];
+	}
+
+	return tweet.media
+		.filter(
+			(item) => item && typeof item.url === "string" && item.url.length > 0,
+		)
+		.map((item) => ({
+			url: item.url,
+			type:
+				item.type === "image" ||
+				item.type === "video" ||
+				item.type === "gif" ||
+				item.type === "unknown"
+					? item.type
+					: "unknown",
+			...(typeof item.altText === "string" ? { altText: item.altText } : {}),
+			...(Number.isFinite(item.width) ? { width: Number(item.width) } : {}),
+			...(Number.isFinite(item.height) ? { height: Number(item.height) } : {}),
+			...(typeof item.thumbnailUrl === "string" && item.thumbnailUrl.length > 0
+				? { thumbnailUrl: item.thumbnailUrl }
+				: {}),
+		}));
 }
 
 function replaceTweetFts(db: Database.Database, tweetId: string, text: string) {
@@ -162,7 +259,7 @@ function mergeTimelineCollectionIntoLocalStore(
       id, account_id, author_profile_id, kind, text, created_at,
       is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
       entities_json, media_json, quoted_tweet_id
-    ) values (?, ?, ?, ?, ?, ?, 0, null, ?, ?, ?, ?, ?, '[]', null)
+    ) values (?, ?, ?, ?, ?, ?, 0, null, ?, ?, ?, ?, ?, ?, ?)
     on conflict(id) do update set
       account_id = excluded.account_id,
       author_profile_id = excluded.author_profile_id,
@@ -175,7 +272,11 @@ function mergeTimelineCollectionIntoLocalStore(
       like_count = excluded.like_count,
       media_count = excluded.media_count,
       entities_json = excluded.entities_json,
-      media_json = excluded.media_json,
+      media_json = case
+        when excluded.media_json not in ('', '[]', 'null') then excluded.media_json
+        else tweets.media_json
+      end,
+      quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id),
       bookmarked = max(tweets.bookmarked, excluded.bookmarked),
       liked = max(tweets.liked, excluded.liked)
     `,
@@ -192,7 +293,15 @@ function mergeTimelineCollectionIntoLocalStore(
 
 	db.transaction(() => {
 		const updatedAt = new Date().toISOString();
-		for (const tweet of payload.data) {
+		const upsertTweetRecord = (
+			tweet: XurlMentionData,
+			bookmarkedValue: number,
+			likedValue: number,
+		) => {
+			if (tweet.quotedTweet && tweet.quotedTweet.id !== tweet.id) {
+				upsertTweetRecord(tweet.quotedTweet, 0, 0);
+			}
+
 			const author =
 				usersById.get(tweet.author_id) ??
 				({
@@ -203,6 +312,7 @@ function mergeTimelineCollectionIntoLocalStore(
 			const profile = usersById.has(tweet.author_id)
 				? upsertProfileFromXUser(db, author)
 				: ensureStubProfileForXUser(db, tweet.author_id);
+			const mediaItems = toLocalMediaItems(tweet);
 			upsertTweet.run(
 				tweet.id,
 				accountId,
@@ -212,10 +322,17 @@ function mergeTimelineCollectionIntoLocalStore(
 				tweet.created_at,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				getMediaCount(tweet),
-				bookmarked,
-				liked,
-				JSON.stringify(tweet.entities ?? {}),
+				bookmarkedValue,
+				likedValue,
+				JSON.stringify(toLocalEntities(tweet)),
+				JSON.stringify(mediaItems),
+				tweet.quotedTweet?.id ?? null,
 			);
+			replaceTweetFts(db, tweet.id, tweet.text);
+		};
+
+		for (const tweet of payload.data) {
+			upsertTweetRecord(tweet, bookmarked, liked);
 			upsertCollection.run(
 				accountId,
 				tweet.id,
@@ -224,7 +341,6 @@ function mergeTimelineCollectionIntoLocalStore(
 				JSON.stringify(tweet),
 				updatedAt,
 			);
-			replaceTweetFts(db, tweet.id, tweet.text);
 		}
 	})();
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -271,6 +271,8 @@ export interface XurlMentionData {
 	created_at: string;
 	conversation_id?: string;
 	entities?: Record<string, unknown>;
+	media?: TweetMediaItem[];
+	quotedTweet?: XurlMentionData;
 	public_metrics?: XurlPublicMetrics;
 	edit_history_tweet_ids?: string[];
 }


### PR DESCRIPTION
## Problem

`birdclaw sync likes/bookmarks --mode bird` receives richer tweet data from `bird` than it currently stores. The normalized payload keeps media-like URL entities, but drops structured media fields and quoted tweet context before writing to the canonical `tweets` table.

That means live likes/bookmarks imported through `bird` can end up with `media_json = []` and `quoted_tweet_id = null` even though the source payload included media and quote data.

## Change

- Preserve `bird` media as structured `TweetMediaItem` data while still keeping xurl-compatible entities.
- Preserve `bird` quoted tweets in the normalized payload and include quoted authors in `includes.users`.
- Store structured media and quoted tweet context during live likes/bookmarks sync.
- Avoid replacing existing non-empty `media_json` or `quoted_tweet_id` with empty incoming values.
- Keep media URL entities out of link-preview entities when structured media is present.

This intentionally does not change pagination/cursor behavior or mention sync.

## Testing

- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" pnpm test src/lib/bird.test.ts`
- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" pnpm test src/lib/timeline-collections-live.test.ts`
- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" pnpm run check`
- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" pnpm exec tsc --noEmit`
- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" pnpm run build`
- `PATH="/opt/homebrew/opt/node/bin:/opt/homebrew/bin:$PATH" TZ=UTC pnpm test`