### PR TITLE
feat(sync): cap /bookmarks max_results at 90 to dodge X API pagination bug

### DIFF
--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -188,6 +188,45 @@ describe("live timeline collection sync", () => {
 		).toHaveLength(2);
 	});
 
+	it("marks bookmark xurl walks as paginated for the max_results cap", async () => {
+		setupTempHome();
+		mocks.listBookmarkedTweetsViaXurl
+			.mockResolvedValueOnce({
+				data: [],
+				meta: { next_token: "next-page" },
+			})
+			.mockResolvedValueOnce({
+				data: [],
+				meta: {},
+			});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		await syncTimelineCollection({
+			kind: "bookmarks",
+			mode: "xurl",
+			limit: 100,
+			all: true,
+			refresh: true,
+		});
+
+		expect(mocks.listBookmarkedTweetsViaXurl).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				maxResults: 100,
+				isPaginatedWalk: true,
+			}),
+		);
+		expect(mocks.listBookmarkedTweetsViaXurl).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				maxResults: 100,
+				isPaginatedWalk: true,
+				paginationToken: "next-page",
+			}),
+		);
+	});
+
 	it("falls back to bird for bookmarks when xurl fails", async () => {
 		setupTempHome();
 		mocks.lookupUsersByHandles.mockResolvedValue([{ id: "25401953" }]);

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -283,6 +283,7 @@ async function fetchXurlCollection({
 						maxResults: limit,
 						username,
 						userId: resolvedUserId,
+						isPaginatedWalk: all,
 						paginationToken: nextToken,
 					});
 		pages.push(payload);

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -412,6 +412,54 @@ describe("xurl transport wrapper", () => {
 		]);
 	});
 
+	it("caps bookmark max_results only for paginated walks", async () => {
+		execFileAsyncMock
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ data: [] }),
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ data: [] }),
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ data: [] }),
+				stderr: "",
+			});
+		const { listBookmarkedTweetsViaXurl, listLikedTweetsViaXurl } =
+			await import("./xurl");
+
+		await listBookmarkedTweetsViaXurl({
+			maxResults: 100,
+			userId: "25401953",
+			isPaginatedWalk: true,
+		});
+		await listBookmarkedTweetsViaXurl({
+			maxResults: 100,
+			userId: "25401953",
+		});
+		await listLikedTweetsViaXurl({
+			maxResults: 100,
+			userId: "25401953",
+		});
+
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, "xurl", [
+			"--auth",
+			"oauth2",
+			`/2/users/25401953/bookmarks?max_results=90&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=${RICH_USER_FIELDS}`,
+		]);
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, "xurl", [
+			"--auth",
+			"oauth2",
+			`/2/users/25401953/bookmarks?max_results=100&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=${RICH_USER_FIELDS}`,
+		]);
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(3, "xurl", [
+			"--auth",
+			"oauth2",
+			`/2/users/25401953/liked_tweets?max_results=100&expansions=author_id&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&user.fields=${RICH_USER_FIELDS}`,
+		]);
+	});
+
 	it("lists follow users through OAuth2 endpoints with pagination", async () => {
 		execFileAsyncMock.mockResolvedValueOnce({
 			stdout: JSON.stringify({

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -14,6 +14,11 @@ const execFileAsync = promisify(execFile);
 const TRANSPORT_STATUS_TTL_MS = 5 * 60_000;
 const AUTHENTICATED_USER_TTL_MS = 60_000;
 const JSON_RETRY_LIMIT = 6;
+// X bookmarks pagination truncates above 90 until this bug is fixed:
+// https://devcommunity.x.com/t/bookmarks-api-v2-stops-paginating-after-3-pages-no-next-token-returned/257339
+const BOOKMARKS_MAX_RESULTS_CAP = 90;
+
+type TimelineCollectionEndpoint = "liked_tweets" | "bookmarks";
 
 let transportStatusCache:
 	| {
@@ -103,6 +108,16 @@ function getRetryDelayMs(error: unknown, attempt: number) {
 
 	const baseDelay = getJsonRetryBaseDelayMs();
 	return Math.min(baseDelay * 2 ** attempt, 30_000);
+}
+
+function capTimelineCollectionMaxResults(
+	collection: TimelineCollectionEndpoint,
+	maxResults: number,
+	isPaginatedWalk: boolean,
+) {
+	return collection === "bookmarks" && isPaginatedWalk
+		? Math.min(maxResults, BOOKMARKS_MAX_RESULTS_CAP)
+		: maxResults;
 }
 
 async function sleep(ms: number) {
@@ -388,12 +403,14 @@ async function listTimelineCollectionViaXurl({
 	maxResults,
 	username,
 	userId,
+	isPaginatedWalk = false,
 	paginationToken,
 }: {
-	collection: "liked_tweets" | "bookmarks";
+	collection: TimelineCollectionEndpoint;
 	maxResults: number;
 	username?: string;
 	userId?: string;
+	isPaginatedWalk?: boolean;
 	paginationToken?: string;
 }): Promise<XurlMentionsResponse> {
 	let resolvedUserId = userId;
@@ -413,8 +430,13 @@ async function listTimelineCollectionViaXurl({
 		}
 	}
 
+	const requestMaxResults = capTimelineCollectionMaxResults(
+		collection,
+		maxResults,
+		isPaginatedWalk,
+	);
 	const query = new URLSearchParams({
-		max_results: String(maxResults),
+		max_results: String(requestMaxResults),
 		expansions: "author_id",
 		"tweet.fields":
 			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
@@ -461,6 +483,7 @@ export async function listBookmarkedTweetsViaXurl(options: {
 	maxResults: number;
 	username?: string;
 	userId?: string;
+	isPaginatedWalk?: boolean;
 	paginationToken?: string;
 }): Promise<XurlMentionsResponse> {
 	return listTimelineCollectionViaXurl({


### PR DESCRIPTION
## Summary

`GET /2/users/:id/bookmarks` with `max_results=100` can stop early with `next_token: null`; `max_results=90` paginates to exhaustion. X staff confirmed the server-side bug in [dev forum thread #257339](https://devcommunity.x.com/t/bookmarks-api-v2-stops-paginating-after-3-pages-no-next-token-returned/257339).

On the repro account, `max_results=100` returned 98/1,120 bookmarks; `max_results=90` returned all 1,120 across 13 pages.

This caps `max_results` at 90 only for `/bookmarks` paginated walks in the xurl request builder. Single-page bookmark reads and other sync endpoints keep their requested value.

`BOOKMARKS_MAX_RESULTS_CAP` lives in `src/lib/xurl.ts` with the dev forum link for removal when X fixes the bug.

> AI-assisted: written with Codex and reviewed with `codex review --uncommitted` before opening.
