### PR TITLE
Polish feed states and conversation loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Add shared web feed loading/error/empty states with timeline-shaped skeleton rows and move conversation expansion into a cached single-thread surface with hover prefetch.
 - Use the Birdclaw crab-bird mark in the web app chrome, loading states, and empty states; soften dark-mode contrast and replace text-only reply warnings with conversation/replied indicators.
 - Allow the local web app to respond when Tailscale Serve forwards requests through the `clawmac.sheep-coho.ts.net` hostname.
 - Speed up the default home timeline load on large local databases and keep malformed archived media URL entities from crashing the web timeline.

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -66,6 +66,7 @@ test("shows the animated Birdclaw mark while the timeline loads", async ({
 	await expect(
 		page.locator('.birdclaw-mark-animated img[src="/birdclaw-mark.png"]'),
 	).toBeVisible();
+	await expect(page.locator('[data-perf="tweet-skeleton-row"]')).toHaveCount(4);
 	await expect(page.getByText("No posts to show")).toHaveCount(0);
 });
 
@@ -148,7 +149,7 @@ test("browses link insights across links, videos, filters, and comments", async 
 	).toBeVisible();
 
 	await page.getByRole("button", { name: "dm" }).click();
-	await expect(page.getByText("No links in this window.")).toBeVisible();
+	await expect(page.getByText("No links in this window")).toBeVisible();
 });
 
 test("replies to an unreplied mention and clears it from the queue", async ({

--- a/src/components/FeedState.test.tsx
+++ b/src/components/FeedState.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	LinkSkeletonRows,
+	TweetSkeletonRows,
+} from "./FeedState";
+
+describe("FeedState", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders loading copy and row skeletons", () => {
+		const { container } = render(
+			<FeedLoading detail="Reading local posts" label="Loading posts">
+				<TweetSkeletonRows count={5} />
+				<LinkSkeletonRows count={3} />
+			</FeedLoading>,
+		);
+
+		expect(screen.getByText("Loading posts")).toBeInTheDocument();
+		expect(screen.getByText("Reading local posts")).toBeInTheDocument();
+		expect(
+			container.querySelectorAll('[data-perf="tweet-skeleton-row"]'),
+		).toHaveLength(5);
+		expect(
+			container.querySelectorAll('[data-perf="link-skeleton-row"]'),
+		).toHaveLength(3);
+	});
+
+	it("renders empty and error variants", () => {
+		const { rerender } = render(
+			<FeedEmpty detail="Try a different filter" label="No posts" />,
+		);
+
+		expect(screen.getByText("No posts")).toBeInTheDocument();
+		expect(screen.getByText("Try a different filter")).toBeInTheDocument();
+
+		rerender(<FeedError message="Network unavailable" />);
+		expect(screen.getByText("Could not load this view")).toBeInTheDocument();
+		expect(screen.getByText("Network unavailable")).toBeInTheDocument();
+
+		rerender(
+			<FeedError
+				action={<button type="button">Retry</button>}
+				message="Link insights unavailable"
+				title="Could not load links"
+			/>,
+		);
+		expect(screen.getByText("Could not load links")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+	});
+});

--- a/src/components/FeedState.tsx
+++ b/src/components/FeedState.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode } from "react";
+import { BirdclawEmpty, BirdclawLoading } from "./BrandMark";
+
+function SkeletonBlock({
+	className,
+	muted = false,
+}: {
+	className: string;
+	muted?: boolean;
+}) {
+	return (
+		<span
+			aria-hidden="true"
+			className={`block animate-pulse rounded-full ${muted ? "bg-[color:color-mix(in_srgb,var(--ink-soft)_16%,transparent)]" : "bg-[color:color-mix(in_srgb,var(--ink-soft)_24%,transparent)]"} ${className}`}
+		/>
+	);
+}
+
+export function TweetSkeletonRows({ count = 4 }: { count?: number }) {
+	return (
+		<div aria-hidden="true" className="divide-y divide-[var(--line)]">
+			{Array.from({ length: count }, (_unused, index) => {
+				const hasMedia = index % 3 === 0;
+				const hasQuote = index % 4 === 2;
+				return (
+					<article
+						className="flex gap-3 px-4 py-3"
+						data-perf="tweet-skeleton-row"
+						key={`tweet-skeleton-${index}`}
+					>
+						<SkeletonBlock className="size-10 shrink-0 rounded-full" />
+						<div className="min-w-0 flex-1 space-y-3">
+							<div className="flex items-center gap-2">
+								<SkeletonBlock className="h-3.5 w-32" />
+								<SkeletonBlock className="h-3 w-20" muted />
+								<SkeletonBlock className="ml-auto h-5 w-16" muted />
+							</div>
+							<div className="space-y-2">
+								<SkeletonBlock className="h-3 w-full" />
+								<SkeletonBlock className="h-3 w-11/12" muted />
+								{index % 2 === 0 ? (
+									<SkeletonBlock className="h-3 w-7/12" muted />
+								) : null}
+							</div>
+							{hasMedia ? (
+								<SkeletonBlock className="h-32 w-full rounded-2xl" muted />
+							) : null}
+							{hasQuote ? (
+								<div className="space-y-2 rounded-2xl border border-[var(--line)] px-3 py-2">
+									<SkeletonBlock className="h-3 w-28" muted />
+									<SkeletonBlock className="h-3 w-full" muted />
+								</div>
+							) : null}
+							<div className="flex max-w-md items-center justify-between">
+								{["thread", "reply", "repost", "like"].map((key) => (
+									<SkeletonBlock className="h-3 w-11" key={key} muted />
+								))}
+							</div>
+						</div>
+					</article>
+				);
+			})}
+		</div>
+	);
+}
+
+export function LinkSkeletonRows({ count = 4 }: { count?: number }) {
+	return (
+		<div aria-hidden="true" className="divide-y divide-[var(--line)]">
+			{Array.from({ length: count }, (_unused, index) => (
+				<article
+					className="flex gap-3 px-4 py-3"
+					data-perf="link-skeleton-row"
+					key={`link-skeleton-${index}`}
+				>
+					<SkeletonBlock className="size-9 shrink-0 rounded-full" muted />
+					<div className="min-w-0 flex-1 space-y-3">
+						<SkeletonBlock className="h-3.5 w-8/12" />
+						<SkeletonBlock className="h-3 w-6/12" muted />
+						<div className="flex flex-wrap gap-2">
+							<SkeletonBlock className="h-3 w-20" muted />
+							<SkeletonBlock className="h-3 w-14" muted />
+							<SkeletonBlock className="h-3 w-24" muted />
+						</div>
+						{index % 2 === 0 ? (
+							<SkeletonBlock
+								className="h-20 w-72 max-w-full rounded-2xl"
+								muted
+							/>
+						) : null}
+					</div>
+				</article>
+			))}
+		</div>
+	);
+}
+
+export function FeedLoading({
+	children,
+	detail,
+	label,
+}: {
+	children?: ReactNode;
+	detail?: string;
+	label: string;
+}) {
+	return (
+		<div className="border-b border-[var(--line)]">
+			<BirdclawLoading detail={detail} label={label} />
+			{children}
+		</div>
+	);
+}
+
+export function FeedError({
+	action,
+	message,
+	title = "Could not load this view",
+}: {
+	action?: ReactNode;
+	message: string;
+	title?: string;
+}) {
+	return (
+		<div className="border-b border-[var(--line)] px-6 py-10 text-center">
+			<div className="mx-auto max-w-sm">
+				<div className="text-[14px] font-bold text-[var(--alert)]">{title}</div>
+				<p className="mt-2 text-[13px] leading-[1.45] text-[var(--ink-soft)]">
+					{message}
+				</p>
+				{action ? (
+					<div className="mt-4 flex justify-center">{action}</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+export function FeedEmpty({
+	detail,
+	label,
+}: {
+	detail?: string;
+	label: string;
+}) {
+	return <BirdclawEmpty detail={detail} label={label} />;
+}

--- a/src/components/SavedTimelineView.test.tsx
+++ b/src/components/SavedTimelineView.test.tsx
@@ -227,4 +227,44 @@ describe("SavedTimelineView", () => {
 		});
 		expect(promptSpy).toHaveBeenCalledTimes(2);
 	});
+
+	it("shows a retryable error when saved posts fail to load", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				throw new Error("Saved store unavailable");
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SavedTimelineView
+				eyebrow="bookmarks"
+				filter="bookmarked"
+				loadingLabel="Loading bookmarks..."
+				searchPlaceholder="Search bookmarks"
+				title="Bookmarks"
+			/>,
+		);
+
+		expect(
+			await screen.findByText("Could not load bookmarks"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Saved store unavailable")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+	});
 });

--- a/src/components/SavedTimelineView.tsx
+++ b/src/components/SavedTimelineView.tsx
@@ -1,7 +1,13 @@
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { BirdclawEmpty, BirdclawLoading } from "#/components/BrandMark";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	TweetSkeletonRows,
+} from "#/components/FeedState";
 import { TimelineCard } from "#/components/TimelineCard";
+import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type { QueryEnvelope, QueryResponse, TimelineItem } from "#/lib/types";
 import {
 	feedClass,
@@ -36,6 +42,7 @@ export function SavedTimelineView({
 	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
 	const [items, setItems] = useState<TimelineItem[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
 
@@ -54,11 +61,42 @@ export function SavedTimelineView({
 			url.searchParams.set("search", search.trim());
 		}
 
+		const controller = new AbortController();
+		let active = true;
+		setError(null);
 		setLoading(true);
-		fetch(url)
+		fetch(url, { signal: controller.signal })
 			.then((response) => response.json())
-			.then((data: QueryResponse) => setItems(data.items as TimelineItem[]))
-			.finally(() => setLoading(false));
+			.then((data: QueryResponse) => {
+				if (active) {
+					setItems(data.items as TimelineItem[]);
+				}
+			})
+			.catch((fetchError: unknown) => {
+				if (
+					fetchError instanceof DOMException &&
+					fetchError.name === "AbortError"
+				) {
+					return;
+				}
+				if (!active) return;
+				setError(
+					fetchError instanceof Error
+						? fetchError.message
+						: `${TITLES[filter]} unavailable`,
+				);
+				setItems([]);
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			active = false;
+			controller.abort();
+		};
 	}, [filter, refreshTick, search]);
 
 	const subtitle = useMemo(() => {
@@ -110,27 +148,45 @@ export function SavedTimelineView({
 					</label>
 				</div>
 			</header>
-			<section className={feedClass}>
-				{loading ? (
-					<BirdclawLoading
-						detail={`Reading local ${TITLES[filter].toLowerCase()}`}
-						label={loadingLabel}
-					/>
-				) : items.length === 0 ? (
-					<BirdclawEmpty
-						detail="Sync this collection or broaden the search."
-						label="Nothing saved here yet"
-					/>
-				) : null}
-				{items.map((item) => (
-					<TimelineCard
-						key={item.id}
-						item={item}
-						onReply={replyToTweet}
-						showReplyControls={false}
-					/>
-				))}
-			</section>
+			<ConversationSurfaceScope>
+				<section className={feedClass}>
+					{loading ? (
+						<FeedLoading
+							detail={`Reading local ${TITLES[filter].toLowerCase()}`}
+							label={loadingLabel}
+						>
+							<TweetSkeletonRows />
+						</FeedLoading>
+					) : error ? (
+						<FeedError
+							action={
+								<button
+									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+									onClick={() => setRefreshTick((value) => value + 1)}
+									type="button"
+								>
+									Retry
+								</button>
+							}
+							message={error}
+							title={`Could not load ${TITLES[filter].toLowerCase()}`}
+						/>
+					) : items.length === 0 ? (
+						<FeedEmpty
+							detail="Sync this collection or broaden the search."
+							label="Nothing saved here yet"
+						/>
+					) : null}
+					{items.map((item) => (
+						<TimelineCard
+							key={item.id}
+							item={item}
+							onReply={replyToTweet}
+							showReplyControls={false}
+						/>
+					))}
+				</section>
+			</ConversationSurfaceScope>
 		</>
 	);
 }

--- a/src/components/TimelineCard.test.tsx
+++ b/src/components/TimelineCard.test.tsx
@@ -6,6 +6,7 @@ import {
 	within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetConversationSurface } from "#/lib/conversation-surface";
 import { TimelineCard } from "./TimelineCard";
 
 const item = {
@@ -105,6 +106,7 @@ const item = {
 describe("TimelineCard", () => {
 	afterEach(() => {
 		cleanup();
+		resetConversationSurface();
 		vi.unstubAllGlobals();
 	});
 
@@ -554,5 +556,68 @@ describe("TimelineCard", () => {
 		expect(await screen.findByText("Parent in thread")).toBeInTheDocument();
 		expect(screen.getByText("2 tweets in conversation")).toBeInTheDocument();
 		expect(screen.getByText("selected")).toBeInTheDocument();
+	});
+
+	it("prefetches conversation context on hover and keeps one thread open", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const tweetId = new URL(
+				String(input),
+				"http://localhost",
+			).searchParams.get("tweetId");
+			return {
+				ok: true,
+				json: async () => ({
+					ok: true,
+					anchorId: tweetId,
+					items: [
+						{
+							id: tweetId,
+							text: `Conversation for ${tweetId}`,
+							createdAt: "2026-03-08T12:00:00.000Z",
+							replyToId: null,
+							author: item.author,
+							entities: {},
+							media: [],
+						},
+						{
+							id: `${tweetId}_reply`,
+							text: `Reply for ${tweetId}`,
+							createdAt: "2026-03-08T12:01:00.000Z",
+							replyToId: tweetId,
+							author: item.author,
+							entities: {},
+							media: [],
+						},
+					],
+				}),
+			};
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const { container } = render(
+			<>
+				<TimelineCard item={{ ...item, id: "tweet_a" }} onReply={vi.fn()} />
+				<TimelineCard item={{ ...item, id: "tweet_b" }} onReply={vi.fn()} />
+			</>,
+		);
+		const rows = container.querySelectorAll("[data-perf='timeline-card']");
+		const first = rows[0];
+		const second = rows[1];
+		if (!first || !second) throw new Error("timeline cards missing");
+
+		fireEvent.mouseEnter(first);
+		expect(fetchMock).toHaveBeenCalledWith("/api/conversation?tweetId=tweet_a");
+
+		fireEvent.click(first);
+		expect(
+			await screen.findByText("Conversation for tweet_a"),
+		).toBeInTheDocument();
+
+		fireEvent.click(second);
+		expect(
+			await screen.findByText("Conversation for tweet_b"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Conversation for tweet_a"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
 	Bookmark,
 	BookmarkCheck,
@@ -10,12 +9,12 @@ import {
 } from "lucide-react";
 import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
 import type {
-	EmbeddedTweet,
 	TimelineItem,
 	TweetEntities,
 	TweetMediaItem,
 	TweetUrlEntity,
 } from "#/lib/types";
+import { useConversationSurface } from "#/lib/conversation-surface";
 import {
 	cx,
 	embeddedCardClass,
@@ -158,14 +157,7 @@ export function TimelineCard({
 }) {
 	const canReply =
 		showReplyControls && item.kind !== "like" && item.kind !== "bookmark";
-	const [conversationOpen, setConversationOpen] = useState(false);
-	const [conversationLoading, setConversationLoading] = useState(false);
-	const [conversationError, setConversationError] = useState<string | null>(
-		null,
-	);
-	const [conversationItems, setConversationItems] = useState<EmbeddedTweet[]>(
-		[],
-	);
+	const conversation = useConversationSurface(item.id);
 	const visibleEntities = getVisibleEntities(
 		item.entities,
 		item.media,
@@ -178,47 +170,15 @@ export function TimelineCard({
 	);
 	const hasConversation = Boolean(item.replyToTweet || item.replyToId);
 
-	async function loadConversation() {
-		if (conversationLoading || conversationItems.length > 0) return;
-		setConversationLoading(true);
-		setConversationError(null);
-		try {
-			const response = await fetch(
-				`/api/conversation?tweetId=${encodeURIComponent(item.id)}`,
-			);
-			const data = (await response.json()) as {
-				ok?: boolean;
-				error?: string;
-				items?: EmbeddedTweet[];
-			};
-			if (!response.ok || data.ok === false) {
-				throw new Error(data.error ?? "Conversation unavailable");
-			}
-			setConversationItems((data.items ?? []).filter(Boolean));
-		} catch (error) {
-			setConversationError(
-				error instanceof Error ? error.message : "Conversation unavailable",
-			);
-		} finally {
-			setConversationLoading(false);
-		}
-	}
-
-	function toggleConversation() {
-		const nextOpen = !conversationOpen;
-		setConversationOpen(nextOpen);
-		if (nextOpen) {
-			void loadConversation();
-		}
-	}
-
 	return (
 		<article
 			className={cx(feedRowClass, "cursor-pointer")}
 			data-perf="timeline-card"
+			onFocus={conversation.prefetch}
+			onMouseEnter={conversation.prefetch}
 			onClick={(event) => {
 				if (isInteractiveTarget(event.target)) return;
-				toggleConversation();
+				conversation.toggle();
 			}}
 		>
 			<AvatarChip
@@ -305,14 +265,14 @@ export function TimelineCard({
 				<footer className={feedRowActionsClass}>
 					<div className="flex items-center gap-3 text-[13px] text-[var(--ink-soft)]">
 						<button
-							aria-expanded={conversationOpen}
+							aria-expanded={conversation.isOpen}
 							aria-label={
-								conversationOpen ? "Hide conversation" : "Show conversation"
+								conversation.isOpen ? "Hide conversation" : "Show conversation"
 							}
 							className={feedActionButtonClass}
 							onClick={(event) => {
 								event.stopPropagation();
-								toggleConversation();
+								conversation.toggle();
 							}}
 							type="button"
 						>
@@ -323,7 +283,7 @@ export function TimelineCard({
 								/>
 							</span>
 							<span className="text-[13px]">
-								{conversationOpen ? "Hide thread" : "Thread"}
+								{conversation.isOpen ? "Hide thread" : "Thread"}
 							</span>
 						</button>
 						{canReply ? (
@@ -393,12 +353,12 @@ export function TimelineCard({
 						<span>{item.accountHandle}</span>
 					</div>
 				</footer>
-				{conversationOpen ? (
+				{conversation.isOpen ? (
 					<ConversationThread
 						anchorId={item.id}
-						error={conversationError}
-						items={conversationItems}
-						loading={conversationLoading}
+						error={conversation.error}
+						items={conversation.items}
+						loading={conversation.loading}
 					/>
 				) : null}
 			</div>

--- a/src/lib/conversation-surface.test.tsx
+++ b/src/lib/conversation-surface.test.tsx
@@ -1,0 +1,129 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ConversationSurfaceScope,
+	resetConversationSurface,
+	useConversationSurface,
+} from "./conversation-surface";
+import type { EmbeddedTweet } from "./types";
+
+interface ConversationResponse {
+	json: () => Promise<{ items: EmbeddedTweet[]; ok: true }>;
+	ok: true;
+}
+
+const tweet: EmbeddedTweet = {
+	author: {
+		avatarHue: 120,
+		bio: "",
+		createdAt: "2026-03-08T11:00:00.000Z",
+		displayName: "Ava",
+		followersCount: 10,
+		handle: "ava",
+		id: "profile_ava",
+	},
+	createdAt: "2026-03-08T12:00:00.000Z",
+	entities: {},
+	id: "tweet_1",
+	media: [],
+	replyToId: null,
+	text: "Conversation anchor",
+};
+
+function Probe({ tweetId }: { tweetId: string }) {
+	const surface = useConversationSurface(tweetId);
+	return (
+		<div>
+			<div data-testid="status">{surface.status}</div>
+			<div data-testid="open">{surface.isOpen ? "open" : "closed"}</div>
+			<div data-testid="items">{surface.items.length}</div>
+			<div data-testid="error">{surface.error ?? ""}</div>
+			<button onClick={surface.prefetch} type="button">
+				prefetch
+			</button>
+			<button onClick={surface.toggle} type="button">
+				toggle
+			</button>
+		</div>
+	);
+}
+
+describe("conversation surface", () => {
+	afterEach(() => {
+		cleanup();
+		resetConversationSurface();
+		vi.unstubAllGlobals();
+	});
+
+	it("caches ready conversations and skips pending prefetches", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ items: [tweet], ok: true }),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<ConversationSurfaceScope>
+				<Probe tweetId="tweet_1" />
+			</ConversationSurfaceScope>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "prefetch" }));
+		fireEvent.click(screen.getByRole("button", { name: "prefetch" }));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("status")).toHaveTextContent("ready");
+		});
+		expect(screen.getByTestId("items")).toHaveTextContent("1");
+
+		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+		expect(screen.getByTestId("open")).toHaveTextContent("open");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("stores load errors and ignores results after reset", async () => {
+		let resolveStale!: (value: ConversationResponse) => void;
+		const staleResponse = new Promise<ConversationResponse>((resolve) => {
+			resolveStale = resolve;
+		});
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				json: async () => ({ error: "Tweet not found", ok: false }),
+			})
+			.mockReturnValueOnce(staleResponse);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<ConversationSurfaceScope>
+				<Probe tweetId="tweet_404" />
+			</ConversationSurfaceScope>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+		await waitFor(() => {
+			expect(screen.getByTestId("status")).toHaveTextContent("error");
+		});
+		expect(screen.getByTestId("error")).toHaveTextContent("Tweet not found");
+
+		fireEvent.click(screen.getByRole("button", { name: "prefetch" }));
+		expect(screen.getByTestId("status")).toHaveTextContent("loading");
+		resetConversationSurface();
+		resolveStale({
+			ok: true,
+			json: async () => ({ items: [tweet], ok: true }),
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("status")).toHaveTextContent("idle");
+		});
+	});
+});

--- a/src/lib/conversation-surface.ts
+++ b/src/lib/conversation-surface.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
+import type { EmbeddedTweet } from "#/lib/types";
+
+type ConversationStatus = "idle" | "loading" | "ready" | "error";
+
+interface ConversationRecord {
+	error: string | null;
+	items: EmbeddedTweet[];
+	status: ConversationStatus;
+}
+
+interface ConversationSurfaceSnapshot {
+	expandedTweetId: string | null;
+	records: ReadonlyMap<string, ConversationRecord>;
+}
+
+type Listener = () => void;
+
+const emptyRecord: ConversationRecord = {
+	error: null,
+	items: [],
+	status: "idle",
+};
+
+let snapshot: ConversationSurfaceSnapshot = {
+	expandedTweetId: null,
+	records: new Map(),
+};
+const listeners = new Set<Listener>();
+const inFlight = new Set<string>();
+let activeScopes = 0;
+let generation = 0;
+
+function emit() {
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+function setSnapshot(next: ConversationSurfaceSnapshot) {
+	snapshot = next;
+	emit();
+}
+
+function updateRecord(tweetId: string, record: ConversationRecord) {
+	const records = new Map(snapshot.records);
+	records.set(tweetId, record);
+	setSnapshot({ ...snapshot, records });
+}
+
+function subscribe(listener: Listener) {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+function getSnapshot() {
+	return snapshot;
+}
+
+async function loadConversation(tweetId: string) {
+	const current = snapshot.records.get(tweetId);
+	if (current?.status === "ready" || inFlight.has(tweetId)) {
+		return;
+	}
+
+	const loadGeneration = generation;
+	inFlight.add(tweetId);
+	updateRecord(tweetId, {
+		error: null,
+		items: current?.items ?? [],
+		status: "loading",
+	});
+
+	try {
+		const response = await fetch(
+			`/api/conversation?tweetId=${encodeURIComponent(tweetId)}`,
+		);
+		const data = (await response.json()) as {
+			error?: string;
+			items?: EmbeddedTweet[];
+			ok?: boolean;
+		};
+		if (!response.ok || data.ok === false) {
+			throw new Error(data.error ?? "Conversation unavailable");
+		}
+		if (loadGeneration !== generation) {
+			return;
+		}
+		updateRecord(tweetId, {
+			error: null,
+			items: (data.items ?? []).filter(Boolean),
+			status: "ready",
+		});
+	} catch (error) {
+		if (loadGeneration !== generation) {
+			return;
+		}
+		updateRecord(tweetId, {
+			error:
+				error instanceof Error ? error.message : "Conversation unavailable",
+			items: [],
+			status: "error",
+		});
+	} finally {
+		inFlight.delete(tweetId);
+	}
+}
+
+export function retainConversationSurfaceScope() {
+	activeScopes += 1;
+	return () => {
+		activeScopes = Math.max(0, activeScopes - 1);
+		if (activeScopes === 0) {
+			resetConversationSurface();
+		}
+	};
+}
+
+export function resetConversationSurface() {
+	generation += 1;
+	inFlight.clear();
+	setSnapshot({
+		expandedTweetId: null,
+		records: new Map(),
+	});
+}
+
+export function ConversationSurfaceScope({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	useEffect(() => retainConversationSurfaceScope(), []);
+	return children;
+}
+
+export function useConversationSurface(tweetId: string) {
+	const currentSnapshot = useSyncExternalStore(
+		subscribe,
+		getSnapshot,
+		getSnapshot,
+	);
+	const record = currentSnapshot.records.get(tweetId) ?? emptyRecord;
+	const isOpen = currentSnapshot.expandedTweetId === tweetId;
+
+	const toggle = useCallback(() => {
+		const nextExpanded = snapshot.expandedTweetId === tweetId ? null : tweetId;
+		setSnapshot({ ...snapshot, expandedTweetId: nextExpanded });
+		if (nextExpanded) {
+			void loadConversation(tweetId);
+		}
+	}, [tweetId]);
+
+	const prefetch = useCallback(() => {
+		const current = snapshot.records.get(tweetId);
+		if (current?.status === "ready" || current?.status === "loading") {
+			return;
+		}
+		void loadConversation(tweetId);
+	}, [tweetId]);
+
+	return {
+		error: record.error,
+		isOpen,
+		items: record.items,
+		loading: record.status === "loading",
+		prefetch,
+		status: record.status,
+		toggle,
+	};
+}

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -137,4 +137,34 @@ describe("home route", () => {
 			expect.anything(),
 		);
 	});
+
+	it("shows a retryable error when timeline loading fails", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 2, dms: 4, needsReply: 2, inbox: 4 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				throw "Timeline unavailable";
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<HomeRoute />);
+
+		expect(await screen.findByText("Could not load posts")).toBeInTheDocument();
+		expect(screen.getByText("Timeline unavailable")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+	});
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { BirdclawEmpty, BirdclawLoading } from "#/components/BrandMark";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	TweetSkeletonRows,
+} from "#/components/FeedState";
 import { TimelineCard } from "#/components/TimelineCard";
+import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type {
 	QueryEnvelope,
 	QueryResponse,
@@ -39,6 +45,7 @@ function HomeRoute() {
 	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
 	const [items, setItems] = useState<TimelineItem[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 	const [replyFilter, setReplyFilter] = useState<ReplyFilter>("all");
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
@@ -58,11 +65,42 @@ function HomeRoute() {
 			url.searchParams.set("search", search.trim());
 		}
 
+		const controller = new AbortController();
+		let active = true;
+		setError(null);
 		setLoading(true);
-		fetch(url)
+		fetch(url, { signal: controller.signal })
 			.then((response) => response.json())
-			.then((data: QueryResponse) => setItems(data.items as TimelineItem[]))
-			.finally(() => setLoading(false));
+			.then((data: QueryResponse) => {
+				if (active) {
+					setItems(data.items as TimelineItem[]);
+				}
+			})
+			.catch((fetchError: unknown) => {
+				if (
+					fetchError instanceof DOMException &&
+					fetchError.name === "AbortError"
+				) {
+					return;
+				}
+				if (!active) return;
+				setError(
+					fetchError instanceof Error
+						? fetchError.message
+						: "Timeline unavailable",
+				);
+				setItems([]);
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			active = false;
+			controller.abort();
+		};
 	}, [refreshTick, replyFilter, search]);
 
 	const subtitle = useMemo(() => {
@@ -128,22 +166,40 @@ function HomeRoute() {
 					})}
 				</div>
 			</header>
-			<section className={feedClass}>
-				{loading ? (
-					<BirdclawLoading
-						detail="Reading the local timeline store"
-						label="Loading posts"
-					/>
-				) : items.length === 0 ? (
-					<BirdclawEmpty
-						detail="Try a different filter or sync the timeline again."
-						label="No posts in this view"
-					/>
-				) : null}
-				{items.map((item) => (
-					<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
-				))}
-			</section>
+			<ConversationSurfaceScope>
+				<section className={feedClass}>
+					{loading ? (
+						<FeedLoading
+							detail="Reading the local timeline store"
+							label="Loading posts"
+						>
+							<TweetSkeletonRows />
+						</FeedLoading>
+					) : error ? (
+						<FeedError
+							action={
+								<button
+									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+									onClick={() => setRefreshTick((value) => value + 1)}
+									type="button"
+								>
+									Retry
+								</button>
+							}
+							message={error}
+							title="Could not load posts"
+						/>
+					) : items.length === 0 ? (
+						<FeedEmpty
+							detail="Try a different filter or sync the timeline again."
+							label="No posts in this view"
+						/>
+					) : null}
+					{items.map((item) => (
+						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
+					))}
+				</section>
+			</ConversationSurfaceScope>
 		</>
 	);
 }

--- a/src/routes/links.test.tsx
+++ b/src/routes/links.test.tsx
@@ -223,4 +223,25 @@ describe("links route", () => {
 			).toBe(true);
 		});
 	});
+
+	it("shows a retryable error when link insights fail", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchMock = vi.fn(async () => {
+			throw new Error("Insights unavailable");
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<LinksRoute />);
+
+		expect(await screen.findByText("Could not load links")).toBeInTheDocument();
+		expect(screen.getByText("Insights unavailable")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+		expect(warnSpy).toHaveBeenCalledWith(
+			"Link insights failed",
+			expect.any(Error),
+		);
+	});
 });

--- a/src/routes/links.tsx
+++ b/src/routes/links.tsx
@@ -11,6 +11,12 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AvatarChip } from "#/components/AvatarChip";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	LinkSkeletonRows,
+} from "#/components/FeedState";
 import { ProfilePreview } from "#/components/ProfilePreview";
 import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
 import type {
@@ -26,7 +32,6 @@ import type {
 } from "#/lib/types";
 import {
 	cx,
-	emptyStateClass,
 	pageHeaderClass,
 	pageHeaderRowClass,
 	pageSubtitleClass,
@@ -649,6 +654,7 @@ function LinksRoute() {
 	const cacheRef = useRef(new Map<string, LinkInsightResponse>());
 	const inFlightRef = useRef(new Set<string>());
 	const mountedRef = useRef(true);
+	const [errorByKey, setErrorByKey] = useState<Record<string, string>>({});
 	const [, bumpCacheVersion] = useState(0);
 	const currentCacheKey = insightCacheKey(
 		kind,
@@ -658,6 +664,8 @@ function LinksRoute() {
 		refreshTick,
 	);
 	const data = cacheRef.current.get(currentCacheKey) ?? null;
+	const error = errorByKey[currentCacheKey] ?? null;
+	const loading = !data && !error;
 
 	useEffect(() => {
 		return () => {
@@ -672,6 +680,11 @@ function LinksRoute() {
 				return;
 			}
 			inFlightRef.current.add(key);
+			setErrorByKey((current) => {
+				const rest = { ...current };
+				delete rest[key];
+				return rest;
+			});
 			fetch(linkInsightsUrl(fetchKind, range, sort, source, refreshTick))
 				.then((response) => response.json())
 				.then((response: LinkInsightResponse) => {
@@ -684,7 +697,17 @@ function LinksRoute() {
 					if (error instanceof DOMException && error.name === "AbortError") {
 						return;
 					}
+					if (!mountedRef.current) {
+						return;
+					}
 					console.warn("Link insights failed", error);
+					setErrorByKey((current) => ({
+						...current,
+						[key]:
+							error instanceof Error
+								? error.message
+								: "Link insights unavailable",
+					}));
 				})
 				.finally(() => {
 					inFlightRef.current.delete(key);
@@ -865,10 +888,32 @@ function LinksRoute() {
 			</header>
 
 			<section className="flex flex-col">
-				{items.length === 0 ? (
-					<div className={emptyStateClass}>
-						{data ? "No links in this window." : "Loading links..."}
-					</div>
+				{loading ? (
+					<FeedLoading
+						detail="Ranking URLs and collecting local discussion"
+						label="Loading links"
+					>
+						<LinkSkeletonRows />
+					</FeedLoading>
+				) : error ? (
+					<FeedError
+						action={
+							<button
+								className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+								onClick={() => setRefreshTick((value) => value + 1)}
+								type="button"
+							>
+								Retry
+							</button>
+						}
+						message={error}
+						title="Could not load links"
+					/>
+				) : items.length === 0 ? (
+					<FeedEmpty
+						detail="Try a different range, source, or search term."
+						label="No links in this window"
+					/>
 				) : null}
 				{items.map((item, index) => (
 					<LinkInsightRow

--- a/src/routes/mentions.test.tsx
+++ b/src/routes/mentions.test.tsx
@@ -139,4 +139,36 @@ describe("mentions route", () => {
 			expect.anything(),
 		);
 	});
+
+	it("shows a retryable error when mentions loading fails", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				throw new Error("Mentions store unavailable");
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<MentionsRoute />);
+
+		expect(
+			await screen.findByText("Could not load mentions"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Mentions store unavailable")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+	});
 });

--- a/src/routes/mentions.tsx
+++ b/src/routes/mentions.tsx
@@ -1,8 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { BirdclawEmpty, BirdclawLoading } from "#/components/BrandMark";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	TweetSkeletonRows,
+} from "#/components/FeedState";
 import { TimelineCard } from "#/components/TimelineCard";
+import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type {
 	QueryEnvelope,
 	QueryResponse,
@@ -39,6 +45,7 @@ function MentionsRoute() {
 	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
 	const [items, setItems] = useState<TimelineItem[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 	const [replyFilter, setReplyFilter] = useState<ReplyFilter>("unreplied");
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
@@ -58,11 +65,42 @@ function MentionsRoute() {
 			url.searchParams.set("search", search.trim());
 		}
 
+		const controller = new AbortController();
+		let active = true;
+		setError(null);
 		setLoading(true);
-		fetch(url)
+		fetch(url, { signal: controller.signal })
 			.then((response) => response.json())
-			.then((data: QueryResponse) => setItems(data.items as TimelineItem[]))
-			.finally(() => setLoading(false));
+			.then((data: QueryResponse) => {
+				if (active) {
+					setItems(data.items as TimelineItem[]);
+				}
+			})
+			.catch((fetchError: unknown) => {
+				if (
+					fetchError instanceof DOMException &&
+					fetchError.name === "AbortError"
+				) {
+					return;
+				}
+				if (!active) return;
+				setError(
+					fetchError instanceof Error
+						? fetchError.message
+						: "Mentions unavailable",
+				);
+				setItems([]);
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			active = false;
+			controller.abort();
+		};
 	}, [refreshTick, replyFilter, search]);
 
 	const subtitle = useMemo(() => {
@@ -128,22 +166,40 @@ function MentionsRoute() {
 					})}
 				</div>
 			</header>
-			<section className={feedClass}>
-				{loading ? (
-					<BirdclawLoading
-						detail="Checking local mentions and reply context"
-						label="Loading mentions"
-					/>
-				) : items.length === 0 ? (
-					<BirdclawEmpty
-						detail="Try All, search less narrowly, or sync mentions."
-						label="No mentions in this view"
-					/>
-				) : null}
-				{items.map((item) => (
-					<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
-				))}
-			</section>
+			<ConversationSurfaceScope>
+				<section className={feedClass}>
+					{loading ? (
+						<FeedLoading
+							detail="Checking local mentions and reply context"
+							label="Loading mentions"
+						>
+							<TweetSkeletonRows />
+						</FeedLoading>
+					) : error ? (
+						<FeedError
+							action={
+								<button
+									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+									onClick={() => setRefreshTick((value) => value + 1)}
+									type="button"
+								>
+									Retry
+								</button>
+							}
+							message={error}
+							title="Could not load mentions"
+						/>
+					) : items.length === 0 ? (
+						<FeedEmpty
+							detail="Try All, search less narrowly, or sync mentions."
+							label="No mentions in this view"
+						/>
+					) : null}
+					{items.map((item) => (
+						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
+					))}
+				</section>
+			</ConversationSurfaceScope>
 		</>
 	);
 }


### PR DESCRIPTION
## Summary
- Adds shared feed loading, error, and empty-state components for home, mentions, likes, bookmarks, and links.
- Adds tweet/link skeleton rows under the animated Birdclaw loading mark so timeline and link loads preserve row shape.
- Moves timeline conversation expansion into a shared one-open cached surface with hover/focus prefetch.
- Adds regression coverage for feed error states and conversation-surface caching/error/reset behavior.

## Proof
- codex review --uncommitted: no actionable correctness issues found
- pnpm typecheck
- pnpm check
- pnpm test -- --runInBand
- pnpm coverage: 611 tests passed, branches 82.12%
- pnpm build
- pnpm e2e
