### PR TITLE
fix: keep dm thread stable during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Keep the selected DM conversation visible while its thread refreshes so the reply composer no longer flashes away mid-action.
 - Send the selected web account through manual sync controls so multi-account timelines sync the intended profile.
 - Run web sync requests as background jobs with status polling so the UI no longer holds one blocking sync request open.
 - Add typed web API fetch handling and explicit DMs loading/error/empty states so failed local reads surface cleanly.

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -11,17 +11,34 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("#/components/DmWorkspace", () => ({
 	DmWorkspace: ({
 		selectedConversation,
+		selectedMessages,
+		conversations,
 		replyDraft,
 		onReplyDraftChange,
 		onReplySend,
+		onSelectConversation,
 	}: {
 		selectedConversation: { id: string; title: string } | null;
+		selectedMessages: Array<{ id: string; text: string }>;
+		conversations: Array<{ id: string; title: string }>;
 		replyDraft: string;
 		onReplyDraftChange: (value: string) => void;
 		onReplySend: (id: string) => void;
+		onSelectConversation: (id: string) => void;
 	}) => (
 		<div>
-			<div>{selectedConversation?.title ?? "none"}</div>
+			{conversations.map((conversation) => (
+				<button
+					key={conversation.id}
+					onClick={() => onSelectConversation(conversation.id)}
+					type="button"
+				>
+					{conversation.title}
+				</button>
+			))}
+			{selectedMessages.map((message) => (
+				<div key={message.id}>{message.text}</div>
+			))}
 			<input
 				aria-label="draft"
 				onChange={(event) => onReplyDraftChange(event.target.value)}
@@ -102,10 +119,11 @@ describe("dms route", () => {
 		render(<DmsRoute />);
 
 		expect(await screen.findByText("Sam Altman")).toBeInTheDocument();
+		const sendButton = await screen.findByRole("button", { name: "send dm" });
 		fireEvent.change(screen.getByLabelText("draft"), {
 			target: { value: "Need details" },
 		});
-		fireEvent.click(screen.getByRole("button", { name: "send dm" }));
+		fireEvent.click(sendButton);
 
 		await waitFor(() => {
 			expect(fetchMock).toHaveBeenCalledWith(
@@ -113,6 +131,138 @@ describe("dms route", () => {
 				expect.objectContaining({ method: "POST" }),
 			);
 		});
+	});
+
+	it("keeps the selected conversation visible while refreshing it", async () => {
+		let queryCalls = 0;
+		let releaseRefresh: (() => void) | undefined;
+		const dmResponse = {
+			resource: "dms",
+			items: [
+				{
+					id: "dm_1",
+					title: "Sam Altman",
+					accountId: "acct_primary",
+					accountHandle: "@steipete",
+				},
+			],
+			selectedConversation: {
+				conversation: {
+					id: "dm_1",
+					title: "Sam Altman",
+					accountId: "acct_primary",
+					accountHandle: "@steipete",
+				},
+				messages: [],
+			},
+		};
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				queryCalls += 1;
+				if (queryCalls === 2) {
+					await new Promise<void>((resolve) => {
+						releaseRefresh = resolve;
+					});
+				}
+				return new Response(JSON.stringify(dmResponse));
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(await screen.findByText("Sam Altman")).toBeInTheDocument();
+		await waitFor(() => {
+			expect(queryCalls).toBeGreaterThan(1);
+		});
+		expect(screen.getByRole("button", { name: "send dm" })).toBeInTheDocument();
+
+		releaseRefresh?.();
+	});
+
+	it("hides stale thread content while switching conversations", async () => {
+		let releaseSwitch: (() => void) | undefined;
+		const conversations = [
+			{
+				id: "dm_1",
+				title: "Sam Altman",
+				accountId: "acct_primary",
+				accountHandle: "@steipete",
+			},
+			{
+				id: "dm_2",
+				title: "Ada Lovelace",
+				accountId: "acct_primary",
+				accountHandle: "@steipete",
+			},
+		];
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				const requestUrl = new URL(url);
+				const conversationId = requestUrl.searchParams.get("conversationId");
+				if (conversationId === "dm_2") {
+					await new Promise<void>((resolve) => {
+						releaseSwitch = resolve;
+					});
+				}
+				const selectedId = conversationId ?? "dm_1";
+				return new Response(
+					JSON.stringify({
+						resource: "dms",
+						items: conversations,
+						selectedConversation: {
+							conversation: conversations.find(
+								(conversation) => conversation.id === selectedId,
+							),
+							messages: [
+								{
+									id: `message_${selectedId}`,
+									text:
+										selectedId === "dm_1"
+											? "Old thread message"
+											: "New thread message",
+								},
+							],
+						},
+					}),
+				);
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(await screen.findByText("Old thread message")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Ada Lovelace" }));
+		expect(await screen.findByText("Loading messages")).toBeInTheDocument();
+		expect(screen.queryByText("Old thread message")).not.toBeInTheDocument();
+
+		releaseSwitch?.();
+		expect(await screen.findByText("New thread message")).toBeInTheDocument();
 	});
 
 	it("runs a live dm sync and reloads conversations", async () => {

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -49,6 +49,9 @@ function DmsRoute() {
 	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
 	const [items, setItems] = useState<DmConversationItem[]>([]);
 	const [messages, setMessages] = useState<DmMessageItem[]>([]);
+	const [loadedConversationId, setLoadedConversationId] = useState<
+		string | undefined
+	>();
 	const [selectedConversationId, setSelectedConversationId] = useState<
 		string | undefined
 	>();
@@ -95,6 +98,7 @@ function DmsRoute() {
 				const conversations = data.items as DmConversationItem[];
 				const nextSelected =
 					data.selectedConversation?.conversation.id ?? conversations[0]?.id;
+				setLoadedConversationId(data.selectedConversation?.conversation.id);
 				setItems(conversations);
 				setSelectedConversationId((current) => {
 					if (!current) return nextSelected;
@@ -121,6 +125,7 @@ function DmsRoute() {
 				);
 				setItems([]);
 				setMessages([]);
+				setLoadedConversationId(undefined);
 			})
 			.finally(() => {
 				if (active) {
@@ -144,6 +149,13 @@ function DmsRoute() {
 
 	const selectedConversation =
 		items.find((item) => item.id === selectedConversationId) ?? null;
+	const switchingConversation =
+		loading &&
+		Boolean(
+			selectedConversationId &&
+			loadedConversationId &&
+			selectedConversationId !== loadedConversationId,
+		);
 
 	const subtitle = useMemo(() => {
 		if (!meta) return "Loading direct messages...";
@@ -295,7 +307,7 @@ function DmsRoute() {
 				</div>
 			</header>
 
-			{loading ? (
+			{loading && (items.length === 0 || switchingConversation) ? (
 				<FeedLoading
 					detail="Reading local conversations and reply state"
 					label="Loading messages"


### PR DESCRIPTION
## Summary
- Keep the current DM workspace mounted for same-thread refreshes so the reply composer does not flash away.
- Show the loading state during conversation switches to avoid exposing stale messages for the newly selected thread.
- Add DMs route regressions for both refresh and conversation-switch behavior.

## Proof
- codex-review clean: no accepted/actionable findings reported
- `env -u NODE_OPTIONS ./node_modules/.bin/vitest run src/routes/dms.test.tsx`
- `env -u NODE_OPTIONS ./node_modules/.bin/vitest run`
- `env -u NODE_OPTIONS node ./scripts/run-vitest.mjs run --coverage`
- `env -u NODE_OPTIONS ./node_modules/.bin/oxfmt --check src/routes/dms.tsx src/routes/dms.test.tsx CHANGELOG.md`
- `env -u NODE_OPTIONS ./node_modules/.bin/oxlint --import-plugin --node-plugin --vitest-plugin --deny-warnings -A require-mock-type-parameters -A no-control-regex src scripts playwright vite.config.ts vitest.config.ts playwright.config.ts`
- `env -u NODE_OPTIONS ./node_modules/.bin/tsgo --noEmit`
- `env -u NODE_OPTIONS ./node_modules/.bin/vite build`
- `env -u NODE_OPTIONS ./node_modules/.bin/playwright test`
