### PR TITLE
fix: harden cli shutdown forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Harden the published CLI wrapper and release checks so the packaged `birdclaw` binary avoids `tsx` CLI IPC startup and stays covered by lint, format, and smoke tests.
+- Forward shutdown signals through the published CLI and bundled web server, and include referenced script helpers in npm packages.
 - Keep the selected DM conversation visible while its thread refreshes so the reply composer no longer flashes away mid-action.
 - Send the selected web account through manual sync controls so multi-account timelines sync the intended profile.
 - Run web sync requests as background jobs with status polling so the UI no longer holds one blocking sync request open.

--- a/bin/birdclaw.mjs
+++ b/bin/birdclaw.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -9,22 +9,61 @@ const require = createRequire(import.meta.url);
 const tsxLoader = pathToFileURL(require.resolve("tsx")).href;
 const birdclawCli = join(packageRoot, "src", "cli.ts");
 
-const result = spawnSync(
+const child = spawn(
 	process.execPath,
 	["--import", tsxLoader, birdclawCli, ...process.argv.slice(2)],
 	{
 		stdio: "inherit",
 		env: process.env,
+		detached: process.platform !== "win32",
 	},
 );
 
-if (result.error) {
-	console.error(result.error.message);
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"];
+
+function removeSignalHandlers() {
+	for (const signal of forwardedSignals) {
+		process.removeListener(signal, forwardSignal);
+	}
+}
+
+function forwardSignal(signal) {
+	if (child.exitCode === null && child.signalCode === null) {
+		signalChild(signal);
+	}
+}
+
+function signalChild(signal) {
+	if (child.pid === undefined) {
+		return;
+	}
+	const targetPid = process.platform === "win32" ? child.pid : -child.pid;
+	try {
+		process.kill(targetPid, signal);
+	} catch (error) {
+		if (error?.code !== "ESRCH") {
+			throw error;
+		}
+	}
+}
+
+for (const signal of forwardedSignals) {
+	process.on(signal, forwardSignal);
+}
+
+child.on("error", (error) => {
+	removeSignalHandlers();
+	console.error(error.message);
 	process.exit(1);
-}
+});
 
-if (result.signal) {
-	process.kill(process.pid, result.signal);
-}
+child.on("exit", (code, signal) => {
+	removeSignalHandlers();
 
-process.exit(result.status ?? 0);
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+
+	process.exit(code ?? 0);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"files": [
 		"bin/",
+		"scripts/",
 		"src/",
 		"!src/**/*.test.ts",
 		"!src/**/*.test.tsx",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1474,9 +1474,54 @@ program
 			{
 				cwd: packageRoot,
 				stdio: "inherit",
+				detached: process.platform !== "win32",
 			},
 		);
-		child.on("exit", (code) => {
+		const forwardedSignals = [
+			"SIGINT",
+			"SIGTERM",
+			"SIGHUP",
+			"SIGQUIT",
+		] as const;
+		const forwardSignal = (signal: NodeJS.Signals) => {
+			if (child.exitCode === null && child.signalCode === null) {
+				signalChild(signal);
+			}
+		};
+		const signalChild = (signal: NodeJS.Signals) => {
+			if (child.pid === undefined) {
+				return;
+			}
+			const targetPid = process.platform === "win32" ? child.pid : -child.pid;
+			try {
+				process.kill(targetPid, signal);
+			} catch (error) {
+				if (
+					!(
+						typeof error === "object" &&
+						error !== null &&
+						"code" in error &&
+						error.code === "ESRCH"
+					)
+				) {
+					throw error;
+				}
+			}
+		};
+		const removeSignalHandlers = () => {
+			for (const signal of forwardedSignals) {
+				process.removeListener(signal, forwardSignal);
+			}
+		};
+		for (const signal of forwardedSignals) {
+			process.on(signal, forwardSignal);
+		}
+		child.on("exit", (code, signal) => {
+			removeSignalHandlers();
+			if (signal) {
+				process.kill(process.pid, signal);
+				return;
+			}
 			process.exit(code ?? 0);
 		});
 	});

--- a/src/package-config.test.ts
+++ b/src/package-config.test.ts
@@ -14,6 +14,7 @@ const packageJson = JSON.parse(
 	version: string;
 	bin: Record<string, string>;
 	scripts: Record<string, string>;
+	files: string[];
 };
 
 function resolvedVitestConfig() {
@@ -50,6 +51,23 @@ describe("package configuration", () => {
 		expect(packageJson.scripts.coverage).toBe(
 			"node ./scripts/run-vitest.mjs run --coverage",
 		);
+	});
+
+	it("publishes script helpers referenced by package scripts", () => {
+		const isPublished = (filePath: string) =>
+			packageJson.files.some(
+				(entry) =>
+					!entry.startsWith("!") &&
+					(entry === filePath ||
+						(entry.endsWith("/") && filePath.startsWith(entry))),
+			);
+
+		for (const script of Object.values(packageJson.scripts)) {
+			for (const match of script.matchAll(/(?:^|\s)(\.\/scripts\/\S+)/g)) {
+				const scriptPath = match[1]?.replace(/^\.\//, "");
+				expect(scriptPath && isPublished(scriptPath)).toBe(true);
+			}
+		}
 	});
 
 	it("preserves Vitest default excludes while adding project excludes", () => {


### PR DESCRIPTION
## Summary

- Replace the published bin wrapper's blocking spawn with async process-group-aware signal forwarding.
- Forward shutdown signals through `birdclaw serve` to the Vite child process group.
- Include `scripts/` in the npm package allowlist and add a regression test for package-script helper coverage.

## Clawpatch

- `fnd_sig-feat-cli-command-332c0e3b24-_01396977a2`: fixed
- `fnd_sig-feat-test-suite-84ae84a25a-a_2839d0eeed`: fixed

## Review

- Codex review command: `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access`
- Final result: `codex-review clean: no accepted/actionable findings reported`

## Proof

- `node bin/birdclaw.mjs --version`
- `node ./scripts/run-vitest.mjs run src/package-config.test.ts src/cli.test.ts --reporter dot`
- parent/process-group SIGTERM and SIGQUIT e2e against `birdclaw serve`
- `pnpm run check`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run coverage` earlier in this patch series: 91.74% statements, 82.16% branches, 92.74% functions, 92.42% lines
- `pnpm exec playwright test`
- `npm_config_cache=/tmp/npm-cache npm pack --dry-run --json`
