### PR TITLE
fix: skip non-numeric IDs when hydrating profiles from X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Skip non-numeric archive placeholder IDs such as self-DM conversation IDs when hydrating profiles through X, so one malformed local ID no longer aborts the batch. Thanks @nfarina.
 - Include expanded short URLs and link occurrences in Git-friendly backups so linked-tweet search survives backup restore.
 - Prefer `bird` for follow graph sync in `auto` mode, keeping `xurl` as an explicit fallback for accounts where OAuth2 follow reads work.
 - Update the docs site and app icons to use the Birdclaw crab-bird mark instead of the generic bird logo.

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -126,6 +126,60 @@ describe("profile hydration", () => {
 		expect(title.title).toBe("Sam Altman");
 	});
 
+	it("skips non-numeric archive placeholder ids before calling X", async () => {
+		const db = getNativeDb();
+		db.exec(`
+      delete from ai_scores;
+      delete from tweet_actions;
+      delete from dm_fts;
+      delete from tweets_fts;
+      delete from dm_messages;
+      delete from dm_conversations;
+      delete from tweets;
+      delete from profiles;
+      delete from accounts;
+    `);
+		db.prepare(
+			"insert into accounts (id, name, handle, transport, is_default, created_at) values ('acct_primary', 'Peter', '@steipete', 'archive', 1, '2009-03-19T22:54:05.000Z')",
+		).run();
+		db.prepare(
+			"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, created_at) values ('profile_me', 'steipete', 'Peter', '', 0, 18, '2009-03-19T22:54:05.000Z')",
+		).run();
+		db.prepare(
+			"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, created_at) values ('profile_user_42', 'id42', 'id42', 'Imported from archive user 42', 0, 210, '2009-03-19T22:54:05.000Z')",
+		).run();
+		db.prepare(
+			"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, created_at) values ('profile_user_9388262-9388262', 'id9388262-9388262', 'id9388262-9388262', 'Imported from archive user 9388262-9388262', 0, 210, '2009-03-19T22:54:05.000Z')",
+		).run();
+		db.prepare(
+			"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, created_at) values ('profile_user_not-a-user', 'idnot-a-user', 'idnot-a-user', 'Imported from archive user not-a-user', 0, 210, '2009-03-19T22:54:05.000Z')",
+		).run();
+
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupUsersByIds.mockResolvedValue([
+			{
+				id: "42",
+				username: "sam",
+				name: "Sam Altman",
+			},
+		]);
+		mocks.lookupAuthenticatedUser.mockResolvedValue(null);
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		const result = await hydrateProfilesFromX();
+
+		expect(mocks.lookupUsersByIds).toHaveBeenCalledTimes(1);
+		expect(mocks.lookupUsersByIds).toHaveBeenCalledWith(["42"]);
+		expect(result).toMatchObject({
+			hydratedProfiles: 1,
+			hydratedAccount: false,
+		});
+	});
+
 	it("covers hydration helper guards", async () => {
 		const { __test__ } = await import("./profile-hydration");
 

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -44,7 +44,7 @@ export async function hydrateProfilesFromX() {
 
 	const candidateIds = candidateRows
 		.map((row) => row.id.replace(/^profile_user_/, ""))
-		.filter((id) => id.length > 0);
+		.filter((id) => /^\d+$/.test(id));
 
 	const updateConversationTitle = db.prepare(`
     update dm_conversations


### PR DESCRIPTION
## Summary
- `birdclaw import hydrate-profiles` was failing with `The 'ids' query parameter value [9388262-9388262] is not valid` from the X API
- Twitter uses `<userA>-<userB>` as the 1:1 DM conversation ID. For a self-DM, both participants equal the account ID and get filtered out in `archive-import.ts:588`, so the conversation ID itself becomes the fallback at `archive-import.ts:594`, producing a `profile_user_9388262-9388262` row
- Filter `candidateIds` in `profile-hydration.ts` to pure numeric strings before hitting `GET /2/users`, so malformed/self-DM rows are skipped instead of poisoning the batch

## Test plan
- [ ] Run `birdclaw import hydrate-profiles` against an archive containing a self-DM and confirm the command completes
- [ ] Verify legitimate `profile_user_<numericId>` rows are still hydrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)