### PR TITLE
refactor: add typed API fetch helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Add typed web API fetch handling and explicit DMs loading/error/empty states so failed local reads surface cleanly.
 - Add explicit web app sync controls for home timeline, mentions, likes, bookmarks, and DMs so fresh live data can be pulled without leaving the UI.
 - Refine the web app sidebar tagline and theme selector so the brand chrome reads more clearly in compact layouts.
 - Add shared web feed loading/error/empty states with timeline-shaped skeleton rows and move conversation expansion into a cached single-thread surface with hover prefetch.

--- a/src/components/SyncNowButton.tsx
+++ b/src/components/SyncNowButton.tsx
@@ -1,5 +1,6 @@
 import { RefreshCw } from "lucide-react";
 import { useState } from "react";
+import { postSync } from "#/lib/api-client";
 import { cx } from "#/lib/ui";
 import type { WebSyncKind, WebSyncResponse } from "#/lib/web-sync";
 
@@ -7,18 +8,6 @@ interface SyncNowButtonProps {
 	kind: WebSyncKind;
 	label: string;
 	onSynced: (result: WebSyncResponse) => void;
-}
-
-function getErrorMessage(data: unknown, fallback: string) {
-	if (data && typeof data === "object") {
-		const message = (data as { message?: unknown; error?: unknown }).message;
-		const error = (data as { error?: unknown }).error;
-		const summary = (data as { summary?: unknown }).summary;
-		if (typeof message === "string") return message;
-		if (typeof error === "string") return error;
-		if (typeof summary === "string") return summary;
-	}
-	return fallback;
 }
 
 export function SyncNowButton({ kind, label, onSynced }: SyncNowButtonProps) {
@@ -31,15 +20,8 @@ export function SyncNowButton({ kind, label, onSynced }: SyncNowButtonProps) {
 		setError(null);
 		setMessage(null);
 		try {
-			const response = await fetch("/api/sync", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({ kind }),
-			});
-			const data = (await response.json()) as WebSyncResponse;
-			if (!response.ok || !data.ok) {
-				throw new Error(getErrorMessage(data, "Sync failed"));
-			}
+			const data = await postSync(kind);
+			if (!data.ok) throw new Error(data.summary);
 			setMessage(data.summary);
 			onSynced(data);
 		} catch (syncError) {

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 import type {
 	QueryEnvelope,
-	QueryResponse,
 	ReplyFilter,
 	ResourceKind,
 	TimelineItem,
 } from "#/lib/types";
+import {
+	fetchQueryEnvelope,
+	fetchQueryResponse,
+	postAction,
+} from "#/lib/api-client";
 
 interface UseTimelineRouteDataOptions {
 	resource: Exclude<ResourceKind, "dms">;
@@ -31,9 +35,7 @@ export function useTimelineRouteData({
 	const [refreshTick, setRefreshTick] = useState(0);
 
 	async function loadStatus() {
-		const response = await fetch("/api/status");
-		const data = (await response.json()) as QueryEnvelope;
-		setMeta(data);
+		setMeta(await fetchQueryEnvelope());
 	}
 
 	useEffect(() => {
@@ -61,9 +63,8 @@ export function useTimelineRouteData({
 		let active = true;
 		setError(null);
 		setLoading(true);
-		fetch(url, { signal: controller.signal })
-			.then((response) => response.json())
-			.then((data: QueryResponse) => {
+		fetchQueryResponse(url, { signal: controller.signal })
+			.then((data) => {
 				if (active) {
 					setItems(data.items as TimelineItem[]);
 				}
@@ -114,15 +115,11 @@ export function useTimelineRouteData({
 		const text = window.prompt("Reply text");
 		if (!text?.trim()) return;
 
-		await fetch("/api/action", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				kind: "replyTweet",
-				accountId: "acct_primary",
-				tweetId,
-				text,
-			}),
+		await postAction({
+			kind: "replyTweet",
+			accountId: "acct_primary",
+			tweetId,
+			text,
 		});
 
 		retry();

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+import type {
+	DmConversationItem,
+	DmMessageItem,
+	QueryEnvelope,
+	QueryResponse,
+	TimelineItem,
+} from "./types";
+import type { WebSyncKind, WebSyncResponse } from "./web-sync";
+
+const jsonRecordSchema = z.object({}).passthrough();
+const resourceKindSchema = z.enum(["home", "mentions", "authored", "dms"]);
+const webSyncKindSchema = z.enum([
+	"timeline",
+	"mentions",
+	"likes",
+	"bookmarks",
+	"dms",
+]);
+
+const queryEnvelopeSchema = z
+	.object({
+		accounts: z.array(jsonRecordSchema),
+		archives: z.array(jsonRecordSchema),
+		transport: z
+			.object({
+				statusText: z.string(),
+			})
+			.passthrough(),
+		stats: z.object({
+			home: z.number(),
+			mentions: z.number(),
+			dms: z.number(),
+			needsReply: z.number(),
+			inbox: z.number(),
+		}),
+	})
+	.transform((value) => value as unknown as QueryEnvelope);
+
+const queryResponseSchema = z
+	.object({
+		resource: resourceKindSchema,
+		items: z.array(jsonRecordSchema),
+		selectedConversation: z
+			.object({
+				conversation: jsonRecordSchema,
+				messages: z.array(jsonRecordSchema),
+			})
+			.nullish(),
+	})
+	.transform(
+		(value) =>
+			({
+				...value,
+				items: value.items as unknown as Array<
+					TimelineItem | DmConversationItem
+				>,
+				selectedConversation: value.selectedConversation
+					? {
+							conversation: value.selectedConversation
+								.conversation as unknown as DmConversationItem,
+							messages: value.selectedConversation
+								.messages as unknown as DmMessageItem[],
+						}
+					: value.selectedConversation,
+			}) as QueryResponse,
+	);
+
+const webSyncResponseSchema = z
+	.object({
+		ok: z.boolean(),
+		kind: webSyncKindSchema,
+		summary: z.string(),
+		steps: z.array(jsonRecordSchema),
+		startedAt: z.string().optional(),
+		finishedAt: z.string().optional(),
+		inProgress: z.boolean().optional(),
+		backup: z.unknown().optional(),
+		error: z.string().optional(),
+	})
+	.transform((value) => value as unknown as WebSyncResponse);
+
+const actionResponseSchema = jsonRecordSchema;
+
+export class ApiFetchError extends Error {
+	constructor(
+		message: string,
+		readonly status?: number,
+	) {
+		super(message);
+		this.name = "ApiFetchError";
+	}
+}
+
+function responseMessage(data: unknown, fallback: string) {
+	if (data && typeof data === "object") {
+		const record = data as {
+			message?: unknown;
+			error?: unknown;
+			summary?: unknown;
+		};
+		if (typeof record.message === "string") return record.message;
+		if (typeof record.error === "string") return record.error;
+		if (typeof record.summary === "string") return record.summary;
+	}
+	return fallback;
+}
+
+async function readJson(response: Response) {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+export async function fetchJson<T>(
+	input: RequestInfo | URL,
+	init: RequestInit | undefined,
+	schema: z.ZodType<T>,
+	fallbackMessage: string,
+): Promise<T> {
+	const response = await fetch(input, init);
+	const data = await readJson(response);
+	if (!response.ok) {
+		throw new ApiFetchError(
+			responseMessage(data, fallbackMessage),
+			response.status,
+		);
+	}
+
+	const parsed = schema.safeParse(data);
+	if (!parsed.success) {
+		throw new ApiFetchError(fallbackMessage);
+	}
+	return parsed.data;
+}
+
+export function fetchQueryEnvelope(init?: RequestInit) {
+	return fetchJson(
+		"/api/status",
+		init,
+		queryEnvelopeSchema,
+		"Status unavailable",
+	);
+}
+
+export function fetchQueryResponse(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) {
+	return fetchJson(input, init, queryResponseSchema, "Query unavailable");
+}
+
+export function postAction(body: Record<string, unknown>) {
+	return fetchJson(
+		"/api/action",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		actionResponseSchema,
+		"Action failed",
+	);
+}
+
+export function postSync(kind: WebSyncKind) {
+	return fetchJson(
+		"/api/sync",
+		{
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ kind }),
+		},
+		webSyncResponseSchema,
+		"Sync failed",
+	);
+}

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -182,4 +182,74 @@ describe("dms route", () => {
 			expect(queryUrls.at(-1)?.searchParams.get("refresh")).toBe("1");
 		});
 	});
+
+	it("shows an explicit empty state when no conversations match", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 0, needsReply: 0, inbox: 1 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				return new Response(
+					JSON.stringify({
+						resource: "dms",
+						items: [],
+						selectedConversation: null,
+					}),
+				);
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(
+			await screen.findByText("No conversations in this view"),
+		).toBeInTheDocument();
+	});
+
+	it("shows a retryable error when conversations fail to load", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				return new Response(
+					JSON.stringify({ message: "DM store unavailable" }),
+					{
+						status: 500,
+					},
+				);
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(
+			await screen.findByText("Could not load messages"),
+		).toBeInTheDocument();
+		expect(screen.getByText("DM store unavailable")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+	});
 });

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -2,12 +2,17 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DmWorkspace } from "#/components/DmWorkspace";
+import { FeedEmpty, FeedError, FeedLoading } from "#/components/FeedState";
 import { SyncNowButton } from "#/components/SyncNowButton";
+import {
+	fetchQueryEnvelope,
+	fetchQueryResponse,
+	postAction,
+} from "#/lib/api-client";
 import type {
 	DmConversationItem,
 	DmMessageItem,
 	QueryEnvelope,
-	QueryResponse,
 	ReplyFilter,
 } from "#/lib/types";
 import {
@@ -54,11 +59,11 @@ function DmsRoute() {
 	const [search, setSearch] = useState("");
 	const [replyDraft, setReplyDraft] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 
 	async function loadStatus() {
-		const response = await fetch("/api/status");
-		const data = (await response.json()) as QueryEnvelope;
-		setMeta(data);
+		setMeta(await fetchQueryEnvelope());
 	}
 
 	useEffect(() => {
@@ -67,6 +72,7 @@ function DmsRoute() {
 
 	useEffect(() => {
 		const controller = new AbortController();
+		let active = true;
 		const url = new URL("/api/query", window.location.origin);
 		url.searchParams.set("resource", "dms");
 		url.searchParams.set("replyFilter", replyFilter);
@@ -81,9 +87,11 @@ function DmsRoute() {
 			url.searchParams.set("search", search.trim());
 		}
 
-		fetch(url, { signal: controller.signal })
-			.then((response) => response.json())
-			.then((data: QueryResponse) => {
+		setError(null);
+		setLoading(true);
+		fetchQueryResponse(url, { signal: controller.signal })
+			.then((data) => {
+				if (!active) return;
 				const conversations = data.items as DmConversationItem[];
 				const nextSelected =
 					data.selectedConversation?.conversation.id ?? conversations[0]?.id;
@@ -98,14 +106,30 @@ function DmsRoute() {
 				});
 				setMessages(data.selectedConversation?.messages ?? []);
 			})
-			.catch((error: unknown) => {
-				if (error instanceof DOMException && error.name === "AbortError") {
+			.catch((fetchError: unknown) => {
+				if (
+					fetchError instanceof DOMException &&
+					fetchError.name === "AbortError"
+				) {
 					return;
 				}
-				throw error;
+				if (!active) return;
+				setError(
+					fetchError instanceof Error
+						? fetchError.message
+						: "Messages unavailable",
+				);
+				setItems([]);
+				setMessages([]);
+			})
+			.finally(() => {
+				if (active) {
+					setLoading(false);
+				}
 			});
 
 		return () => {
+			active = false;
 			controller.abort();
 		};
 	}, [
@@ -175,14 +199,10 @@ function DmsRoute() {
 		);
 
 		try {
-			await fetch("/api/action", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({
-					kind: "replyDm",
-					conversationId,
-					text,
-				}),
+			await postAction({
+				kind: "replyDm",
+				conversationId,
+				text,
 			});
 
 			setSelectedConversationId(conversationId);
@@ -275,15 +295,41 @@ function DmsRoute() {
 				</div>
 			</header>
 
-			<DmWorkspace
-				conversations={items}
-				onReplyDraftChange={setReplyDraft}
-				onReplySend={replyToConversation}
-				onSelectConversation={setSelectedConversationId}
-				replyDraft={replyDraft}
-				selectedConversation={selectedConversation}
-				selectedMessages={messages}
-			/>
+			{loading ? (
+				<FeedLoading
+					detail="Reading local conversations and reply state"
+					label="Loading messages"
+				/>
+			) : error ? (
+				<FeedError
+					action={
+						<button
+							className="rounded-full bg-[var(--accent)] px-4 py-1.5 text-[14px] font-bold text-white"
+							onClick={() => setRefreshTick((value) => value + 1)}
+							type="button"
+						>
+							Retry
+						</button>
+					}
+					message={error}
+					title="Could not load messages"
+				/>
+			) : items.length === 0 ? (
+				<FeedEmpty
+					detail="Sync DMs or broaden the filters to find a conversation."
+					label="No conversations in this view"
+				/>
+			) : (
+				<DmWorkspace
+					conversations={items}
+					onReplyDraftChange={setReplyDraft}
+					onReplySend={replyToConversation}
+					onSelectConversation={setSelectedConversationId}
+					replyDraft={replyDraft}
+					selectedConversation={selectedConversation}
+					selectedMessages={messages}
+				/>
+			)}
 		</>
 	);
 }


### PR DESCRIPTION
## Summary
- add typed fetch helpers for status, query, action, and sync API calls
- reuse helpers from timeline routes, saved timelines, sync controls, and DMs
- add explicit DMs loading, empty, and retryable error states

## Tests
- pnpm typecheck
- pnpm check
- pnpm vitest run src/routes/dms.test.tsx src/components/SyncNowButton.test.tsx src/routes/index.test.tsx src/routes/mentions.test.tsx src/components/SavedTimelineView.test.tsx
- pnpm build
- pnpm e2e

## Review
- codex-review --full-access clean; no accepted/actionable findings
- full pnpm vitest run currently still exposes unrelated backup git test timeouts, tracked for a separate hardening slice
