### PR TITLE
feat(search): expose --min-likes and --quality-reason for tweet search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Add `--min-likes` and `--quality-reason` controls for tweet search quality filtering. Thanks @mvanhorn.
+
 ### Fixed
 
 - Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -147,6 +147,7 @@ async function loadCli() {
 
 describe("cli", () => {
 	beforeEach(() => {
+		process.exitCode = undefined;
 		consoleLogMock.mockClear();
 		ensureBirdclawDirsMock.mockReset();
 		getBirdclawPathsMock.mockReset();
@@ -502,6 +503,9 @@ describe("cli", () => {
 			"2021-01-01",
 			"--originals-only",
 			"--hide-low-quality",
+			"--min-likes",
+			"200",
+			"--quality-reason",
 			"--liked",
 			"--limit",
 			"5",
@@ -604,6 +608,8 @@ describe("cli", () => {
 			until: "2021-01-01",
 			includeReplies: false,
 			qualityFilter: "summary",
+			lowQualityThreshold: 200,
+			includeQualityReason: true,
 			likedOnly: true,
 			bookmarkedOnly: false,
 			limit: 5,
@@ -711,6 +717,8 @@ describe("cli", () => {
 			until: undefined,
 			includeReplies: true,
 			qualityFilter: "all",
+			lowQualityThreshold: undefined,
+			includeQualityReason: false,
 			likedOnly: false,
 			bookmarkedOnly: false,
 			limit: 20,
@@ -739,6 +747,52 @@ describe("cli", () => {
 			"tweet_2",
 			"Reply text",
 		);
+	});
+
+	it("prints quality reasons for tweet search when requested", async () => {
+		listTimelineItemsMock.mockReturnValue([
+			{ id: "tweet_1", qualityReason: "keep:high-likes" },
+		]);
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"search",
+			"tweets",
+			"local",
+			"--quality-reason",
+		]);
+
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"qualityReason": "keep:high-likes"'),
+		);
+	});
+
+	it("rejects invalid min-likes values as json errors", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"search",
+			"tweets",
+			"local",
+			"--min-likes",
+			"2.5",
+		]);
+
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			JSON.stringify({ error: "--min-likes must be a non-negative integer" }),
+		);
+		expect(process.exitCode).toBe(1);
+		expect(maybeAutoUpdateBackupMock).not.toHaveBeenCalled();
+		expect(listTimelineItemsMock).not.toHaveBeenCalled();
+		consoleErrorMock.mockRestore();
 	});
 
 	it("dispatches blocklist commands", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,35 @@ function print(data: unknown, asJson: boolean) {
 	console.log(data);
 }
 
+function printError(error: string) {
+	console.error(JSON.stringify({ error }));
+}
+
+function parseNonNegativeIntegerOption(
+	value: string | undefined,
+	option: string,
+) {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	if (!/^\d+$/.test(trimmed)) {
+		printError(`${option} must be a non-negative integer`);
+		process.exitCode = 1;
+		return undefined;
+	}
+
+	const parsed = Number.parseInt(trimmed, 10);
+	if (!Number.isSafeInteger(parsed)) {
+		printError(`${option} must be a non-negative integer`);
+		process.exitCode = 1;
+		return undefined;
+	}
+
+	return parsed;
+}
+
 function resolveActionOptions(options: { transport?: string }) {
 	return {
 		transport: options.transport as ActionsTransport | undefined,
@@ -171,10 +200,23 @@ searchCommand
 	.option("--until <date>", "Include tweets created before this date")
 	.option("--originals-only", "Exclude authored replies that start with @")
 	.option("--hide-low-quality", "Hide RTs, tiny replies, and link-only noise")
+	.option(
+		"--min-likes <n>",
+		"Override the low-quality like threshold (default 50)",
+	)
+	.option("--quality-reason", "Include qualityReason on each row")
 	.option("--liked", "Only liked tweets")
 	.option("--bookmarked", "Only bookmarked tweets")
 	.option("--limit <n>", "Limit results", "20")
 	.action(async (query, options) => {
+		const minLikes = parseNonNegativeIntegerOption(
+			options.minLikes,
+			"--min-likes",
+		);
+		if (options.minLikes !== undefined && minLikes === undefined) {
+			return;
+		}
+
 		await autoUpdateBeforeRead();
 		const replyFilter = options.replied
 			? "replied"
@@ -189,6 +231,8 @@ searchCommand
 			until: options.until,
 			includeReplies: !options.originalsOnly,
 			qualityFilter: options.hideLowQuality ? "summary" : "all",
+			lowQualityThreshold: minLikes,
+			includeQualityReason: Boolean(options.qualityReason),
 			likedOnly: Boolean(options.liked),
 			bookmarkedOnly: Boolean(options.bookmarked),
 			limit: Number(options.limit),

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -250,6 +250,96 @@ describe("birdclaw queries", () => {
 			"tweet_good_media",
 			"tweet_good_short",
 		]);
+
+		const strictItems = listTimelineItems({
+			resource: "home",
+			account: "acct_primary",
+			since: "2026-03-08T13:00:00.000Z",
+			until: "2026-03-08T14:00:00.000Z",
+			includeReplies: false,
+			qualityFilter: "summary",
+			lowQualityThreshold: 5,
+			limit: 20,
+		});
+		const noLikeGateItems = listTimelineItems({
+			resource: "home",
+			account: "acct_primary",
+			since: "2026-03-08T13:00:00.000Z",
+			until: "2026-03-08T14:00:00.000Z",
+			includeReplies: false,
+			qualityFilter: "summary",
+			lowQualityThreshold: 0,
+			limit: 20,
+		});
+
+		expect(strictItems.map((item) => item.id)).toEqual([
+			"tweet_good_media",
+			"tweet_good_short",
+		]);
+		expect(noLikeGateItems.map((item) => item.id)).toEqual([
+			"tweet_good_media",
+			"tweet_good_short",
+			"tweet_low_link",
+		]);
+	});
+
+	it("includes quality reasons only when requested", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const insertTweet = db.prepare(`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, 'acct_primary', 'profile_me', 'home', ?, ?, 0, null, ?, ?, 0, 0, '{}', '[]', null)
+    `);
+
+		insertTweet.run(
+			"tweet_reason_rt",
+			"RT @someone: borrowed context",
+			"2026-03-08T15:00:00.000Z",
+			120,
+			0,
+		);
+		insertTweet.run(
+			"tweet_reason_media",
+			"https://t.co/screenshot",
+			"2026-03-08T15:01:00.000Z",
+			0,
+			1,
+		);
+		insertTweet.run(
+			"tweet_reason_liked",
+			"short but liked",
+			"2026-03-08T15:02:00.000Z",
+			100,
+			0,
+		);
+
+		const plainItems = listTimelineItems({
+			resource: "home",
+			account: "acct_primary",
+			since: "2026-03-08T15:00:00.000Z",
+			until: "2026-03-08T16:00:00.000Z",
+			qualityFilter: "all",
+			limit: 20,
+		});
+		const items = listTimelineItems({
+			resource: "home",
+			account: "acct_primary",
+			since: "2026-03-08T15:00:00.000Z",
+			until: "2026-03-08T16:00:00.000Z",
+			qualityFilter: "all",
+			includeQualityReason: true,
+			limit: 20,
+		});
+
+		expect(plainItems[0]).not.toHaveProperty("qualityReason");
+		expect(items.map((item) => [item.id, item.qualityReason])).toEqual([
+			["tweet_reason_liked", "keep:high-likes"],
+			["tweet_reason_media", "keep:has-media"],
+			["tweet_reason_rt", "drop:rt"],
+		]);
 	});
 
 	it("hydrates rich tweet entities, media, reply context, and quote context", () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -125,16 +125,28 @@ function buildReplyClause(replyFilter: ReplyFilter) {
 	return "";
 }
 
-function buildTimelineQualityClause(qualityFilter: TimelineQualityFilter) {
+function normalizeLowQualityThreshold(threshold: number | undefined) {
+	const value = threshold ?? 50;
+	if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+		throw new Error("lowQualityThreshold must be a non-negative integer");
+	}
+	return value;
+}
+
+function buildTimelineQualityClause(
+	qualityFilter: TimelineQualityFilter,
+	lowQualityThreshold: number,
+) {
 	if (qualityFilter === "all") {
-		return "";
+		return { sql: "", params: [] };
 	}
 
-	return `
+	return {
+		sql: `
     and not (
       t.text like 'RT @%'
       or (
-        t.like_count < 50
+        t.like_count < ?
         and (
           (
             length(trim(replace(t.text, 'https://t.co/', ''))) < 16
@@ -152,7 +164,48 @@ function buildTimelineQualityClause(qualityFilter: TimelineQualityFilter) {
         )
       )
     )
-  `;
+  `,
+		params: [lowQualityThreshold],
+	};
+}
+
+function getTimelineQualityReason(
+	row: Record<string, unknown>,
+	lowQualityThreshold: number,
+) {
+	const text = String(row.text);
+	const trimmed = text.trim();
+	const strippedShortUrlText = text.replaceAll("https://t.co/", "").trim();
+	const likeCount = Number(row.like_count);
+	const mediaCount = Number(row.media_count);
+
+	if (text.startsWith("RT @")) {
+		return "drop:rt";
+	}
+
+	if (likeCount < lowQualityThreshold) {
+		if (text.startsWith("@") && trimmed.length < 60) {
+			return "drop:short-reply";
+		}
+		if (
+			text.includes("https://t.co/") &&
+			mediaCount === 0 &&
+			strippedShortUrlText.length < 45
+		) {
+			return "drop:short-link-only";
+		}
+		if (strippedShortUrlText.length < 16 && mediaCount === 0) {
+			return "drop:short-text";
+		}
+	}
+
+	if (mediaCount > 0) {
+		return "keep:has-media";
+	}
+	if (likeCount >= lowQualityThreshold) {
+		return "keep:high-likes";
+	}
+	return "keep:long-text";
 }
 
 export async function getQueryEnvelope(): Promise<QueryEnvelope> {
@@ -218,6 +271,8 @@ export function listTimelineItems({
 	until,
 	includeReplies = true,
 	qualityFilter = "all",
+	lowQualityThreshold,
+	includeQualityReason = false,
 	likedOnly = false,
 	bookmarkedOnly = false,
 	limit = 18,
@@ -225,6 +280,8 @@ export function listTimelineItems({
 	const db = getNativeDb();
 	const kind = resource === "mentions" ? "mention" : resource;
 	const params: Array<string | number> = [kind];
+	const normalizedLowQualityThreshold =
+		normalizeLowQualityThreshold(lowQualityThreshold);
 	let join = "";
 	let where = "where t.kind = ?";
 
@@ -242,7 +299,12 @@ export function listTimelineItems({
 		"is_replied",
 		"t.is_replied",
 	);
-	where += buildTimelineQualityClause(qualityFilter);
+	const qualityClause = buildTimelineQualityClause(
+		qualityFilter,
+		normalizedLowQualityThreshold,
+	);
+	where += qualityClause.sql;
+	params.push(...qualityClause.params);
 
 	if (!includeReplies) {
 		where += " and t.text not like '@%'";
@@ -387,7 +449,7 @@ export function listTimelineItems({
 					: {}),
 			},
 		);
-		return {
+		const item = {
 			id: String(row.id),
 			accountId: String(row.account_id),
 			accountHandle: String(row.account_handle),
@@ -405,6 +467,15 @@ export function listTimelineItems({
 			replyToTweet: buildEmbeddedTweet(row, "reply_"),
 			quotedTweet: buildEmbeddedTweet(row, "quoted_"),
 		};
+		return includeQualityReason
+			? {
+					...item,
+					qualityReason: getTimelineQualityReason(
+						row,
+						normalizedLowQualityThreshold,
+					),
+				}
+			: item;
 	});
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,6 +109,7 @@ export interface TimelineItem {
 	media: TweetMediaItem[];
 	replyToTweet?: EmbeddedTweet | null;
 	quotedTweet?: EmbeddedTweet | null;
+	qualityReason?: string | null;
 }
 
 export interface DmMessageItem {
@@ -145,6 +146,8 @@ export interface TimelineQuery {
 	until?: string;
 	includeReplies?: boolean;
 	qualityFilter?: TimelineQualityFilter;
+	lowQualityThreshold?: number;
+	includeQualityReason?: boolean;
 	likedOnly?: boolean;
 	bookmarkedOnly?: boolean;
 	limit?: number;


### PR DESCRIPTION
## Summary

Make the previously hardcoded low-quality like threshold tunable and add an opt-in `qualityReason` label per row, both invited by the agent skill doc shipped in this repo.

`.agents/skills/birdclaw/SKILL.md` "Designing Better Filters" already says:

> add `--min-likes`, media flags, or debug reason output only when the use case needs it
>
> ...
>
> In the current implementation, "low-like" means `like_count < 50`.

Today the threshold is inline in `buildTimelineQualityClause` at `src/lib/queries.ts:137` with no override path, so the same skill doc's guidance ("count how many tweets each proposed rule removes... keep a reason label per rule while tuning") is impossible from outside the repo.

## Demo

![demo](https://files.catbox.moe/696k6g.gif)

## Changes

- `src/lib/queries.ts`: parameterize `buildTimelineQualityClause` with a `lowQualityThreshold`, validate the value (`Number.isFinite + Number.isInteger + >= 0`), bind through `?` instead of inlining; derive a `qualityReason` label in TS for opt-in callers (`keep:high-likes`, `keep:has-media`, `keep:long-text`, `drop:rt`, `drop:short-reply`, `drop:short-link-only`, `drop:short-text`).
- `src/lib/types.ts`: add optional `lowQualityThreshold` and `includeQualityReason` to `TimelineQuery`; optional `qualityReason` on `TimelineItem`.
- `src/cli.ts`: `--min-likes <n>` and `--quality-reason` on `search tweets`. Invalid `--min-likes` returns `{"error":"--min-likes must be a non-negative integer"}` on stderr with a non-zero exit, leaving stdout JSON-clean for agents.
- `src/lib/queries.test.ts`, `src/cli.test.ts`: coverage for thresholds (default, override, edge case at 0), reason labels (kept and dropped variants), invalid `--min-likes` input, and that existing callers see no JSON shape change when they don't ask for `qualityReason`.

## Tests

- `pnpm run check` clean (oxfmt + oxlint, 0 warnings 0 errors)
- `pnpm test src/lib/queries.test.ts src/cli.test.ts`: 38 tests pass
- Smoked locally: `pnpm --silent cli search tweets --hide-low-quality --min-likes 1000 --quality-reason --json` returns `keep:high-likes` / `keep:long-text` / `keep:has-media` per row (depending on which rule kept it).

## Notes

- Defaults preserved (threshold = 50). No JSON shape changes for existing callers; `qualityReason` only appears when `includeQualityReason` is true (`--quality-reason` from the CLI).
- `--min-likes <n>` is meaningful only when `--hide-low-quality` is active (the threshold sits inside the summary predicate). I left it as a separate flag rather than coupling them so a future filter mode can reuse the same knob.
- Unrelated: `src/lib/present.test.ts` fails locally on non-UTC machines (`Mar 8, 5:00 AM` vs `Mar 8, 12:00 PM`). Looks like the same issue PR #2 is fixing, so I left it alone.
- Tweets only. DM search keeps its existing surface; mirroring is a follow-up.
