### PR TITLE
feat: add web sync controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Add explicit web app sync controls for home timeline, mentions, likes, bookmarks, and DMs so fresh live data can be pulled without leaving the UI.
 - Refine the web app sidebar tagline and theme selector so the brand chrome reads more clearly in compact layouts.
 - Add shared web feed loading/error/empty states with timeline-shaped skeleton rows and move conversation expansion into a cached single-thread surface with hover prefetch.
 - Use the Birdclaw crab-bird mark in the web app chrome, loading states, and empty states; soften dark-mode contrast and replace text-only reply warnings with conversation/replied indicators.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Start the app:
 birdclaw serve
 ```
 
+Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs to run the matching live sync from the web UI and then reload the local view. These controls are explicit because live reads can be slow, auth-dependent, or rate-limited.
+
 When running behind a trusted reverse proxy such as Tailscale Serve, add any extra proxy hostnames to `BIRDCLAW_ALLOWED_HOSTS`. The clawmac Tailscale hostname is allowed by default.
 
 First moderation pass:
@@ -361,6 +363,7 @@ Notes:
 - `bird` mode uses your local `bird` CLI and caches its mentions output into birdclaw's canonical store
 - filters still work in `xurl` mode; filtered payloads are rebuilt from the local canonical store after sync
 - `sync authored`, `sync mentions`, `sync mention-threads`, `sync likes`, `sync bookmarks`, and `sync timeline` store live results in the canonical local store; per-account authored/home/mention/like/bookmark membership is kept as edges so shared tweets do not clobber account ownership
+- the web UI has explicit Sync buttons for home timeline, mentions, likes, bookmarks, and DMs; they call the same sync paths and then reload the local DB-backed view
 
 ### Research bookmarks and threads
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,7 +84,7 @@ Open <http://localhost:3000>. The default lanes:
 - **Inbox** — let heuristics or OpenAI float likely-important items
 - **Blocks** — maintain a local-first account-scoped blocklist
 
-`serve` background-syncs by default. Pass `--no-sync` to keep the server purely local.
+Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs when you want fresh live data. Browser reloads only reread local SQLite; explicit sync avoids surprise live reads and rate-limit spend.
 
 ## 6. Run real CLI workflows
 

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -4,25 +4,38 @@ test("navigates across the primary surfaces", async ({ page }) => {
 	await page.goto("/");
 
 	await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
-	await expect(page.getByText("Quiet signal for Twitter.")).toBeVisible();
+	await expect(
+		page.getByText("Fast search for your Twitter archive."),
+	).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Sync timeline" }),
+	).toBeVisible();
 	await expect(
 		page.locator('img[src="/birdclaw-mark.png"]').first(),
 	).toBeVisible();
 
 	await page.getByRole("link", { name: "Mentions" }).click();
 	await expect(page.getByRole("heading", { name: "Mentions" })).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Sync mentions" }),
+	).toBeVisible();
 
 	await page.getByRole("link", { name: "Likes" }).click();
 	await expect(page.getByRole("heading", { name: "Likes" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Sync likes" })).toBeVisible();
 
 	await page.getByRole("link", { name: "Bookmarks" }).click();
 	await expect(page.getByRole("heading", { name: "Bookmarks" })).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Sync bookmarks" }),
+	).toBeVisible();
 
 	await page.getByRole("link", { name: "Links" }).click();
 	await expect(page.getByRole("heading", { name: "Links" })).toBeVisible();
 
 	await page.getByRole("link", { name: "DMs" }).click();
 	await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Sync DMs" })).toBeVisible();
 
 	await page.getByRole("link", { name: "Inbox" }).click();
 	await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
@@ -33,6 +46,46 @@ test("navigates across the primary surfaces", async ({ page }) => {
 			name: "Maintain a clean blocklist locally.",
 		}),
 	).toBeVisible();
+});
+
+test("manual sync controls post to the sync endpoint", async ({ page }) => {
+	const syncKinds: string[] = [];
+	await page.route("**/api/sync**", async (route) => {
+		const body = route.request().postDataJSON() as { kind?: string };
+		syncKinds.push(body.kind ?? "");
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				ok: true,
+				kind: body.kind,
+				summary: "Synced 3 items",
+				steps: [],
+			}),
+		});
+	});
+
+	async function clickSync(path: string, buttonName: string) {
+		await page.goto(path);
+		const button = page.getByRole("button", { name: buttonName });
+		await expect(button).toBeEnabled();
+		await page.waitForTimeout(1500);
+		const request = page.waitForRequest(
+			(req) => req.url().includes("/api/sync") && req.method() === "POST",
+		);
+		await button.click();
+		await request;
+	}
+
+	await clickSync("/", "Sync timeline");
+	await clickSync("/mentions", "Sync mentions");
+	await clickSync("/likes", "Sync likes");
+	await clickSync("/bookmarks", "Sync bookmarks");
+	await clickSync("/dms", "Sync DMs");
+
+	await expect
+		.poll(() => syncKinds)
+		.toEqual(["timeline", "mentions", "likes", "bookmarks", "dms"]);
 });
 
 test("filters the home timeline by reply state", async ({ page }) => {

--- a/src/components/SavedTimelineView.test.tsx
+++ b/src/components/SavedTimelineView.test.tsx
@@ -165,6 +165,66 @@ describe("SavedTimelineView", () => {
 		});
 	});
 
+	it("syncs the matching saved collection and reloads local data", async () => {
+		const queryUrls: URL[] = [];
+		const syncBodies: unknown[] = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/api/status")) {
+					return new Response(
+						JSON.stringify({
+							stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+							transport: { statusText: "local" },
+							accounts: [],
+							archives: [],
+						}),
+					);
+				}
+				if (url.includes("/api/query")) {
+					queryUrls.push(new URL(url));
+					return new Response(
+						JSON.stringify({
+							resource: "home",
+							items: [{ id: "liked_sync", text: "fresh liked thing" }],
+						}),
+					);
+				}
+				if (url.endsWith("/api/sync") && init?.body) {
+					syncBodies.push(JSON.parse(String(init.body)));
+					return new Response(
+						JSON.stringify({
+							ok: true,
+							kind: "likes",
+							summary: "Synced 4 items",
+							steps: [],
+						}),
+					);
+				}
+				throw new Error(`Unexpected fetch ${url}`);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SavedTimelineView
+				eyebrow="liked posts"
+				filter="liked"
+				loadingLabel="Loading liked posts..."
+				searchPlaceholder="Search likes"
+				title="Liked"
+			/>,
+		);
+
+		expect(await screen.findByText("fresh liked thing")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Sync likes" }));
+
+		await waitFor(() => {
+			expect(syncBodies).toEqual([{ kind: "likes" }]);
+			expect(queryUrls.at(-1)?.searchParams.get("refresh")).toBe("1");
+		});
+	});
+
 	it("ignores empty replies and refreshes after sending a reply", async () => {
 		const actionBodies: unknown[] = [];
 		const queryUrls: URL[] = [];

--- a/src/components/SavedTimelineView.tsx
+++ b/src/components/SavedTimelineView.tsx
@@ -6,6 +6,7 @@ import {
 	FeedLoading,
 	TweetSkeletonRows,
 } from "#/components/FeedState";
+import { SyncNowButton } from "#/components/SyncNowButton";
 import { TimelineCard } from "#/components/TimelineCard";
 import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type { QueryEnvelope, QueryResponse, TimelineItem } from "#/lib/types";
@@ -46,10 +47,14 @@ export function SavedTimelineView({
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
 
+	async function loadStatus() {
+		const response = await fetch("/api/status");
+		const data = (await response.json()) as QueryEnvelope;
+		setMeta(data);
+	}
+
 	useEffect(() => {
-		fetch("/api/status")
-			.then((response) => response.json())
-			.then((data: QueryEnvelope) => setMeta(data));
+		void loadStatus();
 	}, []);
 
 	useEffect(() => {
@@ -126,6 +131,13 @@ export function SavedTimelineView({
 		setRefreshTick((value) => value + 1);
 	}
 
+	function refreshLocalView() {
+		setRefreshTick((value) => value + 1);
+		void loadStatus();
+	}
+
+	const syncKind = filter === "liked" ? "likes" : "bookmarks";
+
 	return (
 		<>
 			<header className={pageHeaderClass}>
@@ -135,6 +147,11 @@ export function SavedTimelineView({
 						<p className={pageSubtitleClass}>{title}</p>
 						<p className={pageSubtitleClass}>{subtitle}</p>
 					</div>
+					<SyncNowButton
+						kind={syncKind}
+						label={filter === "liked" ? "Sync likes" : "Sync bookmarks"}
+						onSynced={refreshLocalView}
+					/>
 				</div>
 				<div className="px-4 pb-3">
 					<label className={searchFieldShellClass}>

--- a/src/components/SyncNowButton.test.tsx
+++ b/src/components/SyncNowButton.test.tsx
@@ -1,0 +1,129 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncNowButton } from "./SyncNowButton";
+
+describe("SyncNowButton", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
+	});
+
+	it("posts the sync kind and reports success", async () => {
+		const onSynced = vi.fn();
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						ok: true,
+						kind: "timeline",
+						summary: "Synced 12 items",
+						steps: [],
+					}),
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={onSynced}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Sync timeline" }));
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledWith(
+				"/api/sync",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ kind: "timeline" }),
+				}),
+			);
+			expect(onSynced).toHaveBeenCalledWith(
+				expect.objectContaining({ summary: "Synced 12 items" }),
+			);
+		});
+		expect(screen.getByText("Synced 12 items")).toBeInTheDocument();
+	});
+
+	it("keeps an accessible label when the visible text is hidden", () => {
+		render(
+			<SyncNowButton
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Sync timeline" }),
+		).toHaveAttribute("aria-label", "Sync timeline");
+	});
+
+	it("surfaces sync failures", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ ok: false, message: "Rate limited" }), {
+						status: 500,
+					}),
+			),
+		);
+
+		render(
+			<SyncNowButton
+				kind="mentions"
+				label="Sync mentions"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Sync mentions" }));
+
+		expect(await screen.findByText("Rate limited")).toBeInTheDocument();
+	});
+
+	it("surfaces in-progress sync summaries", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							ok: false,
+							kind: "timeline",
+							summary: "Sync already running",
+							steps: [],
+							inProgress: true,
+						}),
+						{ status: 409 },
+					),
+			),
+		);
+
+		render(
+			<SyncNowButton
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Sync timeline" }));
+
+		expect(await screen.findByText("Sync already running")).toBeInTheDocument();
+	});
+});

--- a/src/components/SyncNowButton.tsx
+++ b/src/components/SyncNowButton.tsx
@@ -1,0 +1,83 @@
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { cx } from "#/lib/ui";
+import type { WebSyncKind, WebSyncResponse } from "#/lib/web-sync";
+
+interface SyncNowButtonProps {
+	kind: WebSyncKind;
+	label: string;
+	onSynced: (result: WebSyncResponse) => void;
+}
+
+function getErrorMessage(data: unknown, fallback: string) {
+	if (data && typeof data === "object") {
+		const message = (data as { message?: unknown; error?: unknown }).message;
+		const error = (data as { error?: unknown }).error;
+		const summary = (data as { summary?: unknown }).summary;
+		if (typeof message === "string") return message;
+		if (typeof error === "string") return error;
+		if (typeof summary === "string") return summary;
+	}
+	return fallback;
+}
+
+export function SyncNowButton({ kind, label, onSynced }: SyncNowButtonProps) {
+	const [syncing, setSyncing] = useState(false);
+	const [message, setMessage] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	async function syncNow() {
+		setSyncing(true);
+		setError(null);
+		setMessage(null);
+		try {
+			const response = await fetch("/api/sync", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ kind }),
+			});
+			const data = (await response.json()) as WebSyncResponse;
+			if (!response.ok || !data.ok) {
+				throw new Error(getErrorMessage(data, "Sync failed"));
+			}
+			setMessage(data.summary);
+			onSynced(data);
+		} catch (syncError) {
+			setError(syncError instanceof Error ? syncError.message : "Sync failed");
+		} finally {
+			setSyncing(false);
+		}
+	}
+
+	return (
+		<div className="flex shrink-0 items-center gap-2">
+			<button
+				type="button"
+				className={cx(
+					"inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-[var(--line)] bg-[var(--bg)] px-3 text-[13px] font-semibold text-[var(--ink)] transition-[background,border-color,color,transform] duration-150 hover:border-[color:color-mix(in_srgb,var(--accent)_45%,var(--line))] hover:bg-[var(--accent-soft)] hover:text-[var(--accent)] active:scale-[0.98] disabled:cursor-wait disabled:opacity-65",
+					syncing && "text-[var(--ink-soft)]",
+				)}
+				aria-label={syncing ? `${label}: syncing` : label}
+				disabled={syncing}
+				onClick={syncNow}
+			>
+				<RefreshCw
+					className={cx("size-4", syncing && "animate-spin")}
+					strokeWidth={2}
+				/>
+				<span className="hidden sm:inline">
+					{syncing ? "Syncing..." : label}
+				</span>
+			</button>
+			<span
+				className={cx(
+					"hidden max-w-[190px] truncate text-[12px] sm:inline",
+					error ? "text-[var(--alert)]" : "text-[var(--ink-soft)]",
+				)}
+				role="status"
+			>
+				{error ?? message ?? ""}
+			</span>
+		</div>
+	);
+}

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const maybeAutoSyncBackupMock = vi.fn();
+const syncDirectMessagesViaCachedBirdMock = vi.fn();
+const syncMentionThreadsMock = vi.fn();
+const syncMentionsMock = vi.fn();
+const syncTimelineCollectionMock = vi.fn();
+const syncHomeTimelineMock = vi.fn();
+
+vi.mock("./backup", () => ({
+	maybeAutoSyncBackup: (...args: unknown[]) => maybeAutoSyncBackupMock(...args),
+}));
+
+vi.mock("./dms-live", () => ({
+	syncDirectMessagesViaCachedBird: (...args: unknown[]) =>
+		syncDirectMessagesViaCachedBirdMock(...args),
+}));
+
+vi.mock("./mention-threads-live", () => ({
+	syncMentionThreads: (...args: unknown[]) => syncMentionThreadsMock(...args),
+}));
+
+vi.mock("./mentions-live", () => ({
+	syncMentions: (...args: unknown[]) => syncMentionsMock(...args),
+}));
+
+vi.mock("./timeline-collections-live", () => ({
+	syncTimelineCollection: (...args: unknown[]) =>
+		syncTimelineCollectionMock(...args),
+}));
+
+vi.mock("./timeline-live", () => ({
+	syncHomeTimeline: (...args: unknown[]) => syncHomeTimelineMock(...args),
+}));
+
+import {
+	clearWebSyncLocksForTests,
+	parseWebSyncKind,
+	runWebSync,
+} from "./web-sync";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve;
+	});
+	return { promise, resolve };
+}
+
+describe("web sync dispatcher", () => {
+	beforeEach(() => {
+		clearWebSyncLocksForTests();
+		maybeAutoSyncBackupMock.mockReset();
+		syncDirectMessagesViaCachedBirdMock.mockReset();
+		syncMentionThreadsMock.mockReset();
+		syncMentionsMock.mockReset();
+		syncTimelineCollectionMock.mockReset();
+		syncHomeTimelineMock.mockReset();
+		maybeAutoSyncBackupMock.mockResolvedValue({
+			ok: true,
+			enabled: false,
+			skipped: true,
+		});
+	});
+
+	it("syncs the home timeline with a live refresh and backup pass", async () => {
+		syncHomeTimelineMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 42,
+		});
+
+		const result = await runWebSync("timeline");
+
+		expect(syncHomeTimelineMock).toHaveBeenCalledWith({
+			limit: 100,
+			following: true,
+			refresh: true,
+		});
+		expect(maybeAutoSyncBackupMock).toHaveBeenCalled();
+		expect(result).toMatchObject({
+			ok: true,
+			kind: "timeline",
+			summary: "Synced 42 items",
+			steps: [{ kind: "timeline", count: 42, source: "bird" }],
+		});
+	});
+
+	it("syncs mentions and then hydrates mention thread context", async () => {
+		syncMentionsMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			count: 8,
+			partial: false,
+		});
+		syncMentionThreadsMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			mergedTweets: 17,
+			partial: true,
+			warnings: ["rate limited"],
+		});
+
+		const result = await runWebSync("mentions");
+
+		expect(syncMentionsMock).toHaveBeenCalledWith({
+			mode: "xurl",
+			limit: 100,
+			maxPages: 3,
+			refresh: true,
+		});
+		expect(syncMentionThreadsMock).toHaveBeenCalledWith({
+			mode: "xurl",
+			limit: 30,
+			delayMs: 1500,
+			timeoutMs: 15000,
+		});
+		expect(result.summary).toBe("Synced 25 items (partial)");
+		expect(result.steps.at(1)).toMatchObject({
+			kind: "mention-threads",
+			count: 17,
+			warnings: ["rate limited"],
+		});
+	});
+
+	it("syncs saved collections through the shared collection path", async () => {
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 11,
+		});
+
+		await runWebSync("bookmarks");
+
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith({
+			kind: "bookmarks",
+			mode: "auto",
+			limit: 100,
+			maxPages: 5,
+			refresh: true,
+			earlyStop: true,
+		});
+	});
+
+	it("returns an in-progress response for duplicate sync clicks", async () => {
+		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		syncHomeTimelineMock.mockReturnValue(pending.promise);
+
+		const first = runWebSync("timeline");
+		const second = await runWebSync("timeline");
+		pending.resolve({ ok: true, source: "bird", count: 1 });
+		await first;
+
+		expect(second).toMatchObject({
+			ok: false,
+			kind: "timeline",
+			inProgress: true,
+			summary: "Sync already running",
+		});
+		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("parses only supported sync kinds", () => {
+		expect(parseWebSyncKind("likes")).toBe("likes");
+		expect(parseWebSyncKind("blocks")).toBeNull();
+		expect(parseWebSyncKind(undefined)).toBeNull();
+	});
+});

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -1,0 +1,197 @@
+import { maybeAutoSyncBackup } from "./backup";
+import { syncDirectMessagesViaCachedBird } from "./dms-live";
+import { syncMentionThreads } from "./mention-threads-live";
+import { syncMentions } from "./mentions-live";
+import { syncTimelineCollection } from "./timeline-collections-live";
+import { syncHomeTimeline } from "./timeline-live";
+
+export type WebSyncKind =
+	| "timeline"
+	| "mentions"
+	| "likes"
+	| "bookmarks"
+	| "dms";
+
+export interface WebSyncStep {
+	kind: WebSyncKind | "mention-threads";
+	label: string;
+	count: number;
+	source?: string;
+	partial?: boolean;
+	warnings?: string[];
+}
+
+export interface WebSyncResponse {
+	ok: boolean;
+	kind: WebSyncKind;
+	startedAt: string;
+	finishedAt?: string;
+	summary: string;
+	steps: WebSyncStep[];
+	inProgress?: boolean;
+	backup?: Awaited<ReturnType<typeof maybeAutoSyncBackup>>;
+	error?: string;
+}
+
+const runningSyncs = new Map<WebSyncKind, Promise<WebSyncResponse>>();
+
+function assertRecord(
+	value: unknown,
+): asserts value is Record<string, unknown> {
+	if (!value || typeof value !== "object") {
+		throw new Error("Expected sync result object");
+	}
+}
+
+function readNumber(value: unknown, key: string): number {
+	assertRecord(value);
+	const raw = value[key];
+	return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+}
+
+function readString(value: unknown, key: string) {
+	assertRecord(value);
+	const raw = value[key];
+	return typeof raw === "string" ? raw : undefined;
+}
+
+function readBoolean(value: unknown, key: string) {
+	assertRecord(value);
+	const raw = value[key];
+	return typeof raw === "boolean" ? raw : undefined;
+}
+
+export function parseWebSyncKind(value: unknown): WebSyncKind | null {
+	return value === "timeline" ||
+		value === "mentions" ||
+		value === "likes" ||
+		value === "bookmarks" ||
+		value === "dms"
+		? value
+		: null;
+}
+
+function summarizeSteps(steps: WebSyncStep[]) {
+	const total = steps.reduce((sum, step) => sum + step.count, 0);
+	const partial = steps.some((step) => step.partial);
+	const suffix = partial ? " (partial)" : "";
+	return `Synced ${String(total)} items${suffix}`;
+}
+
+async function performWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
+	const startedAt = new Date().toISOString();
+	const steps: WebSyncStep[] = [];
+
+	if (kind === "timeline") {
+		const result = await syncHomeTimeline({
+			limit: 100,
+			following: true,
+			refresh: true,
+		});
+		steps.push({
+			kind,
+			label: "Home timeline",
+			count: readNumber(result, "count"),
+			source: readString(result, "source"),
+		});
+	} else if (kind === "mentions") {
+		const mentions = await syncMentions({
+			mode: "xurl",
+			limit: 100,
+			maxPages: 3,
+			refresh: true,
+		});
+		steps.push({
+			kind,
+			label: "Mentions",
+			count: readNumber(mentions, "count"),
+			source: readString(mentions, "source"),
+			partial: readBoolean(mentions, "partial"),
+		});
+
+		const threads = await syncMentionThreads({
+			mode: "xurl",
+			limit: 30,
+			delayMs: 1500,
+			timeoutMs: 15000,
+		});
+		steps.push({
+			kind: "mention-threads",
+			label: "Mention threads",
+			count: readNumber(threads, "mergedTweets"),
+			source: readString(threads, "source"),
+			partial: readBoolean(threads, "partial"),
+			warnings:
+				Array.isArray(threads.warnings) && threads.warnings.length > 0
+					? threads.warnings.map(String)
+					: undefined,
+		});
+	} else if (kind === "likes" || kind === "bookmarks") {
+		const result = await syncTimelineCollection({
+			kind,
+			mode: "auto",
+			limit: 100,
+			maxPages: 5,
+			refresh: true,
+			earlyStop: true,
+		});
+		steps.push({
+			kind,
+			label: kind === "likes" ? "Likes" : "Bookmarks",
+			count: readNumber(result, "count"),
+			source: readString(result, "source"),
+		});
+	} else {
+		const result = await syncDirectMessagesViaCachedBird({
+			limit: 50,
+			refresh: true,
+		});
+		steps.push({
+			kind,
+			label: "Direct messages",
+			count: readNumber(result, "messages"),
+			source: readString(result, "source"),
+		});
+	}
+
+	const backup = await maybeAutoSyncBackup();
+	const finishedAt = new Date().toISOString();
+	return {
+		ok: true,
+		kind,
+		startedAt,
+		finishedAt,
+		summary: summarizeSteps(steps),
+		steps,
+		backup,
+	};
+}
+
+export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
+	const current = runningSyncs.get(kind);
+	const startedAt = new Date().toISOString();
+	if (current) {
+		return {
+			ok: false,
+			kind,
+			startedAt,
+			summary: "Sync already running",
+			steps: [],
+			inProgress: true,
+		};
+	}
+
+	const pending = performWebSync(kind);
+	runningSyncs.set(kind, pending);
+	try {
+		return await pending;
+	} finally {
+		if (runningSyncs.get(kind) === pending) {
+			runningSyncs.delete(kind);
+		}
+	}
+}
+
+export function clearWebSyncLocksForTests() {
+	runningSyncs.clear();
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DmsRouteImport } from './routes/dms'
 import { Route as BookmarksRouteImport } from './routes/bookmarks'
 import { Route as BlocksRouteImport } from './routes/blocks'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiSyncRouteImport } from './routes/api/sync'
 import { Route as ApiStatusRouteImport } from './routes/api/status'
 import { Route as ApiQueryRouteImport } from './routes/api/query'
 import { Route as ApiProfileHydrateRouteImport } from './routes/api/profile-hydrate'
@@ -66,6 +67,11 @@ const BlocksRoute = BlocksRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSyncRoute = ApiSyncRouteImport.update({
+  id: '/api/sync',
+  path: '/api/sync',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiStatusRoute = ApiStatusRouteImport.update({
@@ -138,6 +144,7 @@ export interface FileRoutesByFullPath {
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
+  '/api/sync': typeof ApiSyncRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -158,6 +165,7 @@ export interface FileRoutesByTo {
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
+  '/api/sync': typeof ApiSyncRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -179,6 +187,7 @@ export interface FileRoutesById {
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
+  '/api/sync': typeof ApiSyncRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -201,6 +210,7 @@ export interface FileRouteTypes {
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
+    | '/api/sync'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -221,6 +231,7 @@ export interface FileRouteTypes {
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
+    | '/api/sync'
   id:
     | '__root__'
     | '/'
@@ -241,6 +252,7 @@ export interface FileRouteTypes {
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
+    | '/api/sync'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -262,6 +274,7 @@ export interface RootRouteChildren {
   ApiProfileHydrateRoute: typeof ApiProfileHydrateRoute
   ApiQueryRoute: typeof ApiQueryRoute
   ApiStatusRoute: typeof ApiStatusRoute
+  ApiSyncRoute: typeof ApiSyncRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -320,6 +333,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/sync': {
+      id: '/api/sync'
+      path: '/api/sync'
+      fullPath: '/api/sync'
+      preLoaderRoute: typeof ApiSyncRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/status': {
@@ -414,6 +434,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiProfileHydrateRoute: ApiProfileHydrateRoute,
   ApiQueryRoute: ApiQueryRoute,
   ApiStatusRoute: ApiStatusRoute,
+  ApiSyncRoute: ApiSyncRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/sync.test.ts
+++ b/src/routes/api/sync.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRouteHandler } from "#/test/route-handlers";
+
+const runWebSyncMock = vi.fn();
+
+vi.mock("#/lib/web-sync", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("#/lib/web-sync")>();
+	return {
+		...actual,
+		runWebSync: (...args: unknown[]) => runWebSyncMock(...args),
+	};
+});
+
+import { Route } from "./sync";
+
+const POST = getRouteHandler(Route, "POST");
+
+describe("api sync route", () => {
+	beforeEach(() => {
+		runWebSyncMock.mockReset();
+	});
+
+	it("runs a supported sync kind", async () => {
+		runWebSyncMock.mockResolvedValue({
+			ok: true,
+			kind: "timeline",
+			summary: "Synced 5 items",
+			steps: [],
+		});
+
+		const response = await POST({
+			request: new Request("http://localhost/api/sync", {
+				method: "POST",
+				body: JSON.stringify({ kind: "timeline" }),
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(runWebSyncMock).toHaveBeenCalledWith("timeline");
+		expect(await response.json()).toMatchObject({
+			ok: true,
+			summary: "Synced 5 items",
+		});
+	});
+
+	it("returns conflict while a matching sync is already running", async () => {
+		runWebSyncMock.mockResolvedValue({
+			ok: false,
+			kind: "mentions",
+			inProgress: true,
+			summary: "Sync already running",
+			steps: [],
+		});
+
+		const response = await POST({
+			request: new Request("http://localhost/api/sync", {
+				method: "POST",
+				body: JSON.stringify({ kind: "mentions" }),
+			}),
+		});
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toMatchObject({ inProgress: true });
+	});
+
+	it("rejects unknown sync kinds", async () => {
+		const response = await POST({
+			request: new Request("http://localhost/api/sync", {
+				method: "POST",
+				body: JSON.stringify({ kind: "blocks" }),
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(runWebSyncMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/api/sync.tsx
+++ b/src/routes/api/sync.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { parseWebSyncKind, runWebSync } from "#/lib/web-sync";
+
+function json(data: unknown, init?: ResponseInit) {
+	return new Response(JSON.stringify(data), {
+		...init,
+		headers: {
+			"content-type": "application/json",
+			...init?.headers,
+		},
+	});
+}
+
+export const Route = createFileRoute("/api/sync")({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				const body = (await request.json().catch(() => ({}))) as Record<
+					string,
+					unknown
+				>;
+				const kind = parseWebSyncKind(body.kind);
+				if (!kind) {
+					return json(
+						{ ok: false, message: "Unknown sync kind" },
+						{ status: 400 },
+					);
+				}
+
+				try {
+					const result = await runWebSync(kind);
+					return json(result, { status: result.inProgress ? 409 : 200 });
+				} catch (error) {
+					return json(
+						{
+							ok: false,
+							kind,
+							message: error instanceof Error ? error.message : "Sync failed",
+						},
+						{ status: 500 },
+					);
+				}
+			},
+		},
+	},
+});

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -114,4 +114,72 @@ describe("dms route", () => {
 			);
 		});
 	});
+
+	it("runs a live dm sync and reloads conversations", async () => {
+		const queryUrls: URL[] = [];
+		const syncBodies: unknown[] = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/api/status")) {
+					return new Response(
+						JSON.stringify({
+							stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+							transport: { statusText: "local" },
+							accounts: [],
+							archives: [],
+						}),
+					);
+				}
+				if (url.includes("/api/query")) {
+					queryUrls.push(new URL(url));
+					return new Response(
+						JSON.stringify({
+							resource: "dms",
+							items: [
+								{
+									id: "dm_1",
+									title: "Sam Altman",
+									accountId: "acct_primary",
+									accountHandle: "@steipete",
+								},
+							],
+							selectedConversation: {
+								conversation: {
+									id: "dm_1",
+									title: "Sam Altman",
+									accountId: "acct_primary",
+									accountHandle: "@steipete",
+								},
+								messages: [],
+							},
+						}),
+					);
+				}
+				if (url.endsWith("/api/sync") && init?.body) {
+					syncBodies.push(JSON.parse(String(init.body)));
+					return new Response(
+						JSON.stringify({
+							ok: true,
+							kind: "dms",
+							summary: "Synced 9 items",
+							steps: [],
+						}),
+					);
+				}
+				throw new Error(`Unexpected fetch ${url}`);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(await screen.findByText("Sam Altman")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Sync DMs" }));
+
+		await waitFor(() => {
+			expect(syncBodies).toEqual([{ kind: "dms" }]);
+			expect(queryUrls.at(-1)?.searchParams.get("refresh")).toBe("1");
+		});
+	});
 });

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DmWorkspace } from "#/components/DmWorkspace";
+import { SyncNowButton } from "#/components/SyncNowButton";
 import type {
 	DmConversationItem,
 	DmMessageItem,
@@ -54,10 +55,14 @@ function DmsRoute() {
 	const [replyDraft, setReplyDraft] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
 
+	async function loadStatus() {
+		const response = await fetch("/api/status");
+		const data = (await response.json()) as QueryEnvelope;
+		setMeta(data);
+	}
+
 	useEffect(() => {
-		fetch("/api/status")
-			.then((response) => response.json())
-			.then((data: QueryEnvelope) => setMeta(data));
+		void loadStatus();
 	}, []);
 
 	useEffect(() => {
@@ -190,6 +195,11 @@ function DmsRoute() {
 		}
 	}
 
+	function refreshLocalView() {
+		setRefreshTick((value) => value + 1);
+		void loadStatus();
+	}
+
 	return (
 		<>
 			<header className={pageHeaderClass}>
@@ -198,6 +208,11 @@ function DmsRoute() {
 						<h1 className={pageTitleClass}>Messages</h1>
 						<p className={pageSubtitleClass}>{subtitle}</p>
 					</div>
+					<SyncNowButton
+						kind="dms"
+						label="Sync DMs"
+						onSynced={refreshLocalView}
+					/>
 				</div>
 				<div className="flex flex-wrap items-center gap-2 px-4 pb-3">
 					<label className={cx(searchFieldShellClass, "flex-1 min-w-[200px]")}>

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -138,6 +138,59 @@ describe("home route", () => {
 		);
 	});
 
+	it("runs a live timeline sync and reloads local data", async () => {
+		const queryUrls: URL[] = [];
+		const syncBodies: unknown[] = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/api/status")) {
+					return new Response(
+						JSON.stringify({
+							stats: { home: 3, mentions: 2, dms: 4, needsReply: 2, inbox: 4 },
+							transport: { statusText: "local" },
+							accounts: [],
+							archives: [],
+						}),
+					);
+				}
+				if (url.includes("/api/query")) {
+					queryUrls.push(new URL(url));
+					return new Response(
+						JSON.stringify({
+							resource: "home",
+							items: [{ id: "tweet_sync", text: "Fresh post" }],
+						}),
+					);
+				}
+				if (url.endsWith("/api/sync") && init?.body) {
+					syncBodies.push(JSON.parse(String(init.body)));
+					return new Response(
+						JSON.stringify({
+							ok: true,
+							kind: "timeline",
+							summary: "Synced 12 items",
+							steps: [],
+						}),
+					);
+				}
+				throw new Error(`Unexpected fetch ${url}`);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<HomeRoute />);
+
+		expect(await screen.findByText("Fresh post")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Sync timeline" }));
+
+		await waitFor(() => {
+			expect(syncBodies).toEqual([{ kind: "timeline" }]);
+			expect(queryUrls.at(-1)?.searchParams.get("refresh")).toBe("1");
+		});
+		expect(screen.getByText("Synced 12 items")).toBeInTheDocument();
+	});
+
 	it("shows a retryable error when timeline loading fails", async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import {
 	FeedLoading,
 	TweetSkeletonRows,
 } from "#/components/FeedState";
+import { SyncNowButton } from "#/components/SyncNowButton";
 import { TimelineCard } from "#/components/TimelineCard";
 import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type {
@@ -50,10 +51,14 @@ function HomeRoute() {
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
 
+	async function loadStatus() {
+		const response = await fetch("/api/status");
+		const data = (await response.json()) as QueryEnvelope;
+		setMeta(data);
+	}
+
 	useEffect(() => {
-		fetch("/api/status")
-			.then((response) => response.json())
-			.then((data: QueryEnvelope) => setMeta(data));
+		void loadStatus();
 	}, []);
 
 	useEffect(() => {
@@ -126,6 +131,11 @@ function HomeRoute() {
 		setRefreshTick((value) => value + 1);
 	}
 
+	function refreshLocalView() {
+		setRefreshTick((value) => value + 1);
+		void loadStatus();
+	}
+
 	return (
 		<>
 			<header className={pageHeaderClass}>
@@ -134,6 +144,11 @@ function HomeRoute() {
 						<h1 className={pageTitleClass}>Home</h1>
 						<p className={pageSubtitleClass}>{subtitle}</p>
 					</div>
+					<SyncNowButton
+						kind="timeline"
+						label="Sync timeline"
+						onSynced={refreshLocalView}
+					/>
 				</div>
 				<div className="px-4 pb-3">
 					<label className={searchFieldShellClass}>

--- a/src/routes/mentions.test.tsx
+++ b/src/routes/mentions.test.tsx
@@ -140,6 +140,59 @@ describe("mentions route", () => {
 		);
 	});
 
+	it("runs a live mentions sync and reloads local data", async () => {
+		const queryUrls: URL[] = [];
+		const syncBodies: unknown[] = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				if (url.endsWith("/api/status")) {
+					return new Response(
+						JSON.stringify({
+							stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+							transport: { statusText: "local" },
+							accounts: [],
+							archives: [],
+						}),
+					);
+				}
+				if (url.includes("/api/query")) {
+					queryUrls.push(new URL(url));
+					return new Response(
+						JSON.stringify({
+							resource: "mentions",
+							items: [{ id: "mention_sync", text: "@steipete fresh" }],
+						}),
+					);
+				}
+				if (url.endsWith("/api/sync") && init?.body) {
+					syncBodies.push(JSON.parse(String(init.body)));
+					return new Response(
+						JSON.stringify({
+							ok: true,
+							kind: "mentions",
+							summary: "Synced 7 items",
+							steps: [],
+						}),
+					);
+				}
+				throw new Error(`Unexpected fetch ${url}`);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<MentionsRoute />);
+
+		expect(await screen.findByText("@steipete fresh")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Sync mentions" }));
+
+		await waitFor(() => {
+			expect(syncBodies).toEqual([{ kind: "mentions" }]);
+			expect(queryUrls.at(-1)?.searchParams.get("refresh")).toBe("1");
+		});
+		expect(screen.getByText("Synced 7 items")).toBeInTheDocument();
+	});
+
 	it("shows a retryable error when mentions loading fails", async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);

--- a/src/routes/mentions.tsx
+++ b/src/routes/mentions.tsx
@@ -7,6 +7,7 @@ import {
 	FeedLoading,
 	TweetSkeletonRows,
 } from "#/components/FeedState";
+import { SyncNowButton } from "#/components/SyncNowButton";
 import { TimelineCard } from "#/components/TimelineCard";
 import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type {
@@ -50,10 +51,14 @@ function MentionsRoute() {
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
 
+	async function loadStatus() {
+		const response = await fetch("/api/status");
+		const data = (await response.json()) as QueryEnvelope;
+		setMeta(data);
+	}
+
 	useEffect(() => {
-		fetch("/api/status")
-			.then((response) => response.json())
-			.then((data: QueryEnvelope) => setMeta(data));
+		void loadStatus();
 	}, []);
 
 	useEffect(() => {
@@ -126,6 +131,11 @@ function MentionsRoute() {
 		setRefreshTick((value) => value + 1);
 	}
 
+	function refreshLocalView() {
+		setRefreshTick((value) => value + 1);
+		void loadStatus();
+	}
+
 	return (
 		<>
 			<header className={pageHeaderClass}>
@@ -134,6 +144,11 @@ function MentionsRoute() {
 						<h1 className={pageTitleClass}>Mentions</h1>
 						<p className={pageSubtitleClass}>{subtitle}</p>
 					</div>
+					<SyncNowButton
+						kind="mentions"
+						label="Sync mentions"
+						onSynced={refreshLocalView}
+					/>
 				</div>
 				<div className="px-4 pb-3">
 					<label className={searchFieldShellClass}>


### PR DESCRIPTION
## Summary
- add explicit web sync controls for Home, Mentions, Likes, Bookmarks, and DMs
- add a server sync endpoint with per-kind in-process locking and backup auto-sync after successful writes
- document explicit UI sync behavior and cover it with unit and Playwright e2e tests

## Tests
- pnpm test
- pnpm typecheck
- pnpm check
- pnpm build
- pnpm e2e

## Review
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access
- final pass clean: no accepted/actionable findings reported
