### PR TITLE
refactor: share timeline route frame

### DIFF
--- a/src/components/SavedTimelineView.tsx
+++ b/src/components/SavedTimelineView.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
 	FeedEmpty,
 	FeedError,
@@ -8,8 +8,8 @@ import {
 } from "#/components/FeedState";
 import { SyncNowButton } from "#/components/SyncNowButton";
 import { TimelineCard } from "#/components/TimelineCard";
+import { useTimelineRouteData } from "#/components/useTimelineRouteData";
 import { ConversationSurfaceScope } from "#/lib/conversation-surface";
-import type { QueryEnvelope, QueryResponse, TimelineItem } from "#/lib/types";
 import {
 	feedClass,
 	pageHeaderClass,
@@ -40,69 +40,15 @@ export function SavedTimelineView({
 	loadingLabel,
 	searchPlaceholder,
 }: SavedTimelineViewProps) {
-	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
-	const [items, setItems] = useState<TimelineItem[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
 	const [search, setSearch] = useState("");
-	const [refreshTick, setRefreshTick] = useState(0);
-
-	async function loadStatus() {
-		const response = await fetch("/api/status");
-		const data = (await response.json()) as QueryEnvelope;
-		setMeta(data);
-	}
-
-	useEffect(() => {
-		void loadStatus();
-	}, []);
-
-	useEffect(() => {
-		const url = new URL("/api/query", window.location.origin);
-		url.searchParams.set("resource", "home");
-		url.searchParams.set(filter, "true");
-		url.searchParams.set("refresh", String(refreshTick));
-		if (search.trim()) {
-			url.searchParams.set("search", search.trim());
-		}
-
-		const controller = new AbortController();
-		let active = true;
-		setError(null);
-		setLoading(true);
-		fetch(url, { signal: controller.signal })
-			.then((response) => response.json())
-			.then((data: QueryResponse) => {
-				if (active) {
-					setItems(data.items as TimelineItem[]);
-				}
-			})
-			.catch((fetchError: unknown) => {
-				if (
-					fetchError instanceof DOMException &&
-					fetchError.name === "AbortError"
-				) {
-					return;
-				}
-				if (!active) return;
-				setError(
-					fetchError instanceof Error
-						? fetchError.message
-						: `${TITLES[filter]} unavailable`,
-				);
-				setItems([]);
-			})
-			.finally(() => {
-				if (active) {
-					setLoading(false);
-				}
-			});
-
-		return () => {
-			active = false;
-			controller.abort();
-		};
-	}, [filter, refreshTick, search]);
+	const { meta, items, loading, error, retry, refreshLocalView, replyToTweet } =
+		useTimelineRouteData({
+			resource: "home",
+			search,
+			errorFallback: `${TITLES[filter]} unavailable`,
+			likedOnly: filter === "liked",
+			bookmarkedOnly: filter === "bookmarked",
+		});
 
 	const subtitle = useMemo(() => {
 		if (!meta) {
@@ -112,29 +58,6 @@ export function SavedTimelineView({
 		}
 		return `${String(items.length)} visible · ${meta.transport.statusText}`;
 	}, [items.length, loadingLabel, meta]);
-
-	async function replyToTweet(tweetId: string) {
-		const text = window.prompt("Reply text");
-		if (!text?.trim()) return;
-
-		await fetch("/api/action", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				kind: "replyTweet",
-				accountId: "acct_primary",
-				tweetId,
-				text,
-			}),
-		});
-
-		setRefreshTick((value) => value + 1);
-	}
-
-	function refreshLocalView() {
-		setRefreshTick((value) => value + 1);
-		void loadStatus();
-	}
 
 	const syncKind = filter === "liked" ? "likes" : "bookmarks";
 
@@ -179,7 +102,7 @@ export function SavedTimelineView({
 							action={
 								<button
 									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
-									onClick={() => setRefreshTick((value) => value + 1)}
+									onClick={retry}
 									type="button"
 								>
 									Retry

--- a/src/components/TimelineRouteFrame.tsx
+++ b/src/components/TimelineRouteFrame.tsx
@@ -1,0 +1,155 @@
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	FeedEmpty,
+	FeedError,
+	FeedLoading,
+	TweetSkeletonRows,
+} from "#/components/FeedState";
+import { SyncNowButton } from "#/components/SyncNowButton";
+import { TimelineCard } from "#/components/TimelineCard";
+import { ConversationSurfaceScope } from "#/lib/conversation-surface";
+import type { QueryEnvelope, ReplyFilter } from "#/lib/types";
+import type { WebSyncKind } from "#/lib/web-sync";
+import {
+	cx,
+	feedClass,
+	pageHeaderClass,
+	pageHeaderRowClass,
+	pageSubtitleClass,
+	pageTitleClass,
+	searchFieldIconClass,
+	searchFieldInputClass,
+	searchFieldShellClass,
+	tabButtonActiveClass,
+	tabButtonClass,
+	tabButtonIndicatorClass,
+	tabStripClass,
+} from "#/lib/ui";
+import { useTimelineRouteData } from "./useTimelineRouteData";
+
+const TABS: Array<{ value: ReplyFilter; label: string }> = [
+	{ value: "all", label: "All" },
+	{ value: "unreplied", label: "Unreplied" },
+	{ value: "replied", label: "Replied" },
+];
+
+interface TimelineRouteFrameProps {
+	title: string;
+	resource: "home" | "mentions";
+	initialReplyFilter: ReplyFilter;
+	searchPlaceholder: string;
+	syncKind: WebSyncKind;
+	syncLabel: string;
+	loadingLabel: string;
+	loadingDetail: string;
+	errorTitle: string;
+	errorFallback: string;
+	emptyLabel: string;
+	emptyDetail: string;
+	subtitle: (meta: QueryEnvelope | null) => string;
+}
+
+export function TimelineRouteFrame({
+	title,
+	resource,
+	initialReplyFilter,
+	searchPlaceholder,
+	syncKind,
+	syncLabel,
+	loadingLabel,
+	loadingDetail,
+	errorTitle,
+	errorFallback,
+	emptyLabel,
+	emptyDetail,
+	subtitle,
+}: TimelineRouteFrameProps) {
+	const [replyFilter, setReplyFilter] =
+		useState<ReplyFilter>(initialReplyFilter);
+	const [search, setSearch] = useState("");
+	const { meta, items, loading, error, retry, refreshLocalView, replyToTweet } =
+		useTimelineRouteData({
+			resource,
+			replyFilter,
+			search,
+			errorFallback,
+		});
+	const subtitleText = useMemo(() => subtitle(meta), [meta, subtitle]);
+
+	return (
+		<>
+			<header className={pageHeaderClass}>
+				<div className={pageHeaderRowClass}>
+					<div className="flex min-w-0 flex-col">
+						<h1 className={pageTitleClass}>{title}</h1>
+						<p className={pageSubtitleClass}>{subtitleText}</p>
+					</div>
+					<SyncNowButton
+						kind={syncKind}
+						label={syncLabel}
+						onSynced={refreshLocalView}
+					/>
+				</div>
+				<div className="px-4 pb-3">
+					<label className={searchFieldShellClass}>
+						<Search className={searchFieldIconClass} strokeWidth={2} />
+						<input
+							className={searchFieldInputClass}
+							onChange={(event) => setSearch(event.target.value)}
+							placeholder={searchPlaceholder}
+							value={search}
+						/>
+					</label>
+				</div>
+				<div className={tabStripClass}>
+					{TABS.map((tab) => {
+						const active = replyFilter === tab.value;
+						return (
+							<button
+								key={tab.value}
+								type="button"
+								aria-pressed={active}
+								className={cx(tabButtonClass, active && tabButtonActiveClass)}
+								onClick={() => setReplyFilter(tab.value)}
+							>
+								<span className="relative inline-flex flex-col items-center justify-center py-1">
+									{tab.label}
+									{active ? <span className={tabButtonIndicatorClass} /> : null}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			</header>
+			<ConversationSurfaceScope>
+				<section className={feedClass}>
+					{loading ? (
+						<FeedLoading detail={loadingDetail} label={loadingLabel}>
+							<TweetSkeletonRows />
+						</FeedLoading>
+					) : error ? (
+						<FeedError
+							action={
+								<button
+									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+									onClick={retry}
+									type="button"
+								>
+									Retry
+								</button>
+							}
+							message={error}
+							title={errorTitle}
+						/>
+					) : items.length === 0 ? (
+						<FeedEmpty detail={emptyDetail} label={emptyLabel} />
+					) : null}
+					{items.map((item) => (
+						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
+					))}
+				</section>
+			</ConversationSurfaceScope>
+		</>
+	);
+}

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import type {
+	QueryEnvelope,
+	QueryResponse,
+	ReplyFilter,
+	ResourceKind,
+	TimelineItem,
+} from "#/lib/types";
+
+interface UseTimelineRouteDataOptions {
+	resource: Exclude<ResourceKind, "dms">;
+	search: string;
+	errorFallback: string;
+	replyFilter?: ReplyFilter;
+	likedOnly?: boolean;
+	bookmarkedOnly?: boolean;
+}
+
+export function useTimelineRouteData({
+	resource,
+	search,
+	errorFallback,
+	replyFilter,
+	likedOnly = false,
+	bookmarkedOnly = false,
+}: UseTimelineRouteDataOptions) {
+	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
+	const [items, setItems] = useState<TimelineItem[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [refreshTick, setRefreshTick] = useState(0);
+
+	async function loadStatus() {
+		const response = await fetch("/api/status");
+		const data = (await response.json()) as QueryEnvelope;
+		setMeta(data);
+	}
+
+	useEffect(() => {
+		void loadStatus();
+	}, []);
+
+	useEffect(() => {
+		const url = new URL("/api/query", window.location.origin);
+		url.searchParams.set("resource", resource);
+		url.searchParams.set("refresh", String(refreshTick));
+		if (replyFilter) {
+			url.searchParams.set("replyFilter", replyFilter);
+		}
+		if (likedOnly) {
+			url.searchParams.set("liked", "true");
+		}
+		if (bookmarkedOnly) {
+			url.searchParams.set("bookmarked", "true");
+		}
+		if (search.trim()) {
+			url.searchParams.set("search", search.trim());
+		}
+
+		const controller = new AbortController();
+		let active = true;
+		setError(null);
+		setLoading(true);
+		fetch(url, { signal: controller.signal })
+			.then((response) => response.json())
+			.then((data: QueryResponse) => {
+				if (active) {
+					setItems(data.items as TimelineItem[]);
+				}
+			})
+			.catch((fetchError: unknown) => {
+				if (
+					fetchError instanceof DOMException &&
+					fetchError.name === "AbortError"
+				) {
+					return;
+				}
+				if (!active) return;
+				setError(
+					fetchError instanceof Error ? fetchError.message : errorFallback,
+				);
+				setItems([]);
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
+			});
+
+		return () => {
+			active = false;
+			controller.abort();
+		};
+	}, [
+		bookmarkedOnly,
+		errorFallback,
+		likedOnly,
+		refreshTick,
+		replyFilter,
+		resource,
+		search,
+	]);
+
+	function retry() {
+		setRefreshTick((value) => value + 1);
+	}
+
+	function refreshLocalView() {
+		setRefreshTick((value) => value + 1);
+		void loadStatus();
+	}
+
+	async function replyToTweet(tweetId: string) {
+		const text = window.prompt("Reply text");
+		if (!text?.trim()) return;
+
+		await fetch("/api/action", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				kind: "replyTweet",
+				accountId: "acct_primary",
+				tweetId,
+				text,
+			}),
+		});
+
+		retry();
+	}
+
+	return {
+		meta,
+		items,
+		loading,
+		error,
+		retry,
+		refreshLocalView,
+		replyToTweet,
+	};
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,220 +1,32 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import {
-	FeedEmpty,
-	FeedError,
-	FeedLoading,
-	TweetSkeletonRows,
-} from "#/components/FeedState";
-import { SyncNowButton } from "#/components/SyncNowButton";
-import { TimelineCard } from "#/components/TimelineCard";
-import { ConversationSurfaceScope } from "#/lib/conversation-surface";
-import type {
-	QueryEnvelope,
-	QueryResponse,
-	ReplyFilter,
-	TimelineItem,
-} from "#/lib/types";
-import {
-	cx,
-	feedClass,
-	pageHeaderClass,
-	pageHeaderRowClass,
-	pageSubtitleClass,
-	pageTitleClass,
-	searchFieldIconClass,
-	searchFieldInputClass,
-	searchFieldShellClass,
-	tabButtonActiveClass,
-	tabButtonClass,
-	tabButtonIndicatorClass,
-	tabStripClass,
-} from "#/lib/ui";
+import { TimelineRouteFrame } from "#/components/TimelineRouteFrame";
+import type { QueryEnvelope } from "#/lib/types";
 
 export const Route = createFileRoute("/")({
 	component: HomeRoute,
 });
 
-const TABS: Array<{ value: ReplyFilter; label: string }> = [
-	{ value: "all", label: "All" },
-	{ value: "unreplied", label: "Unreplied" },
-	{ value: "replied", label: "Replied" },
-];
+function homeSubtitle(meta: QueryEnvelope | null) {
+	if (!meta) return "Loading local context...";
+	return `${String(meta.stats.home)} items · ${String(meta.stats.needsReply)} waiting · ${meta.transport.statusText}`;
+}
 
 function HomeRoute() {
-	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
-	const [items, setItems] = useState<TimelineItem[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-	const [replyFilter, setReplyFilter] = useState<ReplyFilter>("all");
-	const [search, setSearch] = useState("");
-	const [refreshTick, setRefreshTick] = useState(0);
-
-	async function loadStatus() {
-		const response = await fetch("/api/status");
-		const data = (await response.json()) as QueryEnvelope;
-		setMeta(data);
-	}
-
-	useEffect(() => {
-		void loadStatus();
-	}, []);
-
-	useEffect(() => {
-		const url = new URL("/api/query", window.location.origin);
-		url.searchParams.set("resource", "home");
-		url.searchParams.set("replyFilter", replyFilter);
-		url.searchParams.set("refresh", String(refreshTick));
-		if (search.trim()) {
-			url.searchParams.set("search", search.trim());
-		}
-
-		const controller = new AbortController();
-		let active = true;
-		setError(null);
-		setLoading(true);
-		fetch(url, { signal: controller.signal })
-			.then((response) => response.json())
-			.then((data: QueryResponse) => {
-				if (active) {
-					setItems(data.items as TimelineItem[]);
-				}
-			})
-			.catch((fetchError: unknown) => {
-				if (
-					fetchError instanceof DOMException &&
-					fetchError.name === "AbortError"
-				) {
-					return;
-				}
-				if (!active) return;
-				setError(
-					fetchError instanceof Error
-						? fetchError.message
-						: "Timeline unavailable",
-				);
-				setItems([]);
-			})
-			.finally(() => {
-				if (active) {
-					setLoading(false);
-				}
-			});
-
-		return () => {
-			active = false;
-			controller.abort();
-		};
-	}, [refreshTick, replyFilter, search]);
-
-	const subtitle = useMemo(() => {
-		if (!meta) return "Loading local context...";
-		return `${String(meta.stats.home)} items · ${String(meta.stats.needsReply)} waiting · ${meta.transport.statusText}`;
-	}, [meta]);
-
-	async function replyToTweet(tweetId: string) {
-		const text = window.prompt("Reply text");
-		if (!text?.trim()) return;
-
-		await fetch("/api/action", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				kind: "replyTweet",
-				accountId: "acct_primary",
-				tweetId,
-				text,
-			}),
-		});
-
-		setRefreshTick((value) => value + 1);
-	}
-
-	function refreshLocalView() {
-		setRefreshTick((value) => value + 1);
-		void loadStatus();
-	}
-
 	return (
-		<>
-			<header className={pageHeaderClass}>
-				<div className={pageHeaderRowClass}>
-					<div className="flex min-w-0 flex-col">
-						<h1 className={pageTitleClass}>Home</h1>
-						<p className={pageSubtitleClass}>{subtitle}</p>
-					</div>
-					<SyncNowButton
-						kind="timeline"
-						label="Sync timeline"
-						onSynced={refreshLocalView}
-					/>
-				</div>
-				<div className="px-4 pb-3">
-					<label className={searchFieldShellClass}>
-						<Search className={searchFieldIconClass} strokeWidth={2} />
-						<input
-							className={searchFieldInputClass}
-							onChange={(event) => setSearch(event.target.value)}
-							placeholder="Search local timeline"
-							value={search}
-						/>
-					</label>
-				</div>
-				<div className={tabStripClass}>
-					{TABS.map((tab) => {
-						const active = replyFilter === tab.value;
-						return (
-							<button
-								key={tab.value}
-								type="button"
-								aria-pressed={active}
-								className={cx(tabButtonClass, active && tabButtonActiveClass)}
-								onClick={() => setReplyFilter(tab.value)}
-							>
-								<span className="relative inline-flex flex-col items-center justify-center py-1">
-									{tab.label}
-									{active ? <span className={tabButtonIndicatorClass} /> : null}
-								</span>
-							</button>
-						);
-					})}
-				</div>
-			</header>
-			<ConversationSurfaceScope>
-				<section className={feedClass}>
-					{loading ? (
-						<FeedLoading
-							detail="Reading the local timeline store"
-							label="Loading posts"
-						>
-							<TweetSkeletonRows />
-						</FeedLoading>
-					) : error ? (
-						<FeedError
-							action={
-								<button
-									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
-									onClick={() => setRefreshTick((value) => value + 1)}
-									type="button"
-								>
-									Retry
-								</button>
-							}
-							message={error}
-							title="Could not load posts"
-						/>
-					) : items.length === 0 ? (
-						<FeedEmpty
-							detail="Try a different filter or sync the timeline again."
-							label="No posts in this view"
-						/>
-					) : null}
-					{items.map((item) => (
-						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
-					))}
-				</section>
-			</ConversationSurfaceScope>
-		</>
+		<TimelineRouteFrame
+			emptyDetail="Try a different filter or sync the timeline again."
+			emptyLabel="No posts in this view"
+			errorFallback="Timeline unavailable"
+			errorTitle="Could not load posts"
+			initialReplyFilter="all"
+			loadingDetail="Reading the local timeline store"
+			loadingLabel="Loading posts"
+			resource="home"
+			searchPlaceholder="Search local timeline"
+			subtitle={homeSubtitle}
+			syncKind="timeline"
+			syncLabel="Sync timeline"
+			title="Home"
+		/>
 	);
 }

--- a/src/routes/mentions.tsx
+++ b/src/routes/mentions.tsx
@@ -1,220 +1,32 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import {
-	FeedEmpty,
-	FeedError,
-	FeedLoading,
-	TweetSkeletonRows,
-} from "#/components/FeedState";
-import { SyncNowButton } from "#/components/SyncNowButton";
-import { TimelineCard } from "#/components/TimelineCard";
-import { ConversationSurfaceScope } from "#/lib/conversation-surface";
-import type {
-	QueryEnvelope,
-	QueryResponse,
-	ReplyFilter,
-	TimelineItem,
-} from "#/lib/types";
-import {
-	cx,
-	feedClass,
-	pageHeaderClass,
-	pageHeaderRowClass,
-	pageSubtitleClass,
-	pageTitleClass,
-	searchFieldIconClass,
-	searchFieldInputClass,
-	searchFieldShellClass,
-	tabButtonActiveClass,
-	tabButtonClass,
-	tabButtonIndicatorClass,
-	tabStripClass,
-} from "#/lib/ui";
+import { TimelineRouteFrame } from "#/components/TimelineRouteFrame";
+import type { QueryEnvelope } from "#/lib/types";
 
 export const Route = createFileRoute("/mentions")({
 	component: MentionsRoute,
 });
 
-const TABS: Array<{ value: ReplyFilter; label: string }> = [
-	{ value: "all", label: "All" },
-	{ value: "unreplied", label: "Unreplied" },
-	{ value: "replied", label: "Replied" },
-];
+function mentionsSubtitle(meta: QueryEnvelope | null) {
+	if (!meta) return "Loading mentions...";
+	return `${String(meta.stats.mentions)} mention/reply items in local store`;
+}
 
 function MentionsRoute() {
-	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
-	const [items, setItems] = useState<TimelineItem[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-	const [replyFilter, setReplyFilter] = useState<ReplyFilter>("unreplied");
-	const [search, setSearch] = useState("");
-	const [refreshTick, setRefreshTick] = useState(0);
-
-	async function loadStatus() {
-		const response = await fetch("/api/status");
-		const data = (await response.json()) as QueryEnvelope;
-		setMeta(data);
-	}
-
-	useEffect(() => {
-		void loadStatus();
-	}, []);
-
-	useEffect(() => {
-		const url = new URL("/api/query", window.location.origin);
-		url.searchParams.set("resource", "mentions");
-		url.searchParams.set("replyFilter", replyFilter);
-		url.searchParams.set("refresh", String(refreshTick));
-		if (search.trim()) {
-			url.searchParams.set("search", search.trim());
-		}
-
-		const controller = new AbortController();
-		let active = true;
-		setError(null);
-		setLoading(true);
-		fetch(url, { signal: controller.signal })
-			.then((response) => response.json())
-			.then((data: QueryResponse) => {
-				if (active) {
-					setItems(data.items as TimelineItem[]);
-				}
-			})
-			.catch((fetchError: unknown) => {
-				if (
-					fetchError instanceof DOMException &&
-					fetchError.name === "AbortError"
-				) {
-					return;
-				}
-				if (!active) return;
-				setError(
-					fetchError instanceof Error
-						? fetchError.message
-						: "Mentions unavailable",
-				);
-				setItems([]);
-			})
-			.finally(() => {
-				if (active) {
-					setLoading(false);
-				}
-			});
-
-		return () => {
-			active = false;
-			controller.abort();
-		};
-	}, [refreshTick, replyFilter, search]);
-
-	const subtitle = useMemo(() => {
-		if (!meta) return "Loading mentions...";
-		return `${String(meta.stats.mentions)} mention/reply items in local store`;
-	}, [meta]);
-
-	async function replyToTweet(tweetId: string) {
-		const text = window.prompt("Reply text");
-		if (!text?.trim()) return;
-
-		await fetch("/api/action", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				kind: "replyTweet",
-				accountId: "acct_primary",
-				tweetId,
-				text,
-			}),
-		});
-
-		setRefreshTick((value) => value + 1);
-	}
-
-	function refreshLocalView() {
-		setRefreshTick((value) => value + 1);
-		void loadStatus();
-	}
-
 	return (
-		<>
-			<header className={pageHeaderClass}>
-				<div className={pageHeaderRowClass}>
-					<div className="flex min-w-0 flex-col">
-						<h1 className={pageTitleClass}>Mentions</h1>
-						<p className={pageSubtitleClass}>{subtitle}</p>
-					</div>
-					<SyncNowButton
-						kind="mentions"
-						label="Sync mentions"
-						onSynced={refreshLocalView}
-					/>
-				</div>
-				<div className="px-4 pb-3">
-					<label className={searchFieldShellClass}>
-						<Search className={searchFieldIconClass} strokeWidth={2} />
-						<input
-							className={searchFieldInputClass}
-							onChange={(event) => setSearch(event.target.value)}
-							placeholder="Search mentions"
-							value={search}
-						/>
-					</label>
-				</div>
-				<div className={tabStripClass}>
-					{TABS.map((tab) => {
-						const active = replyFilter === tab.value;
-						return (
-							<button
-								key={tab.value}
-								type="button"
-								aria-pressed={active}
-								className={cx(tabButtonClass, active && tabButtonActiveClass)}
-								onClick={() => setReplyFilter(tab.value)}
-							>
-								<span className="relative inline-flex flex-col items-center justify-center py-1">
-									{tab.label}
-									{active ? <span className={tabButtonIndicatorClass} /> : null}
-								</span>
-							</button>
-						);
-					})}
-				</div>
-			</header>
-			<ConversationSurfaceScope>
-				<section className={feedClass}>
-					{loading ? (
-						<FeedLoading
-							detail="Checking local mentions and reply context"
-							label="Loading mentions"
-						>
-							<TweetSkeletonRows />
-						</FeedLoading>
-					) : error ? (
-						<FeedError
-							action={
-								<button
-									className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
-									onClick={() => setRefreshTick((value) => value + 1)}
-									type="button"
-								>
-									Retry
-								</button>
-							}
-							message={error}
-							title="Could not load mentions"
-						/>
-					) : items.length === 0 ? (
-						<FeedEmpty
-							detail="Try All, search less narrowly, or sync mentions."
-							label="No mentions in this view"
-						/>
-					) : null}
-					{items.map((item) => (
-						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
-					))}
-				</section>
-			</ConversationSurfaceScope>
-		</>
+		<TimelineRouteFrame
+			emptyDetail="Try All, search less narrowly, or sync mentions."
+			emptyLabel="No mentions in this view"
+			errorFallback="Mentions unavailable"
+			errorTitle="Could not load mentions"
+			initialReplyFilter="unreplied"
+			loadingDetail="Checking local mentions and reply context"
+			loadingLabel="Loading mentions"
+			resource="mentions"
+			searchPlaceholder="Search mentions"
+			subtitle={mentionsSubtitle}
+			syncKind="mentions"
+			syncLabel="Sync mentions"
+			title="Mentions"
+		/>
 	);
 }


### PR DESCRIPTION
## Summary
- extract shared timeline status/query/refresh/reply state into `useTimelineRouteData`
- add `TimelineRouteFrame` for Home and Mentions route chrome, tabs, feed states, and sync callback wiring
- move saved Likes/Bookmarks onto the same query hook while preserving their custom header copy

## Tests
- pnpm vitest run src/routes/index.test.tsx src/routes/mentions.test.tsx src/components/SavedTimelineView.test.tsx
- pnpm typecheck
- pnpm check
- pnpm test
- pnpm build
- pnpm e2e

## Review
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access
- final pass clean: no accepted/actionable findings reported
