### PR TITLE
refactor: run web sync as background jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Run web sync requests as background jobs with status polling so the UI no longer holds one blocking sync request open.
 - Add typed web API fetch handling and explicit DMs loading/error/empty states so failed local reads surface cleanly.
 - Add explicit web app sync controls for home timeline, mentions, likes, bookmarks, and DMs so fresh live data can be pulled without leaving the UI.
 - Refine the web app sidebar tagline and theme selector so the brand chrome reads more clearly in compact layouts.

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -57,10 +57,18 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 			status: 200,
 			contentType: "application/json",
 			body: JSON.stringify({
-				ok: true,
+				id: `sync_${body.kind ?? "unknown"}_1`,
 				kind: body.kind,
+				status: "succeeded",
+				startedAt: "2026-05-15T12:00:00.000Z",
 				summary: "Synced 3 items",
-				steps: [],
+				inProgress: false,
+				result: {
+					ok: true,
+					kind: body.kind,
+					summary: "Synced 3 items",
+					steps: [],
+				},
 			}),
 		});
 	});

--- a/src/components/SavedTimelineView.test.tsx
+++ b/src/components/SavedTimelineView.test.tsx
@@ -194,10 +194,18 @@ describe("SavedTimelineView", () => {
 					syncBodies.push(JSON.parse(String(init.body)));
 					return new Response(
 						JSON.stringify({
-							ok: true,
+							id: "sync_likes_1",
 							kind: "likes",
+							status: "succeeded",
+							startedAt: "2026-05-15T12:00:00.000Z",
 							summary: "Synced 4 items",
-							steps: [],
+							inProgress: false,
+							result: {
+								ok: true,
+								kind: "likes",
+								summary: "Synced 4 items",
+								steps: [],
+							},
 						}),
 					);
 				}

--- a/src/components/SyncNowButton.test.tsx
+++ b/src/components/SyncNowButton.test.tsx
@@ -16,6 +16,7 @@ describe("SyncNowButton", () => {
 	afterEach(() => {
 		cleanup();
 		vi.unstubAllGlobals();
+		vi.useRealTimers();
 	});
 
 	it("posts the sync kind and reports success", async () => {
@@ -24,10 +25,18 @@ describe("SyncNowButton", () => {
 			async () =>
 				new Response(
 					JSON.stringify({
-						ok: true,
+						id: "sync_timeline_1",
 						kind: "timeline",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
 						summary: "Synced 12 items",
-						steps: [],
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							summary: "Synced 12 items",
+							steps: [],
+						},
 					}),
 				),
 		);
@@ -96,6 +105,59 @@ describe("SyncNowButton", () => {
 		expect(await screen.findByText("Rate limited")).toBeInTheDocument();
 	});
 
+	it("polls running sync jobs until completion", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/sync")) {
+				return new Response(
+					JSON.stringify({
+						id: "sync_timeline_poll",
+						kind: "timeline",
+						status: "running",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Syncing Home timeline",
+						inProgress: true,
+					}),
+					{ status: 202 },
+				);
+			}
+			if (url.includes("/api/sync?id=sync_timeline_poll")) {
+				return new Response(
+					JSON.stringify({
+						id: "sync_timeline_poll",
+						kind: "timeline",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						finishedAt: "2026-05-15T12:00:03.000Z",
+						summary: "Synced 4 items",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							summary: "Synced 4 items",
+							steps: [],
+						},
+					}),
+				);
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Sync timeline" }));
+
+		expect(await screen.findByText("Synced 4 items")).toBeInTheDocument();
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
 	it("surfaces in-progress sync summaries", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -103,13 +165,20 @@ describe("SyncNowButton", () => {
 				async () =>
 					new Response(
 						JSON.stringify({
-							ok: false,
+							id: "sync_timeline_1",
 							kind: "timeline",
+							status: "failed",
+							startedAt: "2026-05-15T12:00:00.000Z",
 							summary: "Sync already running",
-							steps: [],
-							inProgress: true,
+							inProgress: false,
+							result: {
+								ok: false,
+								kind: "timeline",
+								summary: "Sync already running",
+								steps: [],
+								inProgress: true,
+							},
 						}),
-						{ status: 409 },
 					),
 			),
 		);

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -6,7 +6,11 @@ import type {
 	QueryResponse,
 	TimelineItem,
 } from "./types";
-import type { WebSyncKind, WebSyncResponse } from "./web-sync";
+import type {
+	WebSyncJobSnapshot,
+	WebSyncKind,
+	WebSyncResponse,
+} from "./web-sync";
 
 const jsonRecordSchema = z.object({}).passthrough();
 const resourceKindSchema = z.enum(["home", "mentions", "authored", "dms"]);
@@ -80,7 +84,22 @@ const webSyncResponseSchema = z
 	})
 	.transform((value) => value as unknown as WebSyncResponse);
 
+const webSyncJobSchema = z
+	.object({
+		id: z.string(),
+		kind: webSyncKindSchema,
+		status: z.enum(["running", "succeeded", "failed"]),
+		startedAt: z.string(),
+		finishedAt: z.string().optional(),
+		summary: z.string(),
+		inProgress: z.boolean(),
+		result: webSyncResponseSchema.optional(),
+		error: z.string().optional(),
+	})
+	.transform((value) => value as unknown as WebSyncJobSnapshot);
+
 const actionResponseSchema = jsonRecordSchema;
+const SYNC_POLL_INTERVAL_MS = 500;
 
 export class ApiFetchError extends Error {
 	constructor(
@@ -173,7 +192,33 @@ export function postSync(kind: WebSyncKind) {
 			headers: { "content-type": "application/json" },
 			body: JSON.stringify({ kind }),
 		},
-		webSyncResponseSchema,
+		webSyncJobSchema,
 		"Sync failed",
-	);
+	).then(waitForWebSyncJob);
+}
+
+function fetchSyncJob(id: string) {
+	const url = new URL("/api/sync", window.location.origin);
+	url.searchParams.set("id", id);
+	return fetchJson(url, undefined, webSyncJobSchema, "Sync status unavailable");
+}
+
+function delay(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForWebSyncJob(job: WebSyncJobSnapshot) {
+	let current = job;
+	while (current.inProgress) {
+		await delay(SYNC_POLL_INTERVAL_MS);
+		current = await fetchSyncJob(current.id);
+	}
+
+	if (!current.result) {
+		throw new ApiFetchError(current.error ?? current.summary);
+	}
+	if (!current.result.ok) {
+		throw new ApiFetchError(current.result.error ?? current.result.summary);
+	}
+	return current.result;
 }

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -36,8 +36,10 @@ vi.mock("./timeline-live", () => ({
 
 import {
 	clearWebSyncLocksForTests,
+	getWebSyncJob,
 	parseWebSyncKind,
 	runWebSync,
+	startWebSync,
 } from "./web-sync";
 
 function deferred<T>() {
@@ -51,6 +53,7 @@ function deferred<T>() {
 describe("web sync dispatcher", () => {
 	beforeEach(() => {
 		clearWebSyncLocksForTests();
+		vi.useRealTimers();
 		maybeAutoSyncBackupMock.mockReset();
 		syncDirectMessagesViaCachedBirdMock.mockReset();
 		syncMentionThreadsMock.mockReset();
@@ -159,6 +162,50 @@ describe("web sync dispatcher", () => {
 			summary: "Sync already running",
 		});
 		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("tracks background sync jobs through completion", async () => {
+		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		syncHomeTimelineMock.mockReturnValue(pending.promise);
+
+		const job = startWebSync("timeline");
+
+		expect(job).toMatchObject({
+			kind: "timeline",
+			status: "running",
+			inProgress: true,
+		});
+		expect(getWebSyncJob(job.id)).toMatchObject({ status: "running" });
+
+		pending.resolve({ ok: true, source: "bird", count: 5 });
+		await vi.waitFor(() => {
+			expect(getWebSyncJob(job.id)).toMatchObject({
+				status: "succeeded",
+				inProgress: false,
+				summary: "Synced 5 items",
+			});
+		});
+	});
+
+	it("expires completed background sync jobs after the polling window", async () => {
+		vi.useFakeTimers();
+		syncHomeTimelineMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 5,
+		});
+
+		const job = startWebSync("timeline");
+		await vi.waitFor(() => {
+			expect(getWebSyncJob(job.id)).toMatchObject({
+				status: "succeeded",
+				inProgress: false,
+			});
+		});
+
+		await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+		expect(getWebSyncJob(job.id)).toBeNull();
 	});
 
 	it("parses only supported sync kinds", () => {

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -33,7 +33,32 @@ export interface WebSyncResponse {
 	error?: string;
 }
 
-const runningSyncs = new Map<WebSyncKind, Promise<WebSyncResponse>>();
+export type WebSyncJobStatus = "running" | "succeeded" | "failed";
+
+export interface WebSyncJobSnapshot {
+	id: string;
+	kind: WebSyncKind;
+	status: WebSyncJobStatus;
+	startedAt: string;
+	finishedAt?: string;
+	summary: string;
+	inProgress: boolean;
+	result?: WebSyncResponse;
+	error?: string;
+}
+
+interface WebSyncPlan {
+	label: string;
+	run: () => Promise<WebSyncStep[]>;
+}
+
+const runningSyncs = new Map<WebSyncKind, WebSyncJobSnapshot>();
+const webSyncJobs = new Map<string, WebSyncJobSnapshot>();
+const completedJobCleanupTimers = new Map<
+	string,
+	ReturnType<typeof setTimeout>
+>();
+const COMPLETED_JOB_TTL_MS = 5 * 60 * 1000;
 
 function assertRecord(
 	value: unknown,
@@ -78,81 +103,113 @@ function summarizeSteps(steps: WebSyncStep[]) {
 	return `Synced ${String(total)} items${suffix}`;
 }
 
-async function performWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
-	const startedAt = new Date().toISOString();
-	const steps: WebSyncStep[] = [];
+const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
+	timeline: {
+		label: "Home timeline",
+		run: async () => {
+			const result = await syncHomeTimeline({
+				limit: 100,
+				following: true,
+				refresh: true,
+			});
+			return [
+				{
+					kind: "timeline",
+					label: "Home timeline",
+					count: readNumber(result, "count"),
+					source: readString(result, "source"),
+				},
+			];
+		},
+	},
+	mentions: {
+		label: "Mentions",
+		run: async () => {
+			const mentions = await syncMentions({
+				mode: "xurl",
+				limit: 100,
+				maxPages: 3,
+				refresh: true,
+			});
+			const steps: WebSyncStep[] = [
+				{
+					kind: "mentions",
+					label: "Mentions",
+					count: readNumber(mentions, "count"),
+					source: readString(mentions, "source"),
+					partial: readBoolean(mentions, "partial"),
+				},
+			];
 
-	if (kind === "timeline") {
-		const result = await syncHomeTimeline({
-			limit: 100,
-			following: true,
-			refresh: true,
-		});
-		steps.push({
-			kind,
-			label: "Home timeline",
-			count: readNumber(result, "count"),
-			source: readString(result, "source"),
-		});
-	} else if (kind === "mentions") {
-		const mentions = await syncMentions({
-			mode: "xurl",
-			limit: 100,
-			maxPages: 3,
-			refresh: true,
-		});
-		steps.push({
-			kind,
-			label: "Mentions",
-			count: readNumber(mentions, "count"),
-			source: readString(mentions, "source"),
-			partial: readBoolean(mentions, "partial"),
-		});
+			const threads = await syncMentionThreads({
+				mode: "xurl",
+				limit: 30,
+				delayMs: 1500,
+				timeoutMs: 15000,
+			});
+			steps.push({
+				kind: "mention-threads",
+				label: "Mention threads",
+				count: readNumber(threads, "mergedTweets"),
+				source: readString(threads, "source"),
+				partial: readBoolean(threads, "partial"),
+				warnings:
+					Array.isArray(threads.warnings) && threads.warnings.length > 0
+						? threads.warnings.map(String)
+						: undefined,
+			});
+			return steps;
+		},
+	},
+	likes: {
+		label: "Likes",
+		run: () => syncSavedCollection("likes"),
+	},
+	bookmarks: {
+		label: "Bookmarks",
+		run: () => syncSavedCollection("bookmarks"),
+	},
+	dms: {
+		label: "Direct messages",
+		run: async () => {
+			const result = await syncDirectMessagesViaCachedBird({
+				limit: 50,
+				refresh: true,
+			});
+			return [
+				{
+					kind: "dms",
+					label: "Direct messages",
+					count: readNumber(result, "messages"),
+					source: readString(result, "source"),
+				},
+			];
+		},
+	},
+};
 
-		const threads = await syncMentionThreads({
-			mode: "xurl",
-			limit: 30,
-			delayMs: 1500,
-			timeoutMs: 15000,
-		});
-		steps.push({
-			kind: "mention-threads",
-			label: "Mention threads",
-			count: readNumber(threads, "mergedTweets"),
-			source: readString(threads, "source"),
-			partial: readBoolean(threads, "partial"),
-			warnings:
-				Array.isArray(threads.warnings) && threads.warnings.length > 0
-					? threads.warnings.map(String)
-					: undefined,
-		});
-	} else if (kind === "likes" || kind === "bookmarks") {
-		const result = await syncTimelineCollection({
-			kind,
-			mode: "auto",
-			limit: 100,
-			maxPages: 5,
-			refresh: true,
-			earlyStop: true,
-		});
-		steps.push({
+async function syncSavedCollection(kind: "likes" | "bookmarks") {
+	const result = await syncTimelineCollection({
+		kind,
+		mode: "auto",
+		limit: 100,
+		maxPages: 5,
+		refresh: true,
+		earlyStop: true,
+	});
+	return [
+		{
 			kind,
 			label: kind === "likes" ? "Likes" : "Bookmarks",
 			count: readNumber(result, "count"),
 			source: readString(result, "source"),
-		});
-	} else {
-		const result = await syncDirectMessagesViaCachedBird({
-			limit: 50,
-			refresh: true,
-		});
-		steps.push({
-			kind,
-			label: "Direct messages",
-			count: readNumber(result, "messages"),
-			source: readString(result, "source"),
-		});
-	}
+		},
+	];
+}
+
+async function performWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
+	const startedAt = new Date().toISOString();
+	const steps = await WEB_SYNC_PLANS[kind].run();
 
 	const backup = await maybeAutoSyncBackup();
 	const finishedAt = new Date().toISOString();
@@ -165,6 +222,96 @@ async function performWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
 		steps,
 		backup,
 	};
+}
+
+function createWebSyncJobId(kind: WebSyncKind) {
+	return `sync_${kind}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function setJobSnapshot(snapshot: WebSyncJobSnapshot) {
+	webSyncJobs.set(snapshot.id, snapshot);
+	const cleanupTimer = completedJobCleanupTimers.get(snapshot.id);
+	if (cleanupTimer) {
+		clearTimeout(cleanupTimer);
+		completedJobCleanupTimers.delete(snapshot.id);
+	}
+	if (snapshot.inProgress) {
+		runningSyncs.set(snapshot.kind, snapshot);
+	} else if (runningSyncs.get(snapshot.kind)?.id === snapshot.id) {
+		runningSyncs.delete(snapshot.kind);
+		const timer = setTimeout(() => {
+			webSyncJobs.delete(snapshot.id);
+			completedJobCleanupTimers.delete(snapshot.id);
+		}, COMPLETED_JOB_TTL_MS);
+		timer.unref?.();
+		completedJobCleanupTimers.set(snapshot.id, timer);
+	}
+}
+
+function toFailedResponse(
+	kind: WebSyncKind,
+	startedAt: string,
+	error: unknown,
+): WebSyncResponse {
+	const finishedAt = new Date().toISOString();
+	const message = error instanceof Error ? error.message : "Sync failed";
+	return {
+		ok: false,
+		kind,
+		startedAt,
+		finishedAt,
+		summary: message,
+		steps: [],
+		error: message,
+	};
+}
+
+export function startWebSync(kind: WebSyncKind): WebSyncJobSnapshot {
+	const current = runningSyncs.get(kind);
+	if (current) {
+		return current;
+	}
+
+	const startedAt = new Date().toISOString();
+	const job: WebSyncJobSnapshot = {
+		id: createWebSyncJobId(kind),
+		kind,
+		status: "running",
+		startedAt,
+		summary: `Syncing ${WEB_SYNC_PLANS[kind].label}`,
+		inProgress: true,
+	};
+	setJobSnapshot(job);
+
+	void performWebSync(kind)
+		.then((result) => {
+			setJobSnapshot({
+				...job,
+				status: "succeeded",
+				finishedAt: result.finishedAt,
+				summary: result.summary,
+				inProgress: false,
+				result,
+			});
+		})
+		.catch((error: unknown) => {
+			const result = toFailedResponse(kind, startedAt, error);
+			setJobSnapshot({
+				...job,
+				status: "failed",
+				finishedAt: result.finishedAt,
+				summary: result.summary,
+				inProgress: false,
+				result,
+				error: result.error,
+			});
+		});
+
+	return job;
+}
+
+export function getWebSyncJob(id: string): WebSyncJobSnapshot | null {
+	return webSyncJobs.get(id) ?? null;
 }
 
 export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
@@ -181,17 +328,25 @@ export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
 		};
 	}
 
-	const pending = performWebSync(kind);
-	runningSyncs.set(kind, pending);
-	try {
-		return await pending;
-	} finally {
-		if (runningSyncs.get(kind) === pending) {
-			runningSyncs.delete(kind);
+	const job = startWebSync(kind);
+	while (job.inProgress) {
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		const latest = getWebSyncJob(job.id);
+		if (!latest?.inProgress) {
+			if (!latest?.result) throw new Error("Sync job disappeared");
+			return latest.result;
 		}
 	}
+
+	if (!job.result) throw new Error("Sync job did not finish");
+	return job.result;
 }
 
 export function clearWebSyncLocksForTests() {
 	runningSyncs.clear();
+	webSyncJobs.clear();
+	for (const timer of completedJobCleanupTimers.values()) {
+		clearTimeout(timer);
+	}
+	completedJobCleanupTimers.clear();
 }

--- a/src/routes/api/sync.test.ts
+++ b/src/routes/api/sync.test.ts
@@ -2,31 +2,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
-const runWebSyncMock = vi.fn();
+const getWebSyncJobMock = vi.fn();
+const startWebSyncMock = vi.fn();
 
 vi.mock("#/lib/web-sync", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("#/lib/web-sync")>();
 	return {
 		...actual,
-		runWebSync: (...args: unknown[]) => runWebSyncMock(...args),
+		getWebSyncJob: (...args: unknown[]) => getWebSyncJobMock(...args),
+		startWebSync: (...args: unknown[]) => startWebSyncMock(...args),
 	};
 });
 
 import { Route } from "./sync";
 
+const GET = getRouteHandler(Route, "GET");
 const POST = getRouteHandler(Route, "POST");
 
 describe("api sync route", () => {
 	beforeEach(() => {
-		runWebSyncMock.mockReset();
+		getWebSyncJobMock.mockReset();
+		startWebSyncMock.mockReset();
 	});
 
-	it("runs a supported sync kind", async () => {
-		runWebSyncMock.mockResolvedValue({
-			ok: true,
+	it("starts a supported sync kind as a background job", async () => {
+		startWebSyncMock.mockReturnValue({
+			id: "sync_timeline_1",
 			kind: "timeline",
-			summary: "Synced 5 items",
-			steps: [],
+			status: "running",
+			startedAt: "2026-05-15T12:00:00.000Z",
+			summary: "Syncing Home timeline",
+			inProgress: true,
 		});
 
 		const response = await POST({
@@ -36,21 +42,23 @@ describe("api sync route", () => {
 			}),
 		});
 
-		expect(response.status).toBe(200);
-		expect(runWebSyncMock).toHaveBeenCalledWith("timeline");
+		expect(response.status).toBe(202);
+		expect(startWebSyncMock).toHaveBeenCalledWith("timeline");
 		expect(await response.json()).toMatchObject({
-			ok: true,
-			summary: "Synced 5 items",
+			id: "sync_timeline_1",
+			status: "running",
+			summary: "Syncing Home timeline",
 		});
 	});
 
-	it("returns conflict while a matching sync is already running", async () => {
-		runWebSyncMock.mockResolvedValue({
-			ok: false,
+	it("returns an existing running job for duplicate sync starts", async () => {
+		startWebSyncMock.mockReturnValue({
+			id: "sync_mentions_1",
 			kind: "mentions",
+			status: "running",
+			startedAt: "2026-05-15T12:00:00.000Z",
 			inProgress: true,
-			summary: "Sync already running",
-			steps: [],
+			summary: "Syncing Mentions",
 		});
 
 		const response = await POST({
@@ -60,8 +68,39 @@ describe("api sync route", () => {
 			}),
 		});
 
-		expect(response.status).toBe(409);
-		expect(await response.json()).toMatchObject({ inProgress: true });
+		expect(response.status).toBe(202);
+		expect(await response.json()).toMatchObject({
+			id: "sync_mentions_1",
+			inProgress: true,
+		});
+	});
+
+	it("returns sync job status by id", async () => {
+		getWebSyncJobMock.mockReturnValue({
+			id: "sync_timeline_1",
+			kind: "timeline",
+			status: "succeeded",
+			startedAt: "2026-05-15T12:00:00.000Z",
+			finishedAt: "2026-05-15T12:00:02.000Z",
+			summary: "Synced 5 items",
+			inProgress: false,
+			result: {
+				ok: true,
+				kind: "timeline",
+				startedAt: "2026-05-15T12:00:00.000Z",
+				finishedAt: "2026-05-15T12:00:02.000Z",
+				summary: "Synced 5 items",
+				steps: [],
+			},
+		});
+
+		const response = await GET({
+			request: new Request("http://localhost/api/sync?id=sync_timeline_1"),
+		});
+
+		expect(response.status).toBe(200);
+		expect(getWebSyncJobMock).toHaveBeenCalledWith("sync_timeline_1");
+		expect(await response.json()).toMatchObject({ status: "succeeded" });
 	});
 
 	it("rejects unknown sync kinds", async () => {
@@ -73,6 +112,16 @@ describe("api sync route", () => {
 		});
 
 		expect(response.status).toBe(400);
-		expect(runWebSyncMock).not.toHaveBeenCalled();
+		expect(startWebSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 for unknown sync job ids", async () => {
+		getWebSyncJobMock.mockReturnValue(null);
+
+		const response = await GET({
+			request: new Request("http://localhost/api/sync?id=missing"),
+		});
+
+		expect(response.status).toBe(404);
 	});
 });

--- a/src/routes/api/sync.tsx
+++ b/src/routes/api/sync.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { parseWebSyncKind, runWebSync } from "#/lib/web-sync";
+import { getWebSyncJob, parseWebSyncKind, startWebSync } from "#/lib/web-sync";
 
 function json(data: unknown, init?: ResponseInit) {
 	return new Response(JSON.stringify(data), {
@@ -14,6 +14,26 @@ function json(data: unknown, init?: ResponseInit) {
 export const Route = createFileRoute("/api/sync")({
 	server: {
 		handlers: {
+			GET: ({ request }) => {
+				const url = new URL(request.url);
+				const id = url.searchParams.get("id");
+				if (!id) {
+					return json(
+						{ ok: false, message: "Missing sync job id" },
+						{ status: 400 },
+					);
+				}
+
+				const job = getWebSyncJob(id);
+				if (!job) {
+					return json(
+						{ ok: false, message: "Sync job not found" },
+						{ status: 404 },
+					);
+				}
+
+				return json(job);
+			},
 			POST: async ({ request }) => {
 				const body = (await request.json().catch(() => ({}))) as Record<
 					string,
@@ -27,19 +47,8 @@ export const Route = createFileRoute("/api/sync")({
 					);
 				}
 
-				try {
-					const result = await runWebSync(kind);
-					return json(result, { status: result.inProgress ? 409 : 200 });
-				} catch (error) {
-					return json(
-						{
-							ok: false,
-							kind,
-							message: error instanceof Error ? error.message : "Sync failed",
-						},
-						{ status: 500 },
-					);
-				}
+				const job = startWebSync(kind);
+				return json(job, { status: job.inProgress ? 202 : 200 });
 			},
 		},
 	},

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -160,10 +160,18 @@ describe("dms route", () => {
 					syncBodies.push(JSON.parse(String(init.body)));
 					return new Response(
 						JSON.stringify({
-							ok: true,
+							id: "sync_dms_1",
 							kind: "dms",
+							status: "succeeded",
+							startedAt: "2026-05-15T12:00:00.000Z",
 							summary: "Synced 9 items",
-							steps: [],
+							inProgress: false,
+							result: {
+								ok: true,
+								kind: "dms",
+								summary: "Synced 9 items",
+								steps: [],
+							},
 						}),
 					);
 				}

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -167,10 +167,18 @@ describe("home route", () => {
 					syncBodies.push(JSON.parse(String(init.body)));
 					return new Response(
 						JSON.stringify({
-							ok: true,
+							id: "sync_timeline_1",
 							kind: "timeline",
+							status: "succeeded",
+							startedAt: "2026-05-15T12:00:00.000Z",
 							summary: "Synced 12 items",
-							steps: [],
+							inProgress: false,
+							result: {
+								ok: true,
+								kind: "timeline",
+								summary: "Synced 12 items",
+								steps: [],
+							},
 						}),
 					);
 				}

--- a/src/routes/mentions.test.tsx
+++ b/src/routes/mentions.test.tsx
@@ -169,10 +169,18 @@ describe("mentions route", () => {
 					syncBodies.push(JSON.parse(String(init.body)));
 					return new Response(
 						JSON.stringify({
-							ok: true,
+							id: "sync_mentions_1",
 							kind: "mentions",
+							status: "succeeded",
+							startedAt: "2026-05-15T12:00:00.000Z",
 							summary: "Synced 7 items",
-							steps: [],
+							inProgress: false,
+							result: {
+								ok: true,
+								kind: "mentions",
+								summary: "Synced 7 items",
+								steps: [],
+							},
 						}),
 					);
 				}


### PR DESCRIPTION
## Summary
- move web sync starts to background job snapshots with GET polling
- keep the existing sync button behavior by polling inside the typed API client
- refactor the sync dispatcher into a shared plan map for timeline, mentions, saved collections, and DMs
- expire completed sync job snapshots after a short polling window

## Tests
- pnpm typecheck
- pnpm check
- pnpm vitest run src/lib/web-sync.test.ts src/routes/api/sync.test.ts src/components/SyncNowButton.test.tsx src/routes/index.test.tsx src/routes/mentions.test.tsx src/components/SavedTimelineView.test.tsx src/routes/dms.test.tsx
- pnpm build
- pnpm e2e

## Review
- codex-review --full-access accepted one cleanup finding; fixed completed-job TTL cleanup
- codex-review --full-access rerun clean; no accepted/actionable findings
- full Vitest still exposes unrelated backup git timeouts; this is planned as a separate hardening slice
