### PR TITLE
feat(sync): add --early-stop dedupe-saturation to sync likes and bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ pnpm cli search tweets --bookmarked --limit 20 --json
 
 ### Sync likes, bookmarks, and home timeline
 
-`auto` tries `xurl` first for likes/bookmarks, then falls back to `bird`. Use `bird` directly when the API path is unavailable for the account/token you have locally. For repeated xurl collection syncs, add `--early-stop` with `--max-pages` to stop paging once a whole page already exists locally.
+`auto` tries `xurl` first for likes/bookmarks, then falls back to `bird`. Use `bird` directly when the API path is unavailable for the account/token you have locally. For repeated xurl collection syncs, add `--early-stop` to stop paging once a whole page already exists locally; without `--all` or `--max-pages`, it caps at 10 pages.
 
 ```bash
 pnpm cli sync likes --mode auto --limit 100 --refresh --json

--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ pnpm cli search tweets --bookmarked --limit 20 --json
 
 ### Sync likes, bookmarks, and home timeline
 
-`auto` tries `xurl` first for likes/bookmarks, then falls back to `bird`. Use `bird` directly when the API path is unavailable for the account/token you have locally.
+`auto` tries `xurl` first for likes/bookmarks, then falls back to `bird`. Use `bird` directly when the API path is unavailable for the account/token you have locally. For repeated xurl collection syncs, add `--early-stop` with `--max-pages` to stop paging once a whole page already exists locally.
 
 ```bash
 pnpm cli sync likes --mode auto --limit 100 --refresh --json
 pnpm cli sync bookmarks --mode auto --limit 100 --refresh --json
+pnpm cli sync likes --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
+pnpm cli sync bookmarks --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
 pnpm cli sync bookmarks --mode bird --all --max-pages 5 --limit 100 --refresh --json
 pnpm cli sync timeline --limit 100 --refresh --json
 pnpm cli sync mention-threads --limit 30 --delay-ms 1500 --timeout-ms 15000 --json

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -235,7 +235,7 @@ Default:
 - update canonical tables
 - refresh cursors
 - refresh FTS incrementally
-- `sync likes` and `sync bookmarks` use cached live transport; `auto` tries `xurl`, then `bird`; pair `--max-pages` with `--early-stop` for dedupe-saturation early-exit on cron runs
+- `sync likes` and `sync bookmarks` use cached live transport; `auto` tries `xurl`, then `bird`; `--early-stop` caps at 10 pages unless paired with `--all` or `--max-pages`
 - `sync timeline` stores the live home timeline through `bird`; it defaults to the chronological Following feed
 - `sync mention-threads` fetches conversation context for recent mentions through `bird thread`; use `--delay-ms` and `--timeout-ms` to stay gentle on live X
 - `sync followers` and `sync following` default to dry-run and require `--yes` for live sync or fresh-cache merge; `auto` prefers `bird`, then falls back to `xurl`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -235,7 +235,7 @@ Default:
 - update canonical tables
 - refresh cursors
 - refresh FTS incrementally
-- `sync likes` and `sync bookmarks` use cached live transport; `auto` tries `xurl`, then `bird`
+- `sync likes` and `sync bookmarks` use cached live transport; `auto` tries `xurl`, then `bird`; pair `--max-pages` with `--early-stop` for dedupe-saturation early-exit on cron runs
 - `sync timeline` stores the live home timeline through `bird`; it defaults to the chronological Following feed
 - `sync mention-threads` fetches conversation context for recent mentions through `bird thread`; use `--delay-ms` and `--timeout-ms` to stay gentle on live X
 - `sync followers` and `sync following` default to dry-run and require `--yes` for live sync or fresh-cache merge; `auto` prefers `bird`, then falls back to `xurl`
@@ -249,6 +249,7 @@ Common flags:
 - `--mode auto|xurl|bird`
 - `--all`
 - `--max-pages <n>`
+- `--early-stop` (on `sync likes` and `sync bookmarks`)
 - `--refresh`
 - `--cache-ttl <seconds>`
 
@@ -256,7 +257,9 @@ Examples:
 
 ```bash
 birdclaw sync likes --mode auto --limit 100 --refresh --json
+birdclaw sync likes --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
 birdclaw sync bookmarks --mode auto --limit 100 --refresh --json
+birdclaw sync bookmarks --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
 birdclaw sync bookmarks --mode bird --all --max-pages 5 --limit 100 --refresh --json
 birdclaw sync timeline --limit 100 --refresh --json
 birdclaw sync mention-threads --limit 30 --delay-ms 1500 --timeout-ms 15000 --json

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -21,6 +21,7 @@ All `sync *` commands accept:
 - `--limit <n>` — page size in `xurl` mode, total in single-page modes
 - `--all` — keep paginating until the retrievable window is exhausted
 - `--max-pages <n>` — cap a paged scan; implies `--all`
+- `--early-stop` — on `sync likes` and `sync bookmarks`, stop paging once a fetched page is 100% already local (dedupe saturation); cuts repeated API spend to ~one page per run
 - `--refresh` — bypass the cache and force a live fetch
 - `--cache-ttl <seconds>` — tune freshness without forcing a full refresh
 - `--since <cursor-or-id>` — resume from a known cursor or tweet ID
@@ -35,9 +36,12 @@ Mirror the authenticated user's Likes feed:
 ```bash
 birdclaw sync likes --mode auto --limit 100 --refresh --json
 birdclaw sync likes --mode bird --all --max-pages 5 --refresh --json
+birdclaw sync likes --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
 ```
 
 Liked tweets land in the same `tweets` table as archive imports and can be queried with `birdclaw search tweets --liked`.
+
+`--early-stop` halts pagination as soon as one fetched page is 100% already in the local store. Pair it with `--max-pages` on a cron loop: the first run after a long absence walks back as far as `--max-pages` allows, every subsequent run stops at the first saturated page and spends one X API page read instead of `--max-pages` of them.
 
 ## sync bookmarks
 
@@ -46,9 +50,12 @@ Mirror Bookmarks:
 ```bash
 birdclaw sync bookmarks --mode auto --limit 100 --refresh --json
 birdclaw sync bookmarks --mode bird --all --max-pages 5 --limit 100 --refresh --json
+birdclaw sync bookmarks --mode auto --limit 100 --max-pages 5 --early-stop --refresh --json
 ```
 
 Bookmarks are queried via `birdclaw search tweets --bookmarked` and drive the [research](research.md) workflow.
+
+`--early-stop` behaves the same way as on `sync likes`: stop paging when a full page is already locally known. Recommended default for any scheduled bookmark sync against a stable account.
 
 ## sync timeline
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -21,7 +21,7 @@ All `sync *` commands accept:
 - `--limit <n>` — page size in `xurl` mode, total in single-page modes
 - `--all` — keep paginating until the retrievable window is exhausted
 - `--max-pages <n>` — cap a paged scan; implies `--all`
-- `--early-stop` — on `sync likes` and `sync bookmarks`, stop paging once a fetched page is 100% already local (dedupe saturation); cuts repeated API spend to ~one page per run
+- `--early-stop` — on `sync likes` and `sync bookmarks`, stop paging once a fetched page is 100% already local (dedupe saturation); without `--all` or `--max-pages`, caps at 10 pages
 - `--refresh` — bypass the cache and force a live fetch
 - `--cache-ttl <seconds>` — tune freshness without forcing a full refresh
 - `--since <cursor-or-id>` — resume from a known cursor or tweet ID
@@ -41,7 +41,7 @@ birdclaw sync likes --mode auto --limit 100 --max-pages 5 --early-stop --refresh
 
 Liked tweets land in the same `tweets` table as archive imports and can be queried with `birdclaw search tweets --liked`.
 
-`--early-stop` halts pagination as soon as one fetched page is 100% already in the local store. Pair it with `--max-pages` on a cron loop: the first run after a long absence walks back as far as `--max-pages` allows, every subsequent run stops at the first saturated page and spends one X API page read instead of `--max-pages` of them.
+`--early-stop` halts pagination as soon as one fetched page is 100% already in the local store. Pair it with `--max-pages` on a cron loop: the first run after a long absence walks back as far as `--max-pages` allows, every subsequent run stops at the first saturated page and spends one X API page read instead of `--max-pages` of them. If neither `--all` nor `--max-pages` is present, Birdclaw applies a 10-page cap.
 
 ## sync bookmarks
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -816,6 +816,7 @@ describe("cli", () => {
 			maxPages: 3,
 			refresh: true,
 			cacheTtlMs: 30_000,
+			earlyStop: false,
 		});
 		expect(listDmConversationsMock).toHaveBeenCalledWith({
 			account: undefined,
@@ -828,6 +829,50 @@ describe("cli", () => {
 			replyFilter: "replied",
 			limit: 20,
 		});
+	});
+
+	it("passes early-stop to collection sync and prints saturated page json", async () => {
+		syncTimelineCollectionMock.mockResolvedValueOnce({
+			ok: true,
+			source: "xurl",
+			kind: "likes",
+			accountId: "acct_primary",
+			count: 0,
+			saturated_at_page: 1,
+			payload: {
+				data: [],
+				meta: { saturated_at_page: 1 },
+			},
+		});
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"sync",
+			"likes",
+			"--mode",
+			"xurl",
+			"--limit",
+			"100",
+			"--early-stop",
+			"--refresh",
+		]);
+
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith({
+			kind: "likes",
+			account: undefined,
+			mode: "xurl",
+			limit: 100,
+			all: false,
+			maxPages: undefined,
+			refresh: true,
+			cacheTtlMs: 120_000,
+			earlyStop: true,
+		});
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"saturated_at_page": 1'),
+		);
 	});
 
 	it("dispatches follow graph sync and query commands", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -708,7 +708,11 @@ for (const kind of ["likes", "bookmarks"] as const) {
 		.option("--mode <mode>", "auto, xurl, or bird", "auto")
 		.option("--limit <n>", "Per-page/result limit", "20")
 		.option("--all", "Fetch every retrievable page")
-		.option("--max-pages <n>", "Stop after N pages when using --all")
+		.option(
+			"--max-pages <n>",
+			"Stop after N pages when using --all or --early-stop",
+		)
+		.option("--early-stop", "Stop when a fetched page is already fully local")
 		.option("--cache-ttl <seconds>", "Live-cache freshness window", "120")
 		.option("--refresh", "Bypass live-cache freshness window")
 		.action(async (options) => {
@@ -721,6 +725,7 @@ for (const kind of ["likes", "bookmarks"] as const) {
 				maxPages: options.maxPages ? Number(options.maxPages) : undefined,
 				refresh: Boolean(options.refresh),
 				cacheTtlMs: Number(options.cacheTtl) * 1000,
+				earlyStop: Boolean(options.earlyStop),
 			});
 			await autoSyncAfterWrite();
 			print(result, true);

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -564,6 +564,39 @@ describe("live timeline collection sync", () => {
 		});
 	});
 
+	it("does not pass the implicit early-stop cap to bird fallback", async () => {
+		setupTempHome();
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		mocks.listBookmarkedTweetsViaXurl.mockRejectedValue(new Error("xurl down"));
+		mocks.listBookmarkedTweetsViaBird.mockResolvedValue({
+			data: [makeTweet("bookmark_bird_fallback", "bird fallback", "43")],
+			includes: {
+				users: [{ id: "43", username: "amelia", name: "Amelia" }],
+			},
+			meta: { result_count: 1 },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "bookmarks",
+			mode: "auto",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+
+		expect(result).toMatchObject({ ok: true, source: "bird", count: 1 });
+		expect(mocks.listBookmarkedTweetsViaBird).toHaveBeenCalledWith({
+			maxResults: 5,
+			all: false,
+			maxPages: undefined,
+		});
+		consoleError.mockRestore();
+	});
+
 	it("keeps live saved-state scoped to the syncing account", async () => {
 		setupTempHome();
 		mocks.listLikedTweetsViaBird.mockResolvedValue({

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -30,6 +30,48 @@ vi.mock("./xurl", () => ({
 
 const tempRoots: string[] = [];
 
+function makeTweet(id: string, text = id, authorId = "42") {
+	return {
+		id,
+		author_id: authorId,
+		text,
+		created_at: "2026-04-26T13:43:34.000Z",
+	};
+}
+
+function makeUser(id = "42", username = "sam") {
+	return { id, username, name: username };
+}
+
+function insertCollectionRow({
+	tweetId,
+	kind = "likes",
+	source = "archive",
+	updatedAt = "2026-01-01T00:00:00.000Z",
+}: {
+	tweetId: string;
+	kind?: "likes" | "bookmarks";
+	source?: string;
+	updatedAt?: string;
+}) {
+	getNativeDb()
+		.prepare(
+			`
+      insert into tweet_collections (
+        account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
+      ) values (?, ?, ?, null, ?, ?, ?)
+      `,
+		)
+		.run(
+			"acct_primary",
+			tweetId,
+			kind,
+			source,
+			JSON.stringify({ id: tweetId }),
+			updatedAt,
+		);
+}
+
 function setupTempHome() {
 	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
 	tempRoots.push(tempRoot);
@@ -225,6 +267,172 @@ describe("live timeline collection sync", () => {
 				paginationToken: "next-page",
 			}),
 		);
+	});
+
+	it("stops xurl collection paging when a page is fully existing rows", async () => {
+		setupTempHome();
+		insertCollectionRow({ tweetId: "liked_existing" });
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		mocks.listLikedTweetsViaXurl.mockResolvedValue({
+			data: [makeTweet("liked_existing", "already local")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1, next_token: "wasteful-next-page" },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 0,
+			saturated_at_page: 1,
+			payload: { meta: { page_count: 1, saturated_at_page: 1 } },
+		});
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(1);
+		expect(consoleError).toHaveBeenCalledWith(
+			"likes saturated at page 1 (100% existing rows)",
+		);
+		consoleError.mockRestore();
+	});
+
+	it("does not early-stop on a partially deduped page", async () => {
+		setupTempHome();
+		insertCollectionRow({ tweetId: "liked_existing_partial" });
+		mocks.listLikedTweetsViaXurl
+			.mockResolvedValueOnce({
+				data: [
+					makeTweet("liked_existing_partial", "already local"),
+					makeTweet("liked_new_partial", "new on page one", "43"),
+				],
+				includes: { users: [makeUser(), makeUser("43", "jules")] },
+				meta: { result_count: 2, next_token: "next-page" },
+			})
+			.mockResolvedValueOnce({
+				data: [makeTweet("liked_new_second", "new on page two", "44")],
+				includes: { users: [makeUser("44", "mira")] },
+				meta: { result_count: 1 },
+			});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+		const existing = getNativeDb()
+			.prepare(
+				"select source from tweet_collections where tweet_id = ? and kind = ?",
+			)
+			.get("liked_existing_partial", "likes");
+
+		expect(result).toMatchObject({
+			count: 2,
+			payload: { meta: { page_count: 2 } },
+		});
+		expect(result).not.toHaveProperty("saturated_at_page");
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(2);
+		expect(existing).toEqual({ source: "archive" });
+	});
+
+	it("respects max-pages when early-stop never saturates", async () => {
+		setupTempHome();
+		mocks.listBookmarkedTweetsViaXurl
+			.mockResolvedValueOnce({
+				data: [makeTweet("bookmark_new_1", "new bookmark one")],
+				includes: { users: [makeUser()] },
+				meta: { result_count: 1, next_token: "page-2" },
+			})
+			.mockResolvedValueOnce({
+				data: [makeTweet("bookmark_new_2", "new bookmark two", "43")],
+				includes: { users: [makeUser("43", "jules")] },
+				meta: { result_count: 1, next_token: "page-3" },
+			});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "bookmarks",
+			mode: "xurl",
+			limit: 5,
+			maxPages: 2,
+			earlyStop: true,
+			refresh: true,
+		});
+
+		expect(result).toMatchObject({
+			count: 2,
+			payload: { meta: { page_count: 2 } },
+		});
+		expect(result).not.toHaveProperty("saturated_at_page");
+		expect(mocks.listBookmarkedTweetsViaXurl).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps an early-stop rerun idempotent for existing collection rows", async () => {
+		setupTempHome();
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		mocks.listLikedTweetsViaXurl.mockResolvedValueOnce({
+			data: [makeTweet("liked_rerun", "first sync")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1 },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+		getNativeDb()
+			.prepare(
+				"update tweet_collections set source = ?, updated_at = ? where tweet_id = ? and kind = ?",
+			)
+			.run("archive", "2026-01-01T00:00:00.000Z", "liked_rerun", "likes");
+		const before = getNativeDb()
+			.prepare(
+				"select source, updated_at from tweet_collections where tweet_id = ? and kind = ?",
+			)
+			.get("liked_rerun", "likes");
+		mocks.listLikedTweetsViaXurl.mockResolvedValueOnce({
+			data: [makeTweet("liked_rerun", "second sync")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1, next_token: "unused" },
+		});
+
+		const second = await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+		const after = getNativeDb()
+			.prepare(
+				"select source, updated_at from tweet_collections where tweet_id = ? and kind = ?",
+			)
+			.get("liked_rerun", "likes");
+
+		expect(second).toMatchObject({ count: 0, saturated_at_page: 1 });
+		expect(after).toEqual(before);
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(2);
+		consoleError.mockRestore();
 	});
 
 	it("falls back to bird for bookmarks when xurl fails", async () => {

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -149,6 +149,47 @@ describe("live timeline collection sync", () => {
 		});
 	});
 
+	it("preserves authored tweet kind when a collection sync sees the same tweet", async () => {
+		setupTempHome();
+		getNativeDb()
+			.prepare(
+				`
+        insert into tweets (
+          id, account_id, author_profile_id, kind, text, created_at,
+          is_replied, like_count, media_count, bookmarked, liked,
+          entities_json, media_json
+        ) values (?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, '{}', '[]')
+        `,
+			)
+			.run(
+				"authored_liked_1",
+				"acct_primary",
+				"profile_user_42",
+				"authored",
+				"authored before likes sync",
+				"2026-04-26T13:43:34.000Z",
+			);
+		mocks.listLikedTweetsViaXurl.mockResolvedValue({
+			data: [makeTweet("authored_liked_1", "same tweet via likes")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1 },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			refresh: true,
+		});
+		const row = getNativeDb()
+			.prepare("select kind from tweets where id = ?")
+			.get("authored_liked_1");
+
+		expect(row).toEqual({ kind: "authored" });
+	});
+
 	it("paginates xurl collections and deduplicates tweets and users", async () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -421,6 +421,43 @@ describe("live timeline collection sync", () => {
 		expect(mocks.listBookmarkedTweetsViaXurl).toHaveBeenCalledTimes(2);
 	});
 
+	it("caps early-stop pagination when max-pages is omitted", async () => {
+		setupTempHome();
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		for (let page = 1; page <= 10; page += 1) {
+			mocks.listLikedTweetsViaXurl.mockResolvedValueOnce({
+				data: [makeTweet(`liked_capped_${page}`, `capped page ${page}`)],
+				meta: { result_count: 1, next_token: `page-${page + 1}` },
+			});
+		}
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			earlyStop: true,
+			refresh: true,
+		});
+
+		expect(result).toMatchObject({
+			count: 10,
+			payload: { meta: { page_count: 10 } },
+		});
+		expect(result).not.toHaveProperty("saturated_at_page");
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(10);
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenLastCalledWith(
+			expect.objectContaining({ paginationToken: "page-10" }),
+		);
+		expect(consoleError).toHaveBeenCalledWith(
+			"likes early-stop capped at 10 pages by default; pass --max-pages or --all to override",
+		);
+		consoleError.mockRestore();
+	});
+
 	it("keeps an early-stop rerun idempotent for existing collection rows", async () => {
 		setupTempHome();
 		const consoleError = vi

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -18,6 +18,7 @@ export type TimelineCollectionKind = "likes" | "bookmarks";
 export type TimelineCollectionMode = "auto" | "xurl" | "bird";
 
 const DEFAULT_COLLECTION_CACHE_TTL_MS = 2 * 60_000;
+const DEFAULT_EARLY_STOP_MAX_PAGES = 10;
 const MIN_XURL_LIMIT = 5;
 const MAX_XURL_LIMIT = 100;
 
@@ -430,13 +431,18 @@ export async function syncTimelineCollection({
 }) {
 	assertLimit(limit);
 	const parsedMaxPages = parseMaxPages(maxPages);
+	const shouldApplyEarlyStopCap =
+		earlyStop && !all && parsedMaxPages === null && mode !== "bird";
+	const effectiveMaxPages = shouldApplyEarlyStopCap
+		? DEFAULT_EARLY_STOP_MAX_PAGES
+		: parsedMaxPages;
 	if (mode === "xurl" || mode === "auto") {
 		assertXurlLimit(limit);
 	}
 
 	const db = getNativeDb();
 	const resolvedAccount = resolveAccount(db, account);
-	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${parsedMaxPages === null ? "all-pages" : String(parsedMaxPages)}${earlyStop ? ":early-stop" : ""}`;
+	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${effectiveMaxPages === null ? "all-pages" : String(effectiveMaxPages)}${earlyStop ? ":early-stop" : ""}`;
 	const ttlMs = parseCacheTtlMs(cacheTtlMs);
 	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
 	const cacheAgeMs = cached
@@ -458,6 +464,12 @@ export async function syncTimelineCollection({
 		};
 	}
 
+	if (shouldApplyEarlyStopCap) {
+		console.error(
+			`${kind} early-stop capped at ${DEFAULT_EARLY_STOP_MAX_PAGES} pages by default; pass --max-pages or --all to override`,
+		);
+	}
+
 	let source: "xurl" | "bird";
 	let payload: XurlMentionsResponse;
 	if (mode === "bird") {
@@ -465,7 +477,7 @@ export async function syncTimelineCollection({
 			kind,
 			limit,
 			all,
-			maxPages: parsedMaxPages,
+			maxPages: effectiveMaxPages,
 		});
 		source = "bird";
 	} else {
@@ -478,7 +490,7 @@ export async function syncTimelineCollection({
 				userId: resolvedAccount.externalUserId,
 				limit,
 				all,
-				maxPages: parsedMaxPages,
+				maxPages: effectiveMaxPages,
 				earlyStop,
 			});
 			source = "xurl";
@@ -490,7 +502,7 @@ export async function syncTimelineCollection({
 				kind,
 				limit,
 				all,
-				maxPages: parsedMaxPages,
+				maxPages: effectiveMaxPages,
 			});
 			source = "bird";
 		}

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -219,7 +219,7 @@ function mergeTimelineCollectionIntoLocalStore(
       account_id = tweets.account_id,
       author_profile_id = excluded.author_profile_id,
       kind = case
-        when tweets.kind in ('home', 'mention') then tweets.kind
+        when tweets.kind in ('authored', 'home', 'mention') then tweets.kind
         else excluded.kind
       end,
       text = excluded.text,

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -433,7 +433,7 @@ export async function syncTimelineCollection({
 	const parsedMaxPages = parseMaxPages(maxPages);
 	const shouldApplyEarlyStopCap =
 		earlyStop && !all && parsedMaxPages === null && mode !== "bird";
-	const effectiveMaxPages = shouldApplyEarlyStopCap
+	const xurlMaxPages = shouldApplyEarlyStopCap
 		? DEFAULT_EARLY_STOP_MAX_PAGES
 		: parsedMaxPages;
 	if (mode === "xurl" || mode === "auto") {
@@ -442,7 +442,8 @@ export async function syncTimelineCollection({
 
 	const db = getNativeDb();
 	const resolvedAccount = resolveAccount(db, account);
-	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${effectiveMaxPages === null ? "all-pages" : String(effectiveMaxPages)}${earlyStop ? ":early-stop" : ""}`;
+	const cacheMaxPages = mode === "bird" ? parsedMaxPages : xurlMaxPages;
+	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${cacheMaxPages === null ? "all-pages" : String(cacheMaxPages)}${earlyStop ? ":early-stop" : ""}`;
 	const ttlMs = parseCacheTtlMs(cacheTtlMs);
 	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
 	const cacheAgeMs = cached
@@ -477,7 +478,7 @@ export async function syncTimelineCollection({
 			kind,
 			limit,
 			all,
-			maxPages: effectiveMaxPages,
+			maxPages: parsedMaxPages,
 		});
 		source = "bird";
 	} else {
@@ -490,7 +491,7 @@ export async function syncTimelineCollection({
 				userId: resolvedAccount.externalUserId,
 				limit,
 				all,
-				maxPages: effectiveMaxPages,
+				maxPages: xurlMaxPages,
 				earlyStop,
 			});
 			source = "xurl";
@@ -502,7 +503,7 @@ export async function syncTimelineCollection({
 				kind,
 				limit,
 				all,
-				maxPages: effectiveMaxPages,
+				maxPages: parsedMaxPages,
 			});
 			source = "bird";
 		}

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -149,6 +149,52 @@ function mergePayloads(pages: XurlMentionsResponse[]): XurlMentionsResponse {
 	};
 }
 
+function getCollectionPageDedupe(
+	db: Database,
+	accountId: string,
+	kind: TimelineCollectionKind,
+	tweetIds: string[],
+) {
+	const uniqueTweetIds = [...new Set(tweetIds)];
+	if (uniqueTweetIds.length === 0) {
+		return { existingTweetIds: new Set<string>(), uniqueTweetCount: 0 };
+	}
+
+	const rows = db
+		.prepare(
+			`
+      select tweet_id
+      from tweet_collections
+      where account_id = ?
+        and kind = ?
+        and tweet_id in (${uniqueTweetIds.map(() => "?").join(", ")})
+      `,
+		)
+		.all(accountId, kind, ...uniqueTweetIds) as { tweet_id: string }[];
+	return {
+		existingTweetIds: new Set(rows.map((row) => row.tweet_id)),
+		uniqueTweetCount: uniqueTweetIds.length,
+	};
+}
+
+function filterExistingCollectionTweets(
+	payload: XurlMentionsResponse,
+	existingTweetIds: Set<string>,
+) {
+	if (existingTweetIds.size === 0) {
+		return payload;
+	}
+	return {
+		...payload,
+		data: payload.data.filter((tweet) => !existingTweetIds.has(tweet.id)),
+	};
+}
+
+function readSaturatedAtPage(payload: XurlMentionsResponse) {
+	const value = payload.meta?.saturated_at_page;
+	return typeof value === "number" ? value : undefined;
+}
+
 function mergeTimelineCollectionIntoLocalStore(
 	db: Database,
 	accountId: string,
@@ -244,19 +290,25 @@ function mergeTimelineCollectionIntoLocalStore(
 }
 
 async function fetchXurlCollection({
+	db,
 	kind,
+	accountId,
 	username,
 	userId,
 	limit,
 	all,
 	maxPages,
+	earlyStop,
 }: {
+	db: Database;
 	kind: TimelineCollectionKind;
+	accountId: string;
 	username: string;
 	userId?: string;
 	limit: number;
 	all: boolean;
 	maxPages: number | null;
+	earlyStop: boolean;
 }) {
 	let resolvedUserId = userId;
 	if (!resolvedUserId) {
@@ -270,6 +322,7 @@ async function fetchXurlCollection({
 	const pages: XurlMentionsResponse[] = [];
 	let nextToken: string | undefined;
 	let pageCount = 0;
+	let saturatedAtPage: number | undefined;
 	do {
 		const payload =
 			kind === "likes"
@@ -286,15 +339,48 @@ async function fetchXurlCollection({
 						isPaginatedWalk: all,
 						paginationToken: nextToken,
 					});
-		pages.push(payload);
+		pageCount += 1;
+		if (earlyStop) {
+			const tweetIds = payload.data.map((tweet) => tweet.id);
+			const { existingTweetIds, uniqueTweetCount } = getCollectionPageDedupe(
+				db,
+				accountId,
+				kind,
+				tweetIds,
+			);
+			if (tweetIds.length > 0 && existingTweetIds.size === uniqueTweetCount) {
+				saturatedAtPage = pageCount;
+				console.error(
+					`${kind} saturated at page ${pageCount} (100% existing rows)`,
+				);
+				break;
+			}
+			pages.push(filterExistingCollectionTweets(payload, existingTweetIds));
+		} else {
+			pages.push(payload);
+		}
 		nextToken =
 			typeof payload.meta?.next_token === "string"
 				? payload.meta.next_token
 				: undefined;
-		pageCount += 1;
-	} while (all && nextToken && (maxPages === null || pageCount < maxPages));
+	} while (
+		(all || earlyStop) &&
+		nextToken &&
+		(maxPages === null || pageCount < maxPages)
+	);
 
-	return mergePayloads(pages);
+	const merged = mergePayloads(pages);
+	// A saturated page may expose another token, but our walk is complete.
+	const saturationMeta =
+		saturatedAtPage === undefined
+			? {}
+			: { saturated_at_page: saturatedAtPage, next_token: null };
+	merged.meta = {
+		...merged.meta,
+		page_count: pageCount,
+		...saturationMeta,
+	};
+	return merged;
 }
 
 async function fetchBirdCollection({
@@ -330,6 +416,7 @@ export async function syncTimelineCollection({
 	maxPages,
 	refresh = false,
 	cacheTtlMs,
+	earlyStop = false,
 }: {
 	kind: TimelineCollectionKind;
 	account?: string;
@@ -339,6 +426,7 @@ export async function syncTimelineCollection({
 	maxPages?: number;
 	refresh?: boolean;
 	cacheTtlMs?: number;
+	earlyStop?: boolean;
 }) {
 	assertLimit(limit);
 	const parsedMaxPages = parseMaxPages(maxPages);
@@ -348,7 +436,7 @@ export async function syncTimelineCollection({
 
 	const db = getNativeDb();
 	const resolvedAccount = resolveAccount(db, account);
-	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${parsedMaxPages === null ? "all-pages" : String(parsedMaxPages)}`;
+	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${parsedMaxPages === null ? "all-pages" : String(parsedMaxPages)}${earlyStop ? ":early-stop" : ""}`;
 	const ttlMs = parseCacheTtlMs(cacheTtlMs);
 	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
 	const cacheAgeMs = cached
@@ -356,6 +444,7 @@ export async function syncTimelineCollection({
 		: Number.POSITIVE_INFINITY;
 
 	if (!refresh && cached && cacheAgeMs <= ttlMs) {
+		const saturatedAtPage = readSaturatedAtPage(cached.value);
 		return {
 			ok: true,
 			source: "cache",
@@ -363,6 +452,9 @@ export async function syncTimelineCollection({
 			accountId: resolvedAccount.accountId,
 			count: cached.value.data.length,
 			payload: cached.value,
+			...(saturatedAtPage === undefined
+				? {}
+				: { saturated_at_page: saturatedAtPage }),
 		};
 	}
 
@@ -379,12 +471,15 @@ export async function syncTimelineCollection({
 	} else {
 		try {
 			payload = await fetchXurlCollection({
+				db,
 				kind,
+				accountId: resolvedAccount.accountId,
 				username: resolvedAccount.username,
 				userId: resolvedAccount.externalUserId,
 				limit,
 				all,
 				maxPages: parsedMaxPages,
+				earlyStop,
 			});
 			source = "xurl";
 		} catch (error) {
@@ -409,6 +504,7 @@ export async function syncTimelineCollection({
 		source,
 	);
 	writeSyncCache(cacheKey, payload, db);
+	const saturatedAtPage = readSaturatedAtPage(payload);
 
 	return {
 		ok: true,
@@ -417,5 +513,8 @@ export async function syncTimelineCollection({
 		accountId: resolvedAccount.accountId,
 		count: payload.data.length,
 		payload,
+		...(saturatedAtPage === undefined
+			? {}
+			: { saturated_at_page: saturatedAtPage }),
 	};
 }


### PR DESCRIPTION
## Summary

Adds `--early-stop` to `birdclaw sync likes` and `sync bookmarks`: a conservative pagination policy that halts when a fetched page is entirely composed of already-known items (the canonical "nothing new on this page" signal). Response includes `saturated_at_page: <n>` when saturation triggers (omitted otherwise). Existing flag semantics unchanged; the policy is opt-in.

The policy is xurl-only as a **transport constraint**, not a design choice: the v2 API response gives us a stable per-tweet identity list to dedupe-saturate against. `bird` mode's response shape doesn't expose an equivalent reliable signal, so the same policy can't be implemented there without false-positive risk. Auto-mode fallback to bird therefore does NOT receive the synthetic xurl pagination cap — bird sees the user's original `--max-pages` value untouched.

The fix commits do three things: `282279f` adds `authored` to the upsert's kind-protection list (alongside the existing `home`/`mention` guards); `b55a6c7` adds a default 10-page cap so `--early-stop` alone can't unbounded-scan on a first run; `0306720` keeps that synthetic cap inside the xurl path so the bird fallback receives the user's original `--max-pages` value.

> AI-assisted: written with Codex and reviewed with `codex review --base origin/main` before opening.

## Completeness trade-off

The X API orders likes/bookmarks by **tweet creation time**, not action time — a newly-acted-on OLD tweet can sit behind an already-saturated newer page and be missed by this policy. `--early-stop` is therefore a "current-edge" pagination policy, not a guarantee of full corpus delta. Callers wanting full completeness can omit `--early-stop` or run periodically with `--all`. Documented in `docs/sync.md`.

## Real behavior proof

Environment: macOS, `birdclaw@0.4.1`, HEAD `0306720` via `pnpm exec tsx src/cli.ts`. xurl authenticated as the test account.

```bash
# Run 1: populate
pnpm --silent exec tsx src/cli.ts sync likes \
  --early-stop --refresh --limit 25 --max-pages 1 --json
# count=1, no saturated_at_page (saturation did not trigger)

# Run 2: re-fetch same — saturation expected
pnpm --silent exec tsx src/cli.ts sync likes \
  --early-stop --refresh --limit 25 --max-pages 2 --json
```

Run 2 real output (`--json` is pretty-printed; `payload` shown literally because it's small on the saturated path):

```json
{
  "ok": true,
  "source": "xurl",
  "kind": "likes",
  "accountId": "acct_primary",
  "count": 0,
  "payload": {
    "data": [],
    "meta": {
      "result_count": 0,
      "page_count": 1,
      "next_token": null,
      "saturated_at_page": 1
    }
  },
  "saturated_at_page": 1
}
```

stderr: `likes saturated at page 1 (100% existing rows)`

API hit exactly once per run (page 1); second run stopped after page 1 because all ids were known.

## CLI surface

New flag on `birdclaw sync likes` and `birdclaw sync bookmarks`:

- `--early-stop` — halt pagination on a fully-known page (xurl mode only)

New JSON field (response and `payload.meta`): `saturated_at_page` — present only when saturation triggers.

When `--early-stop` is used without `--max-pages`/`--all`, an implicit 10-page cap engages and a stderr hint is emitted.

## Verification

- `pnpm check && pnpm build && pnpm test` — 429 tests passing
- `codex review --base origin/main` — clean
- Live smoke above

## What was not tested live

- `sync bookmarks` (same code path as likes; covered by unit tests)
- bird transport (not publicly available; unit tests assert the synthetic cap is NOT forwarded to bird)
- First-run implicit-cap engagement (unit-tested only — live test would cost up to 10 pages of reads)

## Compatibility

Backward compatible — flag is opt-in. No migration. Uses existing `sync_cache` table.

## Related PRs

This is one of a coordinated 5-PR set:

- #18 — `--early-stop` dedupe-saturation on sync likes/bookmarks (this PR)
- [#19 — `sync authored` for own-tweets gap](https://github.com/steipete/birdclaw/pull/19)
- [#20 — `sync mentions` + `--mode xurl` on `sync mention-threads`](https://github.com/steipete/birdclaw/pull/20)
- [#21 — `media fetch` + archive media extraction](https://github.com/steipete/birdclaw/pull/21)
- [#22 — archive `follower.js`/`following.js` parsing into follow graph](https://github.com/steipete/birdclaw/pull/22)

Each is independently mergeable against current `main`. After the first merges, the others may surface small rebase conflicts in shared docs (`docs/cli.md`, `docs/sync.md`, `README.md`), shared type unions (`TweetAccountEdgeKind`, `XurlMentionData`, `XurlTweetData`), and the `sync` command tree in `src/cli.ts`. All are "both branches added entries to the same list/union" pattern — "keep both" resolves every one. Verified by integrating all 5 locally on a single branch; 510/510 tests pass across the merged set.

One CI heads-up if you merge two or more before rebasing: `src/lib/xurl.test.ts`'s expected URL asserts a specific query-param order; that order shifts deterministically when #19's `RICH_USER_FIELDS` / `THREAD_TWEET_FIELDS` and #21's `MEDIA_EXPANSION` / `MEDIA_FIELDS` both exist on `main`. One-line test expectation update covers it.
