### PR TITLE
feat(search): return FTS5 snippet on tweet and DM search results

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -351,6 +351,23 @@ describe("cli", () => {
 		expect(exitMock).toHaveBeenCalledWith(0);
 	});
 
+	it("prints tweet search snippets in json output", async () => {
+		listTimelineItemsMock.mockReturnValue([
+			{
+				id: "tweet_006",
+				searchSnippet:
+					"<mark>Agents</mark> need retrieval surfaces with small, stable contracts.",
+			},
+		]);
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "--json", "search", "tweets", "agents"]);
+
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"searchSnippet": "<mark>Agents</mark>'),
+		);
+	});
+
 	it("prints the package version", async () => {
 		const exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
 			return undefined as never;

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -133,6 +133,49 @@ describe("birdclaw queries", () => {
 		);
 	});
 
+	it("uses the latest matching DM message as the search snippet", () => {
+		setupTempHome();
+		const db = getNativeDb();
+
+		const messages = [
+			{
+				id: "msg_dm_search_older",
+				text: "older needleword snippet should not win",
+				createdAt: "2026-03-08T09:00:00.000Z",
+			},
+			{
+				id: "msg_dm_search_latest",
+				text: "latest needleword snippet should win",
+				createdAt: "2026-03-08T10:00:00.000Z",
+			},
+		];
+
+		for (const message of messages) {
+			db.prepare(
+				`
+        insert into dm_messages (
+          id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
+        ) values (?, 'dm_003', 'profile_me', ?, ?, 'outbound', 1, 0)
+        `,
+			).run(message.id, message.text, message.createdAt);
+			db.prepare("insert into dm_fts (message_id, text) values (?, ?)").run(
+				message.id,
+				message.text,
+			);
+		}
+
+		db.prepare(
+			"update dm_conversations set last_message_at = ? where id = 'dm_003'",
+		).run(messages[1].createdAt);
+
+		const filtered = listDmConversations({ search: "needleword" });
+
+		expect(filtered.map((item) => item.id)).toEqual(["dm_003"]);
+		expect(filtered[0]?.searchSnippet).toContain(
+			"latest <mark>needleword</mark> snippet should win",
+		);
+	});
+
 	it("omits DM search snippets when no query is provided", () => {
 		setupTempHome();
 

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -128,6 +128,17 @@ describe("birdclaw queries", () => {
 
 		expect(filtered.map((item) => item.id)).toEqual(["dm_003"]);
 		expect(filtered[0]?.lastMessagePreview).toContain("context rail");
+		expect(filtered[0]?.searchSnippet).toContain(
+			"<mark>context</mark> <mark>rail</mark>",
+		);
+	});
+
+	it("omits DM search snippets when no query is provided", () => {
+		setupTempHome();
+
+		const items = listDmConversations({ limit: 1 });
+
+		expect(items[0]).not.toHaveProperty("searchSnippet");
 	});
 
 	it("hydrates a selected conversation thread with sender context", () => {
@@ -163,6 +174,15 @@ describe("birdclaw queries", () => {
 
 		expect(items.map((item) => item.id)).toEqual(["tweet_006"]);
 		expect(items[0]?.accountId).toBe("acct_studio");
+		expect(items[0]?.searchSnippet).toContain("<mark>Agents</mark>");
+	});
+
+	it("omits timeline search snippets when no query is provided", () => {
+		setupTempHome();
+
+		const items = listTimelineItems({ resource: "home", limit: 1 });
+
+		expect(items[0]).not.toHaveProperty("searchSnippet");
 	});
 
 	it("filters timeline items by liked and bookmarked state across collections", () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -543,18 +543,31 @@ export function listDmConversations({
 
 	if (search?.trim()) {
 		searchSnippetCte = `
-      with dm_search as materialized (
+      with ranked_dm_search as materialized (
         select
+          latest_search.id,
           latest_search.conversation_id,
-          snippet(dm_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet
+          row_number() over (
+            partition by latest_search.conversation_id
+            order by latest_search.created_at desc, latest_search.id desc
+          ) as match_rank
         from dm_messages latest_search
         join dm_fts on dm_fts.message_id = latest_search.id
         where dm_fts.text match ?
+      ),
+      dm_search as materialized (
+        select
+          ranked_dm_search.conversation_id,
+          snippet(dm_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet
+        from ranked_dm_search
+        join dm_fts on dm_fts.message_id = ranked_dm_search.id
+        where ranked_dm_search.match_rank = 1
+          and dm_fts.text match ?
       )
     `;
 		join += " join dm_search on dm_search.conversation_id = c.id ";
 		searchSnippetSelect = ", dm_search.search_snippet as search_snippet";
-		joinParams.push(search.trim());
+		joinParams.push(search.trim(), search.trim());
 	}
 
 	params.push(limit);

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -287,6 +287,7 @@ export function listTimelineItems({
 		normalizeLowQualityThreshold(lowQualityThreshold);
 	let join = "";
 	let where = "where t.kind = ?";
+	let searchSnippetSelect = "";
 
 	if (likedOnly || bookmarkedOnly) {
 		params.length = 0;
@@ -324,8 +325,10 @@ export function listTimelineItems({
 	}
 
 	if (search?.trim()) {
-		join += " join tweets_fts fts on fts.tweet_id = t.id ";
-		where += " and fts.text match ?";
+		join += " join tweets_fts on tweets_fts.tweet_id = t.id ";
+		where += " and tweets_fts.text match ?";
+		searchSnippetSelect =
+			", snippet(tweets_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet";
 		params.push(search.trim());
 	}
 
@@ -394,6 +397,7 @@ export function listTimelineItems({
         qp.avatar_hue as quoted_avatar_hue,
         qp.avatar_url as quoted_avatar_url,
         qp.created_at as quoted_profile_created_at
+        ${searchSnippetSelect}
       from tweets t
       join accounts a on a.id = t.account_id
       join profiles p on p.id = t.author_profile_id
@@ -464,6 +468,9 @@ export function listTimelineItems({
 			accountHandle: String(row.account_handle),
 			kind: row.kind as TimelineItem["kind"],
 			text: String(row.text),
+			...(typeof row.search_snippet === "string"
+				? { searchSnippet: row.search_snippet }
+				: {}),
 			createdAt: String(row.created_at),
 			isReplied: Boolean(row.is_replied),
 			likeCount: Number(row.like_count),
@@ -502,8 +509,11 @@ export function listDmConversations({
 }: DmQuery): DmConversationItem[] {
 	const db = getNativeDb();
 	const params: Array<string | number> = [];
+	const joinParams: Array<string | number> = [];
+	let searchSnippetCte = "";
 	let join = "";
 	let where = "where 1 = 1";
+	let searchSnippetSelect = "";
 
 	if (account && account !== "all") {
 		where += " and a.id = ?";
@@ -532,11 +542,19 @@ export function listDmConversations({
 	}
 
 	if (search?.trim()) {
-		join +=
-			" join dm_messages latest_search on latest_search.conversation_id = c.id ";
-		join += " join dm_fts dmfts on dmfts.message_id = latest_search.id ";
-		where += " and dmfts.text match ?";
-		params.push(search.trim());
+		searchSnippetCte = `
+      with dm_search as materialized (
+        select
+          latest_search.conversation_id,
+          snippet(dm_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet
+        from dm_messages latest_search
+        join dm_fts on dm_fts.message_id = latest_search.id
+        where dm_fts.text match ?
+      )
+    `;
+		join += " join dm_search on dm_search.conversation_id = c.id ";
+		searchSnippetSelect = ", dm_search.search_snippet as search_snippet";
+		joinParams.push(search.trim());
 	}
 
 	params.push(limit);
@@ -544,6 +562,7 @@ export function listDmConversations({
 	const rows = db
 		.prepare(
 			`
+      ${searchSnippetCte}
       select
         c.id,
         c.account_id,
@@ -568,6 +587,7 @@ export function listDmConversations({
           order by latest_message.created_at desc
           limit 1
         ) as last_message_preview
+        ${searchSnippetSelect}
       from dm_conversations c
       join accounts a on a.id = c.account_id
       join profiles p on p.id = c.participant_profile_id
@@ -578,7 +598,7 @@ export function listDmConversations({
       limit ?
       `,
 		)
-		.all(...params) as Array<Record<string, unknown>>;
+		.all(...joinParams, ...params) as Array<Record<string, unknown>>;
 
 	const items = rows.map((row) => {
 		const followersCount = Number(row.followers_count);
@@ -588,6 +608,9 @@ export function listDmConversations({
 			accountId: String(row.account_id),
 			accountHandle: String(row.account_handle),
 			title: String(row.title),
+			...(typeof row.search_snippet === "string"
+				? { searchSnippet: row.search_snippet }
+				: {}),
 			lastMessageAt: String(row.last_message_at),
 			lastMessagePreview: String(row.last_message_preview ?? ""),
 			unreadCount: Number(row.unread_count),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,6 +99,7 @@ export interface TimelineItem {
 	accountHandle: string;
 	kind: "home" | "mention" | "like" | "bookmark";
 	text: string;
+	searchSnippet?: string;
 	createdAt: string;
 	isReplied: boolean;
 	likeCount: number;
@@ -129,6 +130,7 @@ export interface DmConversationItem {
 	accountId: string;
 	accountHandle: string;
 	title: string;
+	searchSnippet?: string;
 	lastMessageAt: string;
 	lastMessagePreview: string;
 	unreadCount: number;

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import type { ComponentType } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#/components/DmWorkspace", () => ({
 	DmWorkspace: ({
@@ -40,6 +46,11 @@ const DmsRoute = Route.options.component as ComponentType;
 describe("dms route", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
 	});
 
 	it("loads dms and posts an inline reply", async () => {


### PR DESCRIPTION
## Summary

When `birdclaw search tweets <query>` or `birdclaw search dms <query>` runs, return an FTS5 `snippet(...)` per row so agents and humans can see why each row matched without re-running the query downstream. Non-search calls keep their existing JSON shape; the new field is opt-in via the presence of an FTS join.

The FTS path is already wired in `src/lib/queries.ts`. `tweets_fts` joins around line 263, `dm_fts` around line 458. `grep -rn "snippet\|highlight\b" src/lib/` returns zero hits today, so the change just uses what SQLite is already configured to do.

## Demo

![demo](https://files.catbox.moe/32rzu4.gif)

## Changes

`src/lib/queries.ts` extends the tweet search SELECT with `snippet(tweets_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet` whenever a search clause is present. Column index `1` is the indexed `text`; column `0` is the unindexed `tweet_id` so it cannot be the source of a snippet.

The DM path needed slightly more care. Joining `dm_fts` directly on `dm_messages` would multiply conversation rows when more than one message in a thread matches, and SQLite would then return an arbitrary snippet for the conversation. The change introduces a `ranked_dm_search` CTE that picks the latest matching message per conversation via `row_number() over (partition by conversation_id order by created_at desc)`, then a second CTE that selects the snippet for `match_rank = 1`. `listDmConversations` joins that to `dm_conversations`, and the result is one row per conversation with a deterministic snippet sourced from the most recent matching message.

`src/lib/types.ts` adds optional `searchSnippet: string` on `TimelineItem` and `DmConversationItem`. The row mapper in queries.ts attaches the field only when the row carries a `search_snippet` column, so existing non-search callers see the same shape they always have.

`src/lib/queries.test.ts` and `src/cli.test.ts` cover three cases: tweet search returning a `<mark>...</mark>` snippet, DM search returning the same, and the snippet being absent when `search` is undefined. There is also a regression test that inserts multiple matching DM messages in one conversation and asserts a single row with the snippet from the latest match.

## Tests

`pnpm run check` is clean (oxfmt + oxlint, zero warnings). `pnpm test` returns 268 / 269 passing. The single failure is `src/lib/present.test.ts` failing as `Mar 8, 5:00 AM vs Mar 8, 12:00 PM` on non-UTC machines, which #2 is already addressing. The diff above does not touch `present.ts` or `present.test.ts`.

Smoked locally on the demo seed: `pnpm --silent cli search tweets agents --json` returns one row whose `searchSnippet` reads `<mark>Agents</mark> need retrieval surfaces...`, `pnpm --silent cli search dms tiny --json` returns one row whose `searchSnippet` reads `Also added a <mark>tiny</mark> context rail...`, and `pnpm --silent cli search tweets --json` returns the existing 16-field shape with `searchSnippet` genuinely omitted (not present, not `null`).

## Notes

The marker tokens, ellipsis, and 16-token window are SQLite defaults that match common search conventions. If you want a config knob or plain-text markers later, the helper is small and easy to swap. Order, rank, and the existing FTS join shape are unchanged otherwise; the snippet is selected alongside existing columns only when the `search` clause is active.

This is independent of #7 in scope but both branches touch `src/lib/types.ts` and `src/lib/queries.ts`. The branch is off `main`, not stacked on #7, so they land in either order without conflict.
