### PR TITLE
fix: detect unauthenticated xurl when no apps registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@
 - Allow Playwright e2e runs to use an alternate local port when `3000` is already occupied.
 - Replace maintainer-local documentation links with repo-relative links and align the setup docs with the Node version file. Thanks @stainlu.
 
+## Unreleased
+
+### Fixed
+
+- Fix live `xurl` status detection when the CLI is installed but not authenticated; thanks @kyupark.
+- Default local `bird` integration to `bird` on PATH and report stale configured command paths with setup guidance.
+
 ## 0.2.1 - 2026-04-27
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,6 +177,19 @@ Backup auto-sync config lives in `~/.birdclaw/config.json`:
 
 Read commands pull + merge only when the last backup check is stale. Data-changing commands run a full backup sync afterward. Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable backup auto-sync for one process.
 
+### local `bird` command
+
+Live local likes, bookmarks, DMs, and moderation verification use `bird` on PATH
+by default. Override it with `BIRDCLAW_BIRD_COMMAND` or:
+
+```json
+{
+	"mentions": {
+		"birdCommand": "/absolute/path/to/bird"
+	}
+}
+```
+
 ### `backup import`
 
 - validates the backup first unless `--no-validate` is passed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1229,6 +1229,9 @@ export async function runCli(argv = process.argv) {
 if (process.argv[1]) {
 	const entryUrl = pathToFileURL(process.argv[1]).href;
 	if (import.meta.url === entryUrl) {
-		void runCli();
+		void runCli().catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		});
 	}
 }

--- a/src/lib/bird-actions.test.ts
+++ b/src/lib/bird-actions.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsyncMock = vi.fn();
+const accessMock = vi.fn();
 
 vi.mock("node:child_process", () => ({
 	execFile: vi.fn(),
@@ -11,10 +12,15 @@ vi.mock("node:util", () => ({
 	promisify: vi.fn(() => execFileAsyncMock),
 }));
 
+vi.mock("node:fs/promises", () => ({
+	access: accessMock,
+}));
+
 describe("bird action transport wrapper", () => {
 	afterEach(() => {
 		vi.resetModules();
 		execFileAsyncMock.mockReset();
+		accessMock.mockReset();
 		delete process.env.BIRDCLAW_BIRD_COMMAND;
 		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
 	});

--- a/src/lib/bird-actions.ts
+++ b/src/lib/bird-actions.ts
@@ -1,9 +1,5 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { getBirdCommand } from "./config";
+import { runBirdCommand } from "./bird-command";
 import type { XurlMentionUser } from "./types";
-
-const execFileAsync = promisify(execFile);
 
 function liveWritesDisabled() {
 	return process.env.BIRDCLAW_DISABLE_LIVE_WRITES === "1";
@@ -40,11 +36,6 @@ function formatExecError(error: unknown, fallback: string) {
 
 function normalizeOutput(stdout?: string, stderr?: string) {
 	return stripAnsi(stdout || stderr || "ok").trim();
-}
-
-async function runBirdCommand(args: string[]) {
-	const birdCommand = getBirdCommand();
-	return execFileAsync(birdCommand, args);
 }
 
 async function runBirdJsonCommand(args: string[]) {

--- a/src/lib/bird-command.ts
+++ b/src/lib/bird-command.ts
@@ -1,0 +1,57 @@
+import { execFile } from "node:child_process";
+import type { ExecFileOptions } from "node:child_process";
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { promisify } from "node:util";
+import { getBirdCommand } from "./config";
+
+const execFileAsync = promisify(execFile);
+
+function isPathCommand(command: string) {
+	return command.includes("/") || command.startsWith(".");
+}
+
+function formatBirdInstallHint(command: string) {
+	return [
+		`bird command unavailable: ${command}`,
+		"Install bird on PATH, set BIRDCLAW_BIRD_COMMAND, or update ~/.birdclaw/config.json mentions.birdCommand.",
+	].join("\n");
+}
+
+async function assertBirdCommandAvailable(command: string) {
+	if (!isPathCommand(command)) {
+		return;
+	}
+
+	try {
+		await access(command, constants.X_OK);
+	} catch {
+		throw new Error(formatBirdInstallHint(command));
+	}
+}
+
+export async function runBirdCommand(
+	args: string[],
+	options?: ExecFileOptions,
+): Promise<{ stdout: string; stderr: string }> {
+	const birdCommand = getBirdCommand();
+	await assertBirdCommandAvailable(birdCommand);
+
+	try {
+		const result =
+			options === undefined
+				? await execFileAsync(birdCommand, args)
+				: await execFileAsync(birdCommand, args, options);
+		return result as { stdout: string; stderr: string };
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			(error.code === "ENOENT" || error.code === "EACCES")
+		) {
+			throw new Error(formatBirdInstallHint(birdCommand));
+		}
+		throw error;
+	}
+}

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -722,7 +722,9 @@ describe("bird transport wrapper", () => {
 		});
 		expect(__test__.formatBirdCommandError(enoent, "/missing/bird")).toEqual(
 			expect.objectContaining({
-				message: expect.stringContaining("bird CLI not found at /missing/bird"),
+				message: expect.stringContaining(
+					"bird command unavailable: /missing/bird",
+				),
 			}),
 		);
 		expect(__test__.formatBirdCommandError("boom", "/tmp/bird")).toBe("boom");

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -27,6 +27,7 @@ function expectBirdCommandCall(callNumber: number, args: string[]) {
 	const call = execFileAsyncMock.mock.calls[callNumber - 1];
 	expect(call).toBeDefined();
 	expect(call[0]).toBe("/bin/bash");
+	expect((call[1] as string[])[0]).toBe("-c");
 	expect((call[1] as string[]).slice(4)).toEqual(["/tmp/bird", ...args]);
 	expect(call[2]).toEqual(
 		expect.objectContaining({ maxBuffer: expect.any(Number) }),
@@ -219,16 +220,17 @@ describe("bird transport wrapper", () => {
 
 	it("explains how to configure bird when the binary is missing", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/missing/bird";
-		execFileAsyncMock.mockRejectedValue(
-			Object.assign(new Error("spawn /missing/bird ENOENT"), {
-				code: "ENOENT",
+		mockBirdRejectOnce(
+			Object.assign(new Error("command failed"), {
+				stderr:
+					"birdclaw-bird: /missing/bird: No such file or directory\nbirdclaw-bird: line 0: exec: /missing/bird: cannot execute: No such file or directory",
 			}),
 		);
 
 		const { listMentionsViaBird } = await import("./bird");
 
 		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"bird CLI not found at /missing/bird",
+			"bird command unavailable: /missing/bird",
 		);
 	});
 

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -181,13 +181,30 @@ function parseBirdJson(stdout: string) {
 }
 
 function formatBirdCommandError(error: unknown, birdCommand: string) {
+	const text = [
+		error instanceof Error ? error.message : "",
+		error &&
+		typeof error === "object" &&
+		"stderr" in error &&
+		typeof error.stderr === "string"
+			? error.stderr
+			: "",
+		error &&
+		typeof error === "object" &&
+		"stdout" in error &&
+		typeof error.stdout === "string"
+			? error.stdout
+			: "",
+	].join("\n");
 	if (
-		error instanceof Error &&
-		"code" in error &&
-		(error as { code?: unknown }).code === "ENOENT"
+		(error instanceof Error &&
+			"code" in error &&
+			(error as { code?: unknown }).code === "ENOENT") ||
+		(/No such file or directory|command not found|cannot execute/i.test(text) &&
+			text.includes(birdCommand))
 	) {
 		return new Error(
-			`bird CLI not found at ${birdCommand}. Install @steipete/bird or set BIRDCLAW_BIRD_COMMAND / mentions.birdCommand to a valid bird binary.`,
+			`bird command unavailable: ${birdCommand}\nInstall bird on PATH, set BIRDCLAW_BIRD_COMMAND, or update ~/.birdclaw/config.json mentions.birdCommand.`,
 		);
 	}
 
@@ -214,7 +231,7 @@ async function runBirdJsonCommand(args: string[], timeoutMs?: number) {
 		const shellScript = 'out="$1"; shift; exec "$@" > "$out"';
 		await execFileAsync(
 			"/bin/bash",
-			["-lc", shellScript, "birdclaw-bird", stdoutPath, birdCommand, ...args],
+			["-c", shellScript, "birdclaw-bird", stdoutPath, birdCommand, ...args],
 			{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
 		);
 		return readFileSync(stdoutPath, "utf8");

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -85,7 +85,7 @@ describe("config", () => {
 		expect(getBirdCommand()).toBe("/tmp/custom-bird");
 	});
 
-	it("resolves bird from PATH before falling back to the local dev path", () => {
+	it("resolves bird from PATH before using the shell fallback", () => {
 		const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-config-"));
 		tempRoots.push(tempRoot);
 		const birdPath = path.join(tempRoot, "bird");
@@ -105,5 +105,10 @@ describe("config", () => {
 		expect(resolveMentionsDataSource()).toBe("xurl");
 		expect(resolveActionsTransport()).toBe("bird");
 		expect(getBirdCommand()).toBe("/tmp/env-bird");
+	});
+
+	it("defaults bird command to PATH lookup", () => {
+		process.env.PATH = "";
+		expect(getBirdCommand()).toBe("bird");
 	});
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -172,7 +172,7 @@ export function getBirdCommand() {
 		return pathCommand;
 	}
 
-	return path.join(os.homedir(), "Projects", "bird", "bird");
+	return "bird";
 }
 
 export function ensureBirdclawDirs(): BirdclawPaths {

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -55,7 +55,8 @@ describe("xurl transport wrapper", () => {
 		execFileAsyncMock
 			.mockResolvedValueOnce({ stdout: "xurl 1.0", stderr: "" })
 			.mockResolvedValueOnce({
-				stdout: "No apps registered. Use 'xurl auth apps add' to register one.\n",
+				stdout:
+					"No apps registered. Use 'xurl auth apps add' to register one.\n",
 				stderr: "",
 			});
 		const { getTransportStatus } = await import("./xurl");
@@ -64,8 +65,25 @@ describe("xurl transport wrapper", () => {
 
 		expect(result.installed).toBe(true);
 		expect(result.availableTransport).toBe("local");
-		expect(result.statusText).toContain("no apps registered");
+		expect(result.statusText).toContain("not authenticated");
 		expect(result.rawStatus).toContain("No apps registered");
+	});
+
+	it("falls back to local mode when xurl has no authenticated user", async () => {
+		execFileAsyncMock
+			.mockResolvedValueOnce({ stdout: "xurl 1.0", stderr: "" })
+			.mockResolvedValueOnce({
+				stdout: "No authenticated user. Run xurl auth login.\n",
+				stderr: "",
+			});
+		const { getTransportStatus } = await import("./xurl");
+
+		const result = await getTransportStatus();
+
+		expect(result.installed).toBe(true);
+		expect(result.availableTransport).toBe("local");
+		expect(result.statusText).toContain("not authenticated");
+		expect(result.rawStatus).toContain("No authenticated user");
 	});
 
 	it("caches transport status for repeated callers", async () => {

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -51,6 +51,23 @@ describe("xurl transport wrapper", () => {
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, "xurl", ["version"]);
 	});
 
+	it("falls back to local mode when xurl has no registered apps", async () => {
+		execFileAsyncMock
+			.mockResolvedValueOnce({ stdout: "xurl 1.0", stderr: "" })
+			.mockResolvedValueOnce({
+				stdout: "No apps registered. Use 'xurl auth apps add' to register one.\n",
+				stderr: "",
+			});
+		const { getTransportStatus } = await import("./xurl");
+
+		const result = await getTransportStatus();
+
+		expect(result.installed).toBe(true);
+		expect(result.availableTransport).toBe("local");
+		expect(result.statusText).toContain("no apps registered");
+		expect(result.rawStatus).toContain("No apps registered");
+	});
+
 	it("caches transport status for repeated callers", async () => {
 		execFileAsyncMock
 			.mockResolvedValueOnce({ stdout: "xurl 1.0", stderr: "" })

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -151,11 +151,24 @@ export async function getTransportStatus(): Promise<TransportStatus> {
 
 		try {
 			const { stdout } = await execFileAsync("xurl", ["auth", "status"]);
+			const rawStatus = stdout.trim();
+
+			// xurl is installed but has no registered apps — effectively unauthenticated
+			if (/no apps registered/i.test(rawStatus)) {
+				return {
+					installed: true,
+					availableTransport: "local",
+					statusText:
+						"xurl installed but no apps registered. local (bird) mode active.",
+					rawStatus,
+				};
+			}
+
 			return {
 				installed: true,
 				availableTransport: "xurl",
 				statusText: "xurl available",
-				rawStatus: stdout.trim(),
+				rawStatus,
 			};
 		} catch (error) {
 			return {

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -129,6 +129,12 @@ async function hasXurl(): Promise<boolean> {
 	}
 }
 
+function isUnauthenticatedXurlStatus(status: string) {
+	return /no apps registered|no authenticated user|not authenticated|not logged in/i.test(
+		status,
+	);
+}
+
 export async function getTransportStatus(): Promise<TransportStatus> {
 	const now = Date.now();
 	if (transportStatusCache?.value && transportStatusCache.expiresAt > now) {
@@ -153,13 +159,12 @@ export async function getTransportStatus(): Promise<TransportStatus> {
 			const { stdout } = await execFileAsync("xurl", ["auth", "status"]);
 			const rawStatus = stdout.trim();
 
-			// xurl is installed but has no registered apps — effectively unauthenticated
-			if (/no apps registered/i.test(rawStatus)) {
+			if (isUnauthenticatedXurlStatus(rawStatus)) {
 				return {
 					installed: true,
 					availableTransport: "local",
 					statusText:
-						"xurl installed but no apps registered. local (bird) mode active.",
+						"xurl installed but not authenticated. local (bird) mode active.",
 					rawStatus,
 				};
 			}


### PR DESCRIPTION
## Problem

`xurl auth status` exits with code 0 even when it prints `"No apps registered. Use 'xurl auth apps add' to register one."`, so `getTransportStatus()` always reported `availableTransport: "xurl"` and `statusText: "xurl available"` — misleading users into thinking the API transport was ready when only the CLI was installed.

## Before

```
birdclaw auth status
{
  installed: true,
  availableTransport: "xurl",
  statusText: "xurl available",
  rawStatus: "No apps registered. Use 'xurl auth apps add' to register one."
}
```

## After

```
birdclaw auth status
{
  installed: true,
  availableTransport: "local",
  statusText: "xurl installed but no apps registered. local (bird) mode active.",
  rawStatus: "No apps registered. Use 'xurl auth apps add' to register one."
}
```

## Changes

- `src/lib/xurl.ts`: Check if `xurl auth status` output contains `"no apps registered"` (case-insensitive) and treat it as unauthenticated local mode
- `src/lib/xurl.test.ts`: Added test for the no-apps-registered fallback case