### PR TITLE
feat: make web sync account aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Send the selected web account through manual sync controls so multi-account timelines sync the intended profile.
 - Run web sync requests as background jobs with status polling so the UI no longer holds one blocking sync request open.
 - Add typed web API fetch handling and explicit DMs loading/error/empty states so failed local reads surface cleanly.
 - Add explicit web app sync controls for home timeline, mentions, likes, bookmarks, and DMs so fresh live data can be pulled without leaving the UI.

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -49,16 +49,20 @@ test("navigates across the primary surfaces", async ({ page }) => {
 });
 
 test("manual sync controls post to the sync endpoint", async ({ page }) => {
-	const syncKinds: string[] = [];
+	const syncBodies: Array<{ kind?: string; accountId?: string }> = [];
 	await page.route("**/api/sync**", async (route) => {
-		const body = route.request().postDataJSON() as { kind?: string };
-		syncKinds.push(body.kind ?? "");
+		const body = route.request().postDataJSON() as {
+			kind?: string;
+			accountId?: string;
+		};
+		syncBodies.push(body);
 		await route.fulfill({
 			status: 200,
 			contentType: "application/json",
 			body: JSON.stringify({
 				id: `sync_${body.kind ?? "unknown"}_1`,
 				kind: body.kind,
+				accountId: body.accountId,
 				status: "succeeded",
 				startedAt: "2026-05-15T12:00:00.000Z",
 				summary: "Synced 3 items",
@@ -66,6 +70,7 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 				result: {
 					ok: true,
 					kind: body.kind,
+					accountId: body.accountId,
 					summary: "Synced 3 items",
 					steps: [],
 				},
@@ -92,8 +97,14 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 	await clickSync("/dms", "Sync DMs");
 
 	await expect
-		.poll(() => syncKinds)
-		.toEqual(["timeline", "mentions", "likes", "bookmarks", "dms"]);
+		.poll(() => syncBodies)
+		.toEqual([
+			{ kind: "timeline" },
+			{ kind: "mentions", accountId: "acct_primary" },
+			{ kind: "likes", accountId: "acct_primary" },
+			{ kind: "bookmarks", accountId: "acct_primary" },
+			{ kind: "dms" },
+		]);
 });
 
 test("filters the home timeline by reply state", async ({ page }) => {

--- a/src/components/SavedTimelineView.tsx
+++ b/src/components/SavedTimelineView.tsx
@@ -71,6 +71,7 @@ export function SavedTimelineView({
 						<p className={pageSubtitleClass}>{subtitle}</p>
 					</div>
 					<SyncNowButton
+						accounts={meta?.accounts}
 						kind={syncKind}
 						label={filter === "liked" ? "Sync likes" : "Sync bookmarks"}
 						onSynced={refreshLocalView}

--- a/src/components/SyncNowButton.test.tsx
+++ b/src/components/SyncNowButton.test.tsx
@@ -81,6 +81,79 @@ describe("SyncNowButton", () => {
 		).toHaveAttribute("aria-label", "Sync timeline");
 	});
 
+	it("posts the selected account id when multiple accounts are available", async () => {
+		const fetchMock = vi.fn(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				const body = JSON.parse(String(init?.body)) as {
+					kind: string;
+					accountId?: string;
+				};
+				return new Response(
+					JSON.stringify({
+						id: "sync_mentions_1",
+						kind: body.kind,
+						accountId: body.accountId,
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Synced 5 items",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: body.kind,
+							accountId: body.accountId,
+							summary: "Synced 5 items",
+							steps: [],
+						},
+					}),
+				);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				accounts={[
+					{
+						id: "acct_primary",
+						name: "Peter",
+						handle: "@steipete",
+						transport: "xurl",
+						isDefault: 1,
+						createdAt: "2026-05-15T12:00:00.000Z",
+					},
+					{
+						id: "acct_studio",
+						name: "Studio",
+						handle: "@studio",
+						transport: "xurl",
+						isDefault: 0,
+						createdAt: "2026-05-15T12:00:00.000Z",
+					},
+				]}
+				kind="mentions"
+				label="Sync mentions"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		fireEvent.change(screen.getByLabelText("Sync account"), {
+			target: { value: "acct_studio" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Sync mentions" }));
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledWith(
+				"/api/sync",
+				expect.objectContaining({
+					body: JSON.stringify({
+						kind: "mentions",
+						accountId: "acct_studio",
+					}),
+				}),
+			);
+		});
+	});
+
 	it("surfaces sync failures", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/src/components/SyncNowButton.tsx
+++ b/src/components/SyncNowButton.tsx
@@ -1,26 +1,51 @@
 import { RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { postSync } from "#/lib/api-client";
-import { cx } from "#/lib/ui";
+import type { AccountRecord } from "#/lib/types";
+import { cx, selectFieldClass } from "#/lib/ui";
 import type { WebSyncKind, WebSyncResponse } from "#/lib/web-sync";
 
 interface SyncNowButtonProps {
 	kind: WebSyncKind;
 	label: string;
+	accounts?: AccountRecord[];
 	onSynced: (result: WebSyncResponse) => void;
 }
 
-export function SyncNowButton({ kind, label, onSynced }: SyncNowButtonProps) {
+export function SyncNowButton({
+	kind,
+	label,
+	accounts = [],
+	onSynced,
+}: SyncNowButtonProps) {
 	const [syncing, setSyncing] = useState(false);
 	const [message, setMessage] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [selectedAccountId, setSelectedAccountId] = useState<
+		string | undefined
+	>();
+	const defaultAccountId = useMemo(
+		() => accounts.find((account) => account.isDefault)?.id ?? accounts[0]?.id,
+		[accounts],
+	);
+	const accountId = selectedAccountId ?? defaultAccountId;
+
+	useEffect(() => {
+		if (!accounts.length) {
+			setSelectedAccountId(undefined);
+			return;
+		}
+		if (!accountId || !accounts.some((account) => account.id === accountId)) {
+			setSelectedAccountId(defaultAccountId);
+		}
+	}, [accountId, accounts, defaultAccountId]);
 
 	async function syncNow() {
 		setSyncing(true);
 		setError(null);
 		setMessage(null);
 		try {
-			const data = await postSync(kind);
+			const data = await postSync(kind, accountId);
 			if (!data.ok) throw new Error(data.summary);
 			setMessage(data.summary);
 			onSynced(data);
@@ -33,6 +58,21 @@ export function SyncNowButton({ kind, label, onSynced }: SyncNowButtonProps) {
 
 	return (
 		<div className="flex shrink-0 items-center gap-2">
+			{accounts.length > 1 ? (
+				<select
+					aria-label="Sync account"
+					className={cx(selectFieldClass, "h-9 w-[132px]")}
+					disabled={syncing}
+					onChange={(event) => setSelectedAccountId(event.target.value)}
+					value={accountId ?? ""}
+				>
+					{accounts.map((account) => (
+						<option key={account.id} value={account.id}>
+							{account.handle}
+						</option>
+					))}
+				</select>
+			) : null}
 			<button
 				type="button"
 				className={cx(

--- a/src/components/TimelineRouteFrame.tsx
+++ b/src/components/TimelineRouteFrame.tsx
@@ -86,6 +86,7 @@ export function TimelineRouteFrame({
 						<p className={pageSubtitleClass}>{subtitleText}</p>
 					</div>
 					<SyncNowButton
+						accounts={syncKind === "mentions" ? meta?.accounts : undefined}
 						kind={syncKind}
 						label={syncLabel}
 						onSynced={refreshLocalView}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -74,6 +74,7 @@ const webSyncResponseSchema = z
 	.object({
 		ok: z.boolean(),
 		kind: webSyncKindSchema,
+		accountId: z.string().optional(),
 		summary: z.string(),
 		steps: z.array(jsonRecordSchema),
 		startedAt: z.string().optional(),
@@ -88,6 +89,7 @@ const webSyncJobSchema = z
 	.object({
 		id: z.string(),
 		kind: webSyncKindSchema,
+		accountId: z.string().optional(),
 		status: z.enum(["running", "succeeded", "failed"]),
 		startedAt: z.string(),
 		finishedAt: z.string().optional(),
@@ -184,13 +186,16 @@ export function postAction(body: Record<string, unknown>) {
 	);
 }
 
-export function postSync(kind: WebSyncKind) {
+export function postSync(kind: WebSyncKind, accountId?: string) {
 	return fetchJson(
 		"/api/sync",
 		{
 			method: "POST",
 			headers: { "content-type": "application/json" },
-			body: JSON.stringify({ kind }),
+			body: JSON.stringify({
+				kind,
+				...(accountId ? { accountId } : {}),
+			}),
 		},
 		webSyncJobSchema,
 		"Sync failed",

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const maybeAutoSyncBackupMock = vi.fn();
 const syncDirectMessagesViaCachedBirdMock = vi.fn();
@@ -34,6 +37,8 @@ vi.mock("./timeline-live", () => ({
 	syncHomeTimeline: (...args: unknown[]) => syncHomeTimelineMock(...args),
 }));
 
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
 import {
 	clearWebSyncLocksForTests,
 	getWebSyncJob,
@@ -48,6 +53,25 @@ function deferred<T>() {
 		resolve = innerResolve;
 	});
 	return { promise, resolve };
+}
+
+const originalBirdclawHome = process.env.BIRDCLAW_HOME;
+const tempRoots: string[] = [];
+
+function setupDefaultAccount(accountId: string) {
+	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-web-sync-"));
+	tempRoots.push(tempRoot);
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	getNativeDb({ seedDemoData: false })
+		.prepare(
+			`
+      insert into accounts (id, name, handle, transport, is_default, created_at)
+      values (?, ?, ?, ?, ?, ?)
+      `,
+		)
+		.run(accountId, "Studio", "@studio", "bird", 1, "2026-01-01T00:00:00.000Z");
 }
 
 describe("web sync dispatcher", () => {
@@ -65,6 +89,19 @@ describe("web sync dispatcher", () => {
 			enabled: false,
 			skipped: true,
 		});
+	});
+
+	afterEach(() => {
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		if (originalBirdclawHome === undefined) {
+			delete process.env.BIRDCLAW_HOME;
+		} else {
+			process.env.BIRDCLAW_HOME = originalBirdclawHome;
+		}
+		for (const tempRoot of tempRoots.splice(0)) {
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
 	});
 
 	it("syncs the home timeline with a live refresh and backup pass", async () => {
@@ -146,6 +183,47 @@ describe("web sync dispatcher", () => {
 		});
 	});
 
+	it("uses account-targeted xurl mode for selected saved collection syncs", async () => {
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			count: 7,
+		});
+
+		await runWebSync("likes", "acct_studio");
+
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith({
+			kind: "likes",
+			account: "acct_studio",
+			mode: "xurl",
+			limit: 100,
+			maxPages: 5,
+			refresh: true,
+			earlyStop: true,
+		});
+	});
+
+	it("keeps auto fallback for default-account saved collection syncs", async () => {
+		setupDefaultAccount("acct_studio");
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 7,
+		});
+
+		await runWebSync("likes", "acct_studio");
+
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith({
+			kind: "likes",
+			account: "acct_studio",
+			mode: "auto",
+			limit: 100,
+			maxPages: 5,
+			refresh: true,
+			earlyStop: true,
+		});
+	});
+
 	it("returns an in-progress response for duplicate sync clicks", async () => {
 		const pending = deferred<{ ok: boolean; source: string; count: number }>();
 		syncHomeTimelineMock.mockReturnValue(pending.promise);
@@ -162,6 +240,93 @@ describe("web sync dispatcher", () => {
 			summary: "Sync already running",
 		});
 		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps account-aware running locks scoped by account", async () => {
+		const primary = deferred<{ ok: boolean; source: string; count: number }>();
+		const studio = deferred<{ ok: boolean; source: string; count: number }>();
+		syncMentionsMock
+			.mockReturnValueOnce(primary.promise)
+			.mockReturnValueOnce(studio.promise);
+		syncMentionThreadsMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			mergedTweets: 0,
+			partial: false,
+		});
+
+		const primaryJob = startWebSync("mentions", "acct_primary");
+		const studioJob = startWebSync("mentions", "acct_studio");
+
+		expect(primaryJob.id).not.toBe(studioJob.id);
+		expect(syncMentionsMock).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ account: "acct_primary" }),
+		);
+		expect(syncMentionsMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ account: "acct_studio" }),
+		);
+
+		primary.resolve({ ok: true, source: "bird", count: 1 });
+		studio.resolve({ ok: true, source: "bird", count: 2 });
+		await vi.waitFor(() => {
+			expect(getWebSyncJob(primaryJob.id)).toMatchObject({
+				status: "succeeded",
+				accountId: "acct_primary",
+			});
+			expect(getWebSyncJob(studioJob.id)).toMatchObject({
+				status: "succeeded",
+				accountId: "acct_studio",
+			});
+		});
+	});
+
+	it("ignores selected accounts for bird-only sync plans", async () => {
+		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		syncHomeTimelineMock.mockReturnValue(pending.promise);
+
+		const defaultJob = startWebSync("timeline");
+		const selectedJob = startWebSync("timeline", "acct_studio");
+
+		expect(selectedJob.id).toBe(defaultJob.id);
+		expect(selectedJob.accountId).toBeUndefined();
+		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+		expect(syncHomeTimelineMock).toHaveBeenCalledWith(
+			expect.objectContaining({ account: undefined }),
+		);
+
+		pending.resolve({ ok: true, source: "bird", count: 1 });
+		await vi.waitFor(() => {
+			expect(getWebSyncJob(defaultJob.id)).toMatchObject({
+				status: "succeeded",
+			});
+		});
+	});
+
+	it("treats omitted account and the default account as the same running sync", async () => {
+		setupDefaultAccount("acct_studio");
+		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		syncMentionsMock.mockReturnValue(pending.promise);
+		syncMentionThreadsMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			mergedTweets: 0,
+			partial: false,
+		});
+
+		const defaultJob = startWebSync("mentions");
+		const explicitDefaultJob = startWebSync("mentions", "acct_studio");
+
+		expect(explicitDefaultJob.id).toBe(defaultJob.id);
+		expect(syncMentionsMock).toHaveBeenCalledTimes(1);
+
+		pending.resolve({ ok: true, source: "bird", count: 1 });
+		await vi.waitFor(() => {
+			expect(getWebSyncJob(defaultJob.id)).toMatchObject({
+				status: "succeeded",
+			});
+		});
 	});
 
 	it("tracks background sync jobs through completion", async () => {

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -1,7 +1,10 @@
+import { existsSync } from "node:fs";
 import { maybeAutoSyncBackup } from "./backup";
+import { getBirdclawPaths } from "./config";
 import { syncDirectMessagesViaCachedBird } from "./dms-live";
 import { syncMentionThreads } from "./mention-threads-live";
 import { syncMentions } from "./mentions-live";
+import NativeSqliteDatabase from "./sqlite";
 import { syncTimelineCollection } from "./timeline-collections-live";
 import { syncHomeTimeline } from "./timeline-live";
 
@@ -24,6 +27,7 @@ export interface WebSyncStep {
 export interface WebSyncResponse {
 	ok: boolean;
 	kind: WebSyncKind;
+	accountId?: string;
 	startedAt: string;
 	finishedAt?: string;
 	summary: string;
@@ -38,6 +42,7 @@ export type WebSyncJobStatus = "running" | "succeeded" | "failed";
 export interface WebSyncJobSnapshot {
 	id: string;
 	kind: WebSyncKind;
+	accountId?: string;
 	status: WebSyncJobStatus;
 	startedAt: string;
 	finishedAt?: string;
@@ -49,11 +54,13 @@ export interface WebSyncJobSnapshot {
 
 interface WebSyncPlan {
 	label: string;
-	run: () => Promise<WebSyncStep[]>;
+	accountAware: boolean;
+	run: (accountId: string | undefined) => Promise<WebSyncStep[]>;
 }
 
-const runningSyncs = new Map<WebSyncKind, WebSyncJobSnapshot>();
+const runningSyncs = new Map<string, WebSyncJobSnapshot>();
 const webSyncJobs = new Map<string, WebSyncJobSnapshot>();
+const webSyncJobKeys = new Map<string, string>();
 const completedJobCleanupTimers = new Map<
 	string,
 	ReturnType<typeof setTimeout>
@@ -106,8 +113,10 @@ function summarizeSteps(steps: WebSyncStep[]) {
 const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	timeline: {
 		label: "Home timeline",
-		run: async () => {
+		accountAware: false,
+		run: async (account) => {
 			const result = await syncHomeTimeline({
+				account,
 				limit: 100,
 				following: true,
 				refresh: true,
@@ -124,8 +133,10 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	},
 	mentions: {
 		label: "Mentions",
-		run: async () => {
+		accountAware: true,
+		run: async (account) => {
 			const mentions = await syncMentions({
+				account,
 				mode: "xurl",
 				limit: 100,
 				maxPages: 3,
@@ -142,6 +153,7 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 			];
 
 			const threads = await syncMentionThreads({
+				account,
 				mode: "xurl",
 				limit: 30,
 				delayMs: 1500,
@@ -163,16 +175,20 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	},
 	likes: {
 		label: "Likes",
-		run: () => syncSavedCollection("likes"),
+		accountAware: true,
+		run: (account) => syncSavedCollection("likes", account),
 	},
 	bookmarks: {
 		label: "Bookmarks",
-		run: () => syncSavedCollection("bookmarks"),
+		accountAware: true,
+		run: (account) => syncSavedCollection("bookmarks", account),
 	},
 	dms: {
 		label: "Direct messages",
-		run: async () => {
+		accountAware: false,
+		run: async (account) => {
 			const result = await syncDirectMessagesViaCachedBird({
+				account,
 				limit: 50,
 				refresh: true,
 			});
@@ -188,10 +204,16 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	},
 };
 
-async function syncSavedCollection(kind: "likes" | "bookmarks") {
+async function syncSavedCollection(
+	kind: "likes" | "bookmarks",
+	account: string | undefined,
+) {
+	const isNonDefaultAccount =
+		account !== undefined && account !== resolveDefaultSyncAccountId();
 	const result = await syncTimelineCollection({
 		kind,
-		mode: "auto",
+		account,
+		mode: isNonDefaultAccount ? "xurl" : "auto",
 		limit: 100,
 		maxPages: 5,
 		refresh: true,
@@ -207,15 +229,19 @@ async function syncSavedCollection(kind: "likes" | "bookmarks") {
 	];
 }
 
-async function performWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
+async function performWebSync(
+	kind: WebSyncKind,
+	accountId?: string,
+): Promise<WebSyncResponse> {
 	const startedAt = new Date().toISOString();
-	const steps = await WEB_SYNC_PLANS[kind].run();
+	const steps = await WEB_SYNC_PLANS[kind].run(accountId);
 
 	const backup = await maybeAutoSyncBackup();
 	const finishedAt = new Date().toISOString();
 	return {
 		ok: true,
 		kind,
+		...(accountId ? { accountId } : {}),
 		startedAt,
 		finishedAt,
 		summary: summarizeSteps(steps),
@@ -228,19 +254,64 @@ function createWebSyncJobId(kind: WebSyncKind) {
 	return `sync_${kind}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function resolveDefaultSyncAccountId() {
+	const dbPath = getBirdclawPaths().dbPath;
+	if (!existsSync(dbPath)) {
+		return "acct_primary";
+	}
+
+	let db: NativeSqliteDatabase | undefined;
+	try {
+		db = new NativeSqliteDatabase(dbPath, { readonly: true });
+		const row = db
+			.prepare(
+				`
+        select id
+        from accounts
+        order by is_default desc, created_at asc
+        limit 1
+        `,
+			)
+			.get() as { id: string } | undefined;
+		return row?.id ?? "acct_primary";
+	} catch {
+		return "acct_primary";
+	} finally {
+		db?.close();
+	}
+}
+
+function getRunningSyncKey(kind: WebSyncKind, accountId: string | undefined) {
+	if (!WEB_SYNC_PLANS[kind].accountAware) {
+		return kind;
+	}
+	return `${kind}:${accountId ?? resolveDefaultSyncAccountId()}`;
+}
+
+function getEffectiveAccountId(
+	kind: WebSyncKind,
+	accountId: string | undefined,
+) {
+	return WEB_SYNC_PLANS[kind].accountAware ? accountId : undefined;
+}
+
 function setJobSnapshot(snapshot: WebSyncJobSnapshot) {
 	webSyncJobs.set(snapshot.id, snapshot);
+	const syncKey =
+		webSyncJobKeys.get(snapshot.id) ??
+		getRunningSyncKey(snapshot.kind, snapshot.accountId);
 	const cleanupTimer = completedJobCleanupTimers.get(snapshot.id);
 	if (cleanupTimer) {
 		clearTimeout(cleanupTimer);
 		completedJobCleanupTimers.delete(snapshot.id);
 	}
 	if (snapshot.inProgress) {
-		runningSyncs.set(snapshot.kind, snapshot);
-	} else if (runningSyncs.get(snapshot.kind)?.id === snapshot.id) {
-		runningSyncs.delete(snapshot.kind);
+		runningSyncs.set(syncKey, snapshot);
+	} else if (runningSyncs.get(syncKey)?.id === snapshot.id) {
+		runningSyncs.delete(syncKey);
 		const timer = setTimeout(() => {
 			webSyncJobs.delete(snapshot.id);
+			webSyncJobKeys.delete(snapshot.id);
 			completedJobCleanupTimers.delete(snapshot.id);
 		}, COMPLETED_JOB_TTL_MS);
 		timer.unref?.();
@@ -252,12 +323,14 @@ function toFailedResponse(
 	kind: WebSyncKind,
 	startedAt: string,
 	error: unknown,
+	accountId?: string,
 ): WebSyncResponse {
 	const finishedAt = new Date().toISOString();
 	const message = error instanceof Error ? error.message : "Sync failed";
 	return {
 		ok: false,
 		kind,
+		...(accountId ? { accountId } : {}),
 		startedAt,
 		finishedAt,
 		summary: message,
@@ -266,8 +339,13 @@ function toFailedResponse(
 	};
 }
 
-export function startWebSync(kind: WebSyncKind): WebSyncJobSnapshot {
-	const current = runningSyncs.get(kind);
+export function startWebSync(
+	kind: WebSyncKind,
+	accountId?: string,
+): WebSyncJobSnapshot {
+	const effectiveAccountId = getEffectiveAccountId(kind, accountId);
+	const syncKey = getRunningSyncKey(kind, effectiveAccountId);
+	const current = runningSyncs.get(syncKey);
 	if (current) {
 		return current;
 	}
@@ -276,14 +354,16 @@ export function startWebSync(kind: WebSyncKind): WebSyncJobSnapshot {
 	const job: WebSyncJobSnapshot = {
 		id: createWebSyncJobId(kind),
 		kind,
+		...(effectiveAccountId ? { accountId: effectiveAccountId } : {}),
 		status: "running",
 		startedAt,
 		summary: `Syncing ${WEB_SYNC_PLANS[kind].label}`,
 		inProgress: true,
 	};
+	webSyncJobKeys.set(job.id, syncKey);
 	setJobSnapshot(job);
 
-	void performWebSync(kind)
+	void performWebSync(kind, effectiveAccountId)
 		.then((result) => {
 			setJobSnapshot({
 				...job,
@@ -295,7 +375,12 @@ export function startWebSync(kind: WebSyncKind): WebSyncJobSnapshot {
 			});
 		})
 		.catch((error: unknown) => {
-			const result = toFailedResponse(kind, startedAt, error);
+			const result = toFailedResponse(
+				kind,
+				startedAt,
+				error,
+				effectiveAccountId,
+			);
 			setJobSnapshot({
 				...job,
 				status: "failed",
@@ -314,13 +399,18 @@ export function getWebSyncJob(id: string): WebSyncJobSnapshot | null {
 	return webSyncJobs.get(id) ?? null;
 }
 
-export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
-	const current = runningSyncs.get(kind);
+export async function runWebSync(
+	kind: WebSyncKind,
+	accountId?: string,
+): Promise<WebSyncResponse> {
+	const effectiveAccountId = getEffectiveAccountId(kind, accountId);
+	const current = runningSyncs.get(getRunningSyncKey(kind, effectiveAccountId));
 	const startedAt = new Date().toISOString();
 	if (current) {
 		return {
 			ok: false,
 			kind,
+			...(effectiveAccountId ? { accountId: effectiveAccountId } : {}),
 			startedAt,
 			summary: "Sync already running",
 			steps: [],
@@ -328,7 +418,7 @@ export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
 		};
 	}
 
-	const job = startWebSync(kind);
+	const job = startWebSync(kind, effectiveAccountId);
 	while (job.inProgress) {
 		await new Promise((resolve) => setTimeout(resolve, 25));
 		const latest = getWebSyncJob(job.id);
@@ -345,6 +435,7 @@ export async function runWebSync(kind: WebSyncKind): Promise<WebSyncResponse> {
 export function clearWebSyncLocksForTests() {
 	runningSyncs.clear();
 	webSyncJobs.clear();
+	webSyncJobKeys.clear();
 	for (const timer of completedJobCleanupTimers.values()) {
 		clearTimeout(timer);
 	}

--- a/src/routes/api/sync.test.ts
+++ b/src/routes/api/sync.test.ts
@@ -29,6 +29,7 @@ describe("api sync route", () => {
 		startWebSyncMock.mockReturnValue({
 			id: "sync_timeline_1",
 			kind: "timeline",
+			accountId: "acct_primary",
 			status: "running",
 			startedAt: "2026-05-15T12:00:00.000Z",
 			summary: "Syncing Home timeline",
@@ -38,14 +39,15 @@ describe("api sync route", () => {
 		const response = await POST({
 			request: new Request("http://localhost/api/sync", {
 				method: "POST",
-				body: JSON.stringify({ kind: "timeline" }),
+				body: JSON.stringify({ kind: "timeline", accountId: "acct_primary" }),
 			}),
 		});
 
 		expect(response.status).toBe(202);
-		expect(startWebSyncMock).toHaveBeenCalledWith("timeline");
+		expect(startWebSyncMock).toHaveBeenCalledWith("timeline", "acct_primary");
 		expect(await response.json()).toMatchObject({
 			id: "sync_timeline_1",
+			accountId: "acct_primary",
 			status: "running",
 			summary: "Syncing Home timeline",
 		});

--- a/src/routes/api/sync.tsx
+++ b/src/routes/api/sync.tsx
@@ -11,6 +11,10 @@ function json(data: unknown, init?: ResponseInit) {
 	});
 }
 
+function parseAccountId(value: unknown) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 export const Route = createFileRoute("/api/sync")({
 	server: {
 		handlers: {
@@ -47,7 +51,7 @@ export const Route = createFileRoute("/api/sync")({
 					);
 				}
 
-				const job = startWebSync(kind);
+				const job = startWebSync(kind, parseAccountId(body.accountId));
 				return json(job, { status: job.inProgress ? 202 : 200 });
 			},
 		},


### PR DESCRIPTION
## Summary
- pass selected account ids through manual sync requests for mentions and saved collections
- keep Bird-only timeline/DM syncs default-scoped so account-agnostic Bird data is not attributed to the wrong account
- scope background sync locks by account where the transport can target an account, and preserve auto/bird fallback for default saved syncs

## Proof
- codex-review: clean, no accepted/actionable findings
- env -u NODE_OPTIONS ./node_modules/.bin/vitest run src/lib/web-sync.test.ts src/components/SyncNowButton.test.tsx src/routes/api/sync.test.ts
- env -u NODE_OPTIONS ./node_modules/.bin/vitest run src/routes/index.test.tsx src/routes/mentions.test.tsx src/components/SavedTimelineView.test.tsx src/routes/dms.test.tsx
- env -u NODE_OPTIONS ./node_modules/.bin/tsgo --noEmit
- env -u NODE_OPTIONS ./node_modules/.bin/oxlint --import-plugin --node-plugin --vitest-plugin --deny-warnings -A require-mock-type-parameters -A no-control-regex src scripts playwright vite.config.ts vitest.config.ts playwright.config.ts
- env -u NODE_OPTIONS ./node_modules/.bin/oxfmt --check src scripts playwright vite.config.ts vitest.config.ts playwright.config.ts
- env -u NODE_OPTIONS ./node_modules/.bin/vite build
- env -u NODE_OPTIONS ./node_modules/.bin/playwright test

## Note
Full Vitest still has the pre-existing backup git timeout failures in src/lib/backup.test.ts; this PR's focused sync/UI coverage passes.
