### PR TITLE
feat(import): parse follower.js and following.js from archive into follow graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add a `/links` web lane for Hacker News-style top URL and video-provider insights with today, week, month, year, and all-time ranges.
+- Import archive `follower.js`/`following.js` files into the local follow graph and add archive-authored tweet edges so fresh archive imports are immediately queryable without live sync. Thanks @cavit99.
 - Add cache-first followers/following sync, local follow graph queries, and backup/export support for graph snapshots and churn events. Thanks @ma08.
 - Hydrate missing link-discussion profile avatars through `bird`/`xurl` so hover sheets can upgrade archive placeholders into real profile cards.
 - Add inline tweet conversation expansion in the web timeline, preserving the selected reply's parent chain before broad thread context.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Status: WIP. Real and usable. Not done. Expect schema churn, transport gaps, and
 - one shared SQLite DB for multiple accounts, with canonical tweets/profiles and account-scoped timeline/collection edges
 - FTS5 search over tweets and DMs
 - archive autodiscovery on macOS
-- archive import for tweets, likes, profiles, and full DMs
+- archive import for tweets, likes, followers/following, profiles, and full DMs
 - archive import for bookmark exports when present
 - live likes and bookmarks sync through `xurl` or `bird`
 - cache-first followers/following sync through `bird` or `xurl`

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -1,11 +1,11 @@
 ---
 title: Archive Import
-description: "Import a Twitter/X archive into local SQLite — autodiscovery, full DM mode, idempotent re-runs, and profile hydration."
+description: "Import a Twitter/X archive into local SQLite — autodiscovery, full DM mode, follower/following parsing, idempotent re-runs, and profile hydration."
 ---
 
 # Archive import
 
-`birdclaw import archive` parses a Twitter/X archive ZIP and writes everything into the canonical SQLite tables: tweets, likes, bookmarks, profiles, DMs, and (when present) blocklists.
+`birdclaw import archive` parses a Twitter/X archive ZIP and writes everything into the canonical SQLite tables: tweets, likes, bookmarks, profiles, followers/following edges, DMs, and (when present) blocklists.
 
 It is **idempotent**. Re-running on the same archive replays the import without producing duplicates, so you can import, then re-import after a fresh archive download to top up.
 
@@ -49,6 +49,16 @@ birdclaw import archive ~/Downloads/twitter-archive.zip --dm-mode metadata --jso
 birdclaw import archive ~/Downloads/twitter-archive.zip --dry-run --json
 ```
 
+## Follower and following edges
+
+When the archive ships with `data/follower.js` and `data/following.js`, `import archive` parses both files and writes the rows into the same local follow graph that [`sync followers`](sync.md#sync-followers--following) and `sync following` populate:
+
+- each entry becomes a stub `profiles` row plus a current `follow_edges` row
+- counts land in the archive-import result envelope under `followGraph.followersCount` and `followGraph.followingCount`
+- re-importing the same archive is a no-op; switching to a fresher archive tops up new edges
+
+A fresh install with just an archive and no live transport still gets a usable [follow graph](follow-graph.md). `birdclaw graph summary`, `graph mutuals`, and `graph top-followers` all work against archive-imported edges. Live `sync followers --yes` can layer churn on top later.
+
 ## Hydrate profiles
 
 The archive ships with stale profile metadata (bios, follower counts, avatars from years ago). Hydrate from live Twitter when you can:
@@ -70,6 +80,7 @@ After import, archive data and live data live in the same canonical tables. Ther
 - **Bookmarks** → `tweets` table + a `bookmarks` collection edge — searchable via `--bookmarked`
 - **DMs** → `dm_conversations` and `dm_events` tables, indexed by FTS5 — searchable via `birdclaw search dms`
 - **Profiles** → `profiles` table — drives @mention resolution, profile evidence, and DM influence scoring
+- **Followers/Following** → `profiles` stub rows plus current `follow_edges` rows; surfaced via `birdclaw graph *`
 - **Affiliations** → `profile_affiliations` table when live profile hydration exposes X badge/highlighted-label organization metadata
 - **Profile history** → `profile_snapshots` table after live hydration observes profile/bio/affiliation changes
 - **Bio entities** → `profile_bio_entities` table for extracted `@handle`, domain, and company-phrase identity hints

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -54,7 +54,7 @@ birdclaw import archive ~/Downloads/twitter-archive.zip --dry-run --json
 When the archive ships with `data/follower.js` and `data/following.js`, `import archive` parses both files and writes the rows into the same local follow graph that [`sync followers`](sync.md#sync-followers--following) and `sync following` populate:
 
 - each entry becomes a stub `profiles` row plus a current `follow_edges` row
-- counts land in the archive-import result envelope under `followGraph.followersCount` and `followGraph.followingCount`
+- counts land in the archive-import result envelope under `counts.followers` and `counts.following`
 - re-importing the same archive is a no-op; switching to a fresher archive tops up new edges
 
 A fresh install with just an archive and no live transport still gets a usable [follow graph](follow-graph.md). `birdclaw graph summary`, `graph mutuals`, and `graph top-followers` all work against archive-imported edges. Live `sync followers --yes` can layer churn on top later.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -216,6 +216,7 @@ birdclaw backup validate ~/Projects/birdclaw-store --json
 - validate archive
 - analyze contents
 - import selected slices
+- parse `data/follower.js` and `data/following.js` into the local follow graph
 - idempotent
 
 Flags:

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -504,7 +504,7 @@ describe("archive import", () => {
 		).toBe(2);
 	});
 
-	it("re-imports follower data without duplicate follow events", async () => {
+	it("re-imports follower data without duplicate follow events or snapshots", async () => {
 		const archivePath = makeFollowArchive({
 			followers: ["101", "102"],
 			following: ["103"],
@@ -514,8 +514,35 @@ describe("archive import", () => {
 		process.env.BIRDCLAW_HOME = homeDir;
 
 		await importArchive(archivePath);
-		await importArchive(archivePath);
 		const db = getNativeDb();
+		const readArchiveSnapshots = () =>
+			db
+				.prepare(
+					`
+          select direction, id, result_count
+          from follow_snapshots
+          where source = 'archive'
+          order by direction
+        `,
+				)
+				.all();
+		const readArchiveMembers = () =>
+			db
+				.prepare(
+					`
+          select s.direction, count(m.profile_id) as count
+          from follow_snapshots s
+          left join follow_snapshot_members m on m.snapshot_id = s.id
+          where s.source = 'archive'
+          group by s.direction
+          order by s.direction
+        `,
+				)
+				.all();
+		const firstSnapshots = readArchiveSnapshots();
+		const firstMembers = readArchiveMembers();
+
+		await importArchive(archivePath);
 
 		expect(
 			(
@@ -531,6 +558,24 @@ describe("archive import", () => {
 				}
 			).count,
 		).toBe(3);
+		expect(readArchiveSnapshots()).toEqual(firstSnapshots);
+		expect(readArchiveMembers()).toEqual(firstMembers);
+		expect(firstSnapshots).toEqual([
+			{
+				direction: "followers",
+				id: "follow_snapshot_archive_acct_primary_followers",
+				result_count: 2,
+			},
+			{
+				direction: "following",
+				id: "follow_snapshot_archive_acct_primary_following",
+				result_count: 1,
+			},
+		]);
+		expect(firstMembers).toEqual([
+			{ count: 2, direction: "followers" },
+			{ count: 1, direction: "following" },
+		]);
 	});
 
 	it("keeps live follow source on xurl edges absent from the archive", async () => {

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -332,6 +332,57 @@ function makeFollowArchive({
 	return archivePath;
 }
 
+function makeFollowDmArchive(userId: string) {
+	const root = mkdtempSync(
+		path.join(os.tmpdir(), "birdclaw-archive-follow-dm-"),
+	);
+	const archiveDir = path.join(root, "sample", "data");
+	mkdirSync(archiveDir, { recursive: true });
+
+	writeFileSync(
+		path.join(archiveDir, "account.js"),
+		'window.YTD.account.part0 = [{ "account": { "accountId": "25401953", "username": "steipete" } }]',
+	);
+	writeFileSync(
+		path.join(archiveDir, "follower.js"),
+		`window.YTD.follower.part0 = ${JSON.stringify([
+			{
+				follower: {
+					accountId: userId,
+					userLink: `https://twitter.com/intent/user?user_id=${userId}`,
+				},
+			},
+		])}`,
+	);
+	writeFileSync(
+		path.join(archiveDir, "direct-messages.js"),
+		`window.YTD.direct_messages.part0 = ${JSON.stringify([
+			{
+				dmConversation: {
+					conversationId: `dm-${userId}`,
+					messages: [
+						{
+							messageCreate: {
+								id: `m-${userId}`,
+								senderId: userId,
+								recipientId: "25401953",
+								createdAt: "2025-06-03T20:00:00.000Z",
+								text: "hello from a follower",
+								mediaUrls: [],
+							},
+						},
+					],
+				},
+			},
+		])}`,
+	);
+
+	const archivePath = path.join(root, "archive.zip");
+	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
+	createdDirs.push(root);
+	return archivePath;
+}
+
 describe("archive import", () => {
 	afterEach(() => {
 		resetDatabaseForTests();
@@ -635,6 +686,60 @@ describe("archive import", () => {
 		});
 	});
 
+	it("merges hydrated profile metadata when archive DM and follower rows overlap", async () => {
+		const archivePath = makeFollowDmArchive("900");
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into profiles (
+        id, handle, display_name, bio, followers_count, following_count,
+        avatar_hue, avatar_url, created_at
+      ) values (
+        'profile_user_900', 'real900', 'Real User', 'Hydrated bio', 123, 45,
+        33, 'https://img.example.com/avatar.jpg', '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+		db.prepare(
+			`
+      insert into follow_edges (
+        account_id, direction, profile_id, external_user_id, source, current,
+        first_seen_at, last_seen_at, ended_at, updated_at
+      ) values (
+        'acct_primary', 'followers', 'profile_user_900', '900', 'xurl', 1,
+        '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null,
+        '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+
+		await importArchive(archivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio, followers_count, following_count,
+            avatar_hue, avatar_url
+          from profiles
+          where id = 'profile_user_900'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "real900",
+			display_name: "Real User",
+			bio: "Hydrated bio",
+			followers_count: 123,
+			following_count: 45,
+			avatar_hue: 33,
+			avatar_url: "https://img.example.com/avatar.jpg",
+		});
+	});
+
 	it("clears archive follower rows when follower file is absent", async () => {
 		const firstArchivePath = makeFollowArchive({
 			followers: ["101", "102"],
@@ -731,6 +836,13 @@ describe("archive import", () => {
 					.get() as { count: number }
 			).count,
 		).toBe(0);
+		expect(
+			db
+				.prepare(
+					"select id from profiles where id in ('profile_user_101', 'profile_user_102') order by id",
+				)
+				.all(),
+		).toEqual([]);
 	});
 
 	it("preserves live follower source when an overlapping archive is later absent", async () => {

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -578,6 +578,76 @@ describe("archive import", () => {
 		]);
 	});
 
+	it("clears archive follower rows when follower file is absent", async () => {
+		const firstArchivePath = makeFollowArchive({
+			followers: ["101", "102"],
+			includeFollowing: false,
+		});
+		const secondArchivePath = makeFollowArchive({
+			following: ["201"],
+			includeFollowers: false,
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(firstArchivePath);
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into follow_edges (
+        account_id, direction, profile_id, external_user_id, source, current,
+        first_seen_at, last_seen_at, ended_at, updated_at
+      ) values (
+        'acct_primary', 'followers', 'profile_user_900', '900', 'xurl', 1,
+        '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null,
+        '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+
+		await importArchive(secondArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select external_user_id, source, current
+          from follow_edges
+          where direction = 'followers'
+          order by external_user_id
+        `,
+				)
+				.all(),
+		).toEqual([{ external_user_id: "900", source: "xurl", current: 1 }]);
+		expect(
+			(
+				db
+					.prepare(
+						`
+            select count(*) as count
+            from follow_snapshots
+            where direction = 'followers' and source = 'archive'
+          `,
+					)
+					.get() as { count: number }
+			).count,
+		).toBe(0);
+		expect(
+			(
+				db
+					.prepare(
+						`
+            select count(*) as count
+            from follow_snapshot_members
+            where snapshot_id like 'follow_snapshot_archive_acct_primary_followers%'
+          `,
+					)
+					.get() as { count: number }
+			).count,
+		).toBe(0);
+	});
+
 	it("keeps live follow source on xurl edges absent from the archive", async () => {
 		const archivePath = makeFollowArchive({
 			followers: ["101"],

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -16,7 +16,7 @@ import {
 
 const createdDirs: string[] = [];
 
-function makeArchive() {
+function makeArchive({ following = [] }: { following?: string[] } = {}) {
 	const root = mkdtempSync(path.join(os.tmpdir(), "birdclaw-archive-"));
 	const archiveDir = path.join(root, "sample", "data");
 	mkdirSync(archiveDir, { recursive: true });
@@ -140,6 +140,19 @@ function makeArchive() {
   }
 ]`,
 	);
+	if (following.length > 0) {
+		writeFileSync(
+			path.join(archiveDir, "following.js"),
+			`window.YTD.following.part0 = ${JSON.stringify(
+				following.map((id) => ({
+					following: {
+						accountId: id,
+						userLink: `https://twitter.com/intent/user?user_id=${id}`,
+					},
+				})),
+			)}`,
+		);
+	}
 
 	const archivePath = path.join(root, "archive.zip");
 	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
@@ -790,6 +803,64 @@ describe("archive import", () => {
 		const db = getNativeDb();
 
 		await importArchive(secondArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio
+          from profiles
+          where id = 'profile_user_42'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "sam",
+			display_name: "sam",
+			bio: "Imported from archive user 42",
+		});
+	});
+
+	it("preserves mention-inferred DM profiles when a later archive lacks mention metadata", async () => {
+		const firstArchivePath = makeRootDataArchive();
+		const secondArchivePath = makeArchive();
+		const thirdArchivePath = makeRootDataArchive();
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(firstArchivePath);
+		await importArchive(secondArchivePath);
+		const db = getNativeDb();
+		await importArchive(thirdArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio
+          from profiles
+          where id = 'profile_user_42'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "sam",
+			display_name: "sam",
+			bio: "Imported from archive user 42",
+		});
+	});
+
+	it("preserves mention-inferred DM profiles when follow rows overlap on re-import", async () => {
+		const firstArchivePath = makeRootDataArchive();
+		const secondArchivePath = makeArchive({ following: ["42"] });
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(firstArchivePath);
+		await importArchive(secondArchivePath);
+		const db = getNativeDb();
 
 		expect(
 			db

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -481,6 +481,53 @@ describe("archive import", () => {
 		expect(bookmarked.map((item) => item.text)).toEqual(["saved archive item"]);
 	}, 30000);
 
+	it("creates authored edges for archive-imported account tweets", async () => {
+		const archivePath = makeArchive();
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(archivePath);
+		const db = getNativeDb();
+		const accountTweets = db
+			.prepare(
+				`
+        select id, created_at
+        from tweets
+        where account_id = 'acct_primary' and author_profile_id = 'profile_me'
+        order by id
+        `,
+			)
+			.all() as Array<{ id: string; created_at: string }>;
+		const authoredEdges = db
+			.prepare(
+				`
+        select edge.tweet_id, edge.source, edge.first_seen_at, edge.last_seen_at
+        from tweet_account_edges edge
+        join tweets tweet on tweet.id = edge.tweet_id
+        where edge.account_id = 'acct_primary'
+          and edge.kind = 'authored'
+          and tweet.author_profile_id = 'profile_me'
+        order by edge.tweet_id
+        `,
+			)
+			.all() as Array<{
+			tweet_id: string;
+			source: string;
+			first_seen_at: string;
+			last_seen_at: string;
+		}>;
+
+		expect(authoredEdges).toEqual(
+			accountTweets.map((tweet) => ({
+				tweet_id: tweet.id,
+				source: "archive",
+				first_seen_at: tweet.created_at,
+				last_seen_at: tweet.created_at,
+			})),
+		);
+	});
+
 	it("imports follower and following archive files into the follow graph", async () => {
 		const archivePath = makeFollowArchive({
 			followers: ["101", "102"],

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -686,6 +686,52 @@ describe("archive import", () => {
 		});
 	});
 
+	it("preserves hydrated profile columns on archive re-import", async () => {
+		const archivePath = makeFollowArchive({
+			followers: ["900"],
+			includeFollowing: false,
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(archivePath);
+		const db = getNativeDb();
+		db.prepare(
+			`
+      update profiles
+      set handle = 'real900',
+        display_name = 'Real User',
+        followers_count = 123,
+        public_metrics_json = ?,
+        location = 'London',
+        raw_json = ?
+      where id = 'profile_user_900'
+      `,
+		).run(
+			'{"followers_count":123,"following_count":45}',
+			'{"id":"900","username":"real900","description":"hydrated"}',
+		);
+
+		await importArchive(archivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select public_metrics_json, location, raw_json
+          from profiles
+          where id = 'profile_user_900'
+        `,
+				)
+				.get(),
+		).toEqual({
+			public_metrics_json: '{"followers_count":123,"following_count":45}',
+			location: "London",
+			raw_json: '{"id":"900","username":"real900","description":"hydrated"}',
+		});
+	});
+
 	it("merges hydrated profile metadata when archive DM and follower rows overlap", async () => {
 		const archivePath = makeFollowDmArchive("900");
 		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -779,6 +779,35 @@ describe("archive import", () => {
 		});
 	});
 
+	it("upgrades DM-only placeholder profiles from archive mention metadata on re-import", async () => {
+		const firstArchivePath = makeRootDataArchive();
+		const secondArchivePath = makeArchive();
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(firstArchivePath);
+		const db = getNativeDb();
+
+		await importArchive(secondArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio
+          from profiles
+          where id = 'profile_user_42'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "sam",
+			display_name: "sam",
+			bio: "Imported from archive user 42",
+		});
+	});
+
 	it("merges hydrated profile metadata when archive DM and follower rows overlap", async () => {
 		const archivePath = makeFollowDmArchive("900");
 		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -214,7 +214,7 @@ function makeRootDataArchive() {
 	return archivePath;
 }
 
-function makeWeirdArchive() {
+function makeWeirdArchive({ followers = [] }: { followers?: string[] } = {}) {
 	const root = mkdtempSync(path.join(os.tmpdir(), "birdclaw-archive-weird-"));
 	const archiveDir = path.join(root, "sample", "data");
 	mkdirSync(archiveDir, { recursive: true });
@@ -286,6 +286,19 @@ function makeWeirdArchive() {
   }
 ]`,
 	);
+	if (followers.length > 0) {
+		writeFileSync(
+			path.join(archiveDir, "follower.js"),
+			`window.YTD.follower.part0 = ${JSON.stringify(
+				followers.map((id) => ({
+					follower: {
+						accountId: id,
+						userLink: `https://twitter.com/intent/user?user_id=${id}`,
+					},
+				})),
+			)}`,
+		);
+	}
 
 	const archivePath = path.join(root, "archive.zip");
 	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
@@ -876,6 +889,52 @@ describe("archive import", () => {
 			handle: "sam",
 			display_name: "sam",
 			bio: "Imported from archive user 42",
+		});
+	});
+
+	it("preserves hydrated group-DM sender profiles when follow rows overlap", async () => {
+		const archivePath = makeWeirdArchive({ followers: ["42"] });
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into profiles (
+        id, handle, display_name, bio, followers_count, following_count,
+        public_metrics_json, avatar_hue, location, raw_json, created_at
+      ) values (
+        'profile_user_42', 'real42', 'Real Group Sender', 'Hydrated bio',
+        321, 54, ?, 33, 'London', ?, '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run(
+			'{"followers_count":321,"following_count":54}',
+			'{"id":"42","username":"real42","description":"hydrated"}',
+		);
+
+		await importArchive(archivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio, followers_count, following_count,
+            public_metrics_json, location, raw_json
+          from profiles
+          where id = 'profile_user_42'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "real42",
+			display_name: "Real Group Sender",
+			bio: "Hydrated bio",
+			followers_count: 321,
+			following_count: 54,
+			public_metrics_json: '{"followers_count":321,"following_count":54}',
+			location: "London",
+			raw_json: '{"id":"42","username":"real42","description":"hydrated"}',
 		});
 	});
 

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -732,6 +732,53 @@ describe("archive import", () => {
 		});
 	});
 
+	it("preserves hydrated DM-only profile columns on archive re-import", async () => {
+		const archivePath = makeRootDataArchive();
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(archivePath);
+		const db = getNativeDb();
+		db.prepare(
+			`
+      update profiles
+      set handle = 'real42',
+        display_name = 'Real DM User',
+        followers_count = 321,
+        public_metrics_json = ?,
+        location = 'London',
+        raw_json = ?
+      where id = 'profile_user_42'
+      `,
+		).run(
+			'{"followers_count":321,"following_count":54}',
+			'{"id":"42","username":"real42","description":"hydrated"}',
+		);
+
+		await importArchive(archivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, followers_count, public_metrics_json,
+            location, raw_json
+          from profiles
+          where id = 'profile_user_42'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "real42",
+			display_name: "Real DM User",
+			followers_count: 321,
+			public_metrics_json: '{"followers_count":321,"following_count":54}',
+			location: "London",
+			raw_json: '{"id":"42","username":"real42","description":"hydrated"}',
+		});
+	});
+
 	it("merges hydrated profile metadata when archive DM and follower rows overlap", async () => {
 		const archivePath = makeFollowDmArchive("900");
 		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -578,6 +578,63 @@ describe("archive import", () => {
 		]);
 	});
 
+	it("preserves hydrated follow profile metadata on archive import", async () => {
+		const archivePath = makeFollowArchive({
+			followers: ["900"],
+			includeFollowing: false,
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into profiles (
+        id, handle, display_name, bio, followers_count, following_count,
+        avatar_hue, avatar_url, created_at
+      ) values (
+        'profile_user_900', 'real900', 'Real User', 'Hydrated bio', 123, 45,
+        33, 'https://img.example.com/avatar.jpg', '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+		db.prepare(
+			`
+      insert into follow_edges (
+        account_id, direction, profile_id, external_user_id, source, current,
+        first_seen_at, last_seen_at, ended_at, updated_at
+      ) values (
+        'acct_primary', 'followers', 'profile_user_900', '900', 'xurl', 1,
+        '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null,
+        '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+
+		await importArchive(archivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select handle, display_name, bio, followers_count, following_count,
+            avatar_hue, avatar_url
+          from profiles
+          where id = 'profile_user_900'
+        `,
+				)
+				.get(),
+		).toEqual({
+			handle: "real900",
+			display_name: "Real User",
+			bio: "Hydrated bio",
+			followers_count: 123,
+			following_count: 45,
+			avatar_hue: 33,
+			avatar_url: "https://img.example.com/avatar.jpg",
+		});
+	});
+
 	it("clears archive follower rows when follower file is absent", async () => {
 		const firstArchivePath = makeFollowArchive({
 			followers: ["101", "102"],
@@ -593,6 +650,20 @@ describe("archive import", () => {
 
 		await importArchive(firstArchivePath);
 		const db = getNativeDb();
+		expect(
+			(
+				db
+					.prepare(
+						`
+            select count(*) as count
+            from follow_events
+            where direction = 'followers'
+              and snapshot_id = 'follow_snapshot_archive_acct_primary_followers'
+          `,
+					)
+					.get() as { count: number }
+			).count,
+		).toBe(2);
 		db.prepare(
 			`
       insert into follow_edges (
@@ -641,6 +712,20 @@ describe("archive import", () => {
             select count(*) as count
             from follow_snapshot_members
             where snapshot_id like 'follow_snapshot_archive_acct_primary_followers%'
+          `,
+					)
+					.get() as { count: number }
+			).count,
+		).toBe(0);
+		expect(
+			(
+				db
+					.prepare(
+						`
+            select count(*) as count
+            from follow_events
+            where direction = 'followers'
+              and snapshot_id = 'follow_snapshot_archive_acct_primary_followers'
           `,
 					)
 					.get() as { count: number }

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -648,6 +648,73 @@ describe("archive import", () => {
 		).toBe(0);
 	});
 
+	it("preserves live follower source when an overlapping archive is later absent", async () => {
+		const firstArchivePath = makeFollowArchive({
+			followers: ["900"],
+			includeFollowing: false,
+		});
+		const secondArchivePath = makeFollowArchive({
+			following: ["201"],
+			includeFollowers: false,
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into follow_edges (
+        account_id, direction, profile_id, external_user_id, source, current,
+        first_seen_at, last_seen_at, ended_at, updated_at
+      ) values (
+        'acct_primary', 'followers', 'profile_user_900', '900', 'xurl', 1,
+        '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null,
+        '2026-05-01T00:00:00.000Z'
+      )
+      `,
+		).run();
+
+		await importArchive(firstArchivePath);
+		expect(
+			db
+				.prepare(
+					`
+          select external_user_id, source, current
+          from follow_edges
+          where direction = 'followers'
+        `,
+				)
+				.all(),
+		).toEqual([{ external_user_id: "900", source: "xurl", current: 1 }]);
+
+		await importArchive(secondArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select external_user_id, source, current
+          from follow_edges
+          where direction = 'followers'
+        `,
+				)
+				.all(),
+		).toEqual([{ external_user_id: "900", source: "xurl", current: 1 }]);
+		expect(
+			(
+				db
+					.prepare(
+						`
+            select count(*) as count
+            from follow_edges
+            where direction = 'followers' and source = 'archive'
+          `,
+					)
+					.get() as { count: number }
+			).count,
+		).toBe(0);
+	});
+
 	it("keeps live follow source on xurl edges absent from the archive", async () => {
 		const archivePath = makeFollowArchive({
 			followers: ["101"],
@@ -684,7 +751,7 @@ describe("archive import", () => {
 			.all();
 
 		expect(rows).toEqual([
-			{ profile_id: "profile_user_101", source: "archive", current: 1 },
+			{ profile_id: "profile_user_101", source: "xurl", current: 1 },
 			{ profile_id: "profile_user_900", source: "xurl", current: 0 },
 		]);
 		expect(events).toEqual([{ external_user_id: "900", kind: "ended" }]);

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { __test__, importArchive } from "./archive-import";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
+import { listFollowEvents, listUnfollowedSince } from "./follow-graph";
 import {
 	getQueryEnvelope,
 	listDmConversations,
@@ -194,7 +195,6 @@ function makeRootDataArchive() {
   }
 ]`,
 	);
-
 	const archivePath = path.join(root, "archive.zip");
 	execFileSync("zip", ["-qr", archivePath, "data"], { cwd: root });
 	createdDirs.push(root);
@@ -573,6 +573,21 @@ describe("archive import", () => {
 			{ profile_id: "profile_user_900", source: "xurl", current: 0 },
 		]);
 		expect(events).toEqual([{ external_user_id: "900", kind: "ended" }]);
+		expect(
+			listUnfollowedSince({ date: "2000-01-01" }).items.map(
+				(item) => item.profile.handle,
+			),
+		).toEqual(["id900"]);
+		expect(
+			listFollowEvents({
+				direction: "followers",
+				kind: "ended",
+				since: "2000-01-01",
+			}).items.map((item) => ({
+				kind: item.kind,
+				handle: item.profile.handle,
+			})),
+		).toEqual([{ kind: "ended", handle: "id900" }]);
 	});
 
 	it("covers parsing helpers and fallback normalizers", () => {

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -280,6 +280,58 @@ function makeWeirdArchive() {
 	return archivePath;
 }
 
+function makeFollowArchive({
+	followers = [],
+	following = [],
+	includeFollowers = true,
+	includeFollowing = true,
+}: {
+	followers?: string[];
+	following?: string[];
+	includeFollowers?: boolean;
+	includeFollowing?: boolean;
+}) {
+	const root = mkdtempSync(path.join(os.tmpdir(), "birdclaw-archive-follow-"));
+	const archiveDir = path.join(root, "sample", "data");
+	mkdirSync(archiveDir, { recursive: true });
+
+	writeFileSync(
+		path.join(archiveDir, "account.js"),
+		'window.YTD.account.part0 = [{ "account": { "accountId": "25401953", "username": "steipete" } }]',
+	);
+	if (includeFollowers) {
+		writeFileSync(
+			path.join(archiveDir, "follower.js"),
+			`window.YTD.follower.part0 = ${JSON.stringify(
+				followers.map((id) => ({
+					follower: {
+						accountId: id,
+						userLink: `https://twitter.com/intent/user?user_id=${id}`,
+					},
+				})),
+			)}`,
+		);
+	}
+	if (includeFollowing) {
+		writeFileSync(
+			path.join(archiveDir, "following.js"),
+			`window.YTD.following.part0 = ${JSON.stringify(
+				following.map((id) => ({
+					following: {
+						accountId: id,
+						userLink: `https://twitter.com/intent/user?user_id=${id}`,
+					},
+				})),
+			)}`,
+		);
+	}
+
+	const archivePath = path.join(root, "archive.zip");
+	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
+	createdDirs.push(root);
+	return archivePath;
+}
+
 describe("archive import", () => {
 	afterEach(() => {
 		resetDatabaseForTests();
@@ -329,6 +381,8 @@ describe("archive import", () => {
 		expect(result.counts.tweets).toBe(2);
 		expect(result.counts.likes).toBe(1);
 		expect(result.counts.bookmarks).toBe(1);
+		expect(result.counts.followers).toBe(0);
+		expect(result.counts.following).toBe(0);
 		expect(envelope.stats.home).toBe(2);
 		expect(envelope.stats.dms).toBe(1);
 		expect(tweets.map((item) => item.text)).toEqual([
@@ -349,6 +403,177 @@ describe("archive import", () => {
 		expect(liked.map((item) => item.text)).toEqual(["liked archive item"]);
 		expect(bookmarked.map((item) => item.text)).toEqual(["saved archive item"]);
 	}, 30000);
+
+	it("imports follower and following archive files into the follow graph", async () => {
+		const archivePath = makeFollowArchive({
+			followers: ["101", "102"],
+			following: ["102", "103"],
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		const result = await importArchive(archivePath);
+		const db = getNativeDb();
+		const edges = db
+			.prepare(
+				`
+        select direction || ':' || profile_id || ':' || external_user_id || ':' || source || ':' || current as value
+        from follow_edges
+        order by direction, external_user_id
+        `,
+			)
+			.all() as Array<{ value: string }>;
+		const events = db
+			.prepare(
+				`
+        select direction || ':' || external_user_id || ':' || kind as value
+        from follow_events
+        order by direction, external_user_id
+        `,
+			)
+			.all() as Array<{ value: string }>;
+		const snapshots = db
+			.prepare(
+				`
+        select direction || ':' || source || ':' || status || ':' || result_count as value
+        from follow_snapshots
+        order by direction
+        `,
+			)
+			.all() as Array<{ value: string }>;
+
+		expect(result.counts.followers).toBe(2);
+		expect(result.counts.following).toBe(2);
+		expect(edges.map((row) => row.value)).toEqual([
+			"followers:profile_user_101:101:archive:1",
+			"followers:profile_user_102:102:archive:1",
+			"following:profile_user_102:102:archive:1",
+			"following:profile_user_103:103:archive:1",
+		]);
+		expect(events.map((row) => row.value)).toEqual([
+			"followers:101:started",
+			"followers:102:started",
+			"following:102:started",
+			"following:103:started",
+		]);
+		expect(snapshots.map((row) => row.value)).toEqual([
+			"followers:archive:complete:2",
+			"following:archive:complete:2",
+		]);
+		expect(
+			db
+				.prepare(
+					"select handle, display_name, bio from profiles where id = 'profile_user_101'",
+				)
+				.get(),
+		).toEqual({ handle: "id101", display_name: "", bio: "" });
+	});
+
+	it("handles empty follower and following files", async () => {
+		const archivePath = makeFollowArchive({});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		const result = await importArchive(archivePath);
+		const db = getNativeDb();
+
+		expect(result.counts.followers).toBe(0);
+		expect(result.counts.following).toBe(0);
+		expect(
+			(
+				db.prepare("select count(*) as count from follow_edges").get() as {
+					count: number;
+				}
+			).count,
+		).toBe(0);
+		expect(
+			(
+				db.prepare("select count(*) as count from follow_events").get() as {
+					count: number;
+				}
+			).count,
+		).toBe(0);
+		expect(
+			(
+				db.prepare("select count(*) as count from follow_snapshots").get() as {
+					count: number;
+				}
+			).count,
+		).toBe(2);
+	});
+
+	it("re-imports follower data without duplicate follow events", async () => {
+		const archivePath = makeFollowArchive({
+			followers: ["101", "102"],
+			following: ["103"],
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+
+		await importArchive(archivePath);
+		await importArchive(archivePath);
+		const db = getNativeDb();
+
+		expect(
+			(
+				db.prepare("select count(*) as count from follow_edges").get() as {
+					count: number;
+				}
+			).count,
+		).toBe(3);
+		expect(
+			(
+				db.prepare("select count(*) as count from follow_events").get() as {
+					count: number;
+				}
+			).count,
+		).toBe(3);
+	});
+
+	it("keeps live follow source on xurl edges absent from the archive", async () => {
+		const archivePath = makeFollowArchive({
+			followers: ["101"],
+			includeFollowing: false,
+		});
+		const homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-home-"));
+		createdDirs.push(homeDir);
+		process.env.BIRDCLAW_HOME = homeDir;
+		const db = getNativeDb();
+		db.prepare(
+			`
+      insert into follow_edges (
+        account_id, direction, profile_id, external_user_id, source, current,
+        first_seen_at, last_seen_at, ended_at, updated_at
+      ) values
+        ('acct_primary', 'followers', 'profile_user_101', '101', 'xurl', 1, '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null, '2026-05-01T00:00:00.000Z'),
+        ('acct_primary', 'followers', 'profile_user_900', '900', 'xurl', 1, '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', null, '2026-05-01T00:00:00.000Z')
+      `,
+		).run();
+
+		await importArchive(archivePath);
+		const rows = db
+			.prepare(
+				`
+        select profile_id, source, current
+        from follow_edges
+        where direction = 'followers'
+        order by profile_id
+        `,
+			)
+			.all();
+		const events = db
+			.prepare("select external_user_id, kind from follow_events")
+			.all();
+
+		expect(rows).toEqual([
+			{ profile_id: "profile_user_101", source: "archive", current: 1 },
+			{ profile_id: "profile_user_900", source: "xurl", current: 0 },
+		]);
+		expect(events).toEqual([{ external_user_id: "900", kind: "ended" }]);
+	});
 
 	it("covers parsing helpers and fallback normalizers", () => {
 		expect(__test__.normalizeArchivePath("data\\tweets.js")).toBe(

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -523,11 +523,25 @@ export async function importArchive(
 			bio: string;
 			followersCount: number;
 			followingCount: number;
+			publicMetricsJson: string;
 			avatarHue: number;
 			avatarUrl: string | null;
+			location: string | null;
+			url: string | null;
+			verifiedType: string | null;
+			entitiesJson: string;
+			rawJson: string;
 			createdAt: string;
 		}
 	>();
+	const defaultProfileMetadata = {
+		publicMetricsJson: "{}",
+		location: null,
+		url: null,
+		verifiedType: null,
+		entitiesJson: "{}",
+		rawJson: "{}",
+	};
 	const conversations = new Map<
 		string,
 		{
@@ -551,10 +565,11 @@ export async function importArchive(
 			getNativeDb()
 				.prepare(
 					`
-        select id, handle, display_name, bio, followers_count, following_count,
-          avatar_hue, avatar_url, created_at
-        from profiles
-      `,
+	        select id, handle, display_name, bio, followers_count, following_count,
+	          public_metrics_json, avatar_hue, avatar_url, location, url,
+	          verified_type, entities_json, raw_json, created_at
+	        from profiles
+	      `,
 				)
 				.all() as Array<{
 				id: string;
@@ -563,8 +578,14 @@ export async function importArchive(
 				bio: string;
 				followers_count: number;
 				following_count: number;
+				public_metrics_json: string;
 				avatar_hue: number;
 				avatar_url: string | null;
+				location: string | null;
+				url: string | null;
+				verified_type: string | null;
+				entities_json: string;
+				raw_json: string;
 				created_at: string;
 			}>
 		).map((profile) => [profile.id, profile]),
@@ -581,8 +602,14 @@ export async function importArchive(
 				bio: existing.bio,
 				followersCount: existing.followers_count,
 				followingCount: existing.following_count,
+				publicMetricsJson: existing.public_metrics_json,
 				avatarHue: existing.avatar_hue,
 				avatarUrl: existing.avatar_url,
+				location: existing.location,
+				url: existing.url,
+				verifiedType: existing.verified_type,
+				entitiesJson: existing.entities_json,
+				rawJson: existing.raw_json,
 				createdAt: existing.created_at,
 			});
 			return;
@@ -597,6 +624,7 @@ export async function importArchive(
 			bio: "",
 			followersCount: 0,
 			followingCount: 0,
+			...defaultProfileMetadata,
 			avatarHue: 210,
 			avatarUrl: null,
 			createdAt: accountPayload.createdAt,
@@ -610,6 +638,7 @@ export async function importArchive(
 		bio: accountPayload.bio,
 		followersCount: 0,
 		followingCount: 0,
+		...defaultProfileMetadata,
 		avatarHue: 18,
 		avatarUrl: null,
 		createdAt: accountPayload.createdAt,
@@ -695,6 +724,7 @@ export async function importArchive(
 						bio: `Group DM with ${externalParticipantIds.length} participants`,
 						followersCount: 0,
 						followingCount: 0,
+						...defaultProfileMetadata,
 						avatarHue: 220,
 						avatarUrl: null,
 						createdAt: accountPayload.createdAt,
@@ -712,6 +742,7 @@ export async function importArchive(
 						bio: `Imported from archive user ${otherUserId}`,
 						followersCount: 0,
 						followingCount: 0,
+						...defaultProfileMetadata,
 						avatarHue: 210,
 						avatarUrl: null,
 						createdAt: accountPayload.createdAt,
@@ -742,6 +773,7 @@ export async function importArchive(
 								bio: `Imported from archive user ${senderId}`,
 								followersCount: 0,
 								followingCount: 0,
+								...defaultProfileMetadata,
 								avatarHue: 240,
 								avatarUrl: null,
 								createdAt: accountPayload.createdAt,
@@ -918,6 +950,7 @@ export async function importArchive(
 			bio: "Imported from archive collection metadata",
 			followersCount: 0,
 			followingCount: 0,
+			...defaultProfileMetadata,
 			avatarHue: 210,
 			avatarUrl: null,
 			createdAt: accountPayload.createdAt,
@@ -932,9 +965,13 @@ export async function importArchive(
     values (?, ?, ?, ?, ?, 1, ?)
   `);
 	const insertProfile = db.prepare(`
-    insert into profiles (id, handle, display_name, bio, followers_count, following_count, avatar_hue, avatar_url, created_at)
-    values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `);
+	    insert into profiles (
+	      id, handle, display_name, bio, followers_count, following_count,
+	      public_metrics_json, avatar_hue, avatar_url, location, url, verified_type,
+	      entities_json, raw_json, created_at
+	    )
+	    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	  `);
 	const insertTweet = db.prepare(`
     insert into tweets (
       id, account_id, author_profile_id, kind, text, created_at, is_replied,
@@ -1197,8 +1234,14 @@ export async function importArchive(
 				profile.bio,
 				profile.followersCount,
 				profile.followingCount,
+				profile.publicMetricsJson,
 				profile.avatarHue,
 				profile.avatarUrl,
+				profile.location,
+				profile.url,
+				profile.verifiedType,
+				profile.entitiesJson,
+				profile.rawJson,
 				profile.createdAt,
 			);
 		}

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -29,10 +29,14 @@ interface ImportedArchiveSummary {
 		dmConversations: number;
 		dmMessages: number;
 		profiles: number;
+		followers: number;
+		following: number;
 	};
 }
 
 type ArchiveRecord = Record<string, unknown>;
+type ArchiveFollowDirection = "followers" | "following";
+type ArchiveFollowKey = "follower" | "following";
 
 function normalizeArchivePath(value: string) {
 	return value.replaceAll("\\", "/");
@@ -295,6 +299,23 @@ function inferProfileFromDirectory(
 	return { handle, displayName };
 }
 
+function getArchiveFollowRows(content: string, key: ArchiveFollowKey) {
+	const rows: Array<{ profileId: string; externalUserId: string }> = [];
+
+	for (const wrapper of parseArchiveArray(content)) {
+		const item = asRecord(wrapper[key]);
+		const externalUserId = String(item?.accountId ?? "");
+		if (!externalUserId) continue;
+
+		rows.push({
+			profileId: `profile_user_${externalUserId}`,
+			externalUserId,
+		});
+	}
+
+	return rows;
+}
+
 function clearImportedData() {
 	const db = getNativeDb();
 	db.exec(`
@@ -339,6 +360,14 @@ export async function importArchive(
 	const dmEntries = getMatchingEntries(
 		entries,
 		/(?:^|\/)data\/direct-messages(?:-group)?(?:-part\d+)?\.js$/i,
+	);
+	const followerEntries = getMatchingEntries(
+		entries,
+		/(?:^|\/)data\/follower(?:-part\d+)?\.js$/i,
+	);
+	const followingEntries = getMatchingEntries(
+		entries,
+		/(?:^|\/)data\/following(?:-part\d+)?\.js$/i,
 	);
 
 	if (!accountEntry) {
@@ -511,6 +540,11 @@ export async function importArchive(
 		}
 	>();
 	const dmMessages: MessageRow[] = [];
+	const followerRows: Array<{ profileId: string; externalUserId: string }> = [];
+	const followingRows: Array<{ profileId: string; externalUserId: string }> =
+		[];
+	const followerIds = new Set<string>();
+	const followingIds = new Set<string>();
 
 	const localProfile = {
 		id: "profile_me",
@@ -760,6 +794,38 @@ export async function importArchive(
 		bookmarkCount += bookmarks.length;
 	}
 
+	for (const entry of followerEntries) {
+		const content = await readArchiveEntry(archivePath, entry);
+		for (const row of getArchiveFollowRows(content, "follower")) {
+			if (followerIds.has(row.externalUserId)) continue;
+			followerIds.add(row.externalUserId);
+			followerRows.push(row);
+		}
+	}
+
+	for (const entry of followingEntries) {
+		const content = await readArchiveEntry(archivePath, entry);
+		for (const row of getArchiveFollowRows(content, "following")) {
+			if (followingIds.has(row.externalUserId)) continue;
+			followingIds.add(row.externalUserId);
+			followingRows.push(row);
+		}
+	}
+
+	for (const row of [...followerRows, ...followingRows]) {
+		if (profiles.has(row.profileId)) continue;
+		profiles.set(row.profileId, {
+			id: row.profileId,
+			handle: `id${row.externalUserId}`,
+			displayName: "",
+			bio: "",
+			followersCount: 0,
+			followingCount: 0,
+			avatarHue: 210,
+			createdAt: accountPayload.createdAt,
+		});
+	}
+
 	if (tweetRows.some((tweet) => tweet.authorProfileId === "profile_unknown")) {
 		profiles.set("profile_unknown", {
 			id: "profile_unknown",
@@ -826,6 +892,125 @@ export async function importArchive(
 	const insertDmFts = db.prepare(
 		"insert into dm_fts (message_id, text) values (?, ?)",
 	);
+	const insertFollowSnapshot = db.prepare(`
+    insert into follow_snapshots (
+      id, account_id, direction, source, status, page_count, result_count,
+      started_at, completed_at, raw_meta_json
+    ) values (?, ?, ?, 'archive', 'complete', ?, ?, ?, ?, ?)
+  `);
+	const insertFollowSnapshotMember = db.prepare(`
+    insert into follow_snapshot_members (
+      snapshot_id, profile_id, external_user_id, position
+    ) values (?, ?, ?, ?)
+  `);
+	const selectFollowEdges = db.prepare(`
+    select profile_id, external_user_id, current
+    from follow_edges
+    where account_id = ? and direction = ?
+  `);
+	const insertFollowEdge = db.prepare(`
+    insert into follow_edges (
+      account_id, direction, profile_id, external_user_id, source, current,
+      first_seen_at, last_seen_at, ended_at, updated_at
+    ) values (?, ?, ?, ?, 'archive', 1, ?, ?, null, ?)
+    on conflict(account_id, direction, profile_id) do update set
+      external_user_id = excluded.external_user_id,
+      source = excluded.source,
+      current = 1,
+      last_seen_at = excluded.last_seen_at,
+      ended_at = null,
+      updated_at = excluded.updated_at
+  `);
+	const endFollowEdge = db.prepare(`
+    update follow_edges
+    set current = 0, ended_at = ?, updated_at = ?
+    where account_id = ? and direction = ? and profile_id = ?
+  `);
+	const insertFollowEvent = db.prepare(`
+    insert into follow_events (
+      id, account_id, direction, profile_id, external_user_id, kind, event_at, snapshot_id
+    ) values (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+	function importFollowRows(
+		direction: ArchiveFollowDirection,
+		rows: Array<{ profileId: string; externalUserId: string }>,
+		entryCount: number,
+		now: string,
+	) {
+		const snapshotId = `follow_snapshot_${randomUUID()}`;
+		const existingEdges = new Map(
+			(
+				selectFollowEdges.all("acct_primary", direction) as Array<{
+					profile_id: string;
+					external_user_id: string;
+					current: number;
+				}>
+			).map((row) => [row.profile_id, row]),
+		);
+		const currentProfileIds = new Set<string>();
+
+		insertFollowSnapshot.run(
+			snapshotId,
+			"acct_primary",
+			direction,
+			entryCount,
+			rows.length,
+			now,
+			now,
+			JSON.stringify({ archivePath, result_count: rows.length }),
+		);
+
+		rows.forEach((row, index) => {
+			currentProfileIds.add(row.profileId);
+			insertFollowSnapshotMember.run(
+				snapshotId,
+				row.profileId,
+				row.externalUserId,
+				index,
+			);
+
+			const previous = existingEdges.get(row.profileId);
+			insertFollowEdge.run(
+				"acct_primary",
+				direction,
+				row.profileId,
+				row.externalUserId,
+				now,
+				now,
+				now,
+			);
+			if (!previous || previous.current === 0) {
+				insertFollowEvent.run(
+					`follow_event_${randomUUID()}`,
+					"acct_primary",
+					direction,
+					row.profileId,
+					row.externalUserId,
+					"started",
+					now,
+					snapshotId,
+				);
+			}
+		});
+
+		for (const [profileId, previous] of existingEdges) {
+			if (previous.current === 0 || currentProfileIds.has(profileId)) {
+				continue;
+			}
+			endFollowEdge.run(now, now, "acct_primary", direction, profileId);
+			insertFollowEvent.run(
+				`follow_event_${randomUUID()}`,
+				"acct_primary",
+				direction,
+				profileId,
+				previous.external_user_id,
+				"ended",
+				now,
+				snapshotId,
+			);
+		}
+	}
 
 	db.transaction(() => {
 		insertAccount.run(
@@ -920,6 +1105,23 @@ export async function importArchive(
 			);
 			insertDmFts.run(message.id, message.text);
 		}
+
+		if (followerEntries.length > 0) {
+			importFollowRows(
+				"followers",
+				followerRows,
+				followerEntries.length,
+				importedAt,
+			);
+		}
+		if (followingEntries.length > 0) {
+			importFollowRows(
+				"following",
+				followingRows,
+				followingEntries.length,
+				importedAt,
+			);
+		}
 	})();
 
 	return {
@@ -937,6 +1139,8 @@ export async function importArchive(
 			dmConversations: conversations.size,
 			dmMessages: dmMessages.length,
 			profiles: profiles.size,
+			followers: followerRows.length,
+			following: followingRows.length,
 		},
 	};
 }

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -916,12 +916,31 @@ export async function importArchive(
       id, account_id, direction, source, status, page_count, result_count,
       started_at, completed_at, raw_meta_json
     ) values (?, ?, ?, 'archive', 'complete', ?, ?, ?, ?, ?)
+    on conflict(id) do update set
+      account_id = excluded.account_id,
+      direction = excluded.direction,
+      source = excluded.source,
+      status = excluded.status,
+      page_count = excluded.page_count,
+      result_count = excluded.result_count,
+      started_at = excluded.started_at,
+      completed_at = excluded.completed_at,
+      raw_meta_json = excluded.raw_meta_json
   `);
 	const insertFollowSnapshotMember = db.prepare(`
     insert into follow_snapshot_members (
       snapshot_id, profile_id, external_user_id, position
     ) values (?, ?, ?, ?)
   `);
+	const selectFollowSnapshotMembers = db.prepare(`
+    select profile_id, external_user_id
+    from follow_snapshot_members
+    where snapshot_id = ?
+    order by position, profile_id
+  `);
+	const deleteFollowSnapshotMembers = db.prepare(
+		"delete from follow_snapshot_members where snapshot_id = ?",
+	);
 	const selectFollowEdges = db.prepare(`
     select profile_id, external_user_id, current
     from follow_edges
@@ -957,7 +976,7 @@ export async function importArchive(
 		entryCount: number,
 		now: string,
 	) {
-		const snapshotId = `follow_snapshot_${randomUUID()}`;
+		const snapshotId = `follow_snapshot_archive_acct_primary_${direction}`;
 		const existingEdges = new Map(
 			(
 				selectFollowEdges.all("acct_primary", direction) as Array<{
@@ -967,6 +986,24 @@ export async function importArchive(
 				}>
 			).map((row) => [row.profile_id, row]),
 		);
+		const existingMemberKey = (
+			selectFollowSnapshotMembers.all(snapshotId) as Array<{
+				profile_id: string;
+				external_user_id: string;
+			}>
+		)
+			.map(
+				(row, index) =>
+					`${String(index)}:${row.profile_id}:${row.external_user_id}`,
+			)
+			.join("\n");
+		const nextMemberKey = rows
+			.map(
+				(row, index) =>
+					`${String(index)}:${row.profileId}:${row.externalUserId}`,
+			)
+			.join("\n");
+		const membersChanged = existingMemberKey !== nextMemberKey;
 		const currentProfileIds = new Set<string>();
 
 		insertFollowSnapshot.run(
@@ -980,14 +1017,19 @@ export async function importArchive(
 			JSON.stringify({ archivePath, result_count: rows.length }),
 		);
 
+		if (membersChanged) {
+			deleteFollowSnapshotMembers.run(snapshotId);
+		}
 		rows.forEach((row, index) => {
 			currentProfileIds.add(row.profileId);
-			insertFollowSnapshotMember.run(
-				snapshotId,
-				row.profileId,
-				row.externalUserId,
-				index,
-			);
+			if (membersChanged) {
+				insertFollowSnapshotMember.run(
+					snapshotId,
+					row.profileId,
+					row.externalUserId,
+					index,
+				);
+			}
 
 			const previous = existingEdges.get(row.profileId);
 			insertFollowEdge.run(

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -591,6 +591,38 @@ export async function importArchive(
 		).map((profile) => [profile.id, profile]),
 	);
 
+	function isArchivePlaceholderProfile(profile: {
+		handle: string;
+		bio: string;
+		followers_count: number;
+		following_count: number;
+		public_metrics_json: string;
+		avatar_url: string | null;
+		location: string | null;
+		url: string | null;
+		verified_type: string | null;
+		entities_json: string;
+		raw_json: string;
+	}) {
+		const hasStubIdentity =
+			/^id\d+$/i.test(profile.handle) ||
+			profile.bio.startsWith("Imported from archive user ");
+		const hasLiveSignals =
+			profile.followers_count > 0 ||
+			profile.following_count > 0 ||
+			profile.public_metrics_json.trim() !== "{}" ||
+			profile.avatar_url !== null ||
+			profile.location !== null ||
+			profile.url !== null ||
+			profile.verified_type !== null ||
+			profile.entities_json.trim() !== "{}" ||
+			profile.raw_json.trim() !== "{}";
+
+		return (
+			!hasLiveSignals && (hasStubIdentity || profile.followers_count === 0)
+		);
+	}
+
 	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
 		if (!profileId) return;
 		const existing = existingProfiles.get(profileId);
@@ -732,7 +764,7 @@ export async function importArchive(
 				} else {
 					const otherUserId = externalParticipantIds[0] ?? conversationId;
 					const existing = existingProfiles.get(participantProfileId);
-					if (existing) {
+					if (existing && !isArchivePlaceholderProfile(existing)) {
 						profiles.set(participantProfileId, {
 							id: participantProfileId,
 							handle: existing.handle,

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -676,25 +676,31 @@ export async function importArchive(
 	function mergeArchiveProfile(incoming: ProfileRow) {
 		const incomingTier = classifyExistingProfile(incoming);
 		const current = profiles.get(incoming.id);
+		const currentTier = current ? classifyExistingProfile(current) : null;
+		const existing = existingProfiles.get(incoming.id);
+		const existingProfile = existing
+			? existingProfileToProfileRow(existing)
+			: null;
+		const existingTier = existingProfile
+			? classifyExistingProfile(existingProfile)
+			: null;
+
 		if (
 			current &&
-			shouldPreserveProfile(classifyExistingProfile(current), incomingTier)
+			currentTier &&
+			shouldPreserveProfile(currentTier, incomingTier) &&
+			(!existingTier || shouldPreserveProfile(currentTier, existingTier))
 		) {
 			return;
 		}
 
-		const existing = existingProfiles.get(incoming.id);
-		if (existing) {
-			const existingProfile = existingProfileToProfileRow(existing);
-			if (
-				shouldPreserveProfile(
-					classifyExistingProfile(existingProfile),
-					incomingTier,
-				)
-			) {
-				profiles.set(incoming.id, existingProfile);
-				return;
-			}
+		if (
+			existingProfile &&
+			existingTier &&
+			shouldPreserveProfile(existingTier, incomingTier)
+		) {
+			profiles.set(incoming.id, existingProfile);
+			return;
 		}
 
 		profiles.set(incoming.id, incoming);

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -968,7 +968,10 @@ export async function importArchive(
     ) values (?, ?, ?, ?, 'archive', 1, ?, ?, null, ?)
     on conflict(account_id, direction, profile_id) do update set
       external_user_id = excluded.external_user_id,
-      source = excluded.source,
+      source = case
+        when follow_edges.source = 'archive' then excluded.source
+        else follow_edges.source
+      end,
       current = 1,
       last_seen_at = excluded.last_seen_at,
       ended_at = null,

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -571,7 +571,7 @@ export async function importArchive(
 	);
 
 	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
-		if (!profileId || profiles.has(profileId)) return;
+		if (!profileId) return;
 		const existing = existingProfiles.get(profileId);
 		if (existing) {
 			profiles.set(profileId, {
@@ -587,6 +587,7 @@ export async function importArchive(
 			});
 			return;
 		}
+		if (profiles.has(profileId)) return;
 		const fallbackId =
 			externalUserId || profileId.replace(/^profile_user_/, "");
 		profiles.set(profileId, {
@@ -876,16 +877,36 @@ export async function importArchive(
 		addArchiveFollowProfile(row.profileId, row.externalUserId);
 	}
 
+	const clearedFollowDirections = new Set<ArchiveFollowDirection>();
+	if (followerEntries.length === 0) clearedFollowDirections.add("followers");
+	if (followingEntries.length === 0) clearedFollowDirections.add("following");
 	const retainedFollowProfiles = getNativeDb()
 		.prepare(
 			`
-      select profile_id, external_user_id from follow_edges
+      select direction, profile_id, external_user_id, source, null as snapshot_id, null as snapshot_source
+      from follow_edges
       union
-      select profile_id, external_user_id from follow_events
+      select ev.direction, ev.profile_id, ev.external_user_id, null as source, ev.snapshot_id, snap.source as snapshot_source
+      from follow_events ev
+      left join follow_snapshots snap on snap.id = ev.snapshot_id
       `,
 		)
-		.all() as Array<{ profile_id: string; external_user_id: string }>;
+		.all() as Array<{
+		direction: ArchiveFollowDirection;
+		profile_id: string;
+		external_user_id: string;
+		source: string | null;
+		snapshot_id: string | null;
+		snapshot_source: string | null;
+	}>;
 	for (const row of retainedFollowProfiles) {
+		const isClearedArchiveRow =
+			clearedFollowDirections.has(row.direction) &&
+			(row.source === "archive" ||
+				row.snapshot_source === "archive" ||
+				row.snapshot_id ===
+					`follow_snapshot_archive_acct_primary_${row.direction}`);
+		if (isClearedArchiveRow) continue;
 		addArchiveFollowProfile(row.profile_id, row.external_user_id);
 	}
 

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -1367,6 +1367,16 @@ export async function importArchive(
 					new Date().toISOString(),
 				);
 			}
+			if (tweet.authorProfileId === localProfile.id) {
+				insertTimelineEdge.run(
+					"acct_primary",
+					tweet.id,
+					"authored",
+					tweet.createdAt,
+					tweet.createdAt,
+					new Date().toISOString(),
+				);
+			}
 			insertTweetFts.run(tweet.id, tweet.text);
 		}
 

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -534,6 +534,8 @@ export async function importArchive(
 			createdAt: string;
 		}
 	>();
+	type ProfileRow =
+		typeof profiles extends Map<string, infer Value> ? Value : never;
 	const defaultProfileMetadata = {
 		publicMetricsJson: "{}",
 		location: null,
@@ -560,6 +562,23 @@ export async function importArchive(
 		[];
 	const followerIds = new Set<string>();
 	const followingIds = new Set<string>();
+	type ExistingProfileRow = {
+		id: string;
+		handle: string;
+		display_name: string;
+		bio: string;
+		followers_count: number;
+		following_count: number;
+		public_metrics_json: string;
+		avatar_hue: number;
+		avatar_url: string | null;
+		location: string | null;
+		url: string | null;
+		verified_type: string | null;
+		entities_json: string;
+		raw_json: string;
+		created_at: string;
+	};
 	const existingProfiles = new Map(
 		(
 			getNativeDb()
@@ -571,85 +590,121 @@ export async function importArchive(
 	        from profiles
 	      `,
 				)
-				.all() as Array<{
-				id: string;
-				handle: string;
-				display_name: string;
-				bio: string;
-				followers_count: number;
-				following_count: number;
-				public_metrics_json: string;
-				avatar_hue: number;
-				avatar_url: string | null;
-				location: string | null;
-				url: string | null;
-				verified_type: string | null;
-				entities_json: string;
-				raw_json: string;
-				created_at: string;
-			}>
+				.all() as ExistingProfileRow[]
 		).map((profile) => [profile.id, profile]),
 	);
 
-	function isArchivePlaceholderProfile(profile: {
-		handle: string;
-		bio: string;
-		followers_count: number;
-		following_count: number;
-		public_metrics_json: string;
-		avatar_url: string | null;
-		location: string | null;
-		url: string | null;
-		verified_type: string | null;
-		entities_json: string;
-		raw_json: string;
-	}) {
-		const hasStubIdentity =
-			/^id\d+$/i.test(profile.handle) ||
-			profile.bio.startsWith("Imported from archive user ");
+	type ArchiveProfileTier =
+		| "archive_follow_stub"
+		| "archive_dm_stub"
+		| "archive_mention_inferred"
+		| "live_or_hydrated";
+	const archiveProfileTierRank: Record<ArchiveProfileTier, number> = {
+		archive_follow_stub: 0,
+		archive_dm_stub: 1,
+		archive_mention_inferred: 2,
+		live_or_hydrated: 3,
+	};
+
+	function classifyExistingProfile(profile: ProfileRow): ArchiveProfileTier {
+		const externalUserId = profile.id.startsWith("profile_user_")
+			? profile.id.slice("profile_user_".length)
+			: "";
+		const fallbackHandle = externalUserId ? `id${externalUserId}` : profile.id;
 		const hasLiveSignals =
-			profile.followers_count > 0 ||
-			profile.following_count > 0 ||
-			profile.public_metrics_json.trim() !== "{}" ||
-			profile.avatar_url !== null ||
+			profile.followersCount > 0 ||
+			profile.followingCount > 0 ||
+			profile.publicMetricsJson.trim() !== "{}" ||
+			profile.avatarUrl !== null ||
 			profile.location !== null ||
 			profile.url !== null ||
-			profile.verified_type !== null ||
-			profile.entities_json.trim() !== "{}" ||
-			profile.raw_json.trim() !== "{}";
+			profile.verifiedType !== null ||
+			profile.entitiesJson.trim() !== "{}" ||
+			profile.rawJson.trim() !== "{}";
 
+		if (hasLiveSignals) return "live_or_hydrated";
+		if (
+			profile.handle === fallbackHandle &&
+			profile.displayName === "" &&
+			profile.bio === ""
+		) {
+			return "archive_follow_stub";
+		}
+		if (profile.bio.startsWith("Imported from archive user ")) {
+			return profile.handle === fallbackHandle &&
+				profile.displayName === fallbackHandle
+				? "archive_dm_stub"
+				: "archive_mention_inferred";
+		}
+		return profile.handle === fallbackHandle && profile.displayName === ""
+			? "archive_follow_stub"
+			: "archive_mention_inferred";
+	}
+
+	function shouldPreserveProfile(
+		existingTier: ArchiveProfileTier,
+		incomingTier: ArchiveProfileTier,
+	) {
 		return (
-			!hasLiveSignals && (hasStubIdentity || profile.followers_count === 0)
+			archiveProfileTierRank[existingTier] >=
+			archiveProfileTierRank[incomingTier]
 		);
+	}
+
+	function existingProfileToProfileRow(
+		profile: ExistingProfileRow,
+	): ProfileRow {
+		return {
+			id: profile.id,
+			handle: profile.handle,
+			displayName: profile.display_name,
+			bio: profile.bio,
+			followersCount: profile.followers_count,
+			followingCount: profile.following_count,
+			publicMetricsJson: profile.public_metrics_json,
+			avatarHue: profile.avatar_hue,
+			avatarUrl: profile.avatar_url,
+			location: profile.location,
+			url: profile.url,
+			verifiedType: profile.verified_type,
+			entitiesJson: profile.entities_json,
+			rawJson: profile.raw_json,
+			createdAt: profile.created_at,
+		};
+	}
+
+	function mergeArchiveProfile(incoming: ProfileRow) {
+		const incomingTier = classifyExistingProfile(incoming);
+		const current = profiles.get(incoming.id);
+		if (
+			current &&
+			shouldPreserveProfile(classifyExistingProfile(current), incomingTier)
+		) {
+			return;
+		}
+
+		const existing = existingProfiles.get(incoming.id);
+		if (existing) {
+			const existingProfile = existingProfileToProfileRow(existing);
+			if (
+				shouldPreserveProfile(
+					classifyExistingProfile(existingProfile),
+					incomingTier,
+				)
+			) {
+				profiles.set(incoming.id, existingProfile);
+				return;
+			}
+		}
+
+		profiles.set(incoming.id, incoming);
 	}
 
 	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
 		if (!profileId) return;
-		const existing = existingProfiles.get(profileId);
-		if (existing) {
-			profiles.set(profileId, {
-				id: profileId,
-				handle: existing.handle,
-				displayName: existing.display_name,
-				bio: existing.bio,
-				followersCount: existing.followers_count,
-				followingCount: existing.following_count,
-				publicMetricsJson: existing.public_metrics_json,
-				avatarHue: existing.avatar_hue,
-				avatarUrl: existing.avatar_url,
-				location: existing.location,
-				url: existing.url,
-				verifiedType: existing.verified_type,
-				entitiesJson: existing.entities_json,
-				rawJson: existing.raw_json,
-				createdAt: existing.created_at,
-			});
-			return;
-		}
-		if (profiles.has(profileId)) return;
 		const fallbackId =
 			externalUserId || profileId.replace(/^profile_user_/, "");
-		profiles.set(profileId, {
+		mergeArchiveProfile({
 			id: profileId,
 			handle: fallbackId ? `id${fallbackId}` : profileId,
 			displayName: "",
@@ -763,43 +818,22 @@ export async function importArchive(
 					});
 				} else {
 					const otherUserId = externalParticipantIds[0] ?? conversationId;
-					const existing = existingProfiles.get(participantProfileId);
-					if (existing && !isArchivePlaceholderProfile(existing)) {
-						profiles.set(participantProfileId, {
-							id: participantProfileId,
-							handle: existing.handle,
-							displayName: existing.display_name,
-							bio: existing.bio,
-							followersCount: existing.followers_count,
-							followingCount: existing.following_count,
-							publicMetricsJson: existing.public_metrics_json,
-							avatarHue: existing.avatar_hue,
-							avatarUrl: existing.avatar_url,
-							location: existing.location,
-							url: existing.url,
-							verifiedType: existing.verified_type,
-							entitiesJson: existing.entities_json,
-							rawJson: existing.raw_json,
-							createdAt: existing.created_at,
-						});
-					} else {
-						const inferred = inferProfileFromDirectory(
-							otherUserId,
-							mentionDirectory,
-						);
-						profiles.set(participantProfileId, {
-							id: participantProfileId,
-							handle: inferred.handle,
-							displayName: inferred.displayName,
-							bio: `Imported from archive user ${otherUserId}`,
-							followersCount: 0,
-							followingCount: 0,
-							...defaultProfileMetadata,
-							avatarHue: 210,
-							avatarUrl: null,
-							createdAt: accountPayload.createdAt,
-						});
-					}
+					const inferred = inferProfileFromDirectory(
+						otherUserId,
+						mentionDirectory,
+					);
+					mergeArchiveProfile({
+						id: participantProfileId,
+						handle: inferred.handle,
+						displayName: inferred.displayName,
+						bio: `Imported from archive user ${otherUserId}`,
+						followersCount: 0,
+						followingCount: 0,
+						...defaultProfileMetadata,
+						avatarHue: 210,
+						avatarUrl: null,
+						createdAt: accountPayload.createdAt,
+					});
 				}
 			}
 

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -546,6 +546,22 @@ export async function importArchive(
 	const followerIds = new Set<string>();
 	const followingIds = new Set<string>();
 
+	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
+		if (!profileId || profiles.has(profileId)) return;
+		const fallbackId =
+			externalUserId || profileId.replace(/^profile_user_/, "");
+		profiles.set(profileId, {
+			id: profileId,
+			handle: fallbackId ? `id${fallbackId}` : profileId,
+			displayName: "",
+			bio: "",
+			followersCount: 0,
+			followingCount: 0,
+			avatarHue: 210,
+			createdAt: accountPayload.createdAt,
+		});
+	}
+
 	const localProfile = {
 		id: "profile_me",
 		handle: accountPayload.username,
@@ -813,17 +829,20 @@ export async function importArchive(
 	}
 
 	for (const row of [...followerRows, ...followingRows]) {
-		if (profiles.has(row.profileId)) continue;
-		profiles.set(row.profileId, {
-			id: row.profileId,
-			handle: `id${row.externalUserId}`,
-			displayName: "",
-			bio: "",
-			followersCount: 0,
-			followingCount: 0,
-			avatarHue: 210,
-			createdAt: accountPayload.createdAt,
-		});
+		addArchiveFollowProfile(row.profileId, row.externalUserId);
+	}
+
+	const retainedFollowProfiles = getNativeDb()
+		.prepare(
+			`
+      select profile_id, external_user_id from follow_edges
+      union
+      select profile_id, external_user_id from follow_events
+      `,
+		)
+		.all() as Array<{ profile_id: string; external_user_id: string }>;
+	for (const row of retainedFollowProfiles) {
+		addArchiveFollowProfile(row.profile_id, row.external_user_id);
 	}
 
 	if (tweetRows.some((tweet) => tweet.authorProfileId === "profile_unknown")) {

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -731,22 +731,43 @@ export async function importArchive(
 					});
 				} else {
 					const otherUserId = externalParticipantIds[0] ?? conversationId;
-					const inferred = inferProfileFromDirectory(
-						otherUserId,
-						mentionDirectory,
-					);
-					profiles.set(participantProfileId, {
-						id: participantProfileId,
-						handle: inferred.handle,
-						displayName: inferred.displayName,
-						bio: `Imported from archive user ${otherUserId}`,
-						followersCount: 0,
-						followingCount: 0,
-						...defaultProfileMetadata,
-						avatarHue: 210,
-						avatarUrl: null,
-						createdAt: accountPayload.createdAt,
-					});
+					const existing = existingProfiles.get(participantProfileId);
+					if (existing) {
+						profiles.set(participantProfileId, {
+							id: participantProfileId,
+							handle: existing.handle,
+							displayName: existing.display_name,
+							bio: existing.bio,
+							followersCount: existing.followers_count,
+							followingCount: existing.following_count,
+							publicMetricsJson: existing.public_metrics_json,
+							avatarHue: existing.avatar_hue,
+							avatarUrl: existing.avatar_url,
+							location: existing.location,
+							url: existing.url,
+							verifiedType: existing.verified_type,
+							entitiesJson: existing.entities_json,
+							rawJson: existing.raw_json,
+							createdAt: existing.created_at,
+						});
+					} else {
+						const inferred = inferProfileFromDirectory(
+							otherUserId,
+							mentionDirectory,
+						);
+						profiles.set(participantProfileId, {
+							id: participantProfileId,
+							handle: inferred.handle,
+							displayName: inferred.displayName,
+							bio: `Imported from archive user ${otherUserId}`,
+							followersCount: 0,
+							followingCount: 0,
+							...defaultProfileMetadata,
+							avatarHue: 210,
+							avatarUrl: null,
+							createdAt: accountPayload.createdAt,
+						});
+					}
 				}
 			}
 

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -941,6 +941,21 @@ export async function importArchive(
 	const deleteFollowSnapshotMembers = db.prepare(
 		"delete from follow_snapshot_members where snapshot_id = ?",
 	);
+	const deleteArchiveFollowSnapshotMembers = db.prepare(`
+    delete from follow_snapshot_members
+    where snapshot_id in (
+      select id from follow_snapshots
+      where account_id = ? and direction = ? and source = 'archive'
+    )
+  `);
+	const deleteArchiveFollowSnapshots = db.prepare(`
+    delete from follow_snapshots
+    where account_id = ? and direction = ? and source = 'archive'
+  `);
+	const deleteArchiveFollowEdges = db.prepare(`
+    delete from follow_edges
+    where account_id = ? and direction = ? and source = 'archive'
+  `);
 	const selectFollowEdges = db.prepare(`
     select profile_id, external_user_id, current
     from follow_edges
@@ -1073,6 +1088,12 @@ export async function importArchive(
 		}
 	}
 
+	function clearArchiveFollowRows(direction: ArchiveFollowDirection) {
+		deleteArchiveFollowSnapshotMembers.run("acct_primary", direction);
+		deleteArchiveFollowSnapshots.run("acct_primary", direction);
+		deleteArchiveFollowEdges.run("acct_primary", direction);
+	}
+
 	db.transaction(() => {
 		insertAccount.run(
 			"acct_primary",
@@ -1174,6 +1195,8 @@ export async function importArchive(
 				followerEntries.length,
 				importedAt,
 			);
+		} else {
+			clearArchiveFollowRows("followers");
 		}
 		if (followingEntries.length > 0) {
 			importFollowRows(
@@ -1182,6 +1205,8 @@ export async function importArchive(
 				followingEntries.length,
 				importedAt,
 			);
+		} else {
+			clearArchiveFollowRows("following");
 		}
 	})();
 

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -524,6 +524,7 @@ export async function importArchive(
 			followersCount: number;
 			followingCount: number;
 			avatarHue: number;
+			avatarUrl: string | null;
 			createdAt: string;
 		}
 	>();
@@ -545,9 +546,47 @@ export async function importArchive(
 		[];
 	const followerIds = new Set<string>();
 	const followingIds = new Set<string>();
+	const existingProfiles = new Map(
+		(
+			getNativeDb()
+				.prepare(
+					`
+        select id, handle, display_name, bio, followers_count, following_count,
+          avatar_hue, avatar_url, created_at
+        from profiles
+      `,
+				)
+				.all() as Array<{
+				id: string;
+				handle: string;
+				display_name: string;
+				bio: string;
+				followers_count: number;
+				following_count: number;
+				avatar_hue: number;
+				avatar_url: string | null;
+				created_at: string;
+			}>
+		).map((profile) => [profile.id, profile]),
+	);
 
 	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
 		if (!profileId || profiles.has(profileId)) return;
+		const existing = existingProfiles.get(profileId);
+		if (existing) {
+			profiles.set(profileId, {
+				id: profileId,
+				handle: existing.handle,
+				displayName: existing.display_name,
+				bio: existing.bio,
+				followersCount: existing.followers_count,
+				followingCount: existing.following_count,
+				avatarHue: existing.avatar_hue,
+				avatarUrl: existing.avatar_url,
+				createdAt: existing.created_at,
+			});
+			return;
+		}
 		const fallbackId =
 			externalUserId || profileId.replace(/^profile_user_/, "");
 		profiles.set(profileId, {
@@ -558,6 +597,7 @@ export async function importArchive(
 			followersCount: 0,
 			followingCount: 0,
 			avatarHue: 210,
+			avatarUrl: null,
 			createdAt: accountPayload.createdAt,
 		});
 	}
@@ -570,6 +610,7 @@ export async function importArchive(
 		followersCount: 0,
 		followingCount: 0,
 		avatarHue: 18,
+		avatarUrl: null,
 		createdAt: accountPayload.createdAt,
 	};
 	profiles.set(localProfile.id, localProfile);
@@ -654,6 +695,7 @@ export async function importArchive(
 						followersCount: 0,
 						followingCount: 0,
 						avatarHue: 220,
+						avatarUrl: null,
 						createdAt: accountPayload.createdAt,
 					});
 				} else {
@@ -670,6 +712,7 @@ export async function importArchive(
 						followersCount: 0,
 						followingCount: 0,
 						avatarHue: 210,
+						avatarUrl: null,
 						createdAt: accountPayload.createdAt,
 					});
 				}
@@ -699,6 +742,7 @@ export async function importArchive(
 								followersCount: 0,
 								followingCount: 0,
 								avatarHue: 240,
+								avatarUrl: null,
 								createdAt: accountPayload.createdAt,
 							});
 						}
@@ -854,6 +898,7 @@ export async function importArchive(
 			followersCount: 0,
 			followingCount: 0,
 			avatarHue: 210,
+			avatarUrl: null,
 			createdAt: accountPayload.createdAt,
 		});
 	}
@@ -941,6 +986,15 @@ export async function importArchive(
 	const deleteFollowSnapshotMembers = db.prepare(
 		"delete from follow_snapshot_members where snapshot_id = ?",
 	);
+	const deleteArchiveFollowEvents = db.prepare(`
+    delete from follow_events
+    where account_id = ? and direction = ? and (
+      snapshot_id = ? or snapshot_id in (
+        select id from follow_snapshots
+        where account_id = ? and direction = ? and source = 'archive'
+      )
+    )
+  `);
 	const deleteArchiveFollowSnapshotMembers = db.prepare(`
     delete from follow_snapshot_members
     where snapshot_id in (
@@ -1092,6 +1146,13 @@ export async function importArchive(
 	}
 
 	function clearArchiveFollowRows(direction: ArchiveFollowDirection) {
+		deleteArchiveFollowEvents.run(
+			"acct_primary",
+			direction,
+			`follow_snapshot_archive_acct_primary_${direction}`,
+			"acct_primary",
+			direction,
+		);
 		deleteArchiveFollowSnapshotMembers.run("acct_primary", direction);
 		deleteArchiveFollowSnapshots.run("acct_primary", direction);
 		deleteArchiveFollowEdges.run("acct_primary", direction);
@@ -1116,7 +1177,7 @@ export async function importArchive(
 				profile.followersCount,
 				profile.followingCount,
 				profile.avatarHue,
-				null,
+				profile.avatarUrl,
 				profile.createdAt,
 			);
 		}

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -465,7 +465,9 @@ function buildShards(db: Database) {
 			case "tweet_account_edges":
 				for (const row of rowSet.rows) {
 					const kind =
-						row.kind === "home" || row.kind === "mention"
+						row.kind === "home" ||
+						row.kind === "mention" ||
+						row.kind === "authored"
 							? row.kind
 							: "unknown";
 					addRows(shards, `data/timeline_edges/${kind}.jsonl`, [row]);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -117,7 +117,7 @@ export interface TweetCollectionsTable {
 export interface TweetAccountEdgesTable {
 	account_id: string;
 	tweet_id: string;
-	kind: "home" | "mention";
+	kind: "home" | "mention" | "authored";
 	first_seen_at: string;
 	last_seen_at: string;
 	seen_count: number;

--- a/src/lib/tweet-account-edges.ts
+++ b/src/lib/tweet-account-edges.ts
@@ -1,6 +1,6 @@
 import type { Database } from "./sqlite";
 
-export type TweetAccountEdgeKind = "home" | "mention";
+export type TweetAccountEdgeKind = "home" | "mention" | "authored";
 
 export function upsertTweetAccountEdge(
 	db: Database,


### PR DESCRIPTION
## Update 2026-05-13 — also creates `authored` edges at import (commit `74fa78f`)

Adds one more import-time change discovered during integration testing: when a tweet's `author_profile_id` matches the imported account's profile, also write a `tweet_account_edges` row with `kind='authored'` alongside the existing `home`-edge insert. Reuses the same `insertTimelineEdge` prepared statement (`source='archive'`, idempotent on re-import).

**Why.** Without this, archive-first users land 19k+ own-tweets in `tweets` but `tweet_account_edges` has zero `authored` rows for them. `birdclaw sync authored` then walks the entire xurl timeline after import to add labels for tweets the DB already has, paying X ~$0.001/tweet for relabeling local data. Empirical from one archive: 19,318 own-tweets in `tweets` with matching `author_profile_id`, only 50 had `authored` edges before this patch.

**Scope.** Archive code path only. From-scratch (no-archive) users are unchanged. Regression test (`creates authored edges for archive-imported account tweets`) asserts 1:1 coverage of own-tweets → `authored` edges after import with `source='archive'` and `first_seen_at`/`last_seen_at` set to each tweet's `created_at`. Full test suite still green (436 passed).

---

## Summary

Extends `birdclaw import archive` to parse `data/follower.js` and `data/following.js` from a Twitter archive ZIP into the canonical `follow_edges` table. A fresh install with just an archive — no `bird` and no `xurl` — gets a usable follow graph: `birdclaw graph summary`, `graph mutuals`, `graph top-followers`, etc. all work against archive-imported edges. Live `sync followers/following` can layer churn on top later.

The archive-overlap correctness path collapsed into a single classifier + merge predicate inside `archive-import.ts`. `d88485a` introduces a 4-tier profile classification (`archive_follow_stub < archive_dm_stub < archive_mention_inferred < live_or_hydrated`) and routes archive follow stubs and one-on-one DM participant profiles through one `mergeArchiveProfile()` predicate. `45b7627` extends the predicate to a 3-way comparison across the in-run map, the existing DB row, and the incoming row so a higher-tier DB row is hoisted into the run even when a lower-tier stub was already written. The structural fix centralizes the invariant earlier per-site patches (`8b7c2fd`, `ed2ae00`, `ee73efb`) were chasing. Earlier commits preserve follow event visibility, make snapshots idempotent across re-imports, and clear stale archive rows when the archive omits a previously-imported file.

> AI-assisted: written with Codex and reviewed with `codex review --base upstream/main` before opening.

## Real behavior proof

Environment: macOS, `birdclaw@0.4.1`, HEAD `45b7627` via `pnpm exec tsx src/cli.ts`. Smoke runs against a clean `BIRDCLAW_HOME=/tmp/bc-pr3-smoke` with a 2.0 GB Twitter archive of `@caviterginsoy`.

```bash
BIRDCLAW_HOME=/tmp/bc-pr3-smoke pnpm --silent exec tsx src/cli.ts \
  import archive ~/Downloads/twitter-2026-05-12-...zip --json
```

Real output (selected fields):

```json
{
  "ok": true,
  "archivePath": ".../twitter-2026-05-12-...zip",
  "account": { "id": "37755246", "handle": "caviterginsoy", "displayName": "Cavit Erginsoy" },
  "counts": {
    "tweets": 19317, "likes": 9458, "bookmarks": 0,
    "dmConversations": 257, "dmMessages": 770, "profiles": 3062,
    "followers": 1544, "following": 1534
  }
}
```

Follow graph queryable immediately after import — no live transport involved:

```bash
BIRDCLAW_HOME=/tmp/bc-pr3-smoke pnpm --silent exec tsx src/cli.ts graph summary --json
```

```json
{
  "accountId": "acct_primary",
  "followers": 1544,
  "following": 1534,
  "mutuals": 219,
  "nonMutualFollowing": 1315,
  "lastCompleteSnapshots": {
    "followers": "2026-05-13T06:41:13.588Z",
    "following": "2026-05-13T06:41:13.588Z"
  },
  "lastIncompleteSnapshots": {}
}
```

Re-running `import archive` on the same archive is idempotent: no duplicate edges, events, or snapshots. Switching to a fresher archive tops up new edges and records churn via `follow_events`.

## What ends up where

Per-archive entry becomes a stub `profiles` row plus a current `follow_edges` row (`direction='followers'` or `'following'`). New archive-only edges get `source='archive'`; overlapping live edges keep their existing `xurl`/`bird` source while current state is updated. Edge totals land in the result envelope under `counts.followers` / `counts.following`. After live profile hydration via `import hydrate-profiles` or `sync followers --yes`, the live data is preserved across subsequent archive re-imports — the merge predicate keeps any row carrying live signals (metrics, avatar, location, url, verified_type, entities or raw_json beyond defaults) over an incoming archive stub.

## Verification

- `pnpm check && pnpm build && pnpm test` — 435 tests passing on `45b7627`
- `codex review` on the structural-fix commit (`d88485a`) and on the 3-way merge commit (`45b7627`) — both clean; the chain of preservation findings is closed
- Smoke above against a fresh `BIRDCLAW_HOME`

## What was not tested live

- Archive without `follower.js`/`following.js` (parser handles absence; covered by unit tests)
- Live fresher-archive top-up against a real account (initial `started` and `ended` churn events covered by unit tests, full top-up smoke not exercised in this PR)
- `import hydrate-profiles` after archive import (existing path; not added by this PR)

## Compatibility

Backward compatible. No migration. Writes into existing `profiles`, `follow_edges`, `follow_snapshots`, `follow_snapshot_members`, `follow_events`. Archives without follow files are handled by the same parser entry point — no regression.

## Noticed but left for steipete (not in this PR)

`docs/cli.md` on `main` documents `import archive` with `--select / --dm-mode / --dry-run / --force` flags that aren't registered in `src/cli.ts`. Pre-existing on main; not a regression introduced here.

## Related PRs

This is one of a coordinated 5-PR set:

- [#18 — `--early-stop` dedupe-saturation on sync likes/bookmarks](https://github.com/steipete/birdclaw/pull/18)
- [#19 — `sync authored` for own-tweets gap](https://github.com/steipete/birdclaw/pull/19)
- [#20 — `sync mentions` + `--mode xurl` on `sync mention-threads`](https://github.com/steipete/birdclaw/pull/20)
- [#21 — `media fetch` + archive media extraction](https://github.com/steipete/birdclaw/pull/21)
- #22 — archive `follower.js`/`following.js` parsing into follow graph (this PR)

Each is independently mergeable against current `main`. After the first merges, the others may surface small rebase conflicts in shared docs (`docs/cli.md`, `docs/sync.md`, `README.md`), shared type unions (`TweetAccountEdgeKind`, `XurlMentionData`, `XurlTweetData`), and the `sync` command tree in `src/cli.ts`. All are "both branches added entries to the same list/union" pattern — "keep both" resolves every one. Verified by integrating all 5 locally on a single branch; 510/510 tests pass across the merged set.

One CI heads-up if you merge two or more before rebasing: `src/lib/xurl.test.ts`'s expected URL asserts a specific query-param order; that order shifts deterministically when #19's `RICH_USER_FIELDS` / `THREAD_TWEET_FIELDS` and #21's `MEDIA_EXPANSION` / `MEDIA_FIELDS` both exist on `main`. One-line test expectation update covers it.

