### PR TITLE
fix: Use full path for module specifier and relax node constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"vitest": "^4.1.5"
 	},
 	"engines": {
-		"node": ">=25.8.1 <26"
+		"node": ">=24 <26"
 	},
 	"packageManager": "pnpm@10.31.0",
 	"pnpm": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { dirname } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
-import { registerModerationCommands } from "#/cli-moderation";
+import { registerModerationCommands } from "#/cli-moderation.ts";
 import { findArchives } from "#/lib/archive-finder";
 import { importArchive } from "#/lib/archive-import";
 import {


### PR DESCRIPTION
Fixes the ERR_INVALID_MODULE_SPECIFIER error in node.js runtime. 

Changes:
1. Adds `.ts` to internal import in `cli.ts`.
2. Lowers node engines requirement to `>=24 <26` to support node v24 LTS.