### PR TITLE
Require consent for plaintext backup pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Require explicit plaintext-private-data consent before `backup export --push`, `backup sync`, or backup auto-sync pushes Git backup shards.
+
 ### Fixed
 
 - Stabilize the presenter timestamp test across local time zones. Thanks @pejmanjohn.

--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 birdclaw import hydrate-profiles --json
 ```
 
-Back up the local SQLite store as canonical JSONL text:
+Back up the local SQLite store as canonical JSONL text. These shards are
+plaintext private data, so only push them to a private repo you control:
 
 ```bash
-birdclaw backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --json
+birdclaw backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --allow-plaintext-private-data --json
 ```
 
 Merge the backup into the current `BIRDCLAW_HOME`:
@@ -374,14 +375,16 @@ data/dms/conversations.jsonl
 data/dms/YYYY.jsonl
 data/moderation/blocks.jsonl
 data/moderation/mutes.jsonl
+data/actions/tweet_actions.jsonl
+data/ai_scores.jsonl
 ```
 
 Tweets are sharded by year for human browsing and yearly analysis. Collection-only tweets whose real creation date is unknown go into `data/tweets/unknown.jsonl` instead of pretending they belong to 1970. DMs are sharded by year with `conversation_id` in each row; this keeps Git fast while preserving conversation membership. Likes and bookmarks are stored as collection edges in `data/collections` and mirrored into the timeline rows for current query compatibility.
 
-Use `backup sync` when the target is a private Git repo. It pulls first, merge-imports the remote backup into local SQLite, exports the local union back into text shards, commits, and pushes.
+Use `backup sync` when the target is a private Git repo. It pulls first, merge-imports the remote backup into local SQLite, exports the local union back into text shards, commits, and pushes. Birdclaw refuses to push plaintext backup data unless you pass `--allow-plaintext-private-data` or configure `backup.allowPlaintextPrivateData: true`.
 
 ```bash
-pnpm cli backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --json
+pnpm cli backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --allow-plaintext-private-data --json
 pnpm cli backup validate ~/Projects/backup-birdclaw --json
 ```
 
@@ -393,12 +396,13 @@ Configure stale-aware backup reads in `~/.birdclaw/config.json`:
 		"repoPath": "/Users/steipete/Projects/backup-birdclaw",
 		"remote": "https://github.com/steipete/backup-birdclaw.git",
 		"autoSync": true,
-		"staleAfterSeconds": 900
+		"staleAfterSeconds": 900,
+		"allowPlaintextPrivateData": true
 	}
 }
 ```
 
-Read paths such as CLI search, inbox, API status/query, and web startup pull + merge from Git only when the last backup check is stale. Data-changing commands run a full backup sync afterward when this config is enabled. Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable that behavior for one process.
+Read paths such as CLI search, inbox, API status/query, and web startup pull + merge from Git only when the last backup check is stale. Data-changing commands run a full backup sync afterward only when this config is enabled with `allowPlaintextPrivateData`. Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable that behavior for one process.
 
 ### Scheduled Bookmark Sync
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,9 +128,10 @@ birdclaw debug transport
 - validates the manifest and file hashes by default
 - `--commit` creates a Git commit in the backup repo
 - `--push` implies commit and pushes the backup repo
+- `--allow-plaintext-private-data` is required with `--push`; use it only after verifying the remote is private
 
 ```bash
-birdclaw backup export --repo ~/Projects/birdclaw-store --commit --push
+birdclaw backup export --repo ~/Projects/birdclaw-store --commit --push --allow-plaintext-private-data
 ```
 
 ### `backup sync`
@@ -139,10 +140,10 @@ birdclaw backup export --repo ~/Projects/birdclaw-store --commit --push
 - pulls the backup repo before reading
 - merge-imports remote backup rows into local SQLite
 - exports the local union back into deterministic text shards
-- commits and pushes the backup repo
+- commits and pushes the backup repo only with explicit plaintext-private-data consent
 
 ```bash
-birdclaw backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --json
+birdclaw backup sync --repo ~/Projects/backup-birdclaw --remote https://github.com/steipete/backup-birdclaw.git --allow-plaintext-private-data --json
 ```
 
 Shard contract:
@@ -152,6 +153,8 @@ Shard contract:
 - collections: `data/collections/likes.jsonl`, `data/collections/bookmarks.jsonl`
 - DMs: `data/dms/conversations.jsonl` plus `data/dms/YYYY.jsonl`
 - moderation: `data/moderation/blocks.jsonl`, `data/moderation/mutes.jsonl`
+- actions: `data/actions/tweet_actions.jsonl`
+- AI scores: `data/ai_scores.jsonl`
 - no SQLite WAL/SHM, FTS shadow tables, or transient live cache rows
 
 Backup auto-sync config lives in `~/.birdclaw/config.json`:
@@ -162,12 +165,13 @@ Backup auto-sync config lives in `~/.birdclaw/config.json`:
 		"repoPath": "/Users/steipete/Projects/backup-birdclaw",
 		"remote": "https://github.com/steipete/backup-birdclaw.git",
 		"autoSync": true,
-		"staleAfterSeconds": 900
+		"staleAfterSeconds": 900,
+		"allowPlaintextPrivateData": true
 	}
 }
 ```
 
-Read commands pull + merge only when the last backup check is stale. Data-changing commands run a full backup sync afterward. Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable backup auto-sync for one process.
+Read commands pull + merge only when the last backup check is stale. Data-changing commands run a full backup sync afterward only when `allowPlaintextPrivateData` is enabled. Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable backup auto-sync for one process.
 
 ### `backup import`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -592,6 +592,10 @@ backupCommand
 	.option("--commit", "Create a git commit in the backup repo")
 	.option("--push", "Push the backup repo after committing")
 	.option(
+		"--allow-plaintext-private-data",
+		"Allow pushing plaintext private backup data after verifying the remote is private",
+	)
+	.option(
 		"--message <message>",
 		"Git commit message",
 		"archive: update birdclaw backup",
@@ -604,6 +608,7 @@ backupCommand
 			push: Boolean(options.push),
 			message: options.message,
 			validate: options.validate,
+			allowPlaintextPrivateData: Boolean(options.allowPlaintextPrivateData),
 		});
 		print(result, true);
 	});
@@ -628,6 +633,10 @@ backupCommand
 	.requiredOption("--repo <path>", "Backup repository/path")
 	.option("--remote <url>", "Git remote to clone/configure")
 	.option(
+		"--allow-plaintext-private-data",
+		"Allow pushing plaintext private backup data after verifying the remote is private",
+	)
+	.option(
 		"--message <message>",
 		"Git commit message",
 		"archive: sync birdclaw backup",
@@ -637,6 +646,7 @@ backupCommand
 			repoPath: options.repo,
 			remote: options.remote,
 			message: options.message,
+			allowPlaintextPrivateData: Boolean(options.allowPlaintextPrivateData),
 		});
 		print(result, true);
 	});

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -6,6 +6,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -57,6 +58,7 @@ function writeBackupConfig(
 		remote?: string;
 		autoSync?: boolean;
 		staleAfterSeconds?: number;
+		allowPlaintextPrivateData?: boolean;
 	},
 ) {
 	writeFileSync(path.join(home, "config.json"), JSON.stringify({ backup }));
@@ -202,6 +204,12 @@ describe("text backup", () => {
 		expect(
 			readFileSync(path.join(repoPath, "data/tweets/2025.jsonl"), "utf8"),
 		).toContain('"bookmarked":1');
+		expect(statSync(path.join(repoPath, "manifest.json")).mode & 0o777).toBe(
+			0o600,
+		);
+		expect(
+			statSync(path.join(repoPath, "data/tweets/2025.jsonl")).mode & 0o777,
+		).toBe(0o600);
 
 		resetDatabaseForTests();
 		resetBirdclawPathsForTests();
@@ -276,6 +284,7 @@ describe("text backup", () => {
 			repoPath,
 			remote: remotePath,
 			message: "archive: initial backup",
+			allowPlaintextPrivateData: true,
 		});
 
 		expect(first.imported).toBe(false);
@@ -290,6 +299,7 @@ describe("text backup", () => {
 			repoPath: secondRepoPath,
 			remote: remotePath,
 			message: "archive: roundtrip backup",
+			allowPlaintextPrivateData: true,
 		});
 
 		expect(second.imported).toBe(true);
@@ -323,6 +333,21 @@ describe("text backup", () => {
 				{ encoding: "utf8" },
 			).trim(),
 		).toBe("1");
+	}, 20000);
+
+	it("requires explicit consent before pushing plaintext private backups", async () => {
+		const remotePath = path.join(makeTempDir("birdclaw-remote-"), "remote.git");
+		execFileSync("git", ["init", "--bare", remotePath]);
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-consent-src-");
+		seedBackupFixture();
+		const repoPath = makeTempDir("birdclaw-consent-work-");
+
+		await expect(exportBackup({ repoPath, push: true })).rejects.toThrow(
+			"Refusing to push plaintext Birdclaw backup",
+		);
+		await expect(syncBackup({ repoPath, remote: remotePath })).rejects.toThrow(
+			"Refusing to push plaintext Birdclaw backup",
+		);
 	}, 20000);
 
 	it("reports validation errors for missing or corrupt backup files", async () => {
@@ -371,6 +396,7 @@ describe("text backup", () => {
 				repoPath: makeTempDir("birdclaw-auto-push-"),
 				remote: remotePath,
 				message: "archive: auto sync seed",
+				allowPlaintextPrivateData: true,
 			});
 
 			resetDatabaseForTests();
@@ -385,6 +411,7 @@ describe("text backup", () => {
 						remote: remotePath,
 						autoSync: true,
 						staleAfterSeconds: 900,
+						allowPlaintextPrivateData: true,
 					},
 				}),
 			);
@@ -578,6 +605,7 @@ describe("text backup", () => {
 						remote: remotePath,
 						autoSync: true,
 						staleAfterSeconds: 900,
+						allowPlaintextPrivateData: true,
 					},
 				}),
 			);

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -14,6 +14,10 @@ const MANIFEST_PATH = "manifest.json";
 const DATA_DIR = "data";
 const AUTO_SYNC_CACHE_KEY = "backup:auto-sync";
 const DEFAULT_STALE_AFTER_SECONDS = 15 * 60;
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const PLAINTEXT_PRIVATE_DATA_PUSH_ERROR =
+	"Refusing to push plaintext Birdclaw backup without explicit private-data consent. Backups include tweets, bookmarks, likes, DMs, action bodies, raw payloads, and AI scores. Verify the remote is private, then pass --allow-plaintext-private-data or set backup.allowPlaintextPrivateData=true.";
 
 type JsonValue =
 	| null
@@ -84,6 +88,24 @@ export interface BackupAutoUpdateResult {
 	error?: string;
 }
 
+export interface BackupExportOptions {
+	repoPath: string;
+	db?: Database.Database;
+	commit?: boolean;
+	push?: boolean;
+	message?: string;
+	validate?: boolean;
+	allowPlaintextPrivateData?: boolean;
+}
+
+export interface BackupSyncOptions {
+	repoPath: string;
+	remote?: string;
+	db?: Database.Database;
+	message?: string;
+	allowPlaintextPrivateData?: boolean;
+}
+
 export interface BackupValidationResult {
 	ok: boolean;
 	repoPath: string;
@@ -132,6 +154,38 @@ function toJsonRecord(row: Record<string, unknown>): JsonRecord {
 
 function sha256(content: string | Buffer) {
 	return createHash("sha256").update(content).digest("hex");
+}
+
+async function ensurePrivateDir(dirPath: string) {
+	await fs.mkdir(dirPath, { recursive: true, mode: PRIVATE_DIR_MODE });
+	try {
+		await fs.chmod(dirPath, PRIVATE_DIR_MODE);
+	} catch {
+		// Some filesystems do not support chmod. Creation mode still protects the
+		// normal local/macOS path this feature targets.
+	}
+}
+
+async function writePrivateTextFile(filePath: string, content: string) {
+	await fs.writeFile(filePath, content, {
+		encoding: "utf8",
+		mode: PRIVATE_FILE_MODE,
+	});
+	await chmodPrivateFile(filePath);
+}
+
+async function chmodPrivateFile(filePath: string) {
+	try {
+		await fs.chmod(filePath, PRIVATE_FILE_MODE);
+	} catch {
+		// See ensurePrivateDir.
+	}
+}
+
+function assertCanPushPlaintextPrivateData(allowed: boolean | undefined) {
+	if (!allowed) {
+		throw new Error(PLAINTEXT_PRIVATE_DATA_PUSH_ERROR);
+	}
 }
 
 const jsonlKeyOrderCache = new Map<string, string[]>();
@@ -372,7 +426,7 @@ async function writeJsonlFile(
 ) {
 	const fullPath = path.join(repoPath, relativePath);
 	const content = `${rows.map((row) => jsonlStringify(row)).join("\n")}\n`;
-	await fs.mkdir(path.dirname(fullPath), { recursive: true });
+	await ensurePrivateDir(path.dirname(fullPath));
 	let shouldWrite = true;
 	try {
 		shouldWrite = (await fs.readFile(fullPath, "utf8")) !== content;
@@ -380,7 +434,9 @@ async function writeJsonlFile(
 		shouldWrite = true;
 	}
 	if (shouldWrite) {
-		await fs.writeFile(fullPath, content, "utf8");
+		await writePrivateTextFile(fullPath, content);
+	} else {
+		await chmodPrivateFile(fullPath);
 	}
 	return {
 		path: relativePath,
@@ -459,13 +515,16 @@ function computeCounts(files: BackupFileManifest[]) {
 async function ensureBackupReadme(repoPath: string) {
 	const readmePath = path.join(repoPath, "README.md");
 	if (existsSync(readmePath)) {
+		await chmodPrivateFile(readmePath);
 		return;
 	}
-	await fs.writeFile(
+	await writePrivateTextFile(
 		readmePath,
 		`# Birdclaw Store
 
-Private text backup for Birdclaw data. The committed files are canonical JSONL shards that can rebuild the local SQLite index.
+Private text backup for Birdclaw data. The committed files are plaintext canonical JSONL shards that can rebuild the local SQLite index.
+
+This store can include tweets, bookmarks, likes, DMs, action bodies, raw source payloads, and AI scores. Keep the Git remote private. Birdclaw refuses to push these plaintext shards unless you explicitly allow plaintext private-data backup pushes.
 
 ## Layout
 
@@ -481,13 +540,14 @@ data/dms/conversations.jsonl
 data/dms/YYYY.jsonl
 data/moderation/blocks.jsonl
 data/moderation/mutes.jsonl
+data/actions/tweet_actions.jsonl
+data/ai_scores.jsonl
 \`\`\`
 
 Tweets are sharded by creation year. Collection-only tweets whose creation date is unknown live in \`data/tweets/unknown.jsonl\`. DMs are sharded by year and keep \`conversation_id\` in each row.
 
 Never commit live tokens, browser cookies, raw SQLite WAL/SHM sidecars, or temporary cache files here.
 `,
-		"utf8",
 	);
 }
 
@@ -496,12 +556,13 @@ async function writeManifest(repoPath: string, manifest: BackupManifest) {
 	const content = `${canonicalStringify(manifest as unknown as JsonRecord)}\n`;
 	try {
 		if ((await fs.readFile(manifestPath, "utf8")) === content) {
+			await chmodPrivateFile(manifestPath);
 			return;
 		}
 	} catch {
 		// New backup repo.
 	}
-	await fs.writeFile(manifestPath, content, "utf8");
+	await writePrivateTextFile(manifestPath, content);
 }
 
 async function readPreviousManifest(repoPath: string) {
@@ -643,8 +704,9 @@ async function ensureBackupGitRepo({
 	if (!(await isGitRepo(repoPath))) {
 		if (remote && !existsSync(repoPath)) {
 			await execFileAsync("git", ["clone", remote, repoPath]);
+			await ensurePrivateDir(repoPath);
 		} else {
-			await fs.mkdir(repoPath, { recursive: true });
+			await ensurePrivateDir(repoPath);
 			await execFileAsync("git", ["-C", repoPath, "init"]);
 		}
 	}
@@ -733,16 +795,13 @@ export async function exportBackup({
 	push = false,
 	message = "archive: update birdclaw backup",
 	validate = true,
-}: {
-	repoPath: string;
-	db?: Database.Database;
-	commit?: boolean;
-	push?: boolean;
-	message?: string;
-	validate?: boolean;
-}): Promise<BackupExportResult> {
+	allowPlaintextPrivateData = false,
+}: BackupExportOptions): Promise<BackupExportResult> {
+	if (push) {
+		assertCanPushPlaintextPrivateData(allowPlaintextPrivateData);
+	}
 	const resolvedRepoPath = path.resolve(repoPath);
-	await fs.mkdir(resolvedRepoPath, { recursive: true });
+	await ensurePrivateDir(resolvedRepoPath);
 	await ensureBackupReadme(resolvedRepoPath);
 
 	const shards = buildShards(db);
@@ -1246,12 +1305,9 @@ export async function syncBackup({
 	remote,
 	db = getNativeDb({ seedDemoData: false }),
 	message = "archive: sync birdclaw backup",
-}: {
-	repoPath: string;
-	remote?: string;
-	db?: Database.Database;
-	message?: string;
-}): Promise<BackupSyncResult> {
+	allowPlaintextPrivateData = false,
+}: BackupSyncOptions): Promise<BackupSyncResult> {
+	assertCanPushPlaintextPrivateData(allowPlaintextPrivateData);
 	const resolvedRepoPath = path.resolve(repoPath);
 	await ensureBackupGitRepo({ repoPath: resolvedRepoPath, remote });
 	const pulled = await pullBackupGitRepo(resolvedRepoPath);
@@ -1269,6 +1325,7 @@ export async function syncBackup({
 		commit: true,
 		push: true,
 		message,
+		allowPlaintextPrivateData,
 	});
 
 	return {
@@ -1376,6 +1433,7 @@ function resolveAutoSyncConfig() {
 			path.join(process.env.HOME || ".", "Projects", "backup-birdclaw"),
 		remote,
 		staleAfterSeconds,
+		allowPlaintextPrivateData: backup.allowPlaintextPrivateData === true,
 	};
 }
 
@@ -1473,6 +1531,7 @@ export async function maybeAutoSyncBackup(
 			repoPath: config.repoPath,
 			remote: config.remote,
 			db: database,
+			allowPlaintextPrivateData: config.allowPlaintextPrivateData,
 		});
 		writeAutoSyncState(database, { checkedAt: now, ok: true });
 		return {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,6 +32,7 @@ export interface BirdclawConfig {
 		remote?: string;
 		autoSync?: boolean;
 		staleAfterSeconds?: number;
+		allowPlaintextPrivateData?: boolean;
 	};
 }
 


### PR DESCRIPTION
## Summary

- require explicit plaintext-private-data consent before backup pushes
- pass the consent through CLI backup export/sync and backup auto-sync config
- chmod backup repos, manifests, README files, and JSONL shards to private local modes
- document the plaintext backup risk and the new CLI/config opt-in

## Verification

- pnpm check
- pnpm test src/lib/backup.test.ts
- TZ=UTC pnpm test
- pnpm build
- pnpm exec tsc --noEmit
