### PR TITLE
docs: align setup requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.
+- Replace maintainer-local documentation links with repo-relative links and align the setup docs with the Node version file. Thanks @stainlu.
 
 ## 0.2.1 - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -487,10 +487,10 @@ GitHub Actions runs:
 - `pnpm build`
 - `pnpm e2e`
 
-Workflow: [ci.yml](/Users/steipete/Projects/birdclaw/.github/workflows/ci.yml)
+Workflow: [ci.yml](.github/workflows/ci.yml)
 
 ## Docs
 
-- [spec.md](/Users/steipete/Projects/birdclaw/docs/spec.md)
-- [cli.md](/Users/steipete/Projects/birdclaw/docs/cli.md)
-- [data-architecture.md](/Users/steipete/Projects/birdclaw/docs/data-architecture.md)
+- [spec.md](docs/spec.md)
+- [cli.md](docs/cli.md)
+- [data-architecture.md](docs/data-architecture.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -48,7 +48,7 @@ Repo: `steipete/birdclaw`
 ## Decisions
 
 - language: TypeScript
-- runtime: Node 22+ with pnpm workspace
+- runtime: Node 25.8.1 with pnpm workspace
 - database: SQLite
 - query layer: Kysely
 - search: FTS5 day 1
@@ -81,7 +81,7 @@ Repo: `steipete/birdclaw`
 
 ### Runtime / workspace
 
-- Node.js 22+
+- Node.js 25.8.1
 - pnpm workspace
 - TypeScript `strict: true`
 - ESM only
@@ -186,8 +186,8 @@ Core rule:
 
 ## Docs
 
-- architecture + schema + transport: [data-architecture.md](/Users/steipete/Projects/birdclaw/docs/data-architecture.md)
-- CLI spec: [cli.md](/Users/steipete/Projects/birdclaw/docs/cli.md)
+- architecture + schema + transport: [data-architecture.md](./data-architecture.md)
+- CLI spec: [cli.md](./cli.md)
 
 ## MVP
 


### PR DESCRIPTION
## Summary
- align the spec Node requirement with `.node-version` and `package.json`
- replace maintainer-local docs and workflow links with repo-relative links

## Verification
- pnpm run check

Note: the local shell still reports Node v22.22.0, so pnpm printed the existing engine warning for the repo's Node 25.8.1 requirement before the check passed.