### PR TITLE
test: remove manual sync e2e sleep

### DIFF
--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -89,8 +89,14 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 				response.request().method() === "GET" &&
 				response.ok(),
 		);
+		const routeDataReady = page.waitForResponse(
+			(response) =>
+				response.url().includes("/api/query") &&
+				response.request().method() === "GET" &&
+				response.ok(),
+		);
 		await page.goto(path);
-		await statusReady;
+		await Promise.all([statusReady, routeDataReady]);
 		if (expectedAccountId) {
 			await expect(page.getByLabel("Sync account")).toHaveValue(
 				expectedAccountId,

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -78,11 +78,26 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 		});
 	});
 
-	async function clickSync(path: string, buttonName: string) {
+	async function clickSync(
+		path: string,
+		buttonName: string,
+		expectedAccountId?: string,
+	) {
+		const statusReady = page.waitForResponse(
+			(response) =>
+				response.url().includes("/api/status") &&
+				response.request().method() === "GET" &&
+				response.ok(),
+		);
 		await page.goto(path);
+		await statusReady;
+		if (expectedAccountId) {
+			await expect(page.getByLabel("Sync account")).toHaveValue(
+				expectedAccountId,
+			);
+		}
 		const button = page.getByRole("button", { name: buttonName });
 		await expect(button).toBeEnabled();
-		await page.waitForTimeout(1500);
 		const request = page.waitForRequest(
 			(req) => req.url().includes("/api/sync") && req.method() === "POST",
 		);
@@ -91,9 +106,9 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 	}
 
 	await clickSync("/", "Sync timeline");
-	await clickSync("/mentions", "Sync mentions");
-	await clickSync("/likes", "Sync likes");
-	await clickSync("/bookmarks", "Sync bookmarks");
+	await clickSync("/mentions", "Sync mentions", "acct_primary");
+	await clickSync("/likes", "Sync likes", "acct_primary");
+	await clickSync("/bookmarks", "Sync bookmarks", "acct_primary");
 	await clickSync("/dms", "Sync DMs");
 
 	await expect


### PR DESCRIPTION
## Summary
- Replace the fixed manual sync E2E sleep with `/api/status` readiness.
- Wait for the expected account picker value before account-aware sync clicks.

## Proof
- codex-review clean: no accepted/actionable findings reported
- `env -u NODE_OPTIONS ./node_modules/.bin/playwright test`
- `env -u NODE_OPTIONS ./node_modules/.bin/oxfmt --check playwright/app.spec.ts`
- `env -u NODE_OPTIONS ./node_modules/.bin/tsgo --noEmit`
