### PR TITLE
Add birdclaw research mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `--min-likes` and `--quality-reason` controls for tweet search quality filtering. Thanks @mvanhorn.
-- Add research mode for turning bookmarked Twitter threads into Markdown briefs. Thanks @anupamchugh.
+- Add research mode for turning bookmarked Twitter threads into Markdown briefs, with shared `xurl`/`bird` tweet lookup fallback for thread expansion. Thanks @anupamchugh.
+
+### Changed
+
+- Use the native TypeScript preview compiler for the `typecheck` script.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `--min-likes` and `--quality-reason` controls for tweet search quality filtering. Thanks @mvanhorn.
+- Add research mode for turning bookmarked Twitter threads into Markdown briefs. Thanks @anupamchugh.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,15 @@ Notes:
 - filters still work in `xurl` mode; filtered payloads are rebuilt from the local canonical store after sync
 - `sync likes` and `sync bookmarks` store live results in the same local timeline table, so `search tweets --liked` and `search tweets --bookmarked` work across archive and live data
 
+### Research bookmarks and threads
+
+`birdclaw research` turns bookmarked tweets into a markdown brief with local thread expansion, live ancestor lookup when needed, and extracted links/handles:
+
+```bash
+birdclaw research "codex" --limit 20 --thread-depth 10 --json
+birdclaw research --account acct_primary --out ~/research/codex.md
+```
+
 ### Search and triage DMs
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"@types/node": "^25.6.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
+		"@typescript/native-preview": "7.0.0-dev.20260505.1",
 		"@vitest/coverage-v8": "^4.1.5",
 		"jsdom": "^29.1.1",
 		"oxfmt": "^0.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260505.1
+        version: 7.0.0-dev.20260505.1
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -1283,6 +1286,53 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-5W94O493huwcjrAkuP9yTQVPosXjX/0fEjCZsDn2D59m7VuPLy78R9D2i3UwlnajC75ubFiLcp/sh5o6/dFZVg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-j+N/276dONuTv2mOLgZy/jLsEZ2JLrxbZ8wBS/LIsMGtvp6elaN/ZESEntpUpIUbeoc5H6nHkjicJKNxQTZ90Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-pP/LpkknUTeyQkIiC916BpW2R4ToXDZI7zTbkG6Llh5bGTPcTbtM/5SxXSzYH04ogrc5AP6yYRZsUxtv1GGeQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-Vo7nGP0Wbs+VafCMabS4pSDcfJj60fLAmuZ2+hfdsUMFMO0BzHIUFyKBhbaeKVgO5V0yAqvBKrWkovZy0YXxGA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-90Bpi2xCPCE3S/pcL5uXn793AKSf8qLVvQ+w87FpwKknHYXQqOQ38KBO9jX2lynoxr8YcVO1S8BS7PngkwicYg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-VkNazv418LbiI0X6SQPCqVFTiBBvCrIxGkdVD7WBO/M3WHZam4qhK8fF61uQclK2NqYPClI2hPbuR5i8+4s4cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-QhueS4Y0hxYnkQoXrAmB0JKpnXn18nNJwqxLSpyEHCEr+XnggiHBNfjT+p1LeG42TEn0w+skcfwc/Mkmk/gyCg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260505.1':
+    resolution: {integrity: sha512-o82qX7L97dwQMpj6DzzokF6SQlChcxduNaL4OWzJhJkz1EP//gZOa0/xNPbPLufoJojHLQcANnpkA4JDXZDFhQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -3362,6 +3412,37 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260505.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260505.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260505.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260505.1
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -25,6 +25,7 @@ const listTimelineItemsMock = vi.fn();
 const listDmConversationsMock = vi.fn();
 const hydrateProfilesFromXMock = vi.fn();
 const inspectProfileRepliesMock = vi.fn();
+const runResearchModeMock = vi.fn();
 const syncTimelineCollectionMock = vi.fn();
 const createPostMock = vi.fn();
 const createTweetReplyMock = vi.fn();
@@ -121,6 +122,10 @@ vi.mock("#/lib/profile-replies", () => ({
 		inspectProfileRepliesMock(...args),
 }));
 
+vi.mock("#/lib/research", () => ({
+	runResearchMode: (...args: unknown[]) => runResearchModeMock(...args),
+}));
+
 vi.mock("#/lib/queries", () => ({
 	getQueryEnvelope: () => getQueryEnvelopeMock(),
 	listTimelineItems: (...args: unknown[]) => listTimelineItemsMock(...args),
@@ -173,6 +178,7 @@ describe("cli", () => {
 		listDmConversationsMock.mockReset();
 		hydrateProfilesFromXMock.mockReset();
 		inspectProfileRepliesMock.mockReset();
+		runResearchModeMock.mockReset();
 		syncTimelineCollectionMock.mockReset();
 		createPostMock.mockReset();
 		createTweetReplyMock.mockReset();
@@ -266,6 +272,15 @@ describe("cli", () => {
 			externalUserId: "42",
 			items: [],
 			meta: { scannedCount: 0, returnedCount: 0, nextToken: null },
+		});
+		runResearchModeMock.mockResolvedValue({
+			query: undefined,
+			account: undefined,
+			generatedAt: "2026-05-02T00:00:00.000Z",
+			seedCount: 1,
+			threadCount: 1,
+			items: [],
+			markdown: "# Birdclaw Research\n",
 		});
 		syncTimelineCollectionMock.mockResolvedValue({
 			ok: true,
@@ -513,6 +528,18 @@ describe("cli", () => {
 		await runCli([
 			"node",
 			"birdclaw",
+			"research",
+			"codex",
+			"--account",
+			"acct_primary",
+			"--limit",
+			"4",
+			"--thread-depth",
+			"6",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
 			"search",
 			"dms",
 			"sam",
@@ -613,6 +640,13 @@ describe("cli", () => {
 			likedOnly: true,
 			bookmarkedOnly: false,
 			limit: 5,
+		});
+		expect(runResearchModeMock).toHaveBeenCalledWith({
+			account: "acct_primary",
+			query: "codex",
+			limit: 4,
+			maxThreadDepth: 6,
+			outPath: undefined,
 		});
 		expect(listDmConversationsMock).toHaveBeenCalledWith({
 			search: "sam",
@@ -1055,6 +1089,23 @@ describe("cli", () => {
 		});
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"result_count": 1'),
+		);
+	});
+
+	it("prints research briefs as markdown by default", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "research", "codex"]);
+
+		expect(runResearchModeMock).toHaveBeenCalledWith({
+			account: undefined,
+			query: "codex",
+			limit: 20,
+			maxThreadDepth: 10,
+			outPath: undefined,
+		});
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining("# Birdclaw Research"),
 		);
 	});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import {
 } from "#/lib/mentions-live";
 import { hydrateProfilesFromX } from "#/lib/profile-hydration";
 import { inspectProfileReplies } from "#/lib/profile-replies";
+import { runResearchMode } from "#/lib/research";
 import {
 	createDmReply,
 	createPost,
@@ -278,6 +279,28 @@ searchCommand
 			limit: Number(options.limit),
 		});
 		print(items, program.opts().json ?? false);
+	});
+
+program
+	.command("research [query]")
+	.description("Build a markdown research brief from bookmarked threads")
+	.option("--account <accountId>", "Account id")
+	.option("--limit <n>", "Seed bookmark limit", "20")
+	.option("--thread-depth <n>", "Maximum ancestor walk depth", "10")
+	.option("--out <path>", "Write the markdown brief to a file")
+	.action(async (query, options) => {
+		await autoUpdateBeforeRead();
+		const report = await runResearchMode({
+			account: options.account,
+			query,
+			limit: Number(options.limit),
+			maxThreadDepth: Number(options.threadDepth),
+			outPath: options.out,
+		});
+		print(
+			program.opts().json ? report : report.markdown,
+			program.opts().json ?? false,
+		);
 	});
 
 const mentionsCommand = program

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -28,6 +28,7 @@ describe("bird transport wrapper", () => {
 					retweetCount: 2,
 					likeCount: 3,
 					conversationId: "tweet_root_1",
+					inReplyToStatusId: "tweet_parent_1",
 					authorId: "42",
 					author: {
 						username: "sam",
@@ -60,6 +61,7 @@ describe("bird transport wrapper", () => {
 					author_id: "42",
 					text: "hello from bird",
 					conversation_id: "tweet_root_1",
+					referenced_tweets: [{ type: "replied_to", id: "tweet_parent_1" }],
 					public_metrics: expect.objectContaining({
 						reply_count: 1,
 						retweet_count: 2,
@@ -341,6 +343,46 @@ describe("bird transport wrapper", () => {
 			includes: { users: [{ id: "44", username: "jules", name: "Jules" }] },
 			meta: expect.objectContaining({ result_count: 1 }),
 		});
+	});
+
+	it("looks up tweets by id through bird read", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		execFileAsyncMock.mockResolvedValueOnce({
+			stdout: JSON.stringify({
+				id: "tweet_1",
+				text: "read from bird",
+				createdAt: "Tue May 05 15:07:12 +0000 2026",
+				authorId: "42",
+				author: { username: "sam", name: "Sam" },
+				conversationId: "tweet_root",
+				inReplyToStatusId: "tweet_root",
+				quotedTweet: { id: "tweet_quote" },
+				likeCount: 9,
+			}),
+		});
+		const { lookupTweetsByIdsViaBird } = await import("./bird");
+
+		await expect(lookupTweetsByIdsViaBird(["tweet_1"])).resolves.toEqual({
+			data: [
+				expect.objectContaining({
+					id: "tweet_1",
+					author_id: "42",
+					text: "read from bird",
+					conversation_id: "tweet_root",
+					referenced_tweets: [
+						{ type: "replied_to", id: "tweet_root" },
+						{ type: "quoted", id: "tweet_quote" },
+					],
+				}),
+			],
+			includes: { users: [{ id: "42", username: "sam", name: "Sam" }] },
+			meta: expect.objectContaining({ result_count: 1 }),
+		});
+		expect(execFileAsyncMock).toHaveBeenCalledWith(
+			"/tmp/bird",
+			["read", "tweet_1", "--json"],
+			expect.objectContaining({ maxBuffer: expect.any(Number) }),
+		);
 	});
 
 	it("rejects unexpected direct messages json", async () => {

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -5,6 +5,8 @@ import type {
 	XurlMentionData,
 	XurlMentionsResponse,
 	XurlMentionUser,
+	XurlReferencedTweet,
+	XurlTweetsResponse,
 } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -54,7 +56,9 @@ interface BirdTweetItem {
 	retweetCount?: number;
 	likeCount?: number;
 	conversationId?: string;
-	inReplyToStatusId?: string;
+	inReplyToStatusId?: string | null;
+	quotedStatusId?: string | null;
+	quotedTweet?: { id?: string | null } | null;
 	author?: BirdTweetAuthor;
 	authorId?: string;
 	media?: BirdTweetMedia[];
@@ -182,6 +186,17 @@ function getBirdTweetItems(payload: unknown, command: string) {
 	throw new Error(`bird ${command} returned unexpected JSON`);
 }
 
+function getBirdTweetItem(payload: unknown, command: string) {
+	if (payload && typeof payload === "object") {
+		const record = payload as { id?: unknown };
+		if (typeof record.id === "string" && record.id.length > 0) {
+			return payload as BirdTweetItem;
+		}
+	}
+
+	throw new Error(`bird ${command} returned unexpected JSON`);
+}
+
 function toMediaEntities(media: BirdTweetMedia[] | undefined) {
 	if (!Array.isArray(media) || media.length === 0) {
 		return undefined;
@@ -199,6 +214,25 @@ function toMediaEntities(media: BirdTweetMedia[] | undefined) {
 				media_key: `bird_media_${index}`,
 			})),
 	};
+}
+
+function toReferencedTweets(item: BirdTweetItem) {
+	const references: XurlReferencedTweet[] = [];
+	if (typeof item.inReplyToStatusId === "string" && item.inReplyToStatusId) {
+		references.push({ type: "replied_to", id: item.inReplyToStatusId });
+	}
+
+	const quotedTweetId =
+		typeof item.quotedStatusId === "string" && item.quotedStatusId
+			? item.quotedStatusId
+			: typeof item.quotedTweet?.id === "string" && item.quotedTweet.id
+				? item.quotedTweet.id
+				: null;
+	if (quotedTweetId) {
+		references.push({ type: "quoted", id: quotedTweetId });
+	}
+
+	return references.length > 0 ? references : undefined;
 }
 
 function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
@@ -222,6 +256,7 @@ function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
 			created_at: toIsoTimestamp(item.createdAt),
 			conversation_id: item.conversationId ?? item.id,
 			entities: toMediaEntities(item.media),
+			referenced_tweets: toReferencedTweets(item),
 			public_metrics: {
 				reply_count: Number(item.replyCount ?? 0),
 				retweet_count: Number(item.retweetCount ?? 0),
@@ -317,6 +352,23 @@ export async function listBookmarkedTweetsViaBird({
 		all,
 		maxPages,
 	});
+}
+
+export async function lookupTweetsByIdsViaBird(
+	ids: string[],
+): Promise<XurlTweetsResponse> {
+	if (ids.length === 0) {
+		return { data: [] };
+	}
+
+	const tweets = await Promise.all(
+		ids.map(async (id) => {
+			const stdout = await runBirdJsonCommand(["read", id, "--json"]);
+			return getBirdTweetItem(parseBirdJson(stdout), "read");
+		}),
+	);
+
+	return normalizeBirdTweets(tweets);
 }
 
 export async function listDirectMessagesViaBird({

--- a/src/lib/research.test.ts
+++ b/src/lib/research.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment node
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+
+const tempRoots: string[] = [];
+
+function setupTempHome() {
+	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-research-"));
+	tempRoots.push(tempRoot);
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	return tempRoot;
+}
+
+function seedResearchThread() {
+	const db = getNativeDb();
+
+	db.prepare(
+		"insert into accounts (id, name, handle, external_user_id, transport, is_default, created_at) values (?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		"acct_research",
+		"Primary",
+		"@researchsam",
+		"42",
+		"xurl",
+		1,
+		"2026-05-01T00:00:00.000Z",
+	);
+
+	db.prepare(
+		"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, avatar_url, created_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		"profile_research_sam",
+		"researchsam",
+		"Research Sam",
+		"",
+		100,
+		10,
+		null,
+		"2026-05-01T00:00:00.000Z",
+	);
+	db.prepare(
+		"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, avatar_url, created_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		"profile_research_lee",
+		"researchlee",
+		"Research Lee",
+		"",
+		20,
+		20,
+		null,
+		"2026-05-01T00:00:00.000Z",
+	);
+	db.prepare(
+		"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, avatar_url, created_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		"profile_research_jules",
+		"researchjules",
+		"Research Jules",
+		"",
+		30,
+		30,
+		null,
+		"2026-05-01T00:00:00.000Z",
+	);
+
+	db.prepare(
+		`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+	).run(
+		"tweet_root",
+		"acct_research",
+		"profile_research_sam",
+		"bookmark",
+		"Check https://t.co/demo with @researchlee",
+		"2026-05-01T10:00:00.000Z",
+		0,
+		null,
+		12,
+		0,
+		1,
+		0,
+		JSON.stringify({
+			mentions: [
+				{
+					username: "researchlee",
+					id: "profile_research_lee",
+					start: 29,
+					end: 41,
+				},
+			],
+			urls: [
+				{
+					url: "https://t.co/demo",
+					expanded_url: "https://github.com/steipete/birdclaw",
+					display_url: "github.com/steipete/birdclaw",
+					start: 6,
+					end: 23,
+				},
+			],
+		}),
+		"[]",
+		null,
+	);
+
+	db.prepare(
+		`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+	).run(
+		"tweet_reply_1",
+		"acct_research",
+		"profile_research_lee",
+		"home",
+		"I agree",
+		"2026-05-01T10:05:00.000Z",
+		1,
+		"tweet_root",
+		2,
+		0,
+		0,
+		0,
+		"{}",
+		"[]",
+		null,
+	);
+
+	db.prepare(
+		`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+	).run(
+		"tweet_reply_2",
+		"acct_research",
+		"profile_research_jules",
+		"home",
+		"Follow-up with details",
+		"2026-05-01T10:10:00.000Z",
+		1,
+		"tweet_reply_1",
+		3,
+		0,
+		0,
+		0,
+		"{}",
+		"[]",
+		null,
+	);
+
+	db.prepare(
+		`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+	).run(
+		"tweet_reply_3",
+		"acct_research",
+		"profile_research_lee",
+		"home",
+		"Another branch",
+		"2026-05-01T10:06:00.000Z",
+		1,
+		"tweet_root",
+		1,
+		0,
+		0,
+		0,
+		"{}",
+		"[]",
+		null,
+	);
+}
+
+describe("research mode", () => {
+	beforeEach(() => {
+		setupTempHome();
+		seedResearchThread();
+	});
+
+	afterEach(() => {
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		delete process.env.BIRDCLAW_HOME;
+
+		for (const tempRoot of tempRoots.splice(0)) {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("expands bookmarked threads into a markdown brief", async () => {
+		const { runResearchMode } = await import("./research");
+
+		const report = await runResearchMode({
+			account: "acct_research",
+			limit: 5,
+			maxThreadDepth: 6,
+		});
+
+		expect(report.seedCount).toBe(1);
+		expect(report.threadCount).toBe(1);
+		expect(report.items[0]?.thread.map((node) => node.id)).toEqual([
+			"tweet_root",
+			"tweet_reply_1",
+			"tweet_reply_3",
+			"tweet_reply_2",
+		]);
+		expect(report.items[0]?.links).toContain(
+			"https://github.com/steipete/birdclaw",
+		);
+		expect(report.items[0]?.handles).toContain("@researchlee");
+		expect(report.markdown).toContain("# Birdclaw Research");
+		expect(report.markdown).toContain("tweet_reply_2");
+		expect(report.markdown).toContain("github.com/steipete/birdclaw");
+	});
+
+	it("writes the markdown brief to disk when requested", async () => {
+		const { runResearchMode } = await import("./research");
+		const outputPath = path.join(process.env.BIRDCLAW_HOME ?? "", "brief.md");
+
+		const report = await runResearchMode({
+			account: "acct_research",
+			limit: 1,
+			maxThreadDepth: 4,
+			outPath: outputPath,
+		});
+
+		expect(report.seedCount).toBe(1);
+		expect(report.markdown).toContain("Birdclaw Research");
+		expect(readFileSync(outputPath, "utf8")).toContain("Birdclaw Research");
+	});
+});

--- a/src/lib/research.test.ts
+++ b/src/lib/research.test.ts
@@ -222,8 +222,8 @@ describe("research mode", () => {
 		expect(report.items[0]?.thread.map((node) => node.id)).toEqual([
 			"tweet_root",
 			"tweet_reply_1",
-			"tweet_reply_3",
 			"tweet_reply_2",
+			"tweet_reply_3",
 		]);
 		expect(report.items[0]?.links).toContain(
 			"https://github.com/steipete/birdclaw",
@@ -232,6 +232,28 @@ describe("research mode", () => {
 		expect(report.markdown).toContain("# Birdclaw Research");
 		expect(report.markdown).toContain("tweet_reply_2");
 		expect(report.markdown).toContain("github.com/steipete/birdclaw");
+		expect(report.markdown.indexOf("Follow-up with details")).toBeLessThan(
+			report.markdown.indexOf("Another branch"),
+		);
+		expect(report.markdown).toContain(
+			"    - [@researchjules](https://x.com/researchjules/status/tweet_reply_2)",
+		);
+	});
+
+	it("honors the thread depth limit when expanding local descendants", async () => {
+		const { runResearchMode } = await import("./research");
+
+		const report = await runResearchMode({
+			account: "acct_research",
+			limit: 5,
+			maxThreadDepth: 1,
+		});
+
+		expect(report.items[0]?.thread.map((node) => node.id)).toEqual([
+			"tweet_root",
+			"tweet_reply_1",
+			"tweet_reply_3",
+		]);
 	});
 
 	it("writes the markdown brief to disk when requested", async () => {

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -1,0 +1,530 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { getNativeDb } from "./db";
+import { listTimelineItems } from "./queries";
+import { renderTweetMarkdown, renderTweetPlainText } from "./tweet-render";
+import type { TweetEntities, XurlMentionUser } from "./types";
+import { lookupTweetsByIds } from "./xurl";
+
+type ResearchNodeSource = "local" | "live";
+
+export interface ResearchNode {
+	id: string;
+	url: string;
+	authorHandle: string;
+	authorName: string;
+	createdAt: string;
+	text: string;
+	plainText: string;
+	markdown: string;
+	likeCount: number;
+	bookmarked: boolean;
+	liked: boolean;
+	replyToTweetId?: string | null;
+	quotedTweetId?: string | null;
+	threadDepth: number;
+	source: ResearchNodeSource;
+}
+
+export interface ResearchThread {
+	seedTweetId: string;
+	seedUrl: string;
+	seedText: string;
+	threadRootId: string;
+	thread: ResearchNode[];
+	links: string[];
+	handles: string[];
+}
+
+export interface ResearchReport {
+	query?: string;
+	account?: string;
+	generatedAt: string;
+	seedCount: number;
+	threadCount: number;
+	items: ResearchThread[];
+	markdown: string;
+}
+
+export interface ResearchOptions {
+	account?: string;
+	query?: string;
+	limit?: number;
+	maxThreadDepth?: number;
+	outPath?: string;
+}
+
+interface ResearchRow {
+	id: string;
+	account_id: string;
+	account_handle: string;
+	kind: string;
+	text: string;
+	created_at: string;
+	is_replied: number;
+	like_count: number;
+	bookmarked: number;
+	liked: number;
+	reply_to_id: string | null;
+	quoted_tweet_id: string | null;
+	entities_json: string;
+	author_handle: string;
+	author_name: string;
+	author_bio: string;
+	author_followers_count: number;
+	author_avatar_hue: number;
+	author_avatar_url: string | null;
+	author_created_at: string;
+	thread_depth?: number;
+}
+
+function parseJsonField<T>(value: unknown, fallback: T): T {
+	if (typeof value !== "string" || value.length === 0) {
+		return fallback;
+	}
+
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function normalizeTweetEntities(raw: unknown): TweetEntities {
+	if (!raw || typeof raw !== "object") {
+		return {};
+	}
+
+	const entities = raw as Record<string, unknown>;
+	const mentions = Array.isArray(entities.mentions) ? entities.mentions : [];
+	const urls = Array.isArray(entities.urls) ? entities.urls : [];
+	const hashtags = Array.isArray(entities.hashtags) ? entities.hashtags : [];
+
+	return {
+		...(mentions.length
+			? {
+					mentions: mentions.map((mention) => {
+						const value =
+							mention && typeof mention === "object"
+								? (mention as Record<string, unknown>)
+								: {};
+						return {
+							username: String(value.username ?? ""),
+							id: typeof value.id === "string" ? String(value.id) : undefined,
+							start: Number(value.start ?? 0),
+							end: Number(value.end ?? 0),
+						};
+					}),
+				}
+			: {}),
+		...(urls.length
+			? {
+					urls: urls.map((url) => {
+						const value =
+							url && typeof url === "object"
+								? (url as Record<string, unknown>)
+								: {};
+						return {
+							url: String(value.url ?? ""),
+							expandedUrl: String(
+								value.expanded_url ?? value.expandedUrl ?? value.url ?? "",
+							),
+							displayUrl: String(
+								value.display_url ?? value.displayUrl ?? value.url ?? "",
+							),
+							start: Number(value.start ?? 0),
+							end: Number(value.end ?? 0),
+						};
+					}),
+				}
+			: {}),
+		...(hashtags.length
+			? {
+					hashtags: hashtags.map((hashtag) => {
+						const value =
+							hashtag && typeof hashtag === "object"
+								? (hashtag as Record<string, unknown>)
+								: {};
+						return {
+							tag: String(value.tag ?? ""),
+							start: Number(value.start ?? 0),
+							end: Number(value.end ?? 0),
+						};
+					}),
+				}
+			: {}),
+	};
+}
+
+function toProfile(record: ResearchRow) {
+	return {
+		id: record.author_handle,
+		handle: record.author_handle,
+		displayName: record.author_name,
+		bio: record.author_bio,
+		followersCount: Number(record.author_followers_count ?? 0),
+		avatarHue: Number(record.author_avatar_hue ?? 0),
+		avatarUrl:
+			typeof record.author_avatar_url === "string"
+				? record.author_avatar_url
+				: undefined,
+		createdAt: record.author_created_at,
+	};
+}
+
+function toResearchNode(
+	record: ResearchRow,
+	source: ResearchNodeSource,
+): ResearchNode {
+	const author = toProfile(record);
+	const entities = normalizeTweetEntities(
+		parseJsonField(record.entities_json, {}),
+	);
+	return {
+		id: record.id,
+		url: `https://x.com/${author.handle}/status/${record.id}`,
+		authorHandle: author.handle,
+		authorName: author.displayName,
+		createdAt: record.created_at,
+		text: record.text,
+		plainText: renderTweetPlainText(record.text, entities),
+		markdown: renderTweetMarkdown(record.text, entities),
+		likeCount: Number(record.like_count ?? 0),
+		bookmarked: Boolean(record.bookmarked),
+		liked: Boolean(record.liked),
+		replyToTweetId: record.reply_to_id,
+		quotedTweetId: record.quoted_tweet_id,
+		threadDepth: Number(record.thread_depth ?? 0),
+		source,
+	};
+}
+
+function getTweetRowById(tweetId: string): ResearchRow | null {
+	const db = getNativeDb();
+	const row = db
+		.prepare(
+			`
+      select
+        t.id,
+        t.account_id,
+        a.handle as account_handle,
+        t.kind,
+        t.text,
+        t.created_at,
+        t.is_replied,
+        t.like_count,
+        t.bookmarked,
+        t.liked,
+        t.reply_to_id,
+        t.quoted_tweet_id,
+        t.entities_json,
+        p.id as author_profile_id,
+        p.handle as author_handle,
+        p.display_name as author_name,
+        p.bio as author_bio,
+        p.followers_count as author_followers_count,
+        p.avatar_hue as author_avatar_hue,
+        p.avatar_url as author_avatar_url,
+        p.created_at as author_created_at
+      from tweets t
+      join accounts a on a.id = t.account_id
+      join profiles p on p.id = t.author_profile_id
+      where t.id = ?
+      `,
+		)
+		.get(tweetId) as ResearchRow | undefined;
+
+	return row ?? null;
+}
+
+function getTweetDescendants(rootTweetId: string): ResearchNode[] {
+	const db = getNativeDb();
+	const rows = db
+		.prepare(
+			`
+      with recursive thread(id, depth) as (
+        select id, 0 as depth
+        from tweets
+        where id = ?
+        union all
+        select child.id, thread.depth + 1
+        from tweets child
+        join thread on child.reply_to_id = thread.id
+      )
+      select
+        t.id,
+        t.account_id,
+        a.handle as account_handle,
+        t.kind,
+        t.text,
+        t.created_at,
+        t.is_replied,
+        t.like_count,
+        t.bookmarked,
+        t.liked,
+        t.reply_to_id,
+        t.quoted_tweet_id,
+        t.entities_json,
+        p.id as author_profile_id,
+        p.handle as author_handle,
+        p.display_name as author_name,
+        p.bio as author_bio,
+        p.followers_count as author_followers_count,
+        p.avatar_hue as author_avatar_hue,
+        p.avatar_url as author_avatar_url,
+        p.created_at as author_created_at,
+        thread.depth as thread_depth
+      from thread
+      join tweets t on t.id = thread.id
+      join accounts a on a.id = t.account_id
+      join profiles p on p.id = t.author_profile_id
+      order by thread.depth asc, t.created_at asc, t.id asc
+      `,
+		)
+		.all(rootTweetId) as ResearchRow[];
+
+	return rows.map((row) => toResearchNode(row, "local"));
+}
+
+async function lookupTweetNode(tweetId: string): Promise<ResearchNode | null> {
+	const payload = await lookupTweetsByIds([tweetId]);
+	const tweet = payload.data[0];
+	if (!tweet) {
+		return null;
+	}
+	const entities = normalizeTweetEntities(tweet.entities);
+
+	const usersById = new Map(
+		(payload.includes?.users ?? []).map((user: XurlMentionUser) => [
+			user.id,
+			user,
+		]),
+	);
+	const author = usersById.get(tweet.author_id) ?? {
+		id: tweet.author_id,
+		username: `user_${tweet.author_id}`,
+		name: `user_${tweet.author_id}`,
+	};
+
+	return {
+		id: tweet.id,
+		url: `https://x.com/${author.username}/status/${tweet.id}`,
+		authorHandle: author.username,
+		authorName: author.name,
+		createdAt: tweet.created_at,
+		text: tweet.text,
+		plainText: renderTweetPlainText(tweet.text, entities),
+		markdown: renderTweetMarkdown(tweet.text, entities),
+		likeCount: Number(tweet.public_metrics?.like_count ?? 0),
+		bookmarked: false,
+		liked: false,
+		replyToTweetId:
+			tweet.referenced_tweets?.find((item) => item.type === "replied_to")?.id ??
+			null,
+		quotedTweetId:
+			tweet.referenced_tweets?.find((item) => item.type === "quoted")?.id ??
+			null,
+		threadDepth: 0,
+		source: "live",
+	};
+}
+
+async function collectAncestorChain(
+	tweetId: string,
+	maxThreadDepth: number,
+): Promise<ResearchNode[]> {
+	const chain: ResearchNode[] = [];
+	let currentId: string | undefined = tweetId;
+	const visited = new Set<string>();
+	let depth = 0;
+
+	while (currentId && !visited.has(currentId) && depth < maxThreadDepth) {
+		visited.add(currentId);
+		const localRow = getTweetRowById(currentId);
+		if (localRow) {
+			chain.push(toResearchNode(localRow, "local"));
+			currentId = localRow.reply_to_id ?? undefined;
+			depth += 1;
+			continue;
+		}
+
+		const remoteNode = await lookupTweetNode(currentId);
+		if (!remoteNode) {
+			break;
+		}
+		chain.push(remoteNode);
+		currentId = remoteNode.replyToTweetId ?? undefined;
+		depth += 1;
+	}
+
+	return chain
+		.reverse()
+		.map((node, index) => ({ ...node, threadDepth: index }));
+}
+
+function dedupeNodes(nodes: ResearchNode[]) {
+	const seen = new Set<string>();
+	const output: ResearchNode[] = [];
+	for (const node of nodes) {
+		if (seen.has(node.id)) {
+			continue;
+		}
+		seen.add(node.id);
+		output.push(node);
+	}
+	return output;
+}
+
+function collectExternalLinks(nodes: ResearchNode[]) {
+	const links = new Set<string>();
+	for (const node of nodes) {
+		for (const match of node.plainText.matchAll(/https?:\/\/[^\s<>\])"]+/g)) {
+			links.add(match[0]);
+		}
+	}
+	return Array.from(links);
+}
+
+function collectHandles(nodes: ResearchNode[]) {
+	const handles = new Set<string>();
+	for (const node of nodes) {
+		handles.add(`@${node.authorHandle}`);
+		for (const match of node.plainText.matchAll(/@([A-Za-z0-9_]+)/g)) {
+			handles.add(`@${match[1]}`);
+		}
+	}
+	return Array.from(handles);
+}
+
+function renderThreadMarkdown(thread: ResearchNode[]) {
+	return thread
+		.map((node) => {
+			const indent = "  ".repeat(node.threadDepth);
+			const source = node.source === "live" ? "live" : "local";
+			return `${indent}- [@${node.authorHandle}](${node.url}) [${source}] ${node.markdown}`;
+		})
+		.join("\n");
+}
+
+function renderReportMarkdown(report: Omit<ResearchReport, "markdown">) {
+	const lines = [
+		"# Birdclaw Research",
+		"",
+		`- Generated: ${report.generatedAt}`,
+		`- Query: ${report.query ? `\`${report.query}\`` : "(all bookmarks)"}`,
+		`- Account: ${report.account ?? "all"}`,
+		`- Seed bookmarks: ${report.seedCount}`,
+		`- Threads expanded: ${report.threadCount}`,
+		"",
+	];
+
+	report.items.forEach((item, index) => {
+		lines.push(
+			`## ${index + 1}. Seed tweet`,
+			"",
+			`- URL: ${item.seedUrl}`,
+			`- Seed tweet: \`${item.seedTweetId}\``,
+			`- Thread root: \`${item.threadRootId}\``,
+			`- Seed text: ${item.seedText}`,
+			"",
+			"### Thread",
+			"",
+			renderThreadMarkdown(item.thread),
+			"",
+		);
+
+		if (item.links.length > 0) {
+			lines.push("### Links", "");
+			for (const link of item.links) {
+				lines.push(`- ${link}`);
+			}
+			lines.push("");
+		}
+
+		if (item.handles.length > 0) {
+			lines.push("### Handles", "");
+			lines.push(`- ${item.handles.join(", ")}`, "");
+		}
+	});
+
+	return lines.join("\n").trimEnd() + "\n";
+}
+
+function resolveSeedTimelineItems({
+	account,
+	query,
+	limit,
+}: {
+	account?: string;
+	query?: string;
+	limit: number;
+}) {
+	return listTimelineItems({
+		resource: "home",
+		account,
+		search: query,
+		bookmarkedOnly: true,
+		includeReplies: true,
+		qualityFilter: "all",
+		limit,
+	});
+}
+
+export async function runResearchMode(
+	options: ResearchOptions = {},
+): Promise<ResearchReport> {
+	const limit = Number.isFinite(options.limit ?? 20)
+		? Math.max(1, Math.floor(options.limit ?? 20))
+		: 20;
+	const maxThreadDepth = Number.isFinite(options.maxThreadDepth ?? 10)
+		? Math.max(1, Math.floor(options.maxThreadDepth ?? 10))
+		: 10;
+	const seeds = resolveSeedTimelineItems({
+		account: options.account,
+		query: options.query,
+		limit,
+	});
+
+	const items: ResearchThread[] = [];
+	for (const seed of seeds) {
+		const ancestorChain = await collectAncestorChain(seed.id, maxThreadDepth);
+		const rootId = ancestorChain[0]?.id ?? seed.id;
+		const localThread = getTweetDescendants(rootId);
+		const thread = dedupeNodes([...ancestorChain, ...localThread]);
+		const links = collectExternalLinks(thread);
+		const handles = collectHandles(thread);
+		items.push({
+			seedTweetId: seed.id,
+			seedUrl: `https://x.com/${seed.author.handle}/status/${seed.id}`,
+			seedText: renderTweetPlainText(seed.text, seed.entities),
+			threadRootId: rootId,
+			thread,
+			links,
+			handles,
+		});
+	}
+
+	const reportBase = {
+		query: options.query,
+		account: options.account,
+		generatedAt: new Date().toISOString(),
+		seedCount: seeds.length,
+		threadCount: items.length,
+		items,
+	};
+	const markdown = renderReportMarkdown(reportBase);
+	const report: ResearchReport = {
+		...reportBase,
+		markdown,
+	};
+
+	if (options.outPath) {
+		const resolved = path.resolve(options.outPath);
+		mkdirSync(path.dirname(resolved), { recursive: true });
+		writeFileSync(resolved, markdown, "utf8");
+	}
+
+	return report;
+}
+
+export type { ResearchRow };

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -237,19 +237,24 @@ function getTweetRowById(tweetId: string): ResearchRow | null {
 	return row ?? null;
 }
 
-function getTweetDescendants(rootTweetId: string): ResearchNode[] {
+function getTweetDescendants(
+	rootTweetId: string,
+	maxThreadDepth: number,
+): ResearchNode[] {
 	const db = getNativeDb();
 	const rows = db
 		.prepare(
 			`
-      with recursive thread(id, depth) as (
-        select id, 0 as depth
+      with recursive thread(id, depth, path) as (
+        select id, 0 as depth, ',' || id || ',' as path
         from tweets
         where id = ?
         union all
-        select child.id, thread.depth + 1
+        select child.id, thread.depth + 1, thread.path || child.id || ','
         from tweets child
         join thread on child.reply_to_id = thread.id
+        where thread.depth < ?
+          and instr(thread.path, ',' || child.id || ',') = 0
       )
       select
         t.id,
@@ -278,10 +283,10 @@ function getTweetDescendants(rootTweetId: string): ResearchNode[] {
       join tweets t on t.id = thread.id
       join accounts a on a.id = t.account_id
       join profiles p on p.id = t.author_profile_id
-      order by thread.depth asc, t.created_at asc, t.id asc
+      order by t.created_at asc, t.id asc
       `,
 		)
-		.all(rootTweetId) as ResearchRow[];
+		.all(rootTweetId, maxThreadDepth) as ResearchRow[];
 
 	return rows.map((row) => toResearchNode(row, "local"));
 }
@@ -367,12 +372,70 @@ function dedupeNodes(nodes: ResearchNode[]) {
 	const output: ResearchNode[] = [];
 	for (const node of nodes) {
 		if (seen.has(node.id)) {
+			const existingIndex = output.findIndex((item) => item.id === node.id);
+			if (
+				existingIndex >= 0 &&
+				output[existingIndex]?.source === "live" &&
+				node.source === "local"
+			) {
+				output[existingIndex] = node;
+			}
 			continue;
 		}
 		seen.add(node.id);
 		output.push(node);
 	}
 	return output;
+}
+
+function compareThreadNodes(a: ResearchNode, b: ResearchNode) {
+	const byCreatedAt = a.createdAt.localeCompare(b.createdAt);
+	return byCreatedAt === 0 ? a.id.localeCompare(b.id) : byCreatedAt;
+}
+
+function orderThreadNodes(rootId: string, nodes: ResearchNode[]) {
+	const byId = new Map(nodes.map((node) => [node.id, node]));
+	const childrenByParentId = new Map<string, ResearchNode[]>();
+
+	for (const node of nodes) {
+		const parentId = node.replyToTweetId;
+		if (!parentId || !byId.has(parentId) || node.id === rootId) {
+			continue;
+		}
+		const siblings = childrenByParentId.get(parentId) ?? [];
+		siblings.push(node);
+		childrenByParentId.set(parentId, siblings);
+	}
+
+	for (const siblings of childrenByParentId.values()) {
+		siblings.sort(compareThreadNodes);
+	}
+
+	const ordered: ResearchNode[] = [];
+	const visited = new Set<string>();
+	const visit = (node: ResearchNode, depth: number) => {
+		if (visited.has(node.id)) {
+			return;
+		}
+		visited.add(node.id);
+		ordered.push({ ...node, threadDepth: depth });
+		for (const child of childrenByParentId.get(node.id) ?? []) {
+			visit(child, depth + 1);
+		}
+	};
+
+	const root = byId.get(rootId);
+	if (root) {
+		visit(root, 0);
+	}
+
+	for (const node of [...nodes].sort(compareThreadNodes)) {
+		if (!visited.has(node.id)) {
+			visit(node, Math.max(0, node.threadDepth));
+		}
+	}
+
+	return ordered;
 }
 
 function collectExternalLinks(nodes: ResearchNode[]) {
@@ -489,8 +552,11 @@ export async function runResearchMode(
 	for (const seed of seeds) {
 		const ancestorChain = await collectAncestorChain(seed.id, maxThreadDepth);
 		const rootId = ancestorChain[0]?.id ?? seed.id;
-		const localThread = getTweetDescendants(rootId);
-		const thread = dedupeNodes([...ancestorChain, ...localThread]);
+		const localThread = getTweetDescendants(rootId, maxThreadDepth);
+		const thread = orderThreadNodes(
+			rootId,
+			dedupeNodes([...ancestorChain, ...localThread]),
+		);
 		const links = collectExternalLinks(thread);
 		const handles = collectHandles(thread);
 		items.push({

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -2,9 +2,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getNativeDb } from "./db";
 import { listTimelineItems } from "./queries";
+import { lookupTweetsByIds } from "./tweet-lookup";
 import { renderTweetMarkdown, renderTweetPlainText } from "./tweet-render";
 import type { TweetEntities, XurlMentionUser } from "./types";
-import { lookupTweetsByIds } from "./xurl";
 
 type ResearchNodeSource = "local" | "live";
 

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
-import { resetDatabaseForTests } from "./db";
+import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listTimelineItems } from "./queries";
 
 const mocks = vi.hoisted(() => ({
@@ -59,6 +59,10 @@ describe("live timeline collection sync", () => {
 					text: "xurl liked item",
 					created_at: "2026-04-26T13:43:34.000Z",
 					public_metrics: { like_count: 12 },
+					referenced_tweets: [
+						{ type: "replied_to", id: "root_1" },
+						{ type: "quoted", id: "quote_1" },
+					],
 				},
 			],
 			includes: {
@@ -87,6 +91,17 @@ describe("live timeline collection sync", () => {
 			liked: true,
 			bookmarked: false,
 			author: { handle: "sam" },
+		});
+		expect(
+			getNativeDb()
+				.prepare(
+					"select is_replied, reply_to_id, quoted_tweet_id from tweets where id = ?",
+				)
+				.get("liked_1"),
+		).toMatchObject({
+			is_replied: 1,
+			reply_to_id: "root_1",
+			quoted_tweet_id: "quote_1",
 		});
 	});
 

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -105,6 +105,12 @@ function replaceTweetFts(db: Database.Database, tweetId: string, text: string) {
 	);
 }
 
+function getReferencedTweetId(tweet: XurlMentionData, type: string) {
+	return (
+		tweet.referenced_tweets?.find((item) => item.type === type)?.id ?? null
+	);
+}
+
 function mergePayloads(pages: XurlMentionsResponse[]): XurlMentionsResponse {
 	const tweets: XurlMentionData[] = [];
 	const seenTweetIds = new Set<string>();
@@ -162,7 +168,7 @@ function mergeTimelineCollectionIntoLocalStore(
       id, account_id, author_profile_id, kind, text, created_at,
       is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
       entities_json, media_json, quoted_tweet_id
-    ) values (?, ?, ?, ?, ?, ?, 0, null, ?, ?, ?, ?, ?, '[]', null)
+    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', ?)
     on conflict(id) do update set
       account_id = excluded.account_id,
       author_profile_id = excluded.author_profile_id,
@@ -176,6 +182,9 @@ function mergeTimelineCollectionIntoLocalStore(
       media_count = excluded.media_count,
       entities_json = excluded.entities_json,
       media_json = excluded.media_json,
+      is_replied = max(tweets.is_replied, excluded.is_replied),
+      reply_to_id = coalesce(excluded.reply_to_id, tweets.reply_to_id),
+      quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id),
       bookmarked = max(tweets.bookmarked, excluded.bookmarked),
       liked = max(tweets.liked, excluded.liked)
     `,
@@ -203,6 +212,8 @@ function mergeTimelineCollectionIntoLocalStore(
 			const profile = usersById.has(tweet.author_id)
 				? upsertProfileFromXUser(db, author)
 				: ensureStubProfileForXUser(db, tweet.author_id);
+			const replyToId = getReferencedTweetId(tweet, "replied_to");
+			const quotedTweetId = getReferencedTweetId(tweet, "quoted");
 			upsertTweet.run(
 				tweet.id,
 				accountId,
@@ -210,11 +221,14 @@ function mergeTimelineCollectionIntoLocalStore(
 				tweetKind,
 				tweet.text,
 				tweet.created_at,
+				replyToId ? 1 : 0,
+				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				getMediaCount(tweet),
 				bookmarked,
 				liked,
 				JSON.stringify(tweet.entities ?? {}),
+				quotedTweetId,
 			);
 			upsertCollection.run(
 				accountId,

--- a/src/lib/tweet-lookup.test.ts
+++ b/src/lib/tweet-lookup.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	lookupTweetsByIdsViaBird: vi.fn(),
+	lookupTweetsByIdsViaXurl: vi.fn(),
+}));
+
+vi.mock("./bird", () => ({
+	lookupTweetsByIdsViaBird: mocks.lookupTweetsByIdsViaBird,
+}));
+
+vi.mock("./xurl", () => ({
+	lookupTweetsByIds: mocks.lookupTweetsByIdsViaXurl,
+}));
+
+describe("shared tweet lookup", () => {
+	afterEach(() => {
+		vi.resetModules();
+		for (const mock of Object.values(mocks)) {
+			mock.mockReset();
+		}
+	});
+
+	it("uses xurl first in auto mode", async () => {
+		mocks.lookupTweetsByIdsViaXurl.mockResolvedValue({
+			data: [
+				{ id: "tweet_1", author_id: "42", text: "xurl", created_at: "now" },
+			],
+		});
+		const { lookupTweetsByIds } = await import("./tweet-lookup");
+
+		await expect(lookupTweetsByIds(["tweet_1"])).resolves.toMatchObject({
+			data: [{ id: "tweet_1", text: "xurl" }],
+		});
+		expect(mocks.lookupTweetsByIdsViaXurl).toHaveBeenCalledWith(["tweet_1"]);
+		expect(mocks.lookupTweetsByIdsViaBird).not.toHaveBeenCalled();
+	});
+
+	it("falls back to bird when xurl lookup fails in auto mode", async () => {
+		mocks.lookupTweetsByIdsViaXurl.mockRejectedValue(new Error("xurl 401"));
+		mocks.lookupTweetsByIdsViaBird.mockResolvedValue({
+			data: [
+				{
+					id: "tweet_1",
+					author_id: "42",
+					text: "bird",
+					created_at: "now",
+					referenced_tweets: [{ type: "replied_to", id: "tweet_root" }],
+				},
+			],
+		});
+		const { lookupTweetsByIds } = await import("./tweet-lookup");
+
+		await expect(lookupTweetsByIds(["tweet_1"])).resolves.toMatchObject({
+			data: [
+				{
+					id: "tweet_1",
+					text: "bird",
+					referenced_tweets: [{ type: "replied_to", id: "tweet_root" }],
+				},
+			],
+		});
+		expect(mocks.lookupTweetsByIdsViaXurl).toHaveBeenCalledWith(["tweet_1"]);
+		expect(mocks.lookupTweetsByIdsViaBird).toHaveBeenCalledWith(["tweet_1"]);
+	});
+
+	it("honors explicit transport modes", async () => {
+		mocks.lookupTweetsByIdsViaXurl.mockResolvedValue({ data: [] });
+		mocks.lookupTweetsByIdsViaBird.mockResolvedValue({ data: [] });
+		const { lookupTweetsByIds } = await import("./tweet-lookup");
+
+		await lookupTweetsByIds(["tweet_1"], "xurl");
+		await lookupTweetsByIds(["tweet_2"], "bird");
+
+		expect(mocks.lookupTweetsByIdsViaXurl).toHaveBeenCalledWith(["tweet_1"]);
+		expect(mocks.lookupTweetsByIdsViaBird).toHaveBeenCalledWith(["tweet_2"]);
+	});
+});

--- a/src/lib/tweet-lookup.ts
+++ b/src/lib/tweet-lookup.ts
@@ -1,0 +1,35 @@
+import { lookupTweetsByIdsViaBird } from "./bird";
+import type { XurlTweetsResponse } from "./types";
+import { lookupTweetsByIds as lookupTweetsByIdsViaXurl } from "./xurl";
+
+export type TweetLookupMode = "auto" | "xurl" | "bird";
+
+function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export async function lookupTweetsByIds(
+	ids: string[],
+	mode: TweetLookupMode = "auto",
+): Promise<XurlTweetsResponse> {
+	if (mode === "bird") {
+		return lookupTweetsByIdsViaBird(ids);
+	}
+	if (mode === "xurl") {
+		return lookupTweetsByIdsViaXurl(ids);
+	}
+
+	try {
+		return await lookupTweetsByIdsViaXurl(ids);
+	} catch (xurlError) {
+		try {
+			return await lookupTweetsByIdsViaBird(ids);
+		} catch (birdError) {
+			throw new Error(
+				`Tweet lookup failed via xurl and bird: xurl: ${errorMessage(
+					xurlError,
+				)}; bird: ${errorMessage(birdError)}`,
+			);
+		}
+	}
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -274,6 +274,7 @@ export interface XurlMentionData {
 	created_at: string;
 	conversation_id?: string;
 	entities?: Record<string, unknown>;
+	referenced_tweets?: XurlReferencedTweet[];
 	public_metrics?: XurlPublicMetrics;
 	edit_history_tweet_ids?: string[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -293,6 +293,18 @@ export interface XurlUserTweet {
 	edit_history_tweet_ids?: string[];
 }
 
+export interface XurlTweetData {
+	id: string;
+	author_id: string;
+	text: string;
+	created_at: string;
+	conversation_id?: string;
+	entities?: Record<string, unknown>;
+	referenced_tweets?: XurlReferencedTweet[];
+	public_metrics?: XurlPublicMetrics;
+	edit_history_tweet_ids?: string[];
+}
+
 export interface ProfileReplyItem {
 	id: string;
 	text: string;
@@ -320,6 +332,14 @@ export interface ProfileRepliesResponse {
 
 export interface XurlMentionsResponse {
 	data: XurlMentionData[];
+	includes?: {
+		users?: XurlMentionUser[];
+	};
+	meta?: Record<string, unknown>;
+}
+
+export interface XurlTweetsResponse {
+	data: XurlTweetData[];
 	includes?: {
 		users?: XurlMentionUser[];
 	};

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -275,6 +275,47 @@ describe("xurl transport wrapper", () => {
 		]);
 	});
 
+	it("looks up tweets by id through the raw tweet endpoint", async () => {
+		execFileAsyncMock.mockResolvedValueOnce({
+			stdout: JSON.stringify({
+				data: [
+					{
+						id: "tweet_1",
+						author_id: "42",
+						text: "hello",
+						created_at: "2026-03-09T00:00:00.000Z",
+						referenced_tweets: [{ type: "replied_to", id: "tweet_root" }],
+					},
+				],
+				includes: {
+					users: [{ id: "42", username: "sam", name: "Sam" }],
+				},
+				meta: { result_count: 1 },
+			}),
+			stderr: "",
+		});
+		const { lookupTweetsByIds } = await import("./xurl");
+
+		await expect(lookupTweetsByIds(["tweet_1"])).resolves.toEqual({
+			data: [
+				{
+					id: "tweet_1",
+					author_id: "42",
+					text: "hello",
+					created_at: "2026-03-09T00:00:00.000Z",
+					referenced_tweets: [{ type: "replied_to", id: "tweet_root" }],
+				},
+			],
+			includes: {
+				users: [{ id: "42", username: "sam", name: "Sam" }],
+			},
+			meta: { result_count: 1 },
+		});
+		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
+			"/2/tweets?ids=tweet_1&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=description%2Cpublic_metrics%2Cprofile_image_url%2Ccreated_at%2Cverified",
+		]);
+	});
+
 	it("lists liked and bookmarked tweets through raw Twitter endpoints", async () => {
 		execFileAsyncMock
 			.mockResolvedValueOnce({

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -363,12 +363,12 @@ describe("xurl transport wrapper", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			"/2/users/25401953/liked_tweets?max_results=5&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics&user.fields=description%2Cpublic_metrics%2Cprofile_image_url%2Ccreated_at%2Cverified",
+			"/2/users/25401953/liked_tweets?max_results=5&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=description%2Cpublic_metrics%2Cprofile_image_url%2Ccreated_at%2Cverified",
 		]);
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			"/2/users/25401953/bookmarks?max_results=100&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics&user.fields=description%2Cpublic_metrics%2Cprofile_image_url%2Ccreated_at%2Cverified&pagination_token=next",
+			"/2/users/25401953/bookmarks?max_results=100&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=description%2Cpublic_metrics%2Cprofile_image_url%2Ccreated_at%2Cverified&pagination_token=next",
 		]);
 	});
 

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -4,6 +4,7 @@ import type {
 	TransportStatus,
 	XurlMentionsResponse,
 	XurlMentionUser,
+	XurlTweetsResponse,
 	XurlUserTweet,
 } from "./types";
 
@@ -510,6 +511,38 @@ export async function listUserTweets(
 		items: data,
 		nextToken:
 			typeof meta?.next_token === "string" ? String(meta.next_token) : null,
+	};
+}
+
+export async function lookupTweetsByIds(
+	ids: string[],
+): Promise<XurlTweetsResponse> {
+	if (ids.length === 0) {
+		return { data: [] };
+	}
+
+	const query = new URLSearchParams({
+		ids: ids.join(","),
+		expansions: "author_id",
+		"tweet.fields":
+			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+		"user.fields":
+			"description,public_metrics,profile_image_url,created_at,verified",
+	});
+
+	const payload = await runJsonCommand([`/2/tweets?${query.toString()}`]);
+	return {
+		data: Array.isArray(payload.data)
+			? (payload.data as XurlTweetsResponse["data"])
+			: [],
+		includes:
+			payload.includes && typeof payload.includes === "object"
+				? (payload.includes as XurlTweetsResponse["includes"])
+				: undefined,
+		meta:
+			payload.meta && typeof payload.meta === "object"
+				? (payload.meta as XurlTweetsResponse["meta"])
+				: undefined,
 	};
 }
 

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -392,7 +392,8 @@ async function listTimelineCollectionViaXurl({
 	const query = new URLSearchParams({
 		max_results: String(maxResults),
 		expansions: "author_id",
-		"tweet.fields": "created_at,conversation_id,entities,public_metrics",
+		"tweet.fields":
+			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
 		"user.fields":
 			"description,public_metrics,profile_image_url,created_at,verified",
 	});

--- a/src/routes/api/status.test.tsx
+++ b/src/routes/api/status.test.tsx
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
 const mocks = vi.hoisted(() => ({
+	maybeAutoUpdateBackup: vi.fn(),
 	getQueryEnvelope: vi.fn(),
+}));
+
+vi.mock("#/lib/backup", () => ({
+	maybeAutoUpdateBackup: mocks.maybeAutoUpdateBackup,
 }));
 
 vi.mock("#/lib/queries", () => ({
@@ -15,6 +20,7 @@ const GET = getRouteHandler(Route, "GET");
 
 describe("status api route", () => {
 	it("returns the query envelope as json", async () => {
+		mocks.maybeAutoUpdateBackup.mockResolvedValue(undefined);
 		mocks.getQueryEnvelope.mockResolvedValue({
 			stats: { home: 4, mentions: 2, dms: 4, needsReply: 2, inbox: 4 },
 			accounts: [{ id: "acct_primary" }],
@@ -32,6 +38,7 @@ describe("status api route", () => {
 			archives: [{ path: "/tmp/archive.zip" }],
 			transport: { statusText: "xurl available" },
 		});
+		expect(mocks.maybeAutoUpdateBackup).toHaveBeenCalledTimes(1);
 		expect(response.headers.get("content-type")).toBe("application/json");
 	});
 });


### PR DESCRIPTION
Adds a new  command that composes bookmarked tweets into a markdown brief, expands local thread ancestry, falls back to tweet lookup when needed, and supports writing the result to disk. Includes transport wrapper and tests.