### PR TITLE
refactor: migrate core IO to Effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Start the Effect rewrite by making `effect` a first-class runtime dependency and moving web API fetches, web sync orchestration, live command helpers, action transport, `bird`/`xurl` JSON/action transports and public adapters, backup export/import/validation and Git orchestration, moderation target resolution, blocks/mutes write helpers, remote block sync, batch blocklist imports, x-web mutations, authored/mentions/mention-thread sync including xurl recent-search and parent-walk fallback internals, conversation loading, home timeline, saved collection, DM live sync, profile hydration/resolution/affiliation/reply inspection, shared tweet lookup, research and whois report generation, follow graph live sync, link preview/index fetches, archive discovery/import subprocesses, avatar/URL caches, OpenAI/inbox scoring, scheduled bookmark sync locking/audit/launchd install, and media-fetch archive reuse/download concurrency onto Effect programs with Promise-compatible public wrappers.
+
 ## 0.5.1 - 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Status: WIP. Real and usable. Not done. Expect schema churn, transport gaps, and
 - CI disables live writes
 - app has no auth layer because it is a local-only tool
 
+### Runtime Architecture
+
+Birdclaw uses [Effect](https://effect.website/) for new and migrated I/O-heavy internals. The current Effect boundary covers browser API fetches, web sync orchestration, sync-job polling, `bird`/`xurl` subprocess helpers and public adapters, backup export/import/validation and Git orchestration, moderation action transport and target resolution, `bird` action/profile adapters, blocks/mutes write helpers, remote block sync, batch blocklist imports, x-web mutations, authored/mentions/mention-thread sync including xurl recent-search and parent-walk fallback internals, conversation loading, home timeline, saved collection, DM live sync, profile hydration/resolution/affiliation/reply inspection, shared tweet lookup, research and whois report generation, follow graph live sync, link preview/index fetches, archive discovery/import subprocesses, avatar/URL caches, OpenAI/inbox scoring, scheduled bookmark sync locking/audit/launchd install, and the paced/concurrent `media fetch` archive-reuse and HTTP download pipeline.
+
+Public CLI and React call sites still expose plain `Promise` wrappers where that keeps the surrounding framework code simple. New core code should prefer `Effect` programs with typed error values, then add a Promise wrapper only at the outer CLI, route, or component boundary.
+
 ## Still In Progress
 
 - broader resumable live sync beyond the targeted paths already wired

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -1,13 +1,65 @@
 # Data And Architecture
 
+## Effect Runtime Boundary
+
+Birdclaw's core I/O code should be written as Effect programs. Use `Effect.gen` for multi-step workflows, typed failures for expected errors, and `Effect.forEach` / `Effect.sleep` for concurrency, retry, timeout, and pacing logic.
+
+Keep framework edges boring:
+
+- CLI command handlers may `await` Promise wrappers.
+- React components may call Promise wrappers from effects and event handlers.
+- route handlers may return normal `Response` values.
+
+Inside `src/lib`, prefer exporting both forms when useful:
+
+```ts
+export function runThingEffect(
+	input: Input,
+): Effect.Effect<Output, ThingError> {
+	return Effect.gen(function* () {
+		// core logic
+	});
+}
+
+export function runThing(input: Input): Promise<Output> {
+	return runEffectPromise(runThingEffect(input));
+}
+```
+
+Use `runEffectPromise` from `src/lib/effect-runtime.ts` for Promise wrappers so typed failures are thrown directly instead of being hidden behind Effect fiber failures.
+
+Current migrated surfaces:
+
+- typed Effect-to-Promise boundary handling in `src/lib/effect-runtime.ts`
+- web API client parsing and sync-job polling in `src/lib/api-client.ts`
+- `bird` command availability and execution in `src/lib/bird-command.ts`
+- `bird` JSON transport, large stdout capture, and temp-file cleanup in `src/lib/bird.ts`
+- `xurl` command execution, JSON parsing, retry delay, mutation helpers, and public adapter wrappers in `src/lib/xurl.ts`
+- backup export/import/validation, Git repo setup, pull, commit/push, stale auto-update, and auto-sync orchestration in `src/lib/backup.ts`
+- moderation action transport fallback and bird action/profile adapter helpers in `src/lib/actions-transport.ts` and `src/lib/bird-actions.ts`
+- moderation target resolution plus local blocks/mutes write helpers, remote block sync, and x-web block/unblock mutations in `src/lib/moderation-target.ts`, `src/lib/moderation-write.ts`, `src/lib/blocks-write.ts`, `src/lib/blocks.ts`, `src/lib/mutes-write.ts`, and `src/lib/x-web.ts`
+- batch blocklist file import in `src/lib/blocklist.ts`
+- authored, mentions, mention-thread sync including xurl recent-search and parent-walk fallback internals, conversation surface, home timeline, saved collection, DM live sync, profile hydration/resolution/affiliation, profile-reply inspection, shared tweet lookup, research and whois report generation, inbox scoring, and follow graph live sync cache/fetch/merge flows in `src/lib/authored-live.ts`, `src/lib/mentions-live.ts`, `src/lib/mention-threads-live.ts`, `src/lib/conversation-surface.ts`, `src/lib/timeline-live.ts`, `src/lib/timeline-collections-live.ts`, `src/lib/dms-live.ts`, `src/lib/profile-hydration.ts`, `src/lib/profile-affiliation-hydration.ts`, `src/lib/profile-resolver.ts`, `src/lib/profile-replies.ts`, `src/lib/tweet-lookup.ts`, `src/lib/research.ts`, `src/lib/whois.ts`, `src/lib/inbox.ts`, and `src/lib/follow-graph.ts`
+- link preview metadata fetches and link-index backfill concurrency in `src/lib/link-preview-metadata.ts` and `src/lib/link-index.ts`
+- `media fetch` archive reuse, HTTP download groups, pacing, and bounded concurrency in `src/lib/media-fetch.ts`
+- archive discovery and archive-import subprocess boundaries in `src/lib/archive-finder.ts` and `src/lib/archive-import.ts`
+- avatar read-through caching and URL expansion cache/fetch flows in `src/lib/avatar-cache.ts` and `src/lib/url-expansion.ts`
+- OpenAI inbox scoring fetch/parse boundary in `src/lib/openai.ts`
+- scheduled bookmark sync audit logging, overlap locking, backup pass, and launchd install in `src/lib/bookmark-sync-job.ts`
+- web sync orchestration, plan runners, backup pass, and job polling in `src/lib/web-sync.ts`
+
+Production `src/lib` code should stay free of ad hoc `async`/`await` orchestration. Next migrations should target remaining CLI, React, and route edges only where an Effect boundary would simplify error handling, cancellation, retries, or concurrency; otherwise keep those framework adapters as small Promise wrappers over core Effect programs.
+
 ## Transport Strategy
 
 Support these adapters:
+
 - `xurl`
 - `bird`
 - official API
 
 Optional later:
+
 - lower-level `xweb`
 
 ### Recommendation
@@ -21,6 +73,7 @@ v1 transport priority:
 5. optional lower-level `xweb`
 
 Reason:
+
 - working `xurl` already exists
 - users with `xurl` setup get zero-friction sync
 - `bird` can cover GraphQL/cookie-backed gaps if needed
@@ -29,16 +82,19 @@ Reason:
 ### `xurl` compatibility
 
 Important stance:
+
 - do not "pretend to be xurl" by mutating or owning `~/.xurl` format in v1
 - shell out to `xurl` as an adapter instead
 
 Why:
+
 - lower auth risk
 - lower coupling to xurl store internals
 - birdclaw stays transport-agnostic
 - users already authenticated in `xurl` get immediate value
 
 Possible later feature:
+
 - `birdclaw auth import-xurl`
 - local one-shot import into birdclaw-managed credentials
 - opt-in only
@@ -46,6 +102,7 @@ Possible later feature:
 ### `bird` compatibility
 
 Treat `bird` the same way:
+
 - adapter, not architecture
 - subprocess or wrapper boundary
 - no dependency on `bird` config/storage as core truth
@@ -54,38 +111,43 @@ Treat `bird` the same way:
 ### Transport interface
 
 ```ts
-type TransportKind = 'archive' | 'xurl' | 'bird' | 'official' | 'xweb';
+import type { Effect } from "effect";
+
+type TransportTask<A, E = TransportError> = Effect.Effect<A, E>;
+type TransportKind = "archive" | "xurl" | "bird" | "official" | "xweb";
 
 interface BirdTransport {
-  kind: TransportKind;
-  capabilities(): Promise<TransportCapabilities>;
-  currentUser(): Promise<AccountIdentity>;
-  listBookmarks(input: CursorInput): Promise<Page<BookmarkRecord>>;
-  listLikes(input: CursorInput): Promise<Page<LikeRecord>>;
-  listMentions(input: CursorInput): Promise<Page<TweetRecord>>;
-  listFollowers(input: CursorInput): Promise<Page<ProfileRecord>>;
-  listFollowing(input: CursorInput): Promise<Page<ProfileRecord>>;
-  listUserTweets(input: UserTimelineInput): Promise<Page<TweetRecord>>;
-  listDmEvents(input: DmEventsInput): Promise<Page<DmEventRecord>>;
-  getTweet(id: string): Promise<TweetRecord | null>;
-  postTweet(input: ComposeTweetInput): Promise<PostResult>;
-  reply(input: ReplyInput): Promise<PostResult>;
-  blockProfile(input: ProfileActionInput): Promise<ActionResult>;
-  unblockProfile(input: ProfileActionInput): Promise<ActionResult>;
-  muteProfile(input: ProfileActionInput): Promise<ActionResult>;
-  unmuteProfile(input: ProfileActionInput): Promise<ActionResult>;
+	kind: TransportKind;
+	capabilities(): TransportTask<TransportCapabilities>;
+	currentUser(): TransportTask<AccountIdentity>;
+	listBookmarks(input: CursorInput): TransportTask<Page<BookmarkRecord>>;
+	listLikes(input: CursorInput): TransportTask<Page<LikeRecord>>;
+	listMentions(input: CursorInput): TransportTask<Page<TweetRecord>>;
+	listFollowers(input: CursorInput): TransportTask<Page<ProfileRecord>>;
+	listFollowing(input: CursorInput): TransportTask<Page<ProfileRecord>>;
+	listUserTweets(input: UserTimelineInput): TransportTask<Page<TweetRecord>>;
+	listDmEvents(input: DmEventsInput): TransportTask<Page<DmEventRecord>>;
+	getTweet(id: string): TransportTask<TweetRecord | null>;
+	postTweet(input: ComposeTweetInput): TransportTask<PostResult>;
+	reply(input: ReplyInput): TransportTask<PostResult>;
+	blockProfile(input: ProfileActionInput): TransportTask<ActionResult>;
+	unblockProfile(input: ProfileActionInput): TransportTask<ActionResult>;
+	muteProfile(input: ProfileActionInput): TransportTask<ActionResult>;
+	unmuteProfile(input: ProfileActionInput): TransportTask<ActionResult>;
 }
 ```
 
 ### Transport config
 
 Per account:
+
 - preferred transport: `auto | xurl | bird | official | xweb`
 - fallback chain
 - capability cache
 - auth status snapshot
 
 `auto` means:
+
 - use `xurl` if available and healthy
 - else use `bird` if available and healthy
 - else use official auth if configured
@@ -166,6 +228,7 @@ SQLite only. Kysely schema in code, migrations checked into repo.
 Use FTS5.
 
 Day-1 search modes:
+
 - exact filters
 - keyword full-text
 - date ranges
@@ -180,6 +243,7 @@ No vector search required for MVP.
 ### Indexing
 
 Indexes from day 1:
+
 - tweet id unique
 - author + created_at desc
 - created_at desc
@@ -196,6 +260,7 @@ Indexes from day 1:
 Borrow the shape from `sweetistics`, but local-first and SQLite-native.
 
 Principles:
+
 - directional edges, not dual booleans
 - snapshots are the source of truth for full crawls
 - events are append-only
@@ -291,6 +356,7 @@ Principles:
 - selected DM imports are scoped to `acct_primary` and preserve other accounts
 
 Selected import slices:
+
 - `tweets`
 - `likes`
 - `bookmarks`
@@ -302,6 +368,7 @@ Selected import slices:
 ## Sync Model
 
 Streams:
+
 - own tweets
 - mentions
 - likes
@@ -311,6 +378,7 @@ Streams:
 - following
 
 Future:
+
 - notifications
 - list timelines
 - graph analytics
@@ -353,6 +421,7 @@ Primary human UI.
 ### AI layer
 
 Local-first ranking metadata stored in DB:
+
 - score
 - reason codes
 - summary
@@ -361,6 +430,7 @@ Local-first ranking metadata stored in DB:
 - acted-on state
 
 Candidate ranking inputs:
+
 - author importance
 - sender follower count / influence
 - sender bio cues
@@ -377,6 +447,7 @@ Candidate ranking inputs:
 ### Web server mode
 
 `birdclaw serve`
+
 - starts local server
 - starts background sync automatically by default
 - opens browser unless `--no-open`
@@ -387,10 +458,12 @@ Candidate ranking inputs:
 Support profiles from day 1.
 
 Reason:
+
 - separate DBs or configs for personal/test/future shared use
 - easier OSS story
 
 Default:
+
 - one profile named `default`
 
 ## Auth / Secrets
@@ -492,6 +565,7 @@ birdclaw/
 ### Live
 
 Opt-in only:
+
 - real `xurl` health check
 - real `bird` health check
 - real sync smoke tests
@@ -499,7 +573,9 @@ Opt-in only:
 ## Distribution
 
 Primary:
+
 - npm package
 
 Secondary later:
+
 - standalone desktop wrapper if the web UX becomes primary

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"@tanstack/router-plugin": "^1.167.35",
 		"@vitejs/plugin-react": "^6.0.1",
 		"commander": "^14.0.3",
+		"effect": "^3.21.2",
 		"kysely": "^0.29.0",
 		"lucide-react": "^1.16.0",
 		"react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      effect:
+        specifier: ^3.21.2
+        version: 3.21.2
       kysely:
         specifier: ^0.29.0
         version: 0.29.0
@@ -1641,6 +1644,9 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   electron-to-chromium@1.5.355:
     resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
 
@@ -1688,6 +1694,10 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2046,6 +2056,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -3687,6 +3700,11 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.355: {}
 
   encoding-sniffer@0.2.1:
@@ -3747,6 +3765,10 @@ snapshots:
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4100,6 +4122,8 @@ snapshots:
       react-is: 17.0.2
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:

--- a/src/lib/actions-transport.test.ts
+++ b/src/lib/actions-transport.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -104,6 +105,24 @@ describe("actions transport", () => {
 	afterEach(() => {
 		delete process.env.BIRDCLAW_ACTIONS_TRANSPORT;
 		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
+	});
+
+	it("builds moderation action effects lazily", async () => {
+		const { runModerationActionEffect } = await import("./actions-transport");
+
+		const effect = runModerationActionEffect({
+			action: "block",
+			query: "7",
+			targetUserId: "7",
+		});
+
+		expect(mocks.blockUserViaBird).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual({
+			ok: true,
+			output: "bird block ok",
+			transport: "bird",
+		});
+		expect(mocks.blockUserViaBird).toHaveBeenCalledWith("7");
 	});
 
 	it("uses bird in auto mode first", async () => {

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -6,6 +6,8 @@ import {
 	unmuteUserViaBird,
 } from "./bird-actions";
 import { type ActionsTransport, resolveActionsTransport } from "./config";
+import { Effect } from "effect";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type {
 	ModerationAction,
 	ModerationActionTransportResult,
@@ -29,27 +31,41 @@ interface RunActionParams {
 	transport?: string;
 }
 
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
 function normalizeFailure(transport: ModerationTransportKind, output: string) {
 	return `${transport}: ${output}`;
 }
 
-async function runBirdAction(
+function runBirdActionEffect(
 	action: ModerationAction,
 	query: string,
-): Promise<ActionTransportResult> {
-	const result =
-		action === "block"
-			? await blockUserViaBird(query)
-			: action === "unblock"
-				? await unblockUserViaBird(query)
-				: action === "mute"
-					? await muteUserViaBird(query)
-					: await unmuteUserViaBird(query);
+): Effect.Effect<ActionTransportResult, unknown> {
+	return Effect.gen(function* () {
+		const result = yield* tryPromise(() =>
+			action === "block"
+				? blockUserViaBird(query)
+				: action === "unblock"
+					? unblockUserViaBird(query)
+					: action === "mute"
+						? muteUserViaBird(query)
+						: unmuteUserViaBird(query),
+		);
 
-	return {
-		...result,
-		transport: "bird",
-	};
+		return {
+			...result,
+			transport: "bird",
+		};
+	});
 }
 
 function getVerifyExpectation(action: ModerationAction) {
@@ -64,145 +80,165 @@ function getVerifyExpectation(action: ModerationAction) {
 			};
 }
 
-async function runXurlAction(
+function runXurlActionEffect(
 	action: ModerationAction,
 	query: string,
 	targetUserId?: string,
-): Promise<ActionTransportResult> {
-	if (!targetUserId) {
+): Effect.Effect<ActionTransportResult, unknown> {
+	return Effect.gen(function* () {
+		if (!targetUserId) {
+			return {
+				ok: false,
+				output: "missing target user id for xurl transport",
+				transport: "xurl",
+			};
+		}
+
+		const sourceUser = yield* tryPromise(() => lookupAuthenticatedUser());
+		const sourceUserId =
+			sourceUser && typeof sourceUser.id === "string" ? sourceUser.id : "";
+		if (!sourceUserId) {
+			return {
+				ok: false,
+				output: "xurl authenticated user unavailable",
+				transport: "xurl",
+			};
+		}
+
+		const result = yield* tryPromise(() =>
+			action === "block"
+				? blockUserViaXurl(sourceUserId, targetUserId)
+				: action === "unblock"
+					? unblockUserViaXurl(sourceUserId, targetUserId)
+					: action === "mute"
+						? muteUserViaXurl(sourceUserId, targetUserId)
+						: unmuteUserViaXurl(sourceUserId, targetUserId),
+		);
+
+		if (!result.ok) {
+			return {
+				...result,
+				transport: "xurl",
+			};
+		}
+
+		const status = yield* tryPromise(() => readBirdStatusViaBird(query));
+		const { field: verifyField, expected: expectedValue } =
+			getVerifyExpectation(action);
+		const actualValue =
+			status && typeof status[verifyField] === "boolean"
+				? Boolean(status[verifyField])
+				: null;
+
+		if (actualValue === null) {
+			return {
+				ok: false,
+				output: `${result.output}\nxurl verify unavailable from bird status`,
+				transport: "xurl",
+			};
+		}
+
+		if (actualValue !== expectedValue) {
+			return {
+				ok: false,
+				output: `${result.output}\nxurl verify mismatch ${verifyField}=${String(actualValue)}`,
+				transport: "xurl",
+			};
+		}
+
 		return {
-			ok: false,
-			output: "missing target user id for xurl transport",
+			ok: true,
+			output: `${result.output}\nverified ${verifyField}=${String(actualValue)}`,
 			transport: "xurl",
 		};
-	}
-
-	const sourceUser = await lookupAuthenticatedUser();
-	const sourceUserId =
-		sourceUser && typeof sourceUser.id === "string" ? sourceUser.id : "";
-	if (!sourceUserId) {
-		return {
-			ok: false,
-			output: "xurl authenticated user unavailable",
-			transport: "xurl",
-		};
-	}
-
-	const result =
-		action === "block"
-			? await blockUserViaXurl(sourceUserId, targetUserId)
-			: action === "unblock"
-				? await unblockUserViaXurl(sourceUserId, targetUserId)
-				: action === "mute"
-					? await muteUserViaXurl(sourceUserId, targetUserId)
-					: await unmuteUserViaXurl(sourceUserId, targetUserId);
-
-	if (!result.ok) {
-		return {
-			...result,
-			transport: "xurl",
-		};
-	}
-
-	const status = await readBirdStatusViaBird(query);
-	const { field: verifyField, expected: expectedValue } =
-		getVerifyExpectation(action);
-	const actualValue =
-		status && typeof status[verifyField] === "boolean"
-			? Boolean(status[verifyField])
-			: null;
-
-	if (actualValue === null) {
-		return {
-			ok: false,
-			output: `${result.output}\nxurl verify unavailable from bird status`,
-			transport: "xurl",
-		};
-	}
-
-	if (actualValue !== expectedValue) {
-		return {
-			ok: false,
-			output: `${result.output}\nxurl verify mismatch ${verifyField}=${String(actualValue)}`,
-			transport: "xurl",
-		};
-	}
-
-	return {
-		ok: true,
-		output: `${result.output}\nverified ${verifyField}=${String(actualValue)}`,
-		transport: "xurl",
-	};
+	});
 }
 
-async function runXWebAction(
+function runXWebActionEffect(
 	action: ModerationAction,
 	targetUserId?: string,
-): Promise<ActionTransportResult> {
-	if (action !== "block" && action !== "unblock") {
+): Effect.Effect<ActionTransportResult, unknown> {
+	return Effect.gen(function* () {
+		if (action !== "block" && action !== "unblock") {
+			return {
+				ok: false,
+				output: `x-web does not support ${action}`,
+				transport: "x-web",
+			};
+		}
+
+		if (!targetUserId) {
+			return {
+				ok: false,
+				output: "missing target user id for x-web transport",
+				transport: "x-web",
+			};
+		}
+
+		const result = yield* tryPromise(() =>
+			action === "block"
+				? blockUserViaXWeb(targetUserId)
+				: unblockUserViaXWeb(targetUserId),
+		);
+
 		return {
-			ok: false,
-			output: `x-web does not support ${action}`,
+			...result,
 			transport: "x-web",
 		};
-	}
-
-	if (!targetUserId) {
-		return {
-			ok: false,
-			output: "missing target user id for x-web transport",
-			transport: "x-web",
-		};
-	}
-
-	const result =
-		action === "block"
-			? await blockUserViaXWeb(targetUserId)
-			: await unblockUserViaXWeb(targetUserId);
-
-	return {
-		...result,
-		transport: "x-web",
-	};
+	});
 }
 
-export async function runModerationAction({
+export function runModerationActionEffect({
 	action,
 	query,
 	targetUserId,
 	transport,
-}: RunActionParams): Promise<ActionTransportResult> {
-	const requestedTransport = resolveActionsTransport(transport);
-	if (requestedTransport === "bird") {
-		return runBirdAction(action, query);
-	}
-	if (requestedTransport === "xurl") {
-		return runXurlAction(action, query, targetUserId);
-	}
+}: RunActionParams): Effect.Effect<ActionTransportResult, unknown> {
+	return Effect.gen(function* () {
+		const requestedTransport = yield* trySync(() =>
+			resolveActionsTransport(transport),
+		);
+		if (requestedTransport === "bird") {
+			return yield* runBirdActionEffect(action, query);
+		}
+		if (requestedTransport === "xurl") {
+			return yield* runXurlActionEffect(action, query, targetUserId);
+		}
 
-	const birdResult = await runBirdAction(action, query);
-	if (birdResult.ok) {
-		return birdResult;
-	}
+		const birdResult = yield* runBirdActionEffect(action, query);
+		if (birdResult.ok) {
+			return birdResult;
+		}
 
-	const xurlResult = await runXurlAction(action, query, targetUserId);
-	if (xurlResult.ok) {
-		return {
-			...xurlResult,
-			output: `${xurlResult.output}\nfalling back after ${normalizeFailure("bird", birdResult.output)}`,
-		};
-	}
-
-	if (action === "block" || action === "unblock") {
-		const xWebResult = await runXWebAction(action, targetUserId);
-		if (xWebResult.ok) {
+		const xurlResult = yield* runXurlActionEffect(action, query, targetUserId);
+		if (xurlResult.ok) {
 			return {
-				...xWebResult,
+				...xurlResult,
+				output: `${xurlResult.output}\nfalling back after ${normalizeFailure("bird", birdResult.output)}`,
+			};
+		}
+
+		if (action === "block" || action === "unblock") {
+			const xWebResult = yield* runXWebActionEffect(action, targetUserId);
+			if (xWebResult.ok) {
+				return {
+					...xWebResult,
+					output: [
+						xWebResult.output,
+						`falling back after ${normalizeFailure("bird", birdResult.output)}`,
+						`falling back after ${normalizeFailure("xurl", xurlResult.output)}`,
+					].join("\n"),
+				};
+			}
+
+			return {
+				ok: false,
 				output: [
-					xWebResult.output,
-					`falling back after ${normalizeFailure("bird", birdResult.output)}`,
-					`falling back after ${normalizeFailure("xurl", xurlResult.output)}`,
+					normalizeFailure("bird", birdResult.output),
+					normalizeFailure("xurl", xurlResult.output),
+					normalizeFailure("x-web", xWebResult.output),
 				].join("\n"),
+				transport: xWebResult.transport,
 			};
 		}
 
@@ -211,20 +247,16 @@ export async function runModerationAction({
 			output: [
 				normalizeFailure("bird", birdResult.output),
 				normalizeFailure("xurl", xurlResult.output),
-				normalizeFailure("x-web", xWebResult.output),
 			].join("\n"),
-			transport: xWebResult.transport,
+			transport: xurlResult.transport,
 		};
-	}
+	});
+}
 
-	return {
-		ok: false,
-		output: [
-			normalizeFailure("bird", birdResult.output),
-			normalizeFailure("xurl", xurlResult.output),
-		].join("\n"),
-		transport: xurlResult.transport,
-	};
+export function runModerationAction(
+	params: RunActionParams,
+): Promise<ActionTransportResult> {
+	return runEffectPromise(runModerationActionEffect(params));
 }
 
 export type { ActionsTransport };

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { ApiFetchError, fetchJson } from "./api-client";
+
+describe("api client", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("preserves ApiFetchError and status across the Promise boundary", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ message: "Rate limited" }), {
+						status: 429,
+					}),
+			),
+		);
+
+		await expect(
+			fetchJson(
+				"/api/test",
+				undefined,
+				z.object({ ok: z.boolean() }),
+				"Failed",
+			),
+		).rejects.toMatchObject({
+			_tag: "ApiFetchError",
+			message: "Rate limited",
+			status: 429,
+		});
+		await expect(
+			fetchJson(
+				"/api/test",
+				undefined,
+				z.object({ ok: z.boolean() }),
+				"Failed",
+			),
+		).rejects.toBeInstanceOf(ApiFetchError);
+	});
+
+	it("preserves AbortError so route hooks can ignore stale requests", async () => {
+		const abortError = new DOMException(
+			"The operation was aborted.",
+			"AbortError",
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw abortError;
+			}),
+		);
+
+		await expect(
+			fetchJson(
+				"/api/test",
+				undefined,
+				z.object({ ok: z.boolean() }),
+				"Failed",
+			),
+		).rejects.toBe(abortError);
+	});
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,4 +1,6 @@
+import { Data, Effect } from "effect";
 import { z } from "zod";
+import { runEffectPromise } from "./effect-runtime";
 import type {
 	DmConversationItem,
 	DmMessageItem,
@@ -103,15 +105,11 @@ const webSyncJobSchema = z
 const actionResponseSchema = jsonRecordSchema;
 const SYNC_POLL_INTERVAL_MS = 500;
 
-export class ApiFetchError extends Error {
-	constructor(
-		message: string,
-		readonly status?: number,
-	) {
-		super(message);
-		this.name = "ApiFetchError";
-	}
-}
+export class ApiFetchError extends Data.TaggedError("ApiFetchError")<{
+	readonly message: string;
+	readonly status?: number;
+	readonly cause?: unknown;
+}> {}
 
 function responseMessage(data: unknown, fallback: string) {
 	if (data && typeof data === "object") {
@@ -127,38 +125,77 @@ function responseMessage(data: unknown, fallback: string) {
 	return fallback;
 }
 
-async function readJson(response: Response) {
-	try {
-		return await response.json();
-	} catch {
-		return null;
+function apiFetchErrorFromCause(cause: unknown, fallbackMessage: string) {
+	if (cause instanceof DOMException && cause.name === "AbortError") {
+		return cause;
 	}
+	if (cause instanceof ApiFetchError) return cause;
+	if (cause instanceof Error) {
+		return new ApiFetchError({ message: cause.message, cause });
+	}
+	if (typeof cause === "string") {
+		return new ApiFetchError({ message: cause, cause });
+	}
+	return new ApiFetchError({ message: fallbackMessage, cause });
 }
 
-export async function fetchJson<T>(
+function readJsonEffect(response: Response) {
+	return Effect.promise(() => response.json().catch(() => null as unknown));
+}
+
+function runApiEffect<T, E>(effect: Effect.Effect<T, E>) {
+	return runEffectPromise(effect);
+}
+
+export function fetchJsonEffect<T>(
+	input: RequestInfo | URL,
+	init: RequestInit | undefined,
+	schema: z.ZodType<T>,
+	fallbackMessage: string,
+) {
+	return Effect.gen(function* () {
+		const response = yield* Effect.tryPromise({
+			try: () => fetch(input, init),
+			catch: (cause) => apiFetchErrorFromCause(cause, fallbackMessage),
+		});
+		const data = yield* readJsonEffect(response);
+		if (!response.ok) {
+			return yield* Effect.fail(
+				new ApiFetchError({
+					message: responseMessage(data, fallbackMessage),
+					status: response.status,
+				}),
+			);
+		}
+
+		const parsed = schema.safeParse(data);
+		if (!parsed.success) {
+			return yield* Effect.fail(
+				new ApiFetchError({
+					message: fallbackMessage,
+					cause: parsed.error,
+				}),
+			);
+		}
+		return parsed.data;
+	});
+}
+
+export function fetchJson<T>(
 	input: RequestInfo | URL,
 	init: RequestInit | undefined,
 	schema: z.ZodType<T>,
 	fallbackMessage: string,
 ): Promise<T> {
-	const response = await fetch(input, init);
-	const data = await readJson(response);
-	if (!response.ok) {
-		throw new ApiFetchError(
-			responseMessage(data, fallbackMessage),
-			response.status,
-		);
-	}
-
-	const parsed = schema.safeParse(data);
-	if (!parsed.success) {
-		throw new ApiFetchError(fallbackMessage);
-	}
-	return parsed.data;
+	return runApiEffect(fetchJsonEffect(input, init, schema, fallbackMessage));
 }
 
 export function fetchQueryEnvelope(init?: RequestInit) {
-	return fetchJson(
+	return runApiEffect(fetchQueryEnvelopeEffect(init));
+}
+
+export function fetchQueryEnvelopeEffect(init?: RequestInit) {
+	return fetchJsonEffect(
 		"/api/status",
 		init,
 		queryEnvelopeSchema,
@@ -170,11 +207,22 @@ export function fetchQueryResponse(
 	input: RequestInfo | URL,
 	init?: RequestInit,
 ) {
-	return fetchJson(input, init, queryResponseSchema, "Query unavailable");
+	return runApiEffect(fetchQueryResponseEffect(input, init));
+}
+
+export function fetchQueryResponseEffect(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) {
+	return fetchJsonEffect(input, init, queryResponseSchema, "Query unavailable");
 }
 
 export function postAction(body: Record<string, unknown>) {
-	return fetchJson(
+	return runApiEffect(postActionEffect(body));
+}
+
+export function postActionEffect(body: Record<string, unknown>) {
+	return fetchJsonEffect(
 		"/api/action",
 		{
 			method: "POST",
@@ -187,7 +235,11 @@ export function postAction(body: Record<string, unknown>) {
 }
 
 export function postSync(kind: WebSyncKind, accountId?: string) {
-	return fetchJson(
+	return runApiEffect(postSyncEffect(kind, accountId));
+}
+
+export function postSyncEffect(kind: WebSyncKind, accountId?: string) {
+	return fetchJsonEffect(
 		"/api/sync",
 		{
 			method: "POST",
@@ -199,31 +251,44 @@ export function postSync(kind: WebSyncKind, accountId?: string) {
 		},
 		webSyncJobSchema,
 		"Sync failed",
-	).then(waitForWebSyncJob);
+	).pipe(Effect.flatMap(waitForWebSyncJobEffect));
 }
 
-function fetchSyncJob(id: string) {
+function fetchSyncJobEffect(id: string) {
 	const url = new URL("/api/sync", window.location.origin);
 	url.searchParams.set("id", id);
-	return fetchJson(url, undefined, webSyncJobSchema, "Sync status unavailable");
+	return fetchJsonEffect(
+		url,
+		undefined,
+		webSyncJobSchema,
+		"Sync status unavailable",
+	);
 }
 
-function delay(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+export function waitForWebSyncJobEffect(job: WebSyncJobSnapshot) {
+	return Effect.gen(function* () {
+		let current = job;
+		while (current.inProgress) {
+			yield* Effect.sleep(SYNC_POLL_INTERVAL_MS);
+			current = yield* fetchSyncJobEffect(current.id);
+		}
+
+		if (!current.result) {
+			return yield* Effect.fail(
+				new ApiFetchError({ message: current.error ?? current.summary }),
+			);
+		}
+		if (!current.result.ok) {
+			return yield* Effect.fail(
+				new ApiFetchError({
+					message: current.result.error ?? current.result.summary,
+				}),
+			);
+		}
+		return current.result;
+	});
 }
 
-async function waitForWebSyncJob(job: WebSyncJobSnapshot) {
-	let current = job;
-	while (current.inProgress) {
-		await delay(SYNC_POLL_INTERVAL_MS);
-		current = await fetchSyncJob(current.id);
-	}
-
-	if (!current.result) {
-		throw new ApiFetchError(current.error ?? current.summary);
-	}
-	if (!current.result.ok) {
-		throw new ApiFetchError(current.result.error ?? current.result.summary);
-	}
-	return current.result;
+export function waitForWebSyncJob(job: WebSyncJobSnapshot) {
+	return runApiEffect(waitForWebSyncJobEffect(job));
 }

--- a/src/lib/archive-finder.test.ts
+++ b/src/lib/archive-finder.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -33,7 +34,7 @@ vi.mock("node:os", () => ({
 	homedir: mocks.homedir,
 }));
 
-import { findArchives } from "./archive-finder";
+import { findArchives, findArchivesEffect } from "./archive-finder";
 
 const originalPlatform = process.platform;
 
@@ -186,5 +187,17 @@ describe("archive finder", () => {
 
 		await expect(findArchives()).resolves.toEqual([]);
 		expect(mocks.execAsync).not.toHaveBeenCalled();
+	});
+
+	it("builds archive discovery effects lazily", async () => {
+		mocks.existsSync.mockReturnValue(false);
+		mocks.execAsync.mockResolvedValue({ stdout: "" });
+
+		const effect = findArchivesEffect();
+
+		expect(mocks.homedir).not.toHaveBeenCalled();
+		expect(mocks.existsSync).not.toHaveBeenCalled();
+		expect(mocks.execAsync).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual([]);
 	});
 });

--- a/src/lib/archive-finder.ts
+++ b/src/lib/archive-finder.ts
@@ -3,6 +3,8 @@ import { existsSync, promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { Effect } from "effect";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { ArchiveCandidate } from "./types";
 
 const execAsync = promisify(exec);
@@ -37,11 +39,9 @@ function formatRelativeDate(date: Date): string {
 	return `${Math.floor(days / 365)} years ago`;
 }
 
-async function getCandidate(
-	filePath: string,
-): Promise<ArchiveCandidate | null> {
-	try {
-		const stats = await fs.stat(filePath);
+function getCandidateEffect(filePath: string) {
+	return Effect.gen(function* () {
+		const stats = yield* tryPromise(() => fs.stat(filePath));
 		if (!stats.isFile() || stats.size < 1024 * 1024) {
 			return null;
 		}
@@ -54,79 +54,94 @@ async function getCandidate(
 			modifiedTime: stats.mtime.toISOString(),
 			dateFormatted: formatRelativeDate(stats.mtime),
 		};
-	} catch {
-		return null;
-	}
+	}).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 
-async function searchDirectory(
-	directoryPath: string,
-): Promise<ArchiveCandidate[]> {
+function searchDirectoryEffect(directoryPath: string) {
 	if (!existsSync(directoryPath)) {
-		return [];
+		return Effect.succeed([]);
 	}
 
-	const entries = await fs.readdir(directoryPath);
-	const matches = entries.filter((entry) =>
-		ARCHIVE_NAME_PATTERNS.some((pattern) => pattern.test(entry)),
-	);
+	return Effect.gen(function* () {
+		const entries = yield* tryPromise(() => fs.readdir(directoryPath));
+		const matches = entries.filter((entry) =>
+			ARCHIVE_NAME_PATTERNS.some((pattern) => pattern.test(entry)),
+		);
 
-	const candidates = await Promise.all(
-		matches.map((entry) => getCandidate(path.join(directoryPath, entry))),
-	);
+		const candidates = yield* Effect.forEach(
+			matches,
+			(entry) => getCandidateEffect(path.join(directoryPath, entry)),
+			{ concurrency: "unbounded" },
+		);
 
-	return candidates.filter((item) => item !== null);
+		return candidates.filter((item) => item !== null);
+	});
 }
 
-export async function findArchives(): Promise<ArchiveCandidate[]> {
+function searchSpotlightEffect(query: string) {
+	return Effect.gen(function* () {
+		const { stdout } = yield* tryPromise(() =>
+			execAsync(`mdfind -onlyin ~ '${query}'`, {
+				timeout: 5000,
+			}),
+		);
+		const paths = stdout
+			.split("\n")
+			.map((item) => item.trim())
+			.filter((item) => item.length > 0 && item.endsWith(".zip"));
+
+		return yield* Effect.forEach(paths, getCandidateEffect, {
+			concurrency: "unbounded",
+		});
+	}).pipe(Effect.catchAll(() => Effect.succeed([])));
+}
+
+export function findArchivesEffect(): Effect.Effect<
+	ArchiveCandidate[],
+	unknown
+> {
 	if (process.platform !== "darwin") {
-		return [];
+		return Effect.succeed([]);
 	}
 
-	const found = new Map<string, ArchiveCandidate>();
-	const downloads = await searchDirectory(path.join(homedir(), "Downloads"));
+	return Effect.gen(function* () {
+		const found = new Map<string, ArchiveCandidate>();
+		const downloads = yield* searchDirectoryEffect(
+			path.join(homedir(), "Downloads"),
+		);
 
-	for (const candidate of downloads) {
-		found.set(candidate.path, candidate);
-	}
+		for (const candidate of downloads) {
+			found.set(candidate.path, candidate);
+		}
 
-	const queries = [
-		'kMDItemDisplayName == "twitter-*.zip"',
-		'kMDItemDisplayName == "x-*.zip"',
-		'kMDItemDisplayName == "*archive*.zip" && kMDItemKind == "Zip archive"',
-	];
+		const queries = [
+			'kMDItemDisplayName == "twitter-*.zip"',
+			'kMDItemDisplayName == "x-*.zip"',
+			'kMDItemDisplayName == "*archive*.zip" && kMDItemKind == "Zip archive"',
+		];
 
-	const spotlightCandidates = await Promise.all(
-		queries.map(async (query) => {
-			try {
-				const { stdout } = await execAsync(`mdfind -onlyin ~ '${query}'`, {
-					timeout: 5000,
-				});
+		const spotlightCandidates = yield* Effect.forEach(
+			queries,
+			searchSpotlightEffect,
+			{ concurrency: "unbounded" },
+		);
 
-				const paths = stdout
-					.split("\n")
-					.map((item) => item.trim())
-					.filter((item) => item.length > 0 && item.endsWith(".zip"));
-
-				return Promise.all(paths.map((filePath) => getCandidate(filePath)));
-			} catch {
-				// Best-effort only.
-				return [];
-			}
-		}),
-	);
-
-	for (const candidates of spotlightCandidates) {
-		for (const candidate of candidates) {
-			if (candidate) {
-				found.set(candidate.path, candidate);
+		for (const candidates of spotlightCandidates) {
+			for (const candidate of candidates) {
+				if (candidate) {
+					found.set(candidate.path, candidate);
+				}
 			}
 		}
-	}
 
-	return [...found.values()].sort(
-		(left, right) =>
-			new Date(right.modifiedTime).getTime() -
-			new Date(left.modifiedTime).getTime(),
-	);
+		return [...found.values()].sort(
+			(left, right) =>
+				new Date(right.modifiedTime).getTime() -
+				new Date(left.modifiedTime).getTime(),
+		);
+	});
+}
+
+export function findArchives(): Promise<ArchiveCandidate[]> {
+	return runEffectPromise(findArchivesEffect());
 }

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -11,8 +11,9 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
-import { __test__, importArchive } from "./archive-import";
+import { __test__, importArchive, importArchiveEffect } from "./archive-import";
 import { getBirdclawPaths, resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listFollowEvents, listUnfollowedSince } from "./follow-graph";
@@ -679,6 +680,17 @@ describe("archive import", () => {
 
 		await importArchive(archivePath);
 		expect(statSync(tweetMediaPath).mtimeMs).toBe(tweetMediaMtime);
+	});
+
+	it("exposes archive import as a lazy Effect", async () => {
+		const archivePath = makeArchiveWithoutAccount();
+
+		const effect = importArchiveEffect(archivePath);
+
+		expect(() => effect).not.toThrow();
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"Archive missing data/account.js",
+		);
 	});
 
 	it("skips archive media extraction for unrelated selected slices", async () => {

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -11,8 +11,10 @@ import {
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
+import { Effect } from "effect";
 import { getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 
 const execFileAsync = promisify(execFile);
 const ARCHIVE_JSON_PAYLOAD = /=\s*(\[[\s\S]*\]|\{[\s\S]*\})/s;
@@ -108,48 +110,60 @@ function parseArchiveArray(content: string): ArchiveRecord[] {
 		: [];
 }
 
-async function runUnzip(
+function runUnzipEffect(
 	_archivePath: string,
 	args: string[],
 	maxBuffer = 1024 * 1024 * 256,
 ) {
-	const { stdout } = await execFileAsync("unzip", args, {
-		maxBuffer,
+	return tryPromise(() =>
+		execFileAsync("unzip", args, {
+			maxBuffer,
+		}),
+	).pipe(Effect.map(({ stdout }) => stdout));
+}
+
+function listArchiveEntriesEffect(
+	archivePath: string,
+): Effect.Effect<string[], unknown> {
+	return Effect.gen(function* () {
+		const stdout = yield* runUnzipEffect(
+			archivePath,
+			["-Z1", archivePath],
+			1024 * 1024 * 64,
+		);
+		return stdout
+			.split("\n")
+			.map((item) => item.trim())
+			.filter((item) => item.length > 0);
 	});
-	return stdout;
 }
 
-async function listArchiveEntries(archivePath: string) {
-	const stdout = await runUnzip(
-		archivePath,
-		["-Z1", archivePath],
-		1024 * 1024 * 64,
-	);
-	return stdout
-		.split("\n")
-		.map((item) => item.trim())
-		.filter((item) => item.length > 0);
+function listArchiveEntryDetailsEffect(
+	archivePath: string,
+): Effect.Effect<Array<{ path: string; size: number }>, unknown> {
+	return Effect.gen(function* () {
+		const stdout = yield* runUnzipEffect(
+			archivePath,
+			["-Z", "-l", archivePath],
+			1024 * 1024 * 64,
+		);
+		return stdout
+			.split("\n")
+			.map((line) => line.trim().split(/\s+/))
+			.filter((parts) => parts.length >= 10 && /^[-d]/.test(parts[0] ?? ""))
+			.map((parts) => ({
+				path: parts.slice(9).join(" "),
+				size: Number(parts[3] ?? 0),
+			}))
+			.filter((entry) => entry.path.length > 0 && Number.isFinite(entry.size));
+	});
 }
 
-async function listArchiveEntryDetails(archivePath: string) {
-	const stdout = await runUnzip(
-		archivePath,
-		["-Z", "-l", archivePath],
-		1024 * 1024 * 64,
-	);
-	return stdout
-		.split("\n")
-		.map((line) => line.trim().split(/\s+/))
-		.filter((parts) => parts.length >= 10 && /^[-d]/.test(parts[0] ?? ""))
-		.map((parts) => ({
-			path: parts.slice(9).join(" "),
-			size: Number(parts[3] ?? 0),
-		}))
-		.filter((entry) => entry.path.length > 0 && Number.isFinite(entry.size));
-}
-
-async function readArchiveEntry(archivePath: string, entryPath: string) {
-	return runUnzip(archivePath, ["-p", archivePath, entryPath]);
+function readArchiveEntryEffect(
+	archivePath: string,
+	entryPath: string,
+): Effect.Effect<string, unknown> {
+	return runUnzipEffect(archivePath, ["-p", archivePath, entryPath]);
 }
 
 function getFirstEntry(entries: string[], pattern: RegExp) {
@@ -515,66 +529,78 @@ function needsArchiveMediaCopy(destinationPath: string, size: number) {
 	return statSync(destinationPath).size !== size;
 }
 
-async function copyArchiveEntryToFile(
+function copyArchiveEntryToFileEffect(
 	archivePath: string,
 	entryPath: string,
 	destinationPath: string,
 ) {
-	mkdirSync(path.dirname(destinationPath), { recursive: true });
-	const temporaryPath = `${destinationPath}.${process.pid}.${randomUUID()}.tmp`;
-	const child = spawn("unzip", ["-p", archivePath, entryPath], {
-		stdio: ["ignore", "pipe", "pipe"],
-	});
-	let stderr = "";
-	child.stderr.setEncoding("utf8");
-	child.stderr.on("data", (chunk) => {
-		stderr += String(chunk);
-	});
-	const exit = new Promise<number | null>((resolve, reject) => {
-		child.on("error", reject);
-		child.on("close", resolve);
-	});
+	return tryPromise(() => {
+		mkdirSync(path.dirname(destinationPath), { recursive: true });
+		const temporaryPath = `${destinationPath}.${process.pid}.${randomUUID()}.tmp`;
+		const child = spawn("unzip", ["-p", archivePath, entryPath], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stderr = "";
+		child.stderr.setEncoding("utf8");
+		child.stderr.on("data", (chunk) => {
+			stderr += String(chunk);
+		});
+		const exit = new Promise<number | null>((resolve, reject) => {
+			child.on("error", reject);
+			child.on("close", resolve);
+		});
 
-	try {
-		await pipeline(child.stdout, createWriteStream(temporaryPath));
-		const exitCode = await exit;
-		if (exitCode !== 0) {
-			throw new Error(
-				`Failed to extract ${entryPath}: ${stderr.trim() || `exit ${String(exitCode)}`}`,
-			);
-		}
-		renameSync(temporaryPath, destinationPath);
-	} catch (error) {
-		child.kill();
-		if (existsSync(temporaryPath)) {
-			unlinkSync(temporaryPath);
-		}
-		throw error;
-	}
+		return pipeline(child.stdout, createWriteStream(temporaryPath))
+			.then(() => exit)
+			.then((exitCode) => {
+				if (exitCode !== 0) {
+					throw new Error(
+						`Failed to extract ${entryPath}: ${
+							stderr.trim() || `exit ${String(exitCode)}`
+						}`,
+					);
+				}
+				renameSync(temporaryPath, destinationPath);
+			})
+			.catch((error: unknown) => {
+				child.kill();
+				if (existsSync(temporaryPath)) {
+					unlinkSync(temporaryPath);
+				}
+				throw error;
+			});
+	});
 }
 
-async function extractArchiveMediaFiles(
+function extractArchiveMediaFilesEffect(
 	archivePath: string,
 	selectedKinds: Set<ArchiveMediaKind> | null,
-) {
-	const counts = createArchiveMediaFileCounts();
-	if (selectedKinds?.size === 0) {
-		return counts;
-	}
-	for (const entry of await listArchiveEntryDetails(archivePath)) {
-		const mediaKind = getArchiveMediaKind(entry.path);
-		if (!mediaKind) continue;
-		if (selectedKinds && !selectedKinds.has(mediaKind.kind)) continue;
+): Effect.Effect<ArchiveMediaFileCounts, unknown> {
+	return Effect.gen(function* () {
+		const counts = createArchiveMediaFileCounts();
+		if (selectedKinds?.size === 0) {
+			return counts;
+		}
+		const entries = yield* listArchiveEntryDetailsEffect(archivePath);
+		for (const entry of entries) {
+			const mediaKind = getArchiveMediaKind(entry.path);
+			if (!mediaKind) continue;
+			if (selectedKinds && !selectedKinds.has(mediaKind.kind)) continue;
 
-		counts[mediaKind.kind] += 1;
-		const destinationPath = getArchiveMediaDestination(
-			entry.path,
-			mediaKind.kind,
-		);
-		if (!needsArchiveMediaCopy(destinationPath, entry.size)) continue;
-		await copyArchiveEntryToFile(archivePath, entry.path, destinationPath);
-	}
-	return counts;
+			counts[mediaKind.kind] += 1;
+			const destinationPath = getArchiveMediaDestination(
+				entry.path,
+				mediaKind.kind,
+			);
+			if (!needsArchiveMediaCopy(destinationPath, entry.size)) continue;
+			yield* copyArchiveEntryToFileEffect(
+				archivePath,
+				entry.path,
+				destinationPath,
+			);
+		}
+		return counts;
+	});
 }
 
 function getArchiveFollowRows(content: string, key: ArchiveFollowKey) {
@@ -632,894 +658,914 @@ function clearMentionSyncState(db = getNativeDb()) {
 	).run();
 }
 
-export async function importArchive(
+function importArchiveInternalEffect(
 	archivePath: string,
 	options: ImportArchiveOptions = {},
-): Promise<ImportedArchiveSummary> {
-	const entries = await listArchiveEntries(archivePath);
-	const selection = selectedSlices(options);
-	const includeTweets = includesSlice(selection, "tweets");
-	const includeLikes = includesSlice(selection, "likes");
-	const includeBookmarks = includesSlice(selection, "bookmarks");
-	const includeDirectMessages = includesSlice(selection, "directMessages");
-	const includeProfiles = includesSlice(selection, "profiles");
-	const includeFollowers = includesSlice(selection, "followers");
-	const includeFollowing = includesSlice(selection, "following");
-	const accountEntry = getFirstEntry(entries, /(?:^|\/)data\/account\.js$/i);
-	const profileEntry = getFirstEntry(entries, /(?:^|\/)data\/profile\.js$/i);
-	const tweetEntries = includeTweets
-		? getMatchingEntries(
-				entries,
-				/(?:^|\/)data\/(?:tweets|community-tweet)(?:-part\d+)?\.js$/i,
-			)
-		: [];
-	const noteTweetEntries = includeTweets
-		? getMatchingEntries(entries, /(?:^|\/)data\/note-tweet(?:-part\d+)?\.js$/i)
-		: [];
-	const likeEntries = includeLikes
-		? getMatchingEntries(
-				entries,
-				/(?:^|\/)data\/(?:like|likes)(?:-part\d+)?\.js$/i,
-			)
-		: [];
-	const bookmarkEntries = includeBookmarks
-		? getMatchingEntries(
-				entries,
-				/(?:^|\/)data\/(?:bookmark|bookmarks)(?:-part\d+)?\.js$/i,
-			)
-		: [];
-	const dmEntries = includeDirectMessages
-		? getMatchingEntries(
-				entries,
-				/(?:^|\/)data\/direct-messages(?:-group)?(?:-part\d+)?\.js$/i,
-			)
-		: [];
-	const followerEntries = includeFollowers
-		? getMatchingEntries(entries, /(?:^|\/)data\/follower(?:-part\d+)?\.js$/i)
-		: [];
-	const followingEntries = includeFollowing
-		? getMatchingEntries(entries, /(?:^|\/)data\/following(?:-part\d+)?\.js$/i)
-		: [];
+): Effect.Effect<ImportedArchiveSummary, unknown> {
+	return Effect.gen(function* () {
+		const entries = yield* listArchiveEntriesEffect(archivePath);
+		const selection = selectedSlices(options);
+		const includeTweets = includesSlice(selection, "tweets");
+		const includeLikes = includesSlice(selection, "likes");
+		const includeBookmarks = includesSlice(selection, "bookmarks");
+		const includeDirectMessages = includesSlice(selection, "directMessages");
+		const includeProfiles = includesSlice(selection, "profiles");
+		const includeFollowers = includesSlice(selection, "followers");
+		const includeFollowing = includesSlice(selection, "following");
+		const accountEntry = getFirstEntry(entries, /(?:^|\/)data\/account\.js$/i);
+		const profileEntry = getFirstEntry(entries, /(?:^|\/)data\/profile\.js$/i);
+		const tweetEntries = includeTweets
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/(?:tweets|community-tweet)(?:-part\d+)?\.js$/i,
+				)
+			: [];
+		const noteTweetEntries = includeTweets
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/note-tweet(?:-part\d+)?\.js$/i,
+				)
+			: [];
+		const likeEntries = includeLikes
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/(?:like|likes)(?:-part\d+)?\.js$/i,
+				)
+			: [];
+		const bookmarkEntries = includeBookmarks
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/(?:bookmark|bookmarks)(?:-part\d+)?\.js$/i,
+				)
+			: [];
+		const dmEntries = includeDirectMessages
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/direct-messages(?:-group)?(?:-part\d+)?\.js$/i,
+				)
+			: [];
+		const followerEntries = includeFollowers
+			? getMatchingEntries(entries, /(?:^|\/)data\/follower(?:-part\d+)?\.js$/i)
+			: [];
+		const followingEntries = includeFollowing
+			? getMatchingEntries(
+					entries,
+					/(?:^|\/)data\/following(?:-part\d+)?\.js$/i,
+				)
+			: [];
 
-	if (!accountEntry) {
-		throw new Error("Archive missing data/account.js");
-	}
-
-	const [accountContent, profileContent] = await Promise.all([
-		readArchiveEntry(archivePath, accountEntry),
-		profileEntry
-			? readArchiveEntry(archivePath, profileEntry)
-			: Promise.resolve("[]"),
-	]);
-
-	const accountPayload = buildAccountPayload(
-		parseArchiveArray(accountContent)[0] ?? null,
-		parseArchiveArray(profileContent)[0] ?? null,
-	);
-
-	const mentionDirectory = new Map<
-		string,
-		{ handle?: string; displayName?: string }
-	>();
-	const tweetRows: Array<{
-		id: string;
-		kind: "home" | "like" | "bookmark";
-		authorProfileId: string;
-		text: string;
-		createdAt: string;
-		isReplied: number;
-		replyToId: string | null;
-		likeCount: number;
-		mediaCount: number;
-		bookmarked: number;
-		liked: number;
-		entitiesJson: string;
-		mediaJson: string;
-		quotedTweetId: string | null;
-	}> = [];
-	const collectionRows: Array<{
-		tweetId: string;
-		kind: "likes" | "bookmarks";
-		collectedAt: string | null;
-		source: string;
-		rawJson: string;
-	}> = [];
-	const tweetRowsById = new Map<string, (typeof tweetRows)[number]>();
-
-	function addTweetRow(row: (typeof tweetRows)[number]) {
-		const existing = tweetRowsById.get(row.id);
-		if (existing) {
-			existing.bookmarked = Math.max(existing.bookmarked, row.bookmarked);
-			existing.liked = Math.max(existing.liked, row.liked);
-			if (!existing.text && row.text) existing.text = row.text;
-			return;
+		if (!accountEntry) {
+			return yield* Effect.fail(new Error("Archive missing data/account.js"));
 		}
-		tweetRows.push(row);
-		tweetRowsById.set(row.id, row);
-	}
 
-	for (const entry of tweetEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		for (const wrapper of parseArchiveArray(content)) {
-			const tweet = asRecord(wrapper.tweet);
-			if (!tweet) continue;
+		const [accountContent, profileContent] = yield* Effect.all([
+			readArchiveEntryEffect(archivePath, accountEntry),
+			profileEntry
+				? readArchiveEntryEffect(archivePath, profileEntry)
+				: Effect.succeed("[]"),
+		]);
 
-			for (const mention of asArray<Record<string, unknown>>(
-				asRecord(tweet.entities)?.user_mentions,
-			)) {
-				const mentionId = String(mention.id_str ?? mention.id ?? "");
-				if (!mentionId) continue;
-				mentionDirectory.set(mentionId, {
-					handle: String(mention.screen_name ?? ""),
-					displayName: String(mention.name ?? mention.screen_name ?? mentionId),
+		const accountPayload = buildAccountPayload(
+			parseArchiveArray(accountContent)[0] ?? null,
+			parseArchiveArray(profileContent)[0] ?? null,
+		);
+
+		const mentionDirectory = new Map<
+			string,
+			{ handle?: string; displayName?: string }
+		>();
+		const tweetRows: Array<{
+			id: string;
+			kind: "home" | "like" | "bookmark";
+			authorProfileId: string;
+			text: string;
+			createdAt: string;
+			isReplied: number;
+			replyToId: string | null;
+			likeCount: number;
+			mediaCount: number;
+			bookmarked: number;
+			liked: number;
+			entitiesJson: string;
+			mediaJson: string;
+			quotedTweetId: string | null;
+		}> = [];
+		const collectionRows: Array<{
+			tweetId: string;
+			kind: "likes" | "bookmarks";
+			collectedAt: string | null;
+			source: string;
+			rawJson: string;
+		}> = [];
+		const tweetRowsById = new Map<string, (typeof tweetRows)[number]>();
+
+		function addTweetRow(row: (typeof tweetRows)[number]) {
+			const existing = tweetRowsById.get(row.id);
+			if (existing) {
+				existing.bookmarked = Math.max(existing.bookmarked, row.bookmarked);
+				existing.liked = Math.max(existing.liked, row.liked);
+				if (!existing.text && row.text) existing.text = row.text;
+				return;
+			}
+			tweetRows.push(row);
+			tweetRowsById.set(row.id, row);
+		}
+
+		for (const entry of tweetEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			for (const wrapper of parseArchiveArray(content)) {
+				const tweet = asRecord(wrapper.tweet);
+				if (!tweet) continue;
+
+				for (const mention of asArray<Record<string, unknown>>(
+					asRecord(tweet.entities)?.user_mentions,
+				)) {
+					const mentionId = String(mention.id_str ?? mention.id ?? "");
+					if (!mentionId) continue;
+					mentionDirectory.set(mentionId, {
+						handle: String(mention.screen_name ?? ""),
+						displayName: String(
+							mention.name ?? mention.screen_name ?? mentionId,
+						),
+					});
+				}
+
+				const replyUserId = String(
+					tweet.in_reply_to_user_id_str ?? tweet.in_reply_to_user_id ?? "",
+				);
+				const replyScreenName = String(tweet.in_reply_to_screen_name ?? "");
+				if (replyUserId && replyScreenName) {
+					mentionDirectory.set(replyUserId, {
+						handle: replyScreenName,
+						displayName: replyScreenName,
+					});
+				}
+
+				addTweetRow({
+					id: String(tweet.id_str ?? tweet.id),
+					kind: "home",
+					authorProfileId: "profile_me",
+					text: String(tweet.full_text ?? tweet.text ?? ""),
+					createdAt: parseTwitterDate(tweet.created_at),
+					isReplied: tweet.in_reply_to_status_id_str ? 1 : 0,
+					replyToId: tweet.in_reply_to_status_id_str
+						? String(tweet.in_reply_to_status_id_str)
+						: null,
+					likeCount: toInt(tweet.favorite_count),
+					mediaCount: getTweetMediaCount(tweet),
+					bookmarked: 0,
+					liked: 0,
+					entitiesJson: JSON.stringify(extractTweetEntities(tweet)),
+					mediaJson: JSON.stringify(extractTweetMedia(tweet)),
+					quotedTweetId: tweet.quoted_status_id_str
+						? String(tweet.quoted_status_id_str)
+						: null,
 				});
 			}
+		}
 
-			const replyUserId = String(
-				tweet.in_reply_to_user_id_str ?? tweet.in_reply_to_user_id ?? "",
-			);
-			const replyScreenName = String(tweet.in_reply_to_screen_name ?? "");
-			if (replyUserId && replyScreenName) {
-				mentionDirectory.set(replyUserId, {
-					handle: replyScreenName,
-					displayName: replyScreenName,
+		for (const entry of noteTweetEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			for (const wrapper of parseArchiveArray(content)) {
+				const noteTweet = asRecord(wrapper.noteTweet);
+				if (!noteTweet) continue;
+				const core = asRecord(noteTweet.core);
+				addTweetRow({
+					id: String(noteTweet.noteTweetId ?? noteTweet.id ?? randomUUID()),
+					kind: "home",
+					authorProfileId: "profile_me",
+					text: String(core?.text ?? ""),
+					createdAt: parseTwitterDate(noteTweet.createdAt),
+					isReplied: 0,
+					replyToId: null,
+					likeCount: 0,
+					mediaCount: 0,
+					bookmarked: 0,
+					liked: 0,
+					entitiesJson: "{}",
+					mediaJson: "[]",
+					quotedTweetId: null,
 				});
 			}
-
-			addTweetRow({
-				id: String(tweet.id_str ?? tweet.id),
-				kind: "home",
-				authorProfileId: "profile_me",
-				text: String(tweet.full_text ?? tweet.text ?? ""),
-				createdAt: parseTwitterDate(tweet.created_at),
-				isReplied: tweet.in_reply_to_status_id_str ? 1 : 0,
-				replyToId: tweet.in_reply_to_status_id_str
-					? String(tweet.in_reply_to_status_id_str)
-					: null,
-				likeCount: toInt(tweet.favorite_count),
-				mediaCount: getTweetMediaCount(tweet),
-				bookmarked: 0,
-				liked: 0,
-				entitiesJson: JSON.stringify(extractTweetEntities(tweet)),
-				mediaJson: JSON.stringify(extractTweetMedia(tweet)),
-				quotedTweetId: tweet.quoted_status_id_str
-					? String(tweet.quoted_status_id_str)
-					: null,
-			});
 		}
-	}
+		const authoredTweetCount = tweetRows.length;
 
-	for (const entry of noteTweetEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		for (const wrapper of parseArchiveArray(content)) {
-			const noteTweet = asRecord(wrapper.noteTweet);
-			if (!noteTweet) continue;
-			const core = asRecord(noteTweet.core);
-			addTweetRow({
-				id: String(noteTweet.noteTweetId ?? noteTweet.id ?? randomUUID()),
-				kind: "home",
-				authorProfileId: "profile_me",
-				text: String(core?.text ?? ""),
-				createdAt: parseTwitterDate(noteTweet.createdAt),
-				isReplied: 0,
-				replyToId: null,
-				likeCount: 0,
-				mediaCount: 0,
-				bookmarked: 0,
-				liked: 0,
-				entitiesJson: "{}",
-				mediaJson: "[]",
-				quotedTweetId: null,
-			});
-		}
-	}
-	const authoredTweetCount = tweetRows.length;
+		type MessageRow = {
+			id: string;
+			conversationId: string;
+			senderProfileId: string;
+			text: string;
+			createdAt: string;
+			direction: "inbound" | "outbound";
+			mediaCount: number;
+		};
 
-	type MessageRow = {
-		id: string;
-		conversationId: string;
-		senderProfileId: string;
-		text: string;
-		createdAt: string;
-		direction: "inbound" | "outbound";
-		mediaCount: number;
-	};
-
-	const profiles = new Map<
-		string,
-		{
+		const profiles = new Map<
+			string,
+			{
+				id: string;
+				handle: string;
+				displayName: string;
+				bio: string;
+				followersCount: number;
+				followingCount: number;
+				publicMetricsJson: string;
+				avatarHue: number;
+				avatarUrl: string | null;
+				location: string | null;
+				url: string | null;
+				verifiedType: string | null;
+				entitiesJson: string;
+				rawJson: string;
+				createdAt: string;
+			}
+		>();
+		type ProfileRow =
+			typeof profiles extends Map<string, infer Value> ? Value : never;
+		const defaultProfileMetadata = {
+			publicMetricsJson: "{}",
+			location: null,
+			url: null,
+			verifiedType: null,
+			entitiesJson: "{}",
+			rawJson: "{}",
+		};
+		const conversations = new Map<
+			string,
+			{
+				id: string;
+				title: string;
+				accountId: string;
+				participantProfileId: string;
+				lastMessageAt: string;
+				unreadCount: number;
+				needsReply: number;
+			}
+		>();
+		const dmMessages: MessageRow[] = [];
+		const followerRows: Array<{ profileId: string; externalUserId: string }> =
+			[];
+		const followingRows: Array<{ profileId: string; externalUserId: string }> =
+			[];
+		const followerIds = new Set<string>();
+		const followingIds = new Set<string>();
+		type ExistingProfileRow = {
 			id: string;
 			handle: string;
-			displayName: string;
+			display_name: string;
 			bio: string;
-			followersCount: number;
-			followingCount: number;
-			publicMetricsJson: string;
-			avatarHue: number;
-			avatarUrl: string | null;
+			followers_count: number;
+			following_count: number;
+			public_metrics_json: string;
+			avatar_hue: number;
+			avatar_url: string | null;
 			location: string | null;
 			url: string | null;
-			verifiedType: string | null;
-			entitiesJson: string;
-			rawJson: string;
-			createdAt: string;
-		}
-	>();
-	type ProfileRow =
-		typeof profiles extends Map<string, infer Value> ? Value : never;
-	const defaultProfileMetadata = {
-		publicMetricsJson: "{}",
-		location: null,
-		url: null,
-		verifiedType: null,
-		entitiesJson: "{}",
-		rawJson: "{}",
-	};
-	const conversations = new Map<
-		string,
-		{
-			id: string;
-			title: string;
-			accountId: string;
-			participantProfileId: string;
-			lastMessageAt: string;
-			unreadCount: number;
-			needsReply: number;
-		}
-	>();
-	const dmMessages: MessageRow[] = [];
-	const followerRows: Array<{ profileId: string; externalUserId: string }> = [];
-	const followingRows: Array<{ profileId: string; externalUserId: string }> =
-		[];
-	const followerIds = new Set<string>();
-	const followingIds = new Set<string>();
-	type ExistingProfileRow = {
-		id: string;
-		handle: string;
-		display_name: string;
-		bio: string;
-		followers_count: number;
-		following_count: number;
-		public_metrics_json: string;
-		avatar_hue: number;
-		avatar_url: string | null;
-		location: string | null;
-		url: string | null;
-		verified_type: string | null;
-		entities_json: string;
-		raw_json: string;
-		created_at: string;
-	};
-	const existingProfiles = new Map(
-		(
-			getNativeDb()
-				.prepare(
-					`
+			verified_type: string | null;
+			entities_json: string;
+			raw_json: string;
+			created_at: string;
+		};
+		const existingProfiles = new Map(
+			(
+				getNativeDb()
+					.prepare(
+						`
 	        select id, handle, display_name, bio, followers_count, following_count,
 	          public_metrics_json, avatar_hue, avatar_url, location, url,
 	          verified_type, entities_json, raw_json, created_at
 	        from profiles
 	      `,
-				)
-				.all() as ExistingProfileRow[]
-		).map((profile) => [profile.id, profile]),
-	);
-	const existingProfilesByHandle = new Map(
-		[...existingProfiles.values()].map((profile) => [
-			profile.handle.toLowerCase(),
-			profile,
-		]),
-	);
-	const existingPrimaryAccount = getNativeDb()
-		.prepare("select handle, external_user_id from accounts where id = ?")
-		.get("acct_primary") as
-		| { handle: string; external_user_id: string | null }
-		| undefined;
-	const profileIdAliases = new Map<string, string>();
+					)
+					.all() as ExistingProfileRow[]
+			).map((profile) => [profile.id, profile]),
+		);
+		const existingProfilesByHandle = new Map(
+			[...existingProfiles.values()].map((profile) => [
+				profile.handle.toLowerCase(),
+				profile,
+			]),
+		);
+		const existingPrimaryAccount = getNativeDb()
+			.prepare("select handle, external_user_id from accounts where id = ?")
+			.get("acct_primary") as
+			| { handle: string; external_user_id: string | null }
+			| undefined;
+		const profileIdAliases = new Map<string, string>();
 
-	type ArchiveProfileTier =
-		| "archive_follow_stub"
-		| "archive_dm_stub"
-		| "archive_mention_inferred"
-		| "live_or_hydrated";
-	const archiveProfileTierRank: Record<ArchiveProfileTier, number> = {
-		archive_follow_stub: 0,
-		archive_dm_stub: 1,
-		archive_mention_inferred: 2,
-		live_or_hydrated: 3,
-	};
+		type ArchiveProfileTier =
+			| "archive_follow_stub"
+			| "archive_dm_stub"
+			| "archive_mention_inferred"
+			| "live_or_hydrated";
+		const archiveProfileTierRank: Record<ArchiveProfileTier, number> = {
+			archive_follow_stub: 0,
+			archive_dm_stub: 1,
+			archive_mention_inferred: 2,
+			live_or_hydrated: 3,
+		};
 
-	function classifyExistingProfile(profile: ProfileRow): ArchiveProfileTier {
-		const externalUserId = profile.id.startsWith("profile_user_")
-			? profile.id.slice("profile_user_".length)
-			: "";
-		const fallbackHandle = externalUserId ? `id${externalUserId}` : profile.id;
-		const hasLiveSignals =
-			profile.followersCount > 0 ||
-			profile.followingCount > 0 ||
-			profile.publicMetricsJson.trim() !== "{}" ||
-			profile.avatarUrl !== null ||
-			profile.location !== null ||
-			profile.url !== null ||
-			profile.verifiedType !== null ||
-			profile.entitiesJson.trim() !== "{}" ||
-			profile.rawJson.trim() !== "{}";
+		function classifyExistingProfile(profile: ProfileRow): ArchiveProfileTier {
+			const externalUserId = profile.id.startsWith("profile_user_")
+				? profile.id.slice("profile_user_".length)
+				: "";
+			const fallbackHandle = externalUserId
+				? `id${externalUserId}`
+				: profile.id;
+			const hasLiveSignals =
+				profile.followersCount > 0 ||
+				profile.followingCount > 0 ||
+				profile.publicMetricsJson.trim() !== "{}" ||
+				profile.avatarUrl !== null ||
+				profile.location !== null ||
+				profile.url !== null ||
+				profile.verifiedType !== null ||
+				profile.entitiesJson.trim() !== "{}" ||
+				profile.rawJson.trim() !== "{}";
 
-		if (hasLiveSignals) return "live_or_hydrated";
-		if (
-			profile.handle === fallbackHandle &&
-			profile.displayName === "" &&
-			profile.bio === ""
-		) {
-			return "archive_follow_stub";
-		}
-		if (profile.bio.startsWith("Imported from archive user ")) {
-			return profile.handle === fallbackHandle &&
-				profile.displayName === fallbackHandle
-				? "archive_dm_stub"
+			if (hasLiveSignals) return "live_or_hydrated";
+			if (
+				profile.handle === fallbackHandle &&
+				profile.displayName === "" &&
+				profile.bio === ""
+			) {
+				return "archive_follow_stub";
+			}
+			if (profile.bio.startsWith("Imported from archive user ")) {
+				return profile.handle === fallbackHandle &&
+					profile.displayName === fallbackHandle
+					? "archive_dm_stub"
+					: "archive_mention_inferred";
+			}
+			return profile.handle === fallbackHandle && profile.displayName === ""
+				? "archive_follow_stub"
 				: "archive_mention_inferred";
 		}
-		return profile.handle === fallbackHandle && profile.displayName === ""
-			? "archive_follow_stub"
-			: "archive_mention_inferred";
-	}
 
-	function shouldPreserveProfile(
-		existingTier: ArchiveProfileTier,
-		incomingTier: ArchiveProfileTier,
-	) {
-		return (
-			archiveProfileTierRank[existingTier] >=
-			archiveProfileTierRank[incomingTier]
-		);
-	}
-
-	function existingProfileToProfileRow(
-		profile: ExistingProfileRow,
-	): ProfileRow {
-		return {
-			id: profile.id,
-			handle: profile.handle,
-			displayName: profile.display_name,
-			bio: profile.bio,
-			followersCount: profile.followers_count,
-			followingCount: profile.following_count,
-			publicMetricsJson: profile.public_metrics_json,
-			avatarHue: profile.avatar_hue,
-			avatarUrl: profile.avatar_url,
-			location: profile.location,
-			url: profile.url,
-			verifiedType: profile.verified_type,
-			entitiesJson: profile.entities_json,
-			rawJson: profile.raw_json,
-			createdAt: profile.created_at,
-		};
-	}
-
-	function mergeArchiveProfile(incoming: ProfileRow) {
-		const existingById = existingProfiles.get(incoming.id);
-		const existingByHandle = selection
-			? existingProfilesByHandle.get(incoming.handle.toLowerCase())
-			: undefined;
-		const targetExisting = existingById ?? existingByHandle;
-		const targetId = targetExisting?.id ?? incoming.id;
-		if (targetId !== incoming.id) {
-			profileIdAliases.set(incoming.id, targetId);
-		}
-		const targetIncoming =
-			targetId === incoming.id ? incoming : { ...incoming, id: targetId };
-		const incomingTier = classifyExistingProfile(incoming);
-		const current = profiles.get(targetId);
-		const currentTier = current ? classifyExistingProfile(current) : null;
-		const existingProfile = targetExisting
-			? existingProfileToProfileRow(targetExisting)
-			: null;
-		const existingTier = existingProfile
-			? classifyExistingProfile(existingProfile)
-			: null;
-
-		if (
-			current &&
-			currentTier &&
-			shouldPreserveProfile(currentTier, incomingTier) &&
-			(!existingTier || shouldPreserveProfile(currentTier, existingTier))
+		function shouldPreserveProfile(
+			existingTier: ArchiveProfileTier,
+			incomingTier: ArchiveProfileTier,
 		) {
-			return;
+			return (
+				archiveProfileTierRank[existingTier] >=
+				archiveProfileTierRank[incomingTier]
+			);
 		}
 
-		if (
-			existingProfile &&
-			existingTier &&
-			shouldPreserveProfile(existingTier, incomingTier)
-		) {
-			profiles.set(targetId, existingProfile);
-			return;
+		function existingProfileToProfileRow(
+			profile: ExistingProfileRow,
+		): ProfileRow {
+			return {
+				id: profile.id,
+				handle: profile.handle,
+				displayName: profile.display_name,
+				bio: profile.bio,
+				followersCount: profile.followers_count,
+				followingCount: profile.following_count,
+				publicMetricsJson: profile.public_metrics_json,
+				avatarHue: profile.avatar_hue,
+				avatarUrl: profile.avatar_url,
+				location: profile.location,
+				url: profile.url,
+				verifiedType: profile.verified_type,
+				entitiesJson: profile.entities_json,
+				rawJson: profile.raw_json,
+				createdAt: profile.created_at,
+			};
 		}
 
-		profiles.set(targetId, targetIncoming);
-	}
+		function mergeArchiveProfile(incoming: ProfileRow) {
+			const existingById = existingProfiles.get(incoming.id);
+			const existingByHandle = selection
+				? existingProfilesByHandle.get(incoming.handle.toLowerCase())
+				: undefined;
+			const targetExisting = existingById ?? existingByHandle;
+			const targetId = targetExisting?.id ?? incoming.id;
+			if (targetId !== incoming.id) {
+				profileIdAliases.set(incoming.id, targetId);
+			}
+			const targetIncoming =
+				targetId === incoming.id ? incoming : { ...incoming, id: targetId };
+			const incomingTier = classifyExistingProfile(incoming);
+			const current = profiles.get(targetId);
+			const currentTier = current ? classifyExistingProfile(current) : null;
+			const existingProfile = targetExisting
+				? existingProfileToProfileRow(targetExisting)
+				: null;
+			const existingTier = existingProfile
+				? classifyExistingProfile(existingProfile)
+				: null;
 
-	function resolveProfileId(profileId: string) {
-		return profileIdAliases.get(profileId) ?? profileId;
-	}
-
-	function isProfileHandleTakenByOtherId(handle: string, profileId: string) {
-		const normalizedHandle = handle.toLowerCase();
-		const existingProfile = existingProfilesByHandle.get(normalizedHandle);
-		if (existingProfile && existingProfile.id !== profileId) return true;
-		for (const profile of profiles.values()) {
 			if (
-				profile.id !== profileId &&
-				profile.handle.toLowerCase() === normalizedHandle
+				current &&
+				currentTier &&
+				shouldPreserveProfile(currentTier, incomingTier) &&
+				(!existingTier || shouldPreserveProfile(currentTier, existingTier))
 			) {
-				return true;
+				return;
+			}
+
+			if (
+				existingProfile &&
+				existingTier &&
+				shouldPreserveProfile(existingTier, incomingTier)
+			) {
+				profiles.set(targetId, existingProfile);
+				return;
+			}
+
+			profiles.set(targetId, targetIncoming);
+		}
+
+		function resolveProfileId(profileId: string) {
+			return profileIdAliases.get(profileId) ?? profileId;
+		}
+
+		function isProfileHandleTakenByOtherId(handle: string, profileId: string) {
+			const normalizedHandle = handle.toLowerCase();
+			const existingProfile = existingProfilesByHandle.get(normalizedHandle);
+			if (existingProfile && existingProfile.id !== profileId) return true;
+			for (const profile of profiles.values()) {
+				if (
+					profile.id !== profileId &&
+					profile.handle.toLowerCase() === normalizedHandle
+				) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		function uniqueArchiveProfileHandle(baseHandle: string, profileId: string) {
+			if (!isProfileHandleTakenByOtherId(baseHandle, profileId)) {
+				return baseHandle;
+			}
+			let index = 1;
+			while (true) {
+				const suffix = index === 1 ? "archive" : `archive_${index}`;
+				const candidate = `${baseHandle}_${suffix}`;
+				if (!isProfileHandleTakenByOtherId(candidate, profileId)) {
+					return candidate;
+				}
+				index += 1;
 			}
 		}
-		return false;
-	}
 
-	function uniqueArchiveProfileHandle(baseHandle: string, profileId: string) {
-		if (!isProfileHandleTakenByOtherId(baseHandle, profileId)) {
-			return baseHandle;
-		}
-		let index = 1;
-		while (true) {
-			const suffix = index === 1 ? "archive" : `archive_${index}`;
-			const candidate = `${baseHandle}_${suffix}`;
-			if (!isProfileHandleTakenByOtherId(candidate, profileId)) {
-				return candidate;
-			}
-			index += 1;
-		}
-	}
-
-	function addArchiveFollowProfile(profileId: string, externalUserId: string) {
-		if (!profileId) return;
-		const fallbackId =
-			externalUserId || profileId.replace(/^profile_user_/, "");
-		mergeArchiveProfile({
-			id: profileId,
-			handle: fallbackId ? `id${fallbackId}` : profileId,
-			displayName: "",
-			bio: "",
-			followersCount: 0,
-			followingCount: 0,
-			...defaultProfileMetadata,
-			avatarHue: 210,
-			avatarUrl: null,
-			createdAt: accountPayload.createdAt,
-		});
-	}
-
-	function assertSelectedAccountMatchesArchive() {
-		if (!selection || !existingPrimaryAccount) return;
-		const existingExternalUserId = existingPrimaryAccount.external_user_id;
-		if (
-			existingExternalUserId &&
-			existingExternalUserId !== accountPayload.accountId
+		function addArchiveFollowProfile(
+			profileId: string,
+			externalUserId: string,
 		) {
-			throw new Error(
-				`Existing acct_primary (${existingExternalUserId}) does not match archive account ${accountPayload.accountId}`,
-			);
-		}
-		const existingHandle = existingPrimaryAccount.handle
-			.replace(/^@/, "")
-			.toLowerCase();
-		if (
-			!existingExternalUserId &&
-			existingHandle !== accountPayload.username.toLowerCase()
-		) {
-			throw new Error(
-				`Existing acct_primary (@${existingHandle}) does not match archive account @${accountPayload.username}`,
-			);
-		}
-	}
-
-	assertSelectedAccountMatchesArchive();
-
-	const existingLocalProfile =
-		selection &&
-		(existingProfiles.get("profile_me") ??
-			[...existingProfiles.values()].find(
-				(profile) =>
-					profile.handle.toLowerCase() ===
-					accountPayload.username.toLowerCase(),
-			));
-	const archivedLocalProfile = existingLocalProfile
-		? {
-				...existingProfileToProfileRow(existingLocalProfile),
-				handle: accountPayload.username,
-				displayName: accountPayload.displayName,
-				bio: accountPayload.bio,
-				createdAt: accountPayload.createdAt,
-			}
-		: {
-				id: "profile_me",
-				handle: accountPayload.username,
-				displayName: accountPayload.displayName,
-				bio: accountPayload.bio,
+			if (!profileId) return;
+			const fallbackId =
+				externalUserId || profileId.replace(/^profile_user_/, "");
+			mergeArchiveProfile({
+				id: profileId,
+				handle: fallbackId ? `id${fallbackId}` : profileId,
+				displayName: "",
+				bio: "",
 				followersCount: 0,
 				followingCount: 0,
 				...defaultProfileMetadata,
-				avatarHue: 18,
+				avatarHue: 210,
 				avatarUrl: null,
 				createdAt: accountPayload.createdAt,
-			};
-	const localProfile =
-		existingLocalProfile && !includeProfiles
-			? existingProfileToProfileRow(existingLocalProfile)
-			: archivedLocalProfile;
-	profiles.set(localProfile.id, localProfile);
+			});
+		}
 
-	const existingDmConversationAccounts = new Map(
-		(
-			getNativeDb()
-				.prepare("select id, account_id from dm_conversations")
-				.all() as Array<{ id: string; account_id: string }>
-		).map((row) => [row.id, row.account_id]),
-	);
-	const existingOtherDmMessageIds = new Set(
-		(
-			getNativeDb()
-				.prepare(
-					`
+		function assertSelectedAccountMatchesArchive() {
+			if (!selection || !existingPrimaryAccount) return;
+			const existingExternalUserId = existingPrimaryAccount.external_user_id;
+			if (
+				existingExternalUserId &&
+				existingExternalUserId !== accountPayload.accountId
+			) {
+				throw new Error(
+					`Existing acct_primary (${existingExternalUserId}) does not match archive account ${accountPayload.accountId}`,
+				);
+			}
+			const existingHandle = existingPrimaryAccount.handle
+				.replace(/^@/, "")
+				.toLowerCase();
+			if (
+				!existingExternalUserId &&
+				existingHandle !== accountPayload.username.toLowerCase()
+			) {
+				throw new Error(
+					`Existing acct_primary (@${existingHandle}) does not match archive account @${accountPayload.username}`,
+				);
+			}
+		}
+
+		assertSelectedAccountMatchesArchive();
+
+		const existingLocalProfile =
+			selection &&
+			(existingProfiles.get("profile_me") ??
+				[...existingProfiles.values()].find(
+					(profile) =>
+						profile.handle.toLowerCase() ===
+						accountPayload.username.toLowerCase(),
+				));
+		const archivedLocalProfile = existingLocalProfile
+			? {
+					...existingProfileToProfileRow(existingLocalProfile),
+					handle: accountPayload.username,
+					displayName: accountPayload.displayName,
+					bio: accountPayload.bio,
+					createdAt: accountPayload.createdAt,
+				}
+			: {
+					id: "profile_me",
+					handle: accountPayload.username,
+					displayName: accountPayload.displayName,
+					bio: accountPayload.bio,
+					followersCount: 0,
+					followingCount: 0,
+					...defaultProfileMetadata,
+					avatarHue: 18,
+					avatarUrl: null,
+					createdAt: accountPayload.createdAt,
+				};
+		const localProfile =
+			existingLocalProfile && !includeProfiles
+				? existingProfileToProfileRow(existingLocalProfile)
+				: archivedLocalProfile;
+		profiles.set(localProfile.id, localProfile);
+
+		const existingDmConversationAccounts = new Map(
+			(
+				getNativeDb()
+					.prepare("select id, account_id from dm_conversations")
+					.all() as Array<{ id: string; account_id: string }>
+			).map((row) => [row.id, row.account_id]),
+		);
+		const existingOtherDmMessageIds = new Set(
+			(
+				getNativeDb()
+					.prepare(
+						`
           select m.id
           from dm_messages m
           join dm_conversations c on c.id = m.conversation_id
           where c.account_id <> 'acct_primary'
         `,
-				)
-				.all() as Array<{ id: string }>
-		).map((row) => row.id),
-	);
-	const archiveDmConversationIdAliases = new Map<string, string>();
-	const archiveDmMessageIdAliases = new Map<string, string>();
+					)
+					.all() as Array<{ id: string }>
+			).map((row) => row.id),
+		);
+		const archiveDmConversationIdAliases = new Map<string, string>();
+		const archiveDmMessageIdAliases = new Map<string, string>();
 
-	function uniquePrimaryArchiveId(
-		baseId: string,
-		isTakenByOtherAccount: (candidate: string) => boolean,
-		isPending: (candidate: string) => boolean,
-	) {
-		let index = 1;
-		while (true) {
-			const suffix = index === 1 ? "" : `:${index}`;
-			const candidate = `acct_primary:${baseId}${suffix}`;
-			if (!isTakenByOtherAccount(candidate) && !isPending(candidate)) {
-				return candidate;
+		function uniquePrimaryArchiveId(
+			baseId: string,
+			isTakenByOtherAccount: (candidate: string) => boolean,
+			isPending: (candidate: string) => boolean,
+		) {
+			let index = 1;
+			while (true) {
+				const suffix = index === 1 ? "" : `:${index}`;
+				const candidate = `acct_primary:${baseId}${suffix}`;
+				if (!isTakenByOtherAccount(candidate) && !isPending(candidate)) {
+					return candidate;
+				}
+				index += 1;
 			}
-			index += 1;
-		}
-	}
-
-	function resolveArchiveDmConversationId(conversationId: string) {
-		const existingAlias = archiveDmConversationIdAliases.get(conversationId);
-		if (existingAlias) return existingAlias;
-		if (!selection) {
-			archiveDmConversationIdAliases.set(conversationId, conversationId);
-			return conversationId;
 		}
 
-		const takenByOtherAccount = (candidate: string) => {
-			const accountId = existingDmConversationAccounts.get(candidate);
-			return accountId !== undefined && accountId !== "acct_primary";
-		};
-		const resolved = takenByOtherAccount(conversationId)
-			? uniquePrimaryArchiveId(
-					conversationId,
-					takenByOtherAccount,
-					(candidate) => conversations.has(candidate),
-				)
-			: conversationId;
-		archiveDmConversationIdAliases.set(conversationId, resolved);
-		return resolved;
-	}
-
-	function resolveArchiveDmMessageId(
-		messageId: string,
-		conversationIdChanged: boolean,
-	) {
-		const existingAlias = archiveDmMessageIdAliases.get(messageId);
-		if (existingAlias) return existingAlias;
-		const shouldRemap =
-			selection &&
-			(conversationIdChanged || existingOtherDmMessageIds.has(messageId));
-		const resolved = shouldRemap
-			? uniquePrimaryArchiveId(
-					messageId,
-					(candidate) => existingOtherDmMessageIds.has(candidate),
-					(candidate) => dmMessages.some((message) => message.id === candidate),
-				)
-			: messageId;
-		archiveDmMessageIdAliases.set(messageId, resolved);
-		return resolved;
-	}
-
-	for (const entry of dmEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		for (const wrapper of parseArchiveArray(content)) {
-			const dmConversation = asRecord(wrapper.dmConversation);
-			if (!dmConversation) continue;
-
-			const rawConversationId = String(dmConversation.conversationId ?? "");
-			if (!rawConversationId) continue;
-			const conversationId = resolveArchiveDmConversationId(rawConversationId);
-			const conversationIdChanged = conversationId !== rawConversationId;
-
-			const conversationName = String(dmConversation.name ?? "").trim();
-			const participantIds = new Set<string>();
-			const rawMessages = asArray<Record<string, unknown>>(
-				dmConversation.messages,
-			);
-
-			for (const event of rawMessages) {
-				const messageCreate = asRecord(event.messageCreate);
-				if (messageCreate) {
-					const senderId = String(messageCreate.senderId ?? "");
-					const recipientId = String(messageCreate.recipientId ?? "");
-					if (senderId) participantIds.add(senderId);
-					if (recipientId) participantIds.add(recipientId);
-				}
-
-				const joinConversation = asRecord(event.joinConversation);
-				if (joinConversation) {
-					for (const userId of asArray<string>(
-						joinConversation.participantsSnapshot,
-					)) {
-						participantIds.add(String(userId));
-					}
-				}
-
-				const participantsJoin = asRecord(event.participantsJoin);
-				if (participantsJoin) {
-					for (const userId of asArray<string>(participantsJoin.userIds)) {
-						participantIds.add(String(userId));
-					}
-					const initiatingUserId = String(
-						participantsJoin.initiatingUserId ?? "",
-					);
-					if (initiatingUserId) {
-						participantIds.add(initiatingUserId);
-					}
-				}
-
-				const participantsLeave = asRecord(event.participantsLeave);
-				if (participantsLeave) {
-					for (const userId of asArray<string>(participantsLeave.userIds)) {
-						participantIds.add(String(userId));
-					}
-					const initiatingUserId = String(
-						participantsLeave.initiatingUserId ?? "",
-					);
-					if (initiatingUserId) {
-						participantIds.add(initiatingUserId);
-					}
-				}
+		function resolveArchiveDmConversationId(conversationId: string) {
+			const existingAlias = archiveDmConversationIdAliases.get(conversationId);
+			if (existingAlias) return existingAlias;
+			if (!selection) {
+				archiveDmConversationIdAliases.set(conversationId, conversationId);
+				return conversationId;
 			}
 
-			const externalParticipantIds = [...participantIds].filter(
-				(userId) => userId && userId !== accountPayload.accountId,
-			);
-			const isGroup =
-				conversationName.length > 0 || externalParticipantIds.length > 1;
-			const participantProfileId = isGroup
-				? `profile_group_${conversationId}`
-				: `profile_user_${externalParticipantIds[0] ?? conversationId}`;
+			const takenByOtherAccount = (candidate: string) => {
+				const accountId = existingDmConversationAccounts.get(candidate);
+				return accountId !== undefined && accountId !== "acct_primary";
+			};
+			const resolved = takenByOtherAccount(conversationId)
+				? uniquePrimaryArchiveId(
+						conversationId,
+						takenByOtherAccount,
+						(candidate) => conversations.has(candidate),
+					)
+				: conversationId;
+			archiveDmConversationIdAliases.set(conversationId, resolved);
+			return resolved;
+		}
 
-			if (!profiles.has(participantProfileId)) {
-				if (isGroup) {
-					profiles.set(participantProfileId, {
-						id: participantProfileId,
-						handle: `group-${conversationId}`,
-						displayName:
-							conversationName || `Group DM ${externalParticipantIds.length}`,
-						bio: `Group DM with ${externalParticipantIds.length} participants`,
-						followersCount: 0,
-						followingCount: 0,
-						...defaultProfileMetadata,
-						avatarHue: 220,
-						avatarUrl: null,
-						createdAt: accountPayload.createdAt,
-					});
-				} else {
-					const otherUserId = externalParticipantIds[0] ?? conversationId;
-					const inferred = inferProfileFromDirectory(
-						otherUserId,
-						mentionDirectory,
-					);
-					mergeArchiveProfile({
-						id: participantProfileId,
-						handle: inferred.handle,
-						displayName: inferred.displayName,
-						bio: `Imported from archive user ${otherUserId}`,
-						followersCount: 0,
-						followingCount: 0,
-						...defaultProfileMetadata,
-						avatarHue: 210,
-						avatarUrl: null,
-						createdAt: accountPayload.createdAt,
-					});
-				}
-			}
+		function resolveArchiveDmMessageId(
+			messageId: string,
+			conversationIdChanged: boolean,
+		) {
+			const existingAlias = archiveDmMessageIdAliases.get(messageId);
+			if (existingAlias) return existingAlias;
+			const shouldRemap =
+				selection &&
+				(conversationIdChanged || existingOtherDmMessageIds.has(messageId));
+			const resolved = shouldRemap
+				? uniquePrimaryArchiveId(
+						messageId,
+						(candidate) => existingOtherDmMessageIds.has(candidate),
+						(candidate) =>
+							dmMessages.some((message) => message.id === candidate),
+					)
+				: messageId;
+			archiveDmMessageIdAliases.set(messageId, resolved);
+			return resolved;
+		}
 
-			const messageEvents = rawMessages
-				.map((event) => asRecord(event.messageCreate))
-				.filter((event): event is Record<string, unknown> => event !== null)
-				.map((messageCreate) => {
-					const senderId = String(messageCreate.senderId ?? "");
-					const rawMessageId = String(
-						messageCreate.id ?? `${rawConversationId}-${senderId}`,
-					);
-					const senderProfileId =
-						senderId === accountPayload.accountId
-							? localProfile.id
-							: `profile_user_${senderId}`;
+		for (const entry of dmEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			for (const wrapper of parseArchiveArray(content)) {
+				const dmConversation = asRecord(wrapper.dmConversation);
+				if (!dmConversation) continue;
 
-					if (senderId && senderId !== accountPayload.accountId) {
-						const inferred = inferProfileFromDirectory(
-							senderId,
-							mentionDirectory,
-						);
-						if (!profiles.has(senderProfileId)) {
-							mergeArchiveProfile({
-								id: senderProfileId,
-								handle: inferred.handle,
-								displayName: inferred.displayName,
-								bio: `Imported from archive user ${senderId}`,
-								followersCount: 0,
-								followingCount: 0,
-								...defaultProfileMetadata,
-								avatarHue: 240,
-								avatarUrl: null,
-								createdAt: accountPayload.createdAt,
-							});
+				const rawConversationId = String(dmConversation.conversationId ?? "");
+				if (!rawConversationId) continue;
+				const conversationId =
+					resolveArchiveDmConversationId(rawConversationId);
+				const conversationIdChanged = conversationId !== rawConversationId;
+
+				const conversationName = String(dmConversation.name ?? "").trim();
+				const participantIds = new Set<string>();
+				const rawMessages = asArray<Record<string, unknown>>(
+					dmConversation.messages,
+				);
+
+				for (const event of rawMessages) {
+					const messageCreate = asRecord(event.messageCreate);
+					if (messageCreate) {
+						const senderId = String(messageCreate.senderId ?? "");
+						const recipientId = String(messageCreate.recipientId ?? "");
+						if (senderId) participantIds.add(senderId);
+						if (recipientId) participantIds.add(recipientId);
+					}
+
+					const joinConversation = asRecord(event.joinConversation);
+					if (joinConversation) {
+						for (const userId of asArray<string>(
+							joinConversation.participantsSnapshot,
+						)) {
+							participantIds.add(String(userId));
 						}
 					}
 
-					return {
-						id: resolveArchiveDmMessageId(rawMessageId, conversationIdChanged),
-						conversationId,
-						senderProfileId: resolveProfileId(senderProfileId),
-						text: String(messageCreate.text ?? ""),
-						createdAt: parseTwitterDate(messageCreate.createdAt),
-						direction:
-							senderId === accountPayload.accountId ? "outbound" : "inbound",
-						mediaCount: asArray(messageCreate.mediaUrls).length,
-					} satisfies MessageRow;
-				})
-				.sort((left, right) =>
-					compareIsoTimestamp(left.createdAt, right.createdAt),
+					const participantsJoin = asRecord(event.participantsJoin);
+					if (participantsJoin) {
+						for (const userId of asArray<string>(participantsJoin.userIds)) {
+							participantIds.add(String(userId));
+						}
+						const initiatingUserId = String(
+							participantsJoin.initiatingUserId ?? "",
+						);
+						if (initiatingUserId) {
+							participantIds.add(initiatingUserId);
+						}
+					}
+
+					const participantsLeave = asRecord(event.participantsLeave);
+					if (participantsLeave) {
+						for (const userId of asArray<string>(participantsLeave.userIds)) {
+							participantIds.add(String(userId));
+						}
+						const initiatingUserId = String(
+							participantsLeave.initiatingUserId ?? "",
+						);
+						if (initiatingUserId) {
+							participantIds.add(initiatingUserId);
+						}
+					}
+				}
+
+				const externalParticipantIds = [...participantIds].filter(
+					(userId) => userId && userId !== accountPayload.accountId,
 				);
+				const isGroup =
+					conversationName.length > 0 || externalParticipantIds.length > 1;
+				const participantProfileId = isGroup
+					? `profile_group_${conversationId}`
+					: `profile_user_${externalParticipantIds[0] ?? conversationId}`;
 
-			if (messageEvents.length === 0) {
-				continue;
+				if (!profiles.has(participantProfileId)) {
+					if (isGroup) {
+						profiles.set(participantProfileId, {
+							id: participantProfileId,
+							handle: `group-${conversationId}`,
+							displayName:
+								conversationName || `Group DM ${externalParticipantIds.length}`,
+							bio: `Group DM with ${externalParticipantIds.length} participants`,
+							followersCount: 0,
+							followingCount: 0,
+							...defaultProfileMetadata,
+							avatarHue: 220,
+							avatarUrl: null,
+							createdAt: accountPayload.createdAt,
+						});
+					} else {
+						const otherUserId = externalParticipantIds[0] ?? conversationId;
+						const inferred = inferProfileFromDirectory(
+							otherUserId,
+							mentionDirectory,
+						);
+						mergeArchiveProfile({
+							id: participantProfileId,
+							handle: inferred.handle,
+							displayName: inferred.displayName,
+							bio: `Imported from archive user ${otherUserId}`,
+							followersCount: 0,
+							followingCount: 0,
+							...defaultProfileMetadata,
+							avatarHue: 210,
+							avatarUrl: null,
+							createdAt: accountPayload.createdAt,
+						});
+					}
+				}
+
+				const messageEvents = rawMessages
+					.map((event) => asRecord(event.messageCreate))
+					.filter((event): event is Record<string, unknown> => event !== null)
+					.map((messageCreate) => {
+						const senderId = String(messageCreate.senderId ?? "");
+						const rawMessageId = String(
+							messageCreate.id ?? `${rawConversationId}-${senderId}`,
+						);
+						const senderProfileId =
+							senderId === accountPayload.accountId
+								? localProfile.id
+								: `profile_user_${senderId}`;
+
+						if (senderId && senderId !== accountPayload.accountId) {
+							const inferred = inferProfileFromDirectory(
+								senderId,
+								mentionDirectory,
+							);
+							if (!profiles.has(senderProfileId)) {
+								mergeArchiveProfile({
+									id: senderProfileId,
+									handle: inferred.handle,
+									displayName: inferred.displayName,
+									bio: `Imported from archive user ${senderId}`,
+									followersCount: 0,
+									followingCount: 0,
+									...defaultProfileMetadata,
+									avatarHue: 240,
+									avatarUrl: null,
+									createdAt: accountPayload.createdAt,
+								});
+							}
+						}
+
+						return {
+							id: resolveArchiveDmMessageId(
+								rawMessageId,
+								conversationIdChanged,
+							),
+							conversationId,
+							senderProfileId: resolveProfileId(senderProfileId),
+							text: String(messageCreate.text ?? ""),
+							createdAt: parseTwitterDate(messageCreate.createdAt),
+							direction:
+								senderId === accountPayload.accountId ? "outbound" : "inbound",
+							mediaCount: asArray(messageCreate.mediaUrls).length,
+						} satisfies MessageRow;
+					})
+					.sort((left, right) =>
+						compareIsoTimestamp(left.createdAt, right.createdAt),
+					);
+
+				if (messageEvents.length === 0) {
+					continue;
+				}
+
+				const lastMessage = messageEvents.at(-1);
+				if (!lastMessage) continue;
+
+				dmMessages.push(...messageEvents);
+				const resolvedParticipantProfileId =
+					resolveProfileId(participantProfileId);
+				conversations.set(conversationId, {
+					id: conversationId,
+					title:
+						profiles.get(resolvedParticipantProfileId)?.displayName ||
+						conversationName ||
+						conversationId,
+					accountId: "acct_primary",
+					participantProfileId: resolvedParticipantProfileId,
+					lastMessageAt: lastMessage.createdAt,
+					unreadCount: 0,
+					needsReply: lastMessage.direction === "inbound" ? 1 : 0,
+				});
 			}
-
-			const lastMessage = messageEvents.at(-1);
-			if (!lastMessage) continue;
-
-			dmMessages.push(...messageEvents);
-			const resolvedParticipantProfileId =
-				resolveProfileId(participantProfileId);
-			conversations.set(conversationId, {
-				id: conversationId,
-				title:
-					profiles.get(resolvedParticipantProfileId)?.displayName ||
-					conversationName ||
-					conversationId,
-				accountId: "acct_primary",
-				participantProfileId: resolvedParticipantProfileId,
-				lastMessageAt: lastMessage.createdAt,
-				unreadCount: 0,
-				needsReply: lastMessage.direction === "inbound" ? 1 : 0,
-			});
 		}
-	}
 
-	let likeCount = 0;
-	for (const entry of likeEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		const likes = parseArchiveArray(content);
-		for (const like of likes) {
-			const tweet = extractCollectionTweet(like, "like");
-			if (!tweet) continue;
-			collectionRows.push({
-				tweetId: tweet.id,
-				kind: "likes",
-				collectedAt: tweet.createdAt,
-				source: "archive",
-				rawJson: JSON.stringify(like),
-			});
-			addTweetRow({
-				id: tweet.id,
-				kind: "like",
-				authorProfileId: "profile_unknown",
-				text: tweet.text,
-				createdAt: tweet.createdAt,
-				isReplied: 0,
-				replyToId: null,
-				likeCount: tweet.likeCount,
-				mediaCount: 0,
-				bookmarked: 0,
-				liked: 1,
-				entitiesJson: "{}",
-				mediaJson: "[]",
-				quotedTweetId: null,
-			});
+		let likeCount = 0;
+		for (const entry of likeEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			const likes = parseArchiveArray(content);
+			for (const like of likes) {
+				const tweet = extractCollectionTweet(like, "like");
+				if (!tweet) continue;
+				collectionRows.push({
+					tweetId: tweet.id,
+					kind: "likes",
+					collectedAt: tweet.createdAt,
+					source: "archive",
+					rawJson: JSON.stringify(like),
+				});
+				addTweetRow({
+					id: tweet.id,
+					kind: "like",
+					authorProfileId: "profile_unknown",
+					text: tweet.text,
+					createdAt: tweet.createdAt,
+					isReplied: 0,
+					replyToId: null,
+					likeCount: tweet.likeCount,
+					mediaCount: 0,
+					bookmarked: 0,
+					liked: 1,
+					entitiesJson: "{}",
+					mediaJson: "[]",
+					quotedTweetId: null,
+				});
+			}
+			likeCount += likes.length;
 		}
-		likeCount += likes.length;
-	}
 
-	let bookmarkCount = 0;
-	for (const entry of bookmarkEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		const bookmarks = parseArchiveArray(content);
-		for (const bookmark of bookmarks) {
-			const tweet = extractCollectionTweet(bookmark, "bookmark");
-			if (!tweet) continue;
-			collectionRows.push({
-				tweetId: tweet.id,
-				kind: "bookmarks",
-				collectedAt: tweet.createdAt,
-				source: "archive",
-				rawJson: JSON.stringify(bookmark),
-			});
-			addTweetRow({
-				id: tweet.id,
-				kind: "bookmark",
-				authorProfileId: "profile_unknown",
-				text: tweet.text,
-				createdAt: tweet.createdAt,
-				isReplied: 0,
-				replyToId: null,
-				likeCount: tweet.likeCount,
-				mediaCount: 0,
-				bookmarked: 1,
-				liked: 0,
-				entitiesJson: "{}",
-				mediaJson: "[]",
-				quotedTweetId: null,
-			});
+		let bookmarkCount = 0;
+		for (const entry of bookmarkEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			const bookmarks = parseArchiveArray(content);
+			for (const bookmark of bookmarks) {
+				const tweet = extractCollectionTweet(bookmark, "bookmark");
+				if (!tweet) continue;
+				collectionRows.push({
+					tweetId: tweet.id,
+					kind: "bookmarks",
+					collectedAt: tweet.createdAt,
+					source: "archive",
+					rawJson: JSON.stringify(bookmark),
+				});
+				addTweetRow({
+					id: tweet.id,
+					kind: "bookmark",
+					authorProfileId: "profile_unknown",
+					text: tweet.text,
+					createdAt: tweet.createdAt,
+					isReplied: 0,
+					replyToId: null,
+					likeCount: tweet.likeCount,
+					mediaCount: 0,
+					bookmarked: 1,
+					liked: 0,
+					entitiesJson: "{}",
+					mediaJson: "[]",
+					quotedTweetId: null,
+				});
+			}
+			bookmarkCount += bookmarks.length;
 		}
-		bookmarkCount += bookmarks.length;
-	}
 
-	const mediaFileCounts = await extractArchiveMediaFiles(
-		archivePath,
-		selectedArchiveMediaKinds(selection),
-	);
+		const mediaFileCounts = yield* extractArchiveMediaFilesEffect(
+			archivePath,
+			selectedArchiveMediaKinds(selection),
+		);
 
-	for (const entry of followerEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		for (const row of getArchiveFollowRows(content, "follower")) {
-			if (followerIds.has(row.externalUserId)) continue;
-			followerIds.add(row.externalUserId);
-			followerRows.push(row);
+		for (const entry of followerEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			for (const row of getArchiveFollowRows(content, "follower")) {
+				if (followerIds.has(row.externalUserId)) continue;
+				followerIds.add(row.externalUserId);
+				followerRows.push(row);
+			}
 		}
-	}
 
-	for (const entry of followingEntries) {
-		const content = await readArchiveEntry(archivePath, entry);
-		for (const row of getArchiveFollowRows(content, "following")) {
-			if (followingIds.has(row.externalUserId)) continue;
-			followingIds.add(row.externalUserId);
-			followingRows.push(row);
+		for (const entry of followingEntries) {
+			const content = yield* readArchiveEntryEffect(archivePath, entry);
+			for (const row of getArchiveFollowRows(content, "following")) {
+				if (followingIds.has(row.externalUserId)) continue;
+				followingIds.add(row.externalUserId);
+				followingRows.push(row);
+			}
 		}
-	}
 
-	for (const row of [...followerRows, ...followingRows]) {
-		addArchiveFollowProfile(row.profileId, row.externalUserId);
-	}
+		for (const row of [...followerRows, ...followingRows]) {
+			addArchiveFollowProfile(row.profileId, row.externalUserId);
+		}
 
-	const clearedFollowDirections = new Set<ArchiveFollowDirection>();
-	if (includeFollowers && followerEntries.length === 0) {
-		clearedFollowDirections.add("followers");
-	}
-	if (includeFollowing && followingEntries.length === 0) {
-		clearedFollowDirections.add("following");
-	}
-	const retainedFollowProfiles = getNativeDb()
-		.prepare(
-			`
+		const clearedFollowDirections = new Set<ArchiveFollowDirection>();
+		if (includeFollowers && followerEntries.length === 0) {
+			clearedFollowDirections.add("followers");
+		}
+		if (includeFollowing && followingEntries.length === 0) {
+			clearedFollowDirections.add("following");
+		}
+		const retainedFollowProfiles = getNativeDb()
+			.prepare(
+				`
       select direction, profile_id, external_user_id, source, null as snapshot_id, null as snapshot_source
       from follow_edges
       union
@@ -1527,57 +1573,59 @@ export async function importArchive(
       from follow_events ev
       left join follow_snapshots snap on snap.id = ev.snapshot_id
       `,
-		)
-		.all() as Array<{
-		direction: ArchiveFollowDirection;
-		profile_id: string;
-		external_user_id: string;
-		source: string | null;
-		snapshot_id: string | null;
-		snapshot_source: string | null;
-	}>;
-	for (const row of retainedFollowProfiles) {
-		const isClearedArchiveRow =
-			clearedFollowDirections.has(row.direction) &&
-			(row.source === "archive" ||
-				row.snapshot_source === "archive" ||
-				row.snapshot_id ===
-					`follow_snapshot_archive_acct_primary_${row.direction}`);
-		if (isClearedArchiveRow) continue;
-		addArchiveFollowProfile(row.profile_id, row.external_user_id);
-	}
+			)
+			.all() as Array<{
+			direction: ArchiveFollowDirection;
+			profile_id: string;
+			external_user_id: string;
+			source: string | null;
+			snapshot_id: string | null;
+			snapshot_source: string | null;
+		}>;
+		for (const row of retainedFollowProfiles) {
+			const isClearedArchiveRow =
+				clearedFollowDirections.has(row.direction) &&
+				(row.source === "archive" ||
+					row.snapshot_source === "archive" ||
+					row.snapshot_id ===
+						`follow_snapshot_archive_acct_primary_${row.direction}`);
+			if (isClearedArchiveRow) continue;
+			addArchiveFollowProfile(row.profile_id, row.external_user_id);
+		}
 
-	if (tweetRows.some((tweet) => tweet.authorProfileId === "profile_unknown")) {
-		const unknownProfile = {
-			id: "profile_unknown",
-			handle: selection
-				? uniqueArchiveProfileHandle("unknown", "profile_unknown")
-				: "unknown",
-			displayName: "Unknown",
-			bio: "Imported from archive collection metadata",
-			followersCount: 0,
-			followingCount: 0,
-			...defaultProfileMetadata,
-			avatarHue: 210,
-			avatarUrl: null,
-			createdAt: accountPayload.createdAt,
-		};
-		const existingUnknownProfile = existingProfiles.get("profile_unknown");
-		profiles.set(
-			"profile_unknown",
-			existingUnknownProfile
-				? existingProfileToProfileRow(existingUnknownProfile)
-				: unknownProfile,
-		);
-	}
+		if (
+			tweetRows.some((tweet) => tweet.authorProfileId === "profile_unknown")
+		) {
+			const unknownProfile = {
+				id: "profile_unknown",
+				handle: selection
+					? uniqueArchiveProfileHandle("unknown", "profile_unknown")
+					: "unknown",
+				displayName: "Unknown",
+				bio: "Imported from archive collection metadata",
+				followersCount: 0,
+				followingCount: 0,
+				...defaultProfileMetadata,
+				avatarHue: 210,
+				avatarUrl: null,
+				createdAt: accountPayload.createdAt,
+			};
+			const existingUnknownProfile = existingProfiles.get("profile_unknown");
+			profiles.set(
+				"profile_unknown",
+				existingUnknownProfile
+					? existingProfileToProfileRow(existingUnknownProfile)
+					: unknownProfile,
+			);
+		}
 
-	if (!selection) {
-		clearImportedData();
-		clearMentionSyncState();
-	}
+		if (!selection) {
+			clearImportedData();
+			clearMentionSyncState();
+		}
 
-	const db = getNativeDb();
-	const insertAccount = db.prepare(`
+		const db = getNativeDb();
+		const insertAccount = db.prepare(`
     insert into accounts (id, name, handle, external_user_id, transport, is_default, created_at)
     values (?, ?, ?, ?, ?, 1, ?)
     on conflict(id) do update set
@@ -1588,11 +1636,11 @@ export async function importArchive(
       is_default = 1,
       created_at = excluded.created_at
   `);
-	const insertAccountIfMissing = db.prepare(`
+		const insertAccountIfMissing = db.prepare(`
     insert or ignore into accounts (id, name, handle, external_user_id, transport, is_default, created_at)
     values (?, ?, ?, ?, ?, 1, ?)
   `);
-	const insertProfile = db.prepare(`
+		const insertProfile = db.prepare(`
 	    insert into profiles (
 	      id, handle, display_name, bio, followers_count, following_count,
 	      public_metrics_json, avatar_hue, avatar_url, location, url, verified_type,
@@ -1615,7 +1663,7 @@ export async function importArchive(
         raw_json = excluded.raw_json,
         created_at = excluded.created_at
 	  `);
-	const insertProfileIfMissing = db.prepare(`
+		const insertProfileIfMissing = db.prepare(`
 	    insert or ignore into profiles (
 	      id, handle, display_name, bio, followers_count, following_count,
 	      public_metrics_json, avatar_hue, avatar_url, location, url, verified_type,
@@ -1623,7 +1671,7 @@ export async function importArchive(
 	    )
 	    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	  `);
-	const insertTweet = db.prepare(`
+		const insertTweet = db.prepare(`
     insert into tweets (
       id, account_id, author_profile_id, kind, text, created_at, is_replied,
       reply_to_id, like_count, media_count, bookmarked, liked, entities_json, media_json, quoted_tweet_id
@@ -1667,14 +1715,16 @@ export async function importArchive(
       media_json = case when excluded.media_json <> '[]' then excluded.media_json else tweets.media_json end,
       quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id)
   `);
-	const deleteTweetFts = db.prepare(
-		"delete from tweets_fts where tweet_id = ?",
-	);
-	const insertTweetFts = db.prepare(
-		"insert into tweets_fts (tweet_id, text) values (?, ?)",
-	);
-	const selectTweetFtsText = db.prepare("select text from tweets where id = ?");
-	const insertTimelineEdge = db.prepare(`
+		const deleteTweetFts = db.prepare(
+			"delete from tweets_fts where tweet_id = ?",
+		);
+		const insertTweetFts = db.prepare(
+			"insert into tweets_fts (tweet_id, text) values (?, ?)",
+		);
+		const selectTweetFtsText = db.prepare(
+			"select text from tweets where id = ?",
+		);
+		const insertTimelineEdge = db.prepare(`
     insert into tweet_account_edges (
       account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count, source,
       raw_json, updated_at
@@ -1684,7 +1734,7 @@ export async function importArchive(
       last_seen_at = max(tweet_account_edges.last_seen_at, excluded.last_seen_at),
       updated_at = max(tweet_account_edges.updated_at, excluded.updated_at)
   `);
-	const insertCollection = db.prepare(`
+		const insertCollection = db.prepare(`
     insert into tweet_collections (
       account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
     ) values (?, ?, ?, ?, ?, ?, ?)
@@ -1700,20 +1750,20 @@ export async function importArchive(
       end,
       updated_at = max(tweet_collections.updated_at, excluded.updated_at)
 	  `);
-	const insertConversation = db.prepare(`
+		const insertConversation = db.prepare(`
     insert into dm_conversations (
       id, account_id, participant_profile_id, title, last_message_at, unread_count, needs_reply
     ) values (?, ?, ?, ?, ?, ?, ?)
   `);
-	const insertMessage = db.prepare(`
+		const insertMessage = db.prepare(`
     insert into dm_messages (
       id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
     ) values (?, ?, ?, ?, ?, ?, ?, ?)
   `);
-	const insertDmFts = db.prepare(
-		"insert into dm_fts (message_id, text) values (?, ?)",
-	);
-	const insertFollowSnapshot = db.prepare(`
+		const insertDmFts = db.prepare(
+			"insert into dm_fts (message_id, text) values (?, ?)",
+		);
+		const insertFollowSnapshot = db.prepare(`
     insert into follow_snapshots (
       id, account_id, direction, source, status, page_count, result_count,
       started_at, completed_at, raw_meta_json
@@ -1729,21 +1779,21 @@ export async function importArchive(
       completed_at = excluded.completed_at,
       raw_meta_json = excluded.raw_meta_json
   `);
-	const insertFollowSnapshotMember = db.prepare(`
+		const insertFollowSnapshotMember = db.prepare(`
     insert into follow_snapshot_members (
       snapshot_id, profile_id, external_user_id, position
     ) values (?, ?, ?, ?)
   `);
-	const selectFollowSnapshotMembers = db.prepare(`
+		const selectFollowSnapshotMembers = db.prepare(`
     select profile_id, external_user_id
     from follow_snapshot_members
     where snapshot_id = ?
     order by position, profile_id
   `);
-	const deleteFollowSnapshotMembers = db.prepare(
-		"delete from follow_snapshot_members where snapshot_id = ?",
-	);
-	const deleteArchiveFollowEvents = db.prepare(`
+		const deleteFollowSnapshotMembers = db.prepare(
+			"delete from follow_snapshot_members where snapshot_id = ?",
+		);
+		const deleteArchiveFollowEvents = db.prepare(`
     delete from follow_events
     where account_id = ? and direction = ? and (
       snapshot_id = ? or snapshot_id in (
@@ -1752,27 +1802,27 @@ export async function importArchive(
       )
     )
   `);
-	const deleteArchiveFollowSnapshotMembers = db.prepare(`
+		const deleteArchiveFollowSnapshotMembers = db.prepare(`
     delete from follow_snapshot_members
     where snapshot_id in (
       select id from follow_snapshots
       where account_id = ? and direction = ? and source = 'archive'
     )
   `);
-	const deleteArchiveFollowSnapshots = db.prepare(`
+		const deleteArchiveFollowSnapshots = db.prepare(`
     delete from follow_snapshots
     where account_id = ? and direction = ? and source = 'archive'
   `);
-	const deleteArchiveFollowEdges = db.prepare(`
+		const deleteArchiveFollowEdges = db.prepare(`
     delete from follow_edges
     where account_id = ? and direction = ? and source = 'archive'
   `);
-	const selectFollowEdges = db.prepare(`
+		const selectFollowEdges = db.prepare(`
     select profile_id, external_user_id, current
     from follow_edges
     where account_id = ? and direction = ?
   `);
-	const insertFollowEdge = db.prepare(`
+		const insertFollowEdge = db.prepare(`
     insert into follow_edges (
       account_id, direction, profile_id, external_user_id, source, current,
       first_seen_at, last_seen_at, ended_at, updated_at
@@ -1788,25 +1838,25 @@ export async function importArchive(
       ended_at = null,
       updated_at = excluded.updated_at
   `);
-	const endFollowEdge = db.prepare(`
+		const endFollowEdge = db.prepare(`
     update follow_edges
     set current = 0, ended_at = ?, updated_at = ?
     where account_id = ? and direction = ? and profile_id = ?
   `);
-	const insertFollowEvent = db.prepare(`
+		const insertFollowEvent = db.prepare(`
     insert into follow_events (
       id, account_id, direction, profile_id, external_user_id, kind, event_at, snapshot_id
     ) values (?, ?, ?, ?, ?, ?, ?, ?)
   `);
-	const clearSelectedLikes = db.prepare(`
+		const clearSelectedLikes = db.prepare(`
 	    delete from tweet_collections
 	    where account_id = ? and kind = 'likes' and source in ('archive', 'legacy')
 	  `);
-	const clearSelectedBookmarks = db.prepare(`
+		const clearSelectedBookmarks = db.prepare(`
 	    delete from tweet_collections
 	    where account_id = ? and kind = 'bookmarks' and source in ('archive', 'legacy')
 	  `);
-	const clearTweetLikedFlag = db.prepare(`
+		const clearTweetLikedFlag = db.prepare(`
 		    update tweets
 		    set liked = 0
 	    where account_id = ?
@@ -1816,7 +1866,7 @@ export async function importArchive(
 		      where account_id = ? and kind = 'likes' and source in ('archive', 'legacy')
 		    )
 	  `);
-	const clearTweetBookmarkedFlag = db.prepare(`
+		const clearTweetBookmarkedFlag = db.prepare(`
 		    update tweets
 		    set bookmarked = 0
 	    where account_id = ?
@@ -1826,7 +1876,7 @@ export async function importArchive(
 		      where account_id = ? and kind = 'bookmarks' and source in ('archive', 'legacy')
 		    )
 	  `);
-	const clearSelectedArchiveTweetEdges = db.prepare(`
+		const clearSelectedArchiveTweetEdges = db.prepare(`
 	    delete from tweet_account_edges
 	    where account_id = ?
 	      and kind in ('home', 'authored')
@@ -1844,12 +1894,12 @@ export async function importArchive(
 	        )
 	      )
 	  `);
-	const deleteOrphanTweetLinkOccurrences = db.prepare(`
+		const deleteOrphanTweetLinkOccurrences = db.prepare(`
 	    delete from link_occurrences
 	    where source_kind = 'tweet'
       and source_id not in (select id from tweets)
 	  `);
-	const deleteOrphanArchiveCollectionTweets = db.prepare(`
+		const deleteOrphanArchiveCollectionTweets = db.prepare(`
     delete from tweets
     where account_id = ?
       and kind in ('like', 'bookmark')
@@ -1870,7 +1920,7 @@ export async function importArchive(
 	          or referencing_tweet.quoted_tweet_id = tweets.id
 	      )
 	  `);
-	const demoteSelectedArchiveTweetsWithCollections = db.prepare(`
+		const demoteSelectedArchiveTweetsWithCollections = db.prepare(`
     update tweets
     set kind = case
       when exists (
@@ -1911,7 +1961,7 @@ export async function importArchive(
         where account_id = ?
       )
   `);
-	const preserveSelectedArchiveTweetsReferencedElsewhere = db.prepare(`
+		const preserveSelectedArchiveTweetsReferencedElsewhere = db.prepare(`
     update tweets
     set kind = 'archive_stale'
     where account_id = ?
@@ -1988,7 +2038,7 @@ export async function importArchive(
 	          )
 	      )
 	  `);
-	const deleteSelectedArchiveTweetsWithoutCollections = db.prepare(`
+		const deleteSelectedArchiveTweetsWithoutCollections = db.prepare(`
     delete from tweets
     where account_id = ?
 	      and id in (
@@ -2061,11 +2111,11 @@ export async function importArchive(
 	          )
 	      )
 	  `);
-	const deleteOrphanTweetFts = db.prepare(`
+		const deleteOrphanTweetFts = db.prepare(`
     delete from tweets_fts
     where tweet_id not in (select id from tweets)
   `);
-	const clearDmFts = db.prepare(`
+		const clearDmFts = db.prepare(`
     delete from dm_fts
     where message_id in (
       select m.id
@@ -2074,7 +2124,7 @@ export async function importArchive(
       where c.account_id = ?
     )
   `);
-	const clearDmLinkOccurrences = db.prepare(`
+		const clearDmLinkOccurrences = db.prepare(`
     delete from link_occurrences
     where source_kind = 'dm'
       and source_id in (
@@ -2084,362 +2134,377 @@ export async function importArchive(
         where c.account_id = ?
       )
   `);
-	const clearDmMessages = db.prepare(`
+		const clearDmMessages = db.prepare(`
     delete from dm_messages
     where conversation_id in (
       select id from dm_conversations where account_id = ?
     )
   `);
-	const clearDmConversations = db.prepare(
-		"delete from dm_conversations where account_id = ?",
-	);
+		const clearDmConversations = db.prepare(
+			"delete from dm_conversations where account_id = ?",
+		);
 
-	function importFollowRows(
-		direction: ArchiveFollowDirection,
-		rows: Array<{ profileId: string; externalUserId: string }>,
-		entryCount: number,
-		now: string,
-	) {
-		const snapshotId = `follow_snapshot_archive_acct_primary_${direction}`;
-		const existingEdges = new Map(
-			(
-				selectFollowEdges.all("acct_primary", direction) as Array<{
+		function importFollowRows(
+			direction: ArchiveFollowDirection,
+			rows: Array<{ profileId: string; externalUserId: string }>,
+			entryCount: number,
+			now: string,
+		) {
+			const snapshotId = `follow_snapshot_archive_acct_primary_${direction}`;
+			const existingEdges = new Map(
+				(
+					selectFollowEdges.all("acct_primary", direction) as Array<{
+						profile_id: string;
+						external_user_id: string;
+						current: number;
+					}>
+				).map((row) => [row.profile_id, row]),
+			);
+			const existingMemberKey = (
+				selectFollowSnapshotMembers.all(snapshotId) as Array<{
 					profile_id: string;
 					external_user_id: string;
-					current: number;
 				}>
-			).map((row) => [row.profile_id, row]),
-		);
-		const existingMemberKey = (
-			selectFollowSnapshotMembers.all(snapshotId) as Array<{
-				profile_id: string;
-				external_user_id: string;
-			}>
-		)
-			.map(
-				(row, index) =>
-					`${String(index)}:${row.profile_id}:${row.external_user_id}`,
 			)
-			.join("\n");
-		const nextMemberKey = rows
-			.map(
-				(row, index) =>
-					`${String(index)}:${row.profileId}:${row.externalUserId}`,
-			)
-			.join("\n");
-		const membersChanged = existingMemberKey !== nextMemberKey;
-		const currentProfileIds = new Set<string>();
+				.map(
+					(row, index) =>
+						`${String(index)}:${row.profile_id}:${row.external_user_id}`,
+				)
+				.join("\n");
+			const nextMemberKey = rows
+				.map(
+					(row, index) =>
+						`${String(index)}:${row.profileId}:${row.externalUserId}`,
+				)
+				.join("\n");
+			const membersChanged = existingMemberKey !== nextMemberKey;
+			const currentProfileIds = new Set<string>();
 
-		insertFollowSnapshot.run(
-			snapshotId,
-			"acct_primary",
-			direction,
-			entryCount,
-			rows.length,
-			now,
-			now,
-			JSON.stringify({ archivePath, result_count: rows.length }),
-		);
-
-		if (membersChanged) {
-			deleteFollowSnapshotMembers.run(snapshotId);
-		}
-		rows.forEach((row, index) => {
-			const profileId = resolveProfileId(row.profileId);
-			currentProfileIds.add(profileId);
-			if (membersChanged) {
-				insertFollowSnapshotMember.run(
-					snapshotId,
-					profileId,
-					row.externalUserId,
-					index,
-				);
-			}
-
-			const previous = existingEdges.get(profileId);
-			insertFollowEdge.run(
+			insertFollowSnapshot.run(
+				snapshotId,
 				"acct_primary",
 				direction,
-				profileId,
-				row.externalUserId,
+				entryCount,
+				rows.length,
 				now,
 				now,
-				now,
+				JSON.stringify({ archivePath, result_count: rows.length }),
 			);
-			if (!previous || previous.current === 0) {
+
+			if (membersChanged) {
+				deleteFollowSnapshotMembers.run(snapshotId);
+			}
+			rows.forEach((row, index) => {
+				const profileId = resolveProfileId(row.profileId);
+				currentProfileIds.add(profileId);
+				if (membersChanged) {
+					insertFollowSnapshotMember.run(
+						snapshotId,
+						profileId,
+						row.externalUserId,
+						index,
+					);
+				}
+
+				const previous = existingEdges.get(profileId);
+				insertFollowEdge.run(
+					"acct_primary",
+					direction,
+					profileId,
+					row.externalUserId,
+					now,
+					now,
+					now,
+				);
+				if (!previous || previous.current === 0) {
+					insertFollowEvent.run(
+						`follow_event_${randomUUID()}`,
+						"acct_primary",
+						direction,
+						profileId,
+						row.externalUserId,
+						"started",
+						now,
+						snapshotId,
+					);
+				}
+			});
+
+			for (const [profileId, previous] of existingEdges) {
+				if (previous.current === 0 || currentProfileIds.has(profileId)) {
+					continue;
+				}
+				endFollowEdge.run(now, now, "acct_primary", direction, profileId);
 				insertFollowEvent.run(
 					`follow_event_${randomUUID()}`,
 					"acct_primary",
 					direction,
 					profileId,
-					row.externalUserId,
-					"started",
+					previous.external_user_id,
+					"ended",
 					now,
 					snapshotId,
 				);
 			}
-		});
+		}
 
-		for (const [profileId, previous] of existingEdges) {
-			if (previous.current === 0 || currentProfileIds.has(profileId)) {
-				continue;
-			}
-			endFollowEdge.run(now, now, "acct_primary", direction, profileId);
-			insertFollowEvent.run(
-				`follow_event_${randomUUID()}`,
+		function clearArchiveFollowRows(direction: ArchiveFollowDirection) {
+			deleteArchiveFollowEvents.run(
 				"acct_primary",
 				direction,
-				profileId,
-				previous.external_user_id,
-				"ended",
-				now,
-				snapshotId,
-			);
-		}
-	}
-
-	function clearArchiveFollowRows(direction: ArchiveFollowDirection) {
-		deleteArchiveFollowEvents.run(
-			"acct_primary",
-			direction,
-			`follow_snapshot_archive_acct_primary_${direction}`,
-			"acct_primary",
-			direction,
-		);
-		deleteArchiveFollowSnapshotMembers.run("acct_primary", direction);
-		deleteArchiveFollowSnapshots.run("acct_primary", direction);
-		deleteArchiveFollowEdges.run("acct_primary", direction);
-	}
-
-	db.transaction(() => {
-		if (selection) {
-			if (includeTweets) {
-				clearAuthoredSyncCursors(db, "acct_primary");
-				demoteSelectedArchiveTweetsWithCollections.run(
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-					"acct_primary",
-				);
-				preserveSelectedArchiveTweetsReferencedElsewhere.run(
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-				);
-				deleteSelectedArchiveTweetsWithoutCollections.run(
-					"acct_primary",
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-				);
-				deleteOrphanTweetFts.run();
-				deleteOrphanTweetLinkOccurrences.run();
-				clearSelectedArchiveTweetEdges.run(
-					"acct_primary",
-					"acct_primary",
-					localProfile.id,
-				);
-			}
-			if (includeLikes) {
-				clearTweetLikedFlag.run("acct_primary", "acct_primary");
-				clearSelectedLikes.run("acct_primary");
-			}
-			if (includeBookmarks) {
-				clearTweetBookmarkedFlag.run("acct_primary", "acct_primary");
-				clearSelectedBookmarks.run("acct_primary");
-			}
-			if (includeLikes || includeBookmarks) {
-				deleteOrphanArchiveCollectionTweets.run("acct_primary");
-				deleteOrphanTweetFts.run();
-				deleteOrphanTweetLinkOccurrences.run();
-			}
-			if (includeDirectMessages) {
-				clearDmLinkOccurrences.run("acct_primary");
-				clearDmFts.run("acct_primary");
-				clearDmMessages.run("acct_primary");
-				clearDmConversations.run("acct_primary");
-			}
-		}
-
-		const writeAccount = selection ? insertAccountIfMissing : insertAccount;
-		writeAccount.run(
-			"acct_primary",
-			accountPayload.displayName,
-			`@${accountPayload.username}`,
-			accountPayload.accountId,
-			"archive",
-			accountPayload.createdAt,
-		);
-
-		const writeProfile =
-			!selection || includeProfiles ? insertProfile : insertProfileIfMissing;
-		for (const profile of profiles.values()) {
-			writeProfile.run(
-				profile.id,
-				profile.handle,
-				profile.displayName,
-				profile.bio,
-				profile.followersCount,
-				profile.followingCount,
-				profile.publicMetricsJson,
-				profile.avatarHue,
-				profile.avatarUrl,
-				profile.location,
-				profile.url,
-				profile.verifiedType,
-				profile.entitiesJson,
-				profile.rawJson,
-				profile.createdAt,
-			);
-		}
-
-		for (const tweet of tweetRows) {
-			const authorProfileId =
-				tweet.authorProfileId === "profile_me"
-					? localProfile.id
-					: resolveProfileId(tweet.authorProfileId);
-			insertTweet.run(
-				tweet.id,
+				`follow_snapshot_archive_acct_primary_${direction}`,
 				"acct_primary",
-				authorProfileId,
-				tweet.kind,
-				tweet.text,
-				tweet.createdAt,
-				tweet.isReplied,
-				tweet.replyToId,
-				tweet.likeCount,
-				tweet.mediaCount,
-				tweet.bookmarked,
-				tweet.liked,
-				tweet.entitiesJson,
-				tweet.mediaJson,
-				tweet.quotedTweetId,
+				direction,
 			);
-			deleteTweetFts.run(tweet.id);
-			if (tweet.kind === "home") {
-				insertTimelineEdge.run(
-					"acct_primary",
+			deleteArchiveFollowSnapshotMembers.run("acct_primary", direction);
+			deleteArchiveFollowSnapshots.run("acct_primary", direction);
+			deleteArchiveFollowEdges.run("acct_primary", direction);
+		}
+
+		db.transaction(() => {
+			if (selection) {
+				if (includeTweets) {
+					clearAuthoredSyncCursors(db, "acct_primary");
+					demoteSelectedArchiveTweetsWithCollections.run(
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+						"acct_primary",
+					);
+					preserveSelectedArchiveTweetsReferencedElsewhere.run(
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+					);
+					deleteSelectedArchiveTweetsWithoutCollections.run(
+						"acct_primary",
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+					);
+					deleteOrphanTweetFts.run();
+					deleteOrphanTweetLinkOccurrences.run();
+					clearSelectedArchiveTweetEdges.run(
+						"acct_primary",
+						"acct_primary",
+						localProfile.id,
+					);
+				}
+				if (includeLikes) {
+					clearTweetLikedFlag.run("acct_primary", "acct_primary");
+					clearSelectedLikes.run("acct_primary");
+				}
+				if (includeBookmarks) {
+					clearTweetBookmarkedFlag.run("acct_primary", "acct_primary");
+					clearSelectedBookmarks.run("acct_primary");
+				}
+				if (includeLikes || includeBookmarks) {
+					deleteOrphanArchiveCollectionTweets.run("acct_primary");
+					deleteOrphanTweetFts.run();
+					deleteOrphanTweetLinkOccurrences.run();
+				}
+				if (includeDirectMessages) {
+					clearDmLinkOccurrences.run("acct_primary");
+					clearDmFts.run("acct_primary");
+					clearDmMessages.run("acct_primary");
+					clearDmConversations.run("acct_primary");
+				}
+			}
+
+			const writeAccount = selection ? insertAccountIfMissing : insertAccount;
+			writeAccount.run(
+				"acct_primary",
+				accountPayload.displayName,
+				`@${accountPayload.username}`,
+				accountPayload.accountId,
+				"archive",
+				accountPayload.createdAt,
+			);
+
+			const writeProfile =
+				!selection || includeProfiles ? insertProfile : insertProfileIfMissing;
+			for (const profile of profiles.values()) {
+				writeProfile.run(
+					profile.id,
+					profile.handle,
+					profile.displayName,
+					profile.bio,
+					profile.followersCount,
+					profile.followingCount,
+					profile.publicMetricsJson,
+					profile.avatarHue,
+					profile.avatarUrl,
+					profile.location,
+					profile.url,
+					profile.verifiedType,
+					profile.entitiesJson,
+					profile.rawJson,
+					profile.createdAt,
+				);
+			}
+
+			for (const tweet of tweetRows) {
+				const authorProfileId =
+					tweet.authorProfileId === "profile_me"
+						? localProfile.id
+						: resolveProfileId(tweet.authorProfileId);
+				insertTweet.run(
 					tweet.id,
+					"acct_primary",
+					authorProfileId,
 					tweet.kind,
+					tweet.text,
 					tweet.createdAt,
-					tweet.createdAt,
-					new Date().toISOString(),
+					tweet.isReplied,
+					tweet.replyToId,
+					tweet.likeCount,
+					tweet.mediaCount,
+					tweet.bookmarked,
+					tweet.liked,
+					tweet.entitiesJson,
+					tweet.mediaJson,
+					tweet.quotedTweetId,
 				);
+				deleteTweetFts.run(tweet.id);
+				if (tweet.kind === "home") {
+					insertTimelineEdge.run(
+						"acct_primary",
+						tweet.id,
+						tweet.kind,
+						tweet.createdAt,
+						tweet.createdAt,
+						new Date().toISOString(),
+					);
+				}
+				if (authorProfileId === localProfile.id) {
+					insertTimelineEdge.run(
+						"acct_primary",
+						tweet.id,
+						"authored",
+						tweet.createdAt,
+						tweet.createdAt,
+						new Date().toISOString(),
+					);
+				}
+				const storedTweet = selectTweetFtsText.get(tweet.id) as
+					| { text: string }
+					| undefined;
+				insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
 			}
-			if (authorProfileId === localProfile.id) {
-				insertTimelineEdge.run(
+
+			const importedAt = new Date().toISOString();
+			for (const collection of collectionRows) {
+				insertCollection.run(
 					"acct_primary",
-					tweet.id,
-					"authored",
-					tweet.createdAt,
-					tweet.createdAt,
-					new Date().toISOString(),
+					collection.tweetId,
+					collection.kind,
+					collection.collectedAt,
+					collection.source,
+					collection.rawJson,
+					importedAt,
 				);
 			}
-			const storedTweet = selectTweetFtsText.get(tweet.id) as
-				| { text: string }
-				| undefined;
-			insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
-		}
 
-		const importedAt = new Date().toISOString();
-		for (const collection of collectionRows) {
-			insertCollection.run(
-				"acct_primary",
-				collection.tweetId,
-				collection.kind,
-				collection.collectedAt,
-				collection.source,
-				collection.rawJson,
-				importedAt,
-			);
-		}
+			for (const conversation of conversations.values()) {
+				insertConversation.run(
+					conversation.id,
+					conversation.accountId,
+					conversation.participantProfileId,
+					conversation.title,
+					conversation.lastMessageAt,
+					conversation.unreadCount,
+					conversation.needsReply,
+				);
+			}
 
-		for (const conversation of conversations.values()) {
-			insertConversation.run(
-				conversation.id,
-				conversation.accountId,
-				conversation.participantProfileId,
-				conversation.title,
-				conversation.lastMessageAt,
-				conversation.unreadCount,
-				conversation.needsReply,
-			);
-		}
+			for (const message of dmMessages) {
+				insertMessage.run(
+					message.id,
+					message.conversationId,
+					message.senderProfileId,
+					message.text,
+					message.createdAt,
+					message.direction,
+					message.direction === "outbound" ? 1 : 0,
+					message.mediaCount,
+				);
+				insertDmFts.run(message.id, message.text);
+			}
 
-		for (const message of dmMessages) {
-			insertMessage.run(
-				message.id,
-				message.conversationId,
-				message.senderProfileId,
-				message.text,
-				message.createdAt,
-				message.direction,
-				message.direction === "outbound" ? 1 : 0,
-				message.mediaCount,
-			);
-			insertDmFts.run(message.id, message.text);
-		}
+			if (includeFollowers && followerEntries.length > 0) {
+				importFollowRows(
+					"followers",
+					followerRows,
+					followerEntries.length,
+					importedAt,
+				);
+			} else if (includeFollowers) {
+				clearArchiveFollowRows("followers");
+			}
+			if (includeFollowing && followingEntries.length > 0) {
+				importFollowRows(
+					"following",
+					followingRows,
+					followingEntries.length,
+					importedAt,
+				);
+			} else if (includeFollowing) {
+				clearArchiveFollowRows("following");
+			}
+		})();
 
-		if (includeFollowers && followerEntries.length > 0) {
-			importFollowRows(
-				"followers",
-				followerRows,
-				followerEntries.length,
-				importedAt,
-			);
-		} else if (includeFollowers) {
-			clearArchiveFollowRows("followers");
-		}
-		if (includeFollowing && followingEntries.length > 0) {
-			importFollowRows(
-				"following",
-				followingRows,
-				followingEntries.length,
-				importedAt,
-			);
-		} else if (includeFollowing) {
-			clearArchiveFollowRows("following");
-		}
-	})();
+		return {
+			ok: true,
+			archivePath,
+			account: {
+				id: accountPayload.accountId,
+				handle: accountPayload.username,
+				displayName: accountPayload.displayName,
+			},
+			counts: {
+				tweets: authoredTweetCount,
+				likes: likeCount,
+				bookmarks: bookmarkCount,
+				dmConversations: conversations.size,
+				dmMessages: dmMessages.length,
+				profiles: profiles.size,
+				mediaFiles: mediaFileCounts,
+				followers: followerRows.length,
+				following: followingRows.length,
+			},
+		};
+	});
+}
 
-	return {
-		ok: true,
-		archivePath,
-		account: {
-			id: accountPayload.accountId,
-			handle: accountPayload.username,
-			displayName: accountPayload.displayName,
-		},
-		counts: {
-			tweets: authoredTweetCount,
-			likes: likeCount,
-			bookmarks: bookmarkCount,
-			dmConversations: conversations.size,
-			dmMessages: dmMessages.length,
-			profiles: profiles.size,
-			mediaFiles: mediaFileCounts,
-			followers: followerRows.length,
-			following: followingRows.length,
-		},
-	};
+export function importArchiveEffect(
+	archivePath: string,
+	options: ImportArchiveOptions = {},
+): Effect.Effect<ImportedArchiveSummary, unknown> {
+	return importArchiveInternalEffect(archivePath, options);
+}
+
+export function importArchive(
+	archivePath: string,
+	options: ImportArchiveOptions = {},
+): Promise<ImportedArchiveSummary> {
+	return runEffectPromise(importArchiveEffect(archivePath, options));
 }
 
 export const __test__ = {

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -176,6 +177,40 @@ describe("live authored tweet sync", () => {
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("builds authored sync effects lazily", async () => {
+		makeTempHome();
+		mocks.listUserTweets.mockResolvedValueOnce({
+			items: [authoredTweet("99", "lazy authored")],
+			nextToken: null,
+		});
+		const { syncAuthoredTweetsEffect } = await import("./authored-live");
+
+		const effect = syncAuthoredTweetsEffect({ limit: 5 });
+
+		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
+		expect(mocks.listUserTweets).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			kind: "authored",
+			count: 1,
+			nextSinceId: "99",
+		});
+		expect(mocks.listUserTweets).toHaveBeenCalledTimes(1);
+	});
+
+	it("validates authored sync effects only when run", async () => {
+		makeTempHome();
+		const { syncAuthoredTweetsEffect } = await import("./authored-live");
+
+		const effect = syncAuthoredTweetsEffect({ limit: 4 });
+
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"xurl mode requires --limit between 5 and 100",
+		);
+		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
+		expect(mocks.listUserTweets).not.toHaveBeenCalled();
 	});
 
 	it("handles an empty authored response without moving the cursor", async () => {

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -1,5 +1,7 @@
 import type { Database } from "./sqlite";
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type {
 	TweetEntities,
@@ -25,6 +27,15 @@ import {
 } from "./xurl";
 
 export type AuthoredSyncMode = "xurl";
+
+export interface SyncAuthoredTweetsOptions {
+	account?: string;
+	mode?: AuthoredSyncMode;
+	limit?: number;
+	maxPages?: number;
+	sinceId?: string;
+	untilId?: string;
+}
 
 export class AuthoredSyncError extends Error {
 	constructor(
@@ -107,6 +118,17 @@ const AUTHORED_MEDIA_FIELDS = [
 	"height",
 	"alt_text",
 ];
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
 
 function assertXurlLimit(limit: number) {
 	if (
@@ -413,57 +435,65 @@ function userFromAuthenticatedPayload(
 	};
 }
 
-async function resolveAuthoredIdentity({
+function resolveAuthoredIdentityEffect({
 	account,
 	db,
 }: {
 	account?: string;
 	db: Database;
 }) {
-	const status = await getTransportStatus();
-	if (status.availableTransport !== "xurl") {
-		throw new AuthoredSyncError(status.statusText, 4);
-	}
+	return Effect.gen(function* () {
+		const status = yield* tryPromise(() => getTransportStatus());
+		if (status.availableTransport !== "xurl") {
+			return yield* Effect.fail(new AuthoredSyncError(status.statusText, 4));
+		}
 
-	const resolvedAccount = resolveAccount(db, account);
-	if (resolvedAccount.externalUserId) {
+		const resolvedAccount = yield* trySync(() => resolveAccount(db, account));
+		if (resolvedAccount.externalUserId) {
+			return {
+				...resolvedAccount,
+				userId: resolvedAccount.externalUserId,
+				authenticatedUser: undefined,
+			};
+		}
+
+		const authenticated = yield* tryPromise(() => lookupAuthenticatedUser());
+		const authenticatedUser = userFromAuthenticatedPayload(authenticated);
+		if (!authenticatedUser?.id) {
+			return yield* Effect.fail(
+				new AuthoredSyncError(
+					"Could not resolve authenticated Twitter user id",
+					4,
+				),
+			);
+		}
+
+		if (
+			normalizeUsername(authenticatedUser.username) !==
+			normalizeUsername(resolvedAccount.username)
+		) {
+			return yield* Effect.fail(
+				new AuthoredSyncError(
+					`xurl is authenticated as @${authenticatedUser.username}, but selected account ${resolvedAccount.accountId} is @${resolvedAccount.username}. Link the account external_user_id or switch xurl login before syncing authored tweets.`,
+					4,
+				),
+			);
+		}
+
+		yield* trySync(() =>
+			persistAccountExternalUserId(
+				db,
+				resolvedAccount.accountId,
+				authenticatedUser.id,
+			),
+		);
+
 		return {
 			...resolvedAccount,
-			userId: resolvedAccount.externalUserId,
-			authenticatedUser: undefined,
+			userId: authenticatedUser.id,
+			authenticatedUser,
 		};
-	}
-
-	const authenticated = await lookupAuthenticatedUser();
-	const authenticatedUser = userFromAuthenticatedPayload(authenticated);
-	if (!authenticatedUser?.id) {
-		throw new AuthoredSyncError(
-			"Could not resolve authenticated Twitter user id",
-			4,
-		);
-	}
-
-	if (
-		normalizeUsername(authenticatedUser.username) !==
-		normalizeUsername(resolvedAccount.username)
-	) {
-		throw new AuthoredSyncError(
-			`xurl is authenticated as @${authenticatedUser.username}, but selected account ${resolvedAccount.accountId} is @${resolvedAccount.username}. Link the account external_user_id or switch xurl login before syncing authored tweets.`,
-			4,
-		);
-	}
-
-	persistAccountExternalUserId(
-		db,
-		resolvedAccount.accountId,
-		authenticatedUser.id,
-	);
-
-	return {
-		...resolvedAccount,
-		userId: authenticatedUser.id,
-		authenticatedUser,
-	};
+	});
 }
 
 function toFallbackUser({
@@ -887,188 +917,215 @@ function buildResult({
 	};
 }
 
-export async function syncAuthoredTweets({
+export function syncAuthoredTweetsEffect({
 	account,
 	mode = "xurl",
 	limit = DEFAULT_LIMIT,
 	maxPages,
 	sinceId,
 	untilId,
-}: {
-	account?: string;
-	mode?: AuthoredSyncMode;
-	limit?: number;
-	maxPages?: number;
-	sinceId?: string;
-	untilId?: string;
-}) {
-	if (mode !== "xurl") {
-		throw new Error("authored sync only supports --mode xurl");
-	}
+}: SyncAuthoredTweetsOptions) {
+	return Effect.gen(function* () {
+		if (mode !== "xurl") {
+			return yield* Effect.fail(
+				new Error("authored sync only supports --mode xurl"),
+			);
+		}
 
-	const pageLimit = assertXurlLimit(limit);
-	const parsedMaxPages = parseMaxPages(maxPages);
-	const db = getNativeDb();
-	const identity = await resolveAuthoredIdentity({ account, db });
-	const cursor = readAuthoredCursor(db, identity.accountId);
-	const usePersistedForward =
-		sinceId === undefined && !untilId && cursor.state === "pending-forward";
-	const usePersistedUntil =
-		sinceId === undefined &&
-		Boolean(untilId) &&
-		cursor.state === "pending-until" &&
-		cursor.untilId === untilId;
-	const shouldSeedFromArchive =
-		!usePersistedForward &&
-		!cursor.sinceId &&
-		sinceId === undefined &&
-		!untilId;
-	const archiveSinceSeed = shouldSeedFromArchive
-		? findArchiveAuthoredSinceSeed(db, identity.accountId)
-		: null;
-	if (shouldSeedFromArchive && !archiveSinceSeed) {
-		console.error(
-			"birdclaw sync authored: no archive baseline found; starting a full backwards scan",
+		const pageLimit = yield* trySync(() => assertXurlLimit(limit));
+		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const db = yield* trySync(() => getNativeDb());
+		const identity = yield* resolveAuthoredIdentityEffect({ account, db });
+		const cursor = yield* trySync(() =>
+			readAuthoredCursor(db, identity.accountId),
 		);
-	}
-	const persistedUntilSinceId: string | null = usePersistedUntil
-		? (("requestedSinceId" in cursor
-				? cursor.requestedSinceId
-				: cursor.sinceId) ?? null)
-		: null;
-	const effectiveSinceId: string | null =
-		sinceId ??
-		archiveSinceSeed ??
-		(untilId ? persistedUntilSinceId : cursor.sinceId) ??
-		null;
-	let nextToken = usePersistedForward
-		? cursor.token
-		: usePersistedUntil
+		const usePersistedForward =
+			sinceId === undefined && !untilId && cursor.state === "pending-forward";
+		const usePersistedUntil =
+			sinceId === undefined &&
+			Boolean(untilId) &&
+			cursor.state === "pending-until" &&
+			cursor.untilId === untilId;
+		const shouldSeedFromArchive =
+			!usePersistedForward &&
+			!cursor.sinceId &&
+			sinceId === undefined &&
+			!untilId;
+		const archiveSinceSeed = shouldSeedFromArchive
+			? yield* trySync(() =>
+					findArchiveAuthoredSinceSeed(db, identity.accountId),
+				)
+			: null;
+		if (shouldSeedFromArchive && !archiveSinceSeed) {
+			console.error(
+				"birdclaw sync authored: no archive baseline found; starting a full backwards scan",
+			);
+		}
+		const persistedUntilSinceId: string | null = usePersistedUntil
+			? (("requestedSinceId" in cursor
+					? cursor.requestedSinceId
+					: cursor.sinceId) ?? null)
+			: null;
+		const effectiveSinceId: string | null =
+			sinceId ??
+			archiveSinceSeed ??
+			(untilId ? persistedUntilSinceId : cursor.sinceId) ??
+			null;
+		let nextToken = usePersistedForward
 			? cursor.token
-			: undefined;
-	let newestSeenId = usePersistedForward
-		? maxTweetId(cursor.sinceId, cursor.pendingNewestId)
-		: cursor.sinceId;
-	const pages: XurlUserTweetsResponse[] = [];
-	const sourceUser = toFallbackUser({
-		userId: identity.userId,
-		username: identity.username,
-		authenticatedUser: identity.authenticatedUser,
-	});
-	let pageCount = 0;
-
-	while (parsedMaxPages === null || pageCount < parsedMaxPages) {
-		let page: XurlUserTweetsResponse;
-		try {
-			page = await listUserTweets(identity.userId, {
-				maxResults: pageLimit,
-				paginationToken: nextToken,
-				excludeRetweets: false,
-				sinceId: effectiveSinceId ?? undefined,
-				untilId,
-				tweetFields: AUTHORED_TWEET_FIELDS,
-				expansions: AUTHORED_EXPANSIONS,
-				userFields: AUTHORED_USER_FIELDS,
-				mediaFields: AUTHORED_MEDIA_FIELDS,
-				auth: "oauth2",
-			});
-		} catch (error) {
-			if (pages.length === 0) {
-				throw error;
-			}
-			const payload = mergePages({
-				pages,
-				userId: identity.userId,
-				nextToken: nextToken ?? null,
-			});
-			return buildResult({
-				accountId: identity.accountId,
-				userId: identity.userId,
-				effectiveSinceId,
-				nextSinceId: untilId ? cursor.sinceId : effectiveSinceId,
-				nextToken: nextToken ?? null,
-				pageCount,
-				payload,
-				partial: true,
-				error: formatError(error),
-			});
-		}
-
-		const pagePayload = mergePages({
-			pages: [page],
+			: usePersistedUntil
+				? cursor.token
+				: undefined;
+		let newestSeenId = usePersistedForward
+			? maxTweetId(cursor.sinceId, cursor.pendingNewestId)
+			: cursor.sinceId;
+		const pages: XurlUserTweetsResponse[] = [];
+		const sourceUser = toFallbackUser({
 			userId: identity.userId,
-			nextToken: page.nextToken,
+			username: identity.username,
+			authenticatedUser: identity.authenticatedUser,
 		});
-		mergeAuthoredPayloadIntoLocalStore({
-			db,
+		let pageCount = 0;
+
+		while (parsedMaxPages === null || pageCount < parsedMaxPages) {
+			const fetched = yield* tryPromise(() =>
+				listUserTweets(identity.userId, {
+					maxResults: pageLimit,
+					paginationToken: nextToken,
+					excludeRetweets: false,
+					sinceId: effectiveSinceId ?? undefined,
+					untilId,
+					tweetFields: AUTHORED_TWEET_FIELDS,
+					expansions: AUTHORED_EXPANSIONS,
+					userFields: AUTHORED_USER_FIELDS,
+					mediaFields: AUTHORED_MEDIA_FIELDS,
+					auth: "oauth2",
+				}),
+			).pipe(
+				Effect.map((page) => ({ ok: true as const, page })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ ok: false as const, error }),
+				),
+			);
+
+			if (!fetched.ok) {
+				if (pages.length === 0) {
+					return yield* Effect.fail(fetched.error);
+				}
+				const payload = mergePages({
+					pages,
+					userId: identity.userId,
+					nextToken: nextToken ?? null,
+				});
+				return buildResult({
+					accountId: identity.accountId,
+					userId: identity.userId,
+					effectiveSinceId,
+					nextSinceId: untilId ? cursor.sinceId : effectiveSinceId,
+					nextToken: nextToken ?? null,
+					pageCount,
+					payload,
+					partial: true,
+					error: formatError(fetched.error),
+				});
+			}
+
+			const page = fetched.page;
+			const pagePayload = mergePages({
+				pages: [page],
+				userId: identity.userId,
+				nextToken: page.nextToken,
+			});
+			yield* trySync(() =>
+				mergeAuthoredPayloadIntoLocalStore({
+					db,
+					accountId: identity.accountId,
+					payload: pagePayload,
+					sourceUser,
+				}),
+			);
+			pages.push(page);
+			pageCount += 1;
+			newestSeenId = maxTweetId(newestSeenId, pagePayload.meta.newest_id);
+			nextToken = page.nextToken ?? undefined;
+
+			const pendingToken = nextToken;
+			if (pendingToken && untilId) {
+				yield* trySync(() =>
+					writePendingUntilCursor(db, identity.accountId, {
+						sinceId: cursor.sinceId,
+						token: pendingToken,
+						untilId,
+						requestedSinceId: effectiveSinceId,
+					}),
+				);
+			} else if (pendingToken) {
+				yield* trySync(() =>
+					writePendingForwardCursor(db, identity.accountId, {
+						sinceId: effectiveSinceId,
+						token: pendingToken,
+						pendingNewestId: newestSeenId,
+					}),
+				);
+			}
+
+			if (!nextToken) {
+				break;
+			}
+		}
+
+		const capped = Boolean(nextToken);
+		const nextSinceId = untilId
+			? cursor.sinceId
+			: capped
+				? effectiveSinceId
+				: maxTweetId(newestSeenId, effectiveSinceId, cursor.sinceId);
+		if (untilId && capped && nextToken) {
+			yield* trySync(() =>
+				writePendingUntilCursor(db, identity.accountId, {
+					sinceId: cursor.sinceId,
+					token: nextToken,
+					untilId,
+					requestedSinceId: effectiveSinceId,
+				}),
+			);
+		} else if (untilId) {
+			yield* trySync(() =>
+				writeCommittedCursor(db, identity.accountId, cursor.sinceId),
+			);
+		} else if (capped && nextToken) {
+			yield* trySync(() =>
+				writePendingForwardCursor(db, identity.accountId, {
+					sinceId: nextSinceId,
+					token: nextToken,
+					pendingNewestId: newestSeenId,
+				}),
+			);
+		} else {
+			yield* trySync(() =>
+				writeCommittedCursor(db, identity.accountId, nextSinceId),
+			);
+		}
+
+		const payload = mergePages({
+			pages,
+			userId: identity.userId,
+			nextToken: nextToken ?? null,
+		});
+		return buildResult({
 			accountId: identity.accountId,
-			payload: pagePayload,
-			sourceUser,
+			userId: identity.userId,
+			effectiveSinceId,
+			nextSinceId,
+			nextToken: nextToken ?? null,
+			pageCount,
+			payload,
+			partial: capped,
+			...(capped ? { error: "max pages reached before sync completed" } : {}),
 		});
-		pages.push(page);
-		pageCount += 1;
-		newestSeenId = maxTweetId(newestSeenId, pagePayload.meta.newest_id);
-		nextToken = page.nextToken ?? undefined;
-
-		if (nextToken && untilId) {
-			writePendingUntilCursor(db, identity.accountId, {
-				sinceId: cursor.sinceId,
-				token: nextToken,
-				untilId,
-				requestedSinceId: effectiveSinceId,
-			});
-		} else if (nextToken) {
-			writePendingForwardCursor(db, identity.accountId, {
-				sinceId: effectiveSinceId,
-				token: nextToken,
-				pendingNewestId: newestSeenId,
-			});
-		}
-
-		if (!nextToken) {
-			break;
-		}
-	}
-
-	const capped = Boolean(nextToken);
-	const nextSinceId = untilId
-		? cursor.sinceId
-		: capped
-			? effectiveSinceId
-			: maxTweetId(newestSeenId, effectiveSinceId, cursor.sinceId);
-	if (untilId && capped && nextToken) {
-		writePendingUntilCursor(db, identity.accountId, {
-			sinceId: cursor.sinceId,
-			token: nextToken,
-			untilId,
-			requestedSinceId: effectiveSinceId,
-		});
-	} else if (untilId) {
-		writeCommittedCursor(db, identity.accountId, cursor.sinceId);
-	} else if (capped && nextToken) {
-		writePendingForwardCursor(db, identity.accountId, {
-			sinceId: nextSinceId,
-			token: nextToken,
-			pendingNewestId: newestSeenId,
-		});
-	} else {
-		writeCommittedCursor(db, identity.accountId, nextSinceId);
-	}
-
-	const payload = mergePages({
-		pages,
-		userId: identity.userId,
-		nextToken: nextToken ?? null,
 	});
-	return buildResult({
-		accountId: identity.accountId,
-		userId: identity.userId,
-		effectiveSinceId,
-		nextSinceId,
-		nextToken: nextToken ?? null,
-		pageCount,
-		payload,
-		partial: capped,
-		...(capped ? { error: "max pages reached before sync completed" } : {}),
-	});
+}
+
+export function syncAuthoredTweets(options: SyncAuthoredTweetsOptions) {
+	return runEffectPromise(syncAuthoredTweetsEffect(options));
 }

--- a/src/lib/avatar-cache.test.ts
+++ b/src/lib/avatar-cache.test.ts
@@ -2,12 +2,14 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	__test__,
 	getAvatarCachePath,
 	normalizeAvatarUrl,
 	readCachedAvatar,
+	readCachedAvatarEffect,
 } from "./avatar-cache";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -212,6 +214,16 @@ describe("avatar cache", () => {
 		);
 
 		await expect(readCachedAvatar("profile_blank")).resolves.toBeNull();
+	});
+
+	it("exposes cached avatar reads as Effects", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-avatar-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const effect = readCachedAvatarEffect("missing");
+
+		await expect(Effect.runPromise(effect)).resolves.toBeNull();
 	});
 
 	it("throws when remote avatar fetch fails", async () => {

--- a/src/lib/avatar-cache.ts
+++ b/src/lib/avatar-cache.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { Effect } from "effect";
 import { getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 
 const AVATAR_SIZE_SUFFIX =
 	/(?:(?:_normal|_bigger|_mini))(?=\.(?:jpg|jpeg|png|webp|gif)(?:$|\?))/i;
@@ -84,6 +86,17 @@ function getAvatarUrlForProfile(profileId: string) {
 	return row?.avatar_url ?? null;
 }
 
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
 export function normalizeAvatarUrl(value: unknown) {
 	if (typeof value !== "string" || value.trim().length === 0) {
 		return null;
@@ -122,57 +135,75 @@ export function getAvatarCachePath(profileId: string, avatarUrl: string) {
 	);
 }
 
-async function fetchRemoteAvatar(avatarUrl: string) {
-	const response = await fetch(avatarUrl, {
-		headers: {
-			"user-agent": "birdclaw/avatar-cache",
-		},
-	});
-	if (!response.ok) {
-		throw new Error(`Avatar fetch failed with ${response.status}`);
-	}
+function fetchRemoteAvatarEffect(avatarUrl: string) {
+	return Effect.gen(function* () {
+		const response = yield* tryPromise(() =>
+			fetch(avatarUrl, {
+				headers: {
+					"user-agent": "birdclaw/avatar-cache",
+				},
+			}),
+		);
+		if (!response.ok) {
+			return yield* Effect.fail(
+				new Error(`Avatar fetch failed with ${response.status}`),
+			);
+		}
 
-	const buffer = Buffer.from(await response.arrayBuffer());
-	return {
-		contentType: response.headers.get("content-type") ?? "image/jpeg",
-		buffer,
-	};
+		const buffer = Buffer.from(yield* tryPromise(() => response.arrayBuffer()));
+		return {
+			contentType: response.headers.get("content-type") ?? "image/jpeg",
+			buffer,
+		};
+	});
 }
 
-export async function readCachedAvatar(profileId: string) {
-	const avatarUrl = getAvatarUrlForProfile(profileId);
-	if (!avatarUrl) {
-		return null;
-	}
+export function readCachedAvatarEffect(profileId: string) {
+	return Effect.gen(function* () {
+		const avatarUrl = yield* trySync(() => getAvatarUrlForProfile(profileId));
+		if (!avatarUrl) {
+			return null;
+		}
 
-	const normalizedAvatarUrl = normalizeAvatarUrl(avatarUrl);
-	if (!normalizedAvatarUrl) {
-		return null;
-	}
+		const normalizedAvatarUrl = normalizeAvatarUrl(avatarUrl);
+		if (!normalizedAvatarUrl) {
+			return null;
+		}
 
-	const cachePath = getAvatarCachePath(profileId, normalizedAvatarUrl);
-	const cachedExtension = path.extname(cachePath);
+		const cachePath = yield* trySync(() =>
+			getAvatarCachePath(profileId, normalizedAvatarUrl),
+		);
+		const cachedExtension = path.extname(cachePath);
 
-	try {
-		return {
-			buffer: readFileSync(cachePath),
-			contentType: getContentTypeFromExtension(cachedExtension),
-			cachePath,
-			avatarUrl: normalizedAvatarUrl,
-		};
-	} catch {
+		const cached = yield* trySync(() => readFileSync(cachePath)).pipe(
+			Effect.map((buffer) => ({ ok: true as const, buffer })),
+			Effect.catchAll(() => Effect.succeed({ ok: false as const })),
+		);
+		if (cached.ok) {
+			return {
+				buffer: cached.buffer,
+				contentType: getContentTypeFromExtension(cachedExtension),
+				cachePath,
+				avatarUrl: normalizedAvatarUrl,
+			};
+		}
+
 		const payload = normalizedAvatarUrl.startsWith("data:")
-			? decodeDataUrl(normalizedAvatarUrl)
-			: await fetchRemoteAvatar(normalizedAvatarUrl);
+			? yield* trySync(() => decodeDataUrl(normalizedAvatarUrl))
+			: yield* fetchRemoteAvatarEffect(normalizedAvatarUrl);
 
-		writeFileSync(cachePath, payload.buffer);
+		yield* trySync(() => writeFileSync(cachePath, payload.buffer));
 		return {
 			buffer: payload.buffer,
 			contentType: payload.contentType,
 			cachePath,
 			avatarUrl: normalizedAvatarUrl,
 		};
-	}
+	});
+}
+
+export function readCachedAvatar(profileId: string) {
+	return runEffectPromise(readCachedAvatarEffect(profileId));
 }
 
 export const __test__ = {

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -10,15 +10,20 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	exportBackup,
+	exportBackupEffect,
 	getBackupDatabaseFingerprint,
 	importBackup,
+	importBackupEffect,
 	maybeAutoSyncBackup,
 	maybeAutoUpdateBackup,
 	syncBackup,
+	updateBackupFromGitEffect,
 	validateBackup,
+	validateBackupEffect,
 } from "./backup";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -267,6 +272,72 @@ afterEach(() => {
 });
 
 describe("text backup", () => {
+	it("builds backup Git update effects lazily", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-lazy-home-");
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		const repoPath = path.join(
+			makeTempDir("birdclaw-backup-lazy-parent-"),
+			"repo",
+		);
+
+		const effect = updateBackupFromGitEffect({ repoPath });
+
+		expect(existsSync(repoPath)).toBe(false);
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			repoPath,
+			pulled: false,
+			imported: false,
+		});
+		expect(existsSync(path.join(repoPath, ".git"))).toBe(true);
+	}, 20000);
+
+	it("exposes backup export, import, and validation as Effects", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-effect-src-");
+		seedBackupFixture();
+		const repoPath = makeTempDir("birdclaw-backup-effect-store-");
+
+		const exported = await Effect.runPromise(exportBackupEffect({ repoPath }));
+		const validation = await Effect.runPromise(validateBackupEffect(repoPath));
+
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-effect-dst-");
+		const imported = await Effect.runPromise(
+			importBackupEffect({ repoPath, mode: "replace" }),
+		);
+
+		expect(exported.validation.ok).toBe(true);
+		expect(validation.ok).toBe(true);
+		expect(imported.ok).toBe(true);
+		expect(imported.mode).toBe("replace");
+	}, 20000);
+
+	it("builds backup import effects lazily", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-import-src-");
+		seedBackupFixture();
+		const repoPath = makeTempDir("birdclaw-backup-import-store-");
+
+		const effect = importBackupEffect({ repoPath, mode: "replace" });
+
+		expect(existsSync(path.join(repoPath, "manifest.json"))).toBe(false);
+		await exportBackup({ repoPath });
+
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-import-dst-");
+		const imported = await Effect.runPromise(effect);
+
+		expect(imported.ok).toBe(true);
+		expect(imported.mode).toBe("replace");
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare("select count(*) as count from tweets where id = 'tweet_2025'")
+				.get(),
+		).toEqual({ count: 1 });
+	}, 20000);
+
 	it("exports JSONL shards and imports them without changing the portable fingerprint", async () => {
 		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-backup-src-");
 		seedBackupFixture();
@@ -521,6 +592,28 @@ describe("text backup", () => {
 		).toBe("1");
 	}, 20000);
 
+	it("does not inherit commit signing for generated backup commits", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-sync-signing-src-");
+		seedBackupFixture();
+		const repoPath = makeTempDir("birdclaw-sync-signing-work-");
+		execFileSync("git", ["init", repoPath]);
+		execFileSync("git", ["-C", repoPath, "config", "commit.gpgsign", "true"]);
+		execFileSync("git", ["-C", repoPath, "config", "gpg.program", "false"]);
+
+		const result = await exportBackup({
+			repoPath,
+			commit: true,
+			message: "archive: unsigned backup",
+		});
+
+		expect(result.git?.committed).toBe(true);
+		expect(
+			execFileSync("git", ["-C", repoPath, "rev-parse", "--verify", "HEAD"], {
+				encoding: "utf8",
+			}).trim(),
+		).toBe(result.git?.commit);
+	}, 20000);
+
 	it("reports validation errors for missing or corrupt backup files", async () => {
 		const missingManifest = await validateBackup(
 			makeTempDir("birdclaw-empty-"),
@@ -683,6 +776,25 @@ describe("text backup", () => {
 				ok: true,
 				enabled: false,
 				skipped: true,
+			});
+
+			resetDatabaseForTests();
+			process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-auto-bad-config-");
+			writeFileSync(
+				path.join(process.env.BIRDCLAW_HOME, "config.json"),
+				"{bad",
+			);
+			resetBirdclawPathsForTests();
+
+			await expect(maybeAutoUpdateBackup()).resolves.toMatchObject({
+				ok: false,
+				enabled: true,
+				skipped: false,
+			});
+			await expect(maybeAutoSyncBackup()).resolves.toMatchObject({
+				ok: false,
+				enabled: true,
+				skipped: false,
 			});
 
 			resetDatabaseForTests();

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -4,9 +4,11 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { Data, Effect } from "effect";
 import type { Database } from "./sqlite";
 import { getBirdclawConfig } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 
 const execFileAsync = promisify(execFile);
 const BACKUP_SCHEMA_VERSION = 1;
@@ -99,6 +101,61 @@ export interface BackupDatabaseFingerprint {
 }
 
 export type BackupImportMode = "merge" | "replace";
+
+export interface BackupImportOptions {
+	repoPath: string;
+	db?: Database;
+	validate?: boolean;
+	mode?: BackupImportMode;
+}
+
+export class BackupGitCommandError extends Data.TaggedError(
+	"BackupGitCommandError",
+)<{
+	readonly message: string;
+	readonly args: readonly string[];
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly cause?: unknown;
+}> {}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+function getErrorOutput(error: unknown, key: "stdout" | "stderr") {
+	if (!error || typeof error !== "object" || !(key in error)) {
+		return undefined;
+	}
+	const output = (error as Record<"stdout" | "stderr", unknown>)[key];
+	return typeof output === "string" ? output : undefined;
+}
+
+function gitCommandError(args: readonly string[], cause: unknown) {
+	const command = `git ${args.join(" ")}`;
+	const message = cause instanceof Error ? cause.message : `${command} failed`;
+	return new BackupGitCommandError({
+		message,
+		args,
+		stdout: getErrorOutput(cause, "stdout"),
+		stderr: getErrorOutput(cause, "stderr"),
+		cause,
+	});
+}
+
+function gitEffect(args: string[]) {
+	return Effect.tryPromise({
+		try: () => execFileAsync("git", args),
+		catch: (cause) => gitCommandError(args, cause),
+	});
+}
 
 function canonicalStringify(value: JsonValue): string {
 	if (value === null || typeof value !== "object") {
@@ -523,61 +580,73 @@ function buildShards(db: Database) {
 	return shards;
 }
 
-async function writeJsonlFile(
+function writeJsonlFileEffect(
 	repoPath: string,
 	relativePath: string,
 	rows: JsonRecord[],
-) {
-	const fullPath = path.join(repoPath, relativePath);
-	const content = `${rows.map((row) => jsonlStringify(row)).join("\n")}\n`;
-	await fs.mkdir(path.dirname(fullPath), { recursive: true });
-	let shouldWrite = true;
-	try {
-		shouldWrite = (await fs.readFile(fullPath, "utf8")) !== content;
-	} catch {
-		shouldWrite = true;
-	}
-	if (shouldWrite) {
-		await fs.writeFile(fullPath, content, "utf8");
-	}
-	return {
-		path: relativePath,
-		rows: rows.length,
-		sha256: sha256(content),
-		bytes: Buffer.byteLength(content),
-	};
+): Effect.Effect<BackupFileManifest, unknown> {
+	return Effect.gen(function* () {
+		const fullPath = yield* trySync(() => path.join(repoPath, relativePath));
+		const content = yield* trySync(
+			() => `${rows.map((row) => jsonlStringify(row)).join("\n")}\n`,
+		);
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(fullPath), { recursive: true }),
+		);
+		const current = yield* tryPromise(() => fs.readFile(fullPath, "utf8")).pipe(
+			Effect.option,
+		);
+		if (current._tag === "None" || current.value !== content) {
+			yield* tryPromise(() => fs.writeFile(fullPath, content, "utf8"));
+		}
+		return {
+			path: relativePath,
+			rows: rows.length,
+			sha256: sha256(content),
+			bytes: Buffer.byteLength(content),
+		};
+	});
 }
 
-async function removeStaleBackupFiles(
+function removeStaleBackupFilesEffect(
 	repoPath: string,
 	expectedPaths: Set<string>,
 	directory = DATA_DIR,
-) {
-	const fullDirectory = path.join(repoPath, directory);
-	let entries: Array<{ name: string; isDirectory: () => boolean }> = [];
-	try {
-		entries = await fs.readdir(fullDirectory, { withFileTypes: true });
-	} catch {
-		return;
-	}
+): Effect.Effect<void, unknown> {
+	return Effect.gen(function* () {
+		const fullDirectory = yield* trySync(() => path.join(repoPath, directory));
+		const entries = yield* tryPromise(() =>
+			fs.readdir(fullDirectory, { withFileTypes: true }),
+		).pipe(Effect.catchAll(() => Effect.succeed([])));
 
-	await Promise.all(
-		entries.map(async (entry) => {
-			const relativePath = path.posix.join(directory, entry.name);
-			const fullPath = path.join(repoPath, relativePath);
-			if (entry.isDirectory()) {
-				await removeStaleBackupFiles(repoPath, expectedPaths, relativePath);
-				const remaining = await fs.readdir(fullPath);
-				if (remaining.length === 0) {
-					await fs.rmdir(fullPath);
-				}
-				return;
-			}
-			if (relativePath.endsWith(".jsonl") && !expectedPaths.has(relativePath)) {
-				await fs.rm(fullPath, { force: true });
-			}
-		}),
-	);
+		yield* Effect.forEach(
+			entries,
+			(entry) =>
+				Effect.gen(function* () {
+					const relativePath = path.posix.join(directory, entry.name);
+					const fullPath = path.join(repoPath, relativePath);
+					if (entry.isDirectory()) {
+						yield* removeStaleBackupFilesEffect(
+							repoPath,
+							expectedPaths,
+							relativePath,
+						);
+						const remaining = yield* tryPromise(() => fs.readdir(fullPath));
+						if (remaining.length === 0) {
+							yield* tryPromise(() => fs.rmdir(fullPath));
+						}
+						return;
+					}
+					if (
+						relativePath.endsWith(".jsonl") &&
+						!expectedPaths.has(relativePath)
+					) {
+						yield* tryPromise(() => fs.rm(fullPath, { force: true }));
+					}
+				}),
+			{ concurrency: "unbounded" },
+		);
+	});
 }
 
 function computeBackupHash(files: BackupFileManifest[]) {
@@ -622,14 +691,18 @@ function computeCounts(files: BackupFileManifest[]) {
 	return counts;
 }
 
-async function ensureBackupReadme(repoPath: string) {
-	const readmePath = path.join(repoPath, "README.md");
-	if (existsSync(readmePath)) {
-		return;
-	}
-	await fs.writeFile(
-		readmePath,
-		`# Birdclaw Store
+function ensureBackupReadmeEffect(
+	repoPath: string,
+): Effect.Effect<void, unknown> {
+	return Effect.gen(function* () {
+		const readmePath = yield* trySync(() => path.join(repoPath, "README.md"));
+		if (yield* trySync(() => existsSync(readmePath))) {
+			return;
+		}
+		yield* tryPromise(() =>
+			fs.writeFile(
+				readmePath,
+				`# Birdclaw Store
 
 Private text backup for Birdclaw data. The committed files are canonical JSONL shards that can rebuild the local SQLite index.
 
@@ -665,32 +738,42 @@ The links shard stores expanded short URLs and their source tweet/DM occurrences
 
 Never commit live tokens, browser cookies, raw SQLite WAL/SHM sidecars, or temporary cache files here.
 `,
-		"utf8",
+				"utf8",
+			),
+		);
+	});
+}
+
+function writeManifestEffect(
+	repoPath: string,
+	manifest: BackupManifest,
+): Effect.Effect<void, unknown> {
+	return Effect.gen(function* () {
+		const manifestPath = yield* trySync(() =>
+			path.join(repoPath, MANIFEST_PATH),
+		);
+		const content = yield* trySync(
+			() => `${canonicalStringify(manifest as unknown as JsonRecord)}\n`,
+		);
+		const current = yield* tryPromise(() =>
+			fs.readFile(manifestPath, "utf8"),
+		).pipe(Effect.option);
+		if (current._tag === "Some" && current.value === content) {
+			return;
+		}
+		yield* tryPromise(() => fs.writeFile(manifestPath, content, "utf8"));
+	});
+}
+
+function readPreviousManifestEffect(
+	repoPath: string,
+): Effect.Effect<BackupManifest | undefined, never> {
+	return readManifestEffect(repoPath).pipe(
+		Effect.catchAll(() => Effect.succeed(undefined)),
 	);
 }
 
-async function writeManifest(repoPath: string, manifest: BackupManifest) {
-	const manifestPath = path.join(repoPath, MANIFEST_PATH);
-	const content = `${canonicalStringify(manifest as unknown as JsonRecord)}\n`;
-	try {
-		if ((await fs.readFile(manifestPath, "utf8")) === content) {
-			return;
-		}
-	} catch {
-		// New backup repo.
-	}
-	await fs.writeFile(manifestPath, content, "utf8");
-}
-
-async function readPreviousManifest(repoPath: string) {
-	try {
-		return await readManifest(repoPath);
-	} catch {
-		return undefined;
-	}
-}
-
-async function maybeCommitAndPush({
+function maybeCommitAndPushEffect({
 	repoPath,
 	message,
 	commit,
@@ -702,211 +785,200 @@ async function maybeCommitAndPush({
 	push: boolean;
 }) {
 	if (!commit && !push) {
-		return undefined;
+		return Effect.succeed(undefined);
 	}
 
-	try {
-		await execFileAsync("git", [
+	return Effect.gen(function* () {
+		yield* gitEffect([
 			"-C",
 			repoPath,
 			"rev-parse",
 			"--is-inside-work-tree",
-		]);
-	} catch {
-		await execFileAsync("git", ["-C", repoPath, "init"]);
-	}
+		]).pipe(
+			Effect.catchAll(() =>
+				gitEffect(["-C", repoPath, "init"]).pipe(Effect.asVoid),
+			),
+		);
 
-	await execFileAsync("git", [
-		"-C",
-		repoPath,
-		"add",
-		"README.md",
-		MANIFEST_PATH,
-		DATA_DIR,
-	]);
-
-	try {
-		await execFileAsync("git", ["-C", repoPath, "config", "user.email"]);
-	} catch {
-		await execFileAsync("git", [
+		yield* gitEffect([
 			"-C",
 			repoPath,
-			"config",
-			"user.email",
-			"birdclaw@example.invalid",
+			"add",
+			"README.md",
+			MANIFEST_PATH,
+			DATA_DIR,
 		]);
-	}
-	try {
-		await execFileAsync("git", ["-C", repoPath, "config", "user.name"]);
-	} catch {
-		await execFileAsync("git", [
+
+		yield* gitEffect(["-C", repoPath, "config", "user.email"]).pipe(
+			Effect.catchAll(() =>
+				gitEffect([
+					"-C",
+					repoPath,
+					"config",
+					"user.email",
+					"birdclaw@example.invalid",
+				]),
+			),
+		);
+		yield* gitEffect(["-C", repoPath, "config", "user.name"]).pipe(
+			Effect.catchAll(() =>
+				gitEffect(["-C", repoPath, "config", "user.name", "Birdclaw Backup"]),
+			),
+		);
+
+		const commitResult = yield* gitEffect([
 			"-C",
 			repoPath,
-			"config",
-			"user.name",
-			"Birdclaw Backup",
-		]);
-	}
+			"diff",
+			"--cached",
+			"--quiet",
+		]).pipe(
+			Effect.as({ committed: false as const, commitHash: undefined }),
+			Effect.catchAll(() =>
+				Effect.gen(function* () {
+					yield* gitEffect([
+						"-C",
+						repoPath,
+						"-c",
+						"commit.gpgsign=false",
+						"commit",
+						"-m",
+						message,
+					]);
+					const { stdout } = yield* gitEffect([
+						"-C",
+						repoPath,
+						"rev-parse",
+						"HEAD",
+					]);
+					return {
+						committed: true as const,
+						commitHash: stdout.trim(),
+					};
+				}),
+			),
+		);
 
-	let committed = false;
-	let commitHash: string | undefined;
-	try {
-		await execFileAsync("git", ["-C", repoPath, "diff", "--cached", "--quiet"]);
-	} catch {
-		await execFileAsync("git", ["-C", repoPath, "commit", "-m", message]);
-		committed = true;
-		const { stdout } = await execFileAsync("git", [
-			"-C",
-			repoPath,
-			"rev-parse",
-			"HEAD",
-		]);
-		commitHash = stdout.trim();
-	}
-
-	if (push) {
-		try {
-			await execFileAsync("git", ["-C", repoPath, "push"]);
-		} catch {
-			await execFileAsync("git", [
-				"-C",
-				repoPath,
-				"push",
-				"-u",
-				"origin",
-				"HEAD:main",
-			]);
+		if (push) {
+			yield* gitEffect(["-C", repoPath, "push"]).pipe(
+				Effect.catchAll(() =>
+					gitEffect(["-C", repoPath, "push", "-u", "origin", "HEAD:main"]),
+				),
+			);
 		}
-	}
 
-	return { committed, pushed: push, commit: commitHash };
+		return {
+			committed: commitResult.committed,
+			pushed: push,
+			commit: commitResult.commitHash,
+		};
+	});
 }
 
-async function isGitRepo(repoPath: string) {
-	try {
-		await execFileAsync("git", [
-			"-C",
-			repoPath,
-			"rev-parse",
-			"--is-inside-work-tree",
-		]);
-		return true;
-	} catch {
-		return false;
-	}
+function isGitRepoEffect(repoPath: string) {
+	return gitEffect(["-C", repoPath, "rev-parse", "--is-inside-work-tree"]).pipe(
+		Effect.as(true),
+		Effect.catchAll(() => Effect.succeed(false)),
+	);
 }
 
-async function hasGitCommits(repoPath: string) {
-	try {
-		await execFileAsync("git", [
-			"-C",
-			repoPath,
-			"rev-parse",
-			"--verify",
-			"HEAD",
-		]);
-		return true;
-	} catch {
-		return false;
-	}
+function hasGitCommitsEffect(repoPath: string) {
+	return gitEffect(["-C", repoPath, "rev-parse", "--verify", "HEAD"]).pipe(
+		Effect.as(true),
+		Effect.catchAll(() => Effect.succeed(false)),
+	);
 }
 
-async function ensureBackupGitRepo({
+function ensureBackupGitRepoEffect({
 	repoPath,
 	remote,
 }: {
 	repoPath: string;
 	remote?: string;
 }) {
-	if (!(await isGitRepo(repoPath))) {
-		if (remote && !existsSync(repoPath)) {
-			await execFileAsync("git", ["clone", remote, repoPath]);
-		} else {
-			await fs.mkdir(repoPath, { recursive: true });
-			await execFileAsync("git", ["-C", repoPath, "init"]);
+	return Effect.gen(function* () {
+		if (!(yield* isGitRepoEffect(repoPath))) {
+			if (remote && !existsSync(repoPath)) {
+				yield* gitEffect(["clone", remote, repoPath]);
+			} else {
+				yield* tryPromise(() => fs.mkdir(repoPath, { recursive: true }));
+				yield* gitEffect(["-C", repoPath, "init"]);
+			}
 		}
-	}
 
-	if (remote) {
-		try {
-			const { stdout } = await execFileAsync("git", [
+		if (remote) {
+			const origin = yield* gitEffect([
 				"-C",
 				repoPath,
 				"remote",
 				"get-url",
 				"origin",
-			]);
-			if (stdout.trim() !== remote) {
-				await execFileAsync("git", [
-					"-C",
-					repoPath,
-					"remote",
-					"set-url",
-					"origin",
-					remote,
-				]);
+			]).pipe(
+				Effect.map(({ stdout }) => ({ ok: true as const, stdout })),
+				Effect.catchAll(() => Effect.succeed({ ok: false as const })),
+			);
+			if (origin.ok) {
+				if (origin.stdout.trim() !== remote) {
+					yield* gitEffect([
+						"-C",
+						repoPath,
+						"remote",
+						"set-url",
+						"origin",
+						remote,
+					]);
+				}
+			} else {
+				yield* gitEffect(["-C", repoPath, "remote", "add", "origin", remote]);
 			}
-		} catch {
-			await execFileAsync("git", [
+		}
+
+		if (remote && !(yield* hasGitCommitsEffect(repoPath))) {
+			const fetched = yield* gitEffect([
 				"-C",
 				repoPath,
-				"remote",
-				"add",
+				"fetch",
 				"origin",
-				remote,
-			]);
-		}
-	}
-
-	if (remote && !(await hasGitCommits(repoPath))) {
-		try {
-			await execFileAsync("git", ["-C", repoPath, "fetch", "origin", "main"]);
-			await execFileAsync("git", [
-				"-C",
-				repoPath,
-				"checkout",
-				"-B",
 				"main",
-				"origin/main",
-			]);
-			return;
-		} catch {
-			// Empty remote or no main branch yet; create the first main commit locally.
+			]).pipe(
+				Effect.flatMap(() =>
+					gitEffect(["-C", repoPath, "checkout", "-B", "main", "origin/main"]),
+				),
+				Effect.as(true),
+				Effect.catchAll(() => Effect.succeed(false)),
+			);
+			if (fetched) return;
 		}
-	}
 
-	if (!(await hasGitCommits(repoPath))) {
-		await execFileAsync("git", ["-C", repoPath, "checkout", "-B", "main"]);
-	}
+		if (!(yield* hasGitCommitsEffect(repoPath))) {
+			yield* gitEffect(["-C", repoPath, "checkout", "-B", "main"]);
+		}
+	});
 }
 
-async function pullBackupGitRepo(repoPath: string) {
-	if (!(await isGitRepo(repoPath)) || !(await hasGitCommits(repoPath))) {
-		return false;
-	}
-	try {
-		await execFileAsync("git", ["-C", repoPath, "pull", "--ff-only"]);
-		return true;
-	} catch {
-		try {
-			await execFileAsync("git", [
-				"-C",
-				repoPath,
-				"pull",
-				"--ff-only",
-				"origin",
-				"main",
-			]);
-			return true;
-		} catch {
+function pullBackupGitRepoEffect(repoPath: string) {
+	return Effect.gen(function* () {
+		if (
+			!(yield* isGitRepoEffect(repoPath)) ||
+			!(yield* hasGitCommitsEffect(repoPath))
+		) {
 			return false;
 		}
-	}
+		return yield* gitEffect(["-C", repoPath, "pull", "--ff-only"]).pipe(
+			Effect.as(true),
+			Effect.catchAll(() =>
+				gitEffect(["-C", repoPath, "pull", "--ff-only", "origin", "main"]).pipe(
+					Effect.as(true),
+					Effect.catchAll(() => Effect.succeed(false)),
+				),
+			),
+		);
+	});
 }
 
-export async function exportBackup({
+export function exportBackupEffect({
 	repoPath,
-	db = getNativeDb({ seedDemoData: false }),
+	db,
 	commit = false,
 	push = false,
 	message = "archive: update birdclaw backup",
@@ -918,100 +990,181 @@ export async function exportBackup({
 	push?: boolean;
 	message?: string;
 	validate?: boolean;
-}): Promise<BackupExportResult> {
-	const resolvedRepoPath = path.resolve(repoPath);
-	await fs.mkdir(resolvedRepoPath, { recursive: true });
-	await ensureBackupReadme(resolvedRepoPath);
+}): Effect.Effect<BackupExportResult, unknown> {
+	return Effect.gen(function* () {
+		const resolvedRepoPath = yield* trySync(() => path.resolve(repoPath));
+		const database =
+			db ?? (yield* trySync(() => getNativeDb({ seedDemoData: false })));
+		yield* tryPromise(() => fs.mkdir(resolvedRepoPath, { recursive: true }));
+		yield* ensureBackupReadmeEffect(resolvedRepoPath);
 
-	const shards = buildShards(db);
-	const shardEntries = [...shards.entries()].sort(([left], [right]) =>
-		left.localeCompare(right),
-	);
-	const expectedPaths = new Set(
-		shardEntries.map(([relativePath]) => relativePath),
-	);
-	const files = await Promise.all(
-		shardEntries.map(([relativePath, rows]) =>
-			writeJsonlFile(resolvedRepoPath, relativePath, rows),
-		),
-	);
-	await removeStaleBackupFiles(resolvedRepoPath, expectedPaths);
-
-	const counts = computeCounts(files);
-	const backupHash = computeBackupHash(files);
-	const previousManifest = await readPreviousManifest(resolvedRepoPath);
-	const manifest: BackupManifest = {
-		app: "birdclaw",
-		schemaVersion: BACKUP_SCHEMA_VERSION,
-		generatedAt:
-			previousManifest?.backupHash === backupHash
-				? previousManifest.generatedAt
-				: new Date().toISOString(),
-		counts,
-		files,
-		backupHash,
-	};
-	await writeManifest(resolvedRepoPath, manifest);
-
-	const validation = validate
-		? await validateBackup(resolvedRepoPath)
-		: {
-				ok: true,
-				repoPath: resolvedRepoPath,
-				files,
-				counts,
-				backupHash: manifest.backupHash,
-				errors: [],
-			};
-	if (!validation.ok) {
-		throw new Error(
-			`Backup validation failed: ${validation.errors.join("; ")}`,
+		const shards = yield* trySync(() => buildShards(database));
+		const shardEntries = yield* trySync(() =>
+			[...shards.entries()].sort(([left], [right]) =>
+				left.localeCompare(right),
+			),
 		);
-	}
+		const expectedPaths = yield* trySync(
+			() => new Set(shardEntries.map(([relativePath]) => relativePath)),
+		);
+		const files = yield* Effect.forEach(
+			shardEntries,
+			([relativePath, rows]) =>
+				writeJsonlFileEffect(resolvedRepoPath, relativePath, rows),
+			{ concurrency: "unbounded" },
+		);
+		yield* removeStaleBackupFilesEffect(resolvedRepoPath, expectedPaths);
 
-	const git = await maybeCommitAndPush({
-		repoPath: resolvedRepoPath,
-		message,
-		commit,
-		push,
+		const counts = yield* trySync(() => computeCounts(files));
+		const backupHash = yield* trySync(() => computeBackupHash(files));
+		const previousManifest =
+			yield* readPreviousManifestEffect(resolvedRepoPath);
+		const manifest: BackupManifest = {
+			app: "birdclaw",
+			schemaVersion: BACKUP_SCHEMA_VERSION,
+			generatedAt:
+				previousManifest?.backupHash === backupHash
+					? previousManifest.generatedAt
+					: new Date().toISOString(),
+			counts,
+			files,
+			backupHash,
+		};
+		yield* writeManifestEffect(resolvedRepoPath, manifest);
+
+		const validation = validate
+			? yield* validateBackupEffect(resolvedRepoPath)
+			: {
+					ok: true,
+					repoPath: resolvedRepoPath,
+					files,
+					counts,
+					backupHash: manifest.backupHash,
+					errors: [],
+				};
+		if (!validation.ok) {
+			return yield* Effect.fail(
+				new Error(`Backup validation failed: ${validation.errors.join("; ")}`),
+			);
+		}
+
+		const git = yield* maybeCommitAndPushEffect({
+			repoPath: resolvedRepoPath,
+			message,
+			commit,
+			push,
+		});
+
+		return {
+			ok: true,
+			repoPath: resolvedRepoPath,
+			manifest,
+			validation,
+			...(git ? { git } : {}),
+		};
 	});
-
-	return {
-		ok: true,
-		repoPath: resolvedRepoPath,
-		manifest,
-		validation,
-		...(git ? { git } : {}),
-	};
 }
 
-async function readManifest(repoPath: string): Promise<BackupManifest> {
-	const content = await fs.readFile(path.join(repoPath, MANIFEST_PATH), "utf8");
-	const parsed = JSON.parse(content) as BackupManifest;
-	if (parsed.app !== "birdclaw") {
-		throw new Error("Backup manifest is not a birdclaw backup");
-	}
-	if (parsed.schemaVersion !== BACKUP_SCHEMA_VERSION) {
-		throw new Error(
-			`Unsupported backup schema version ${String(parsed.schemaVersion)}`,
+export function exportBackup(
+	options: Parameters<typeof exportBackupEffect>[0],
+): Promise<BackupExportResult> {
+	return runEffectPromise(exportBackupEffect(options));
+}
+
+function readManifestEffect(
+	repoPath: string,
+): Effect.Effect<BackupManifest, unknown> {
+	return Effect.gen(function* () {
+		const content = yield* tryPromise(() =>
+			fs.readFile(path.join(repoPath, MANIFEST_PATH), "utf8"),
 		);
-	}
-	return parsed;
+		const parsed = yield* trySync(() => JSON.parse(content) as BackupManifest);
+		if (parsed.app !== "birdclaw") {
+			return yield* Effect.fail(
+				new Error("Backup manifest is not a birdclaw backup"),
+			);
+		}
+		if (parsed.schemaVersion !== BACKUP_SCHEMA_VERSION) {
+			return yield* Effect.fail(
+				new Error(
+					`Unsupported backup schema version ${String(parsed.schemaVersion)}`,
+				),
+			);
+		}
+		return parsed;
+	});
 }
 
-async function readJsonlFile(repoPath: string, relativePath: string) {
-	const content = await fs.readFile(path.join(repoPath, relativePath), "utf8");
-	return content
-		.split("\n")
-		.filter((line) => line.length > 0)
-		.map((line) => JSON.parse(line) as JsonRecord);
+function readJsonlFileEffect(
+	repoPath: string,
+	relativePath: string,
+): Effect.Effect<JsonRecord[], unknown> {
+	return Effect.gen(function* () {
+		const content = yield* tryPromise(() =>
+			fs.readFile(path.join(repoPath, relativePath), "utf8"),
+		);
+		return yield* trySync(() =>
+			content
+				.split("\n")
+				.filter((line) => line.length > 0)
+				.map((line) => JSON.parse(line) as JsonRecord),
+		);
+	});
 }
 
-async function readJsonlFiles(repoPath: string, relativePaths: string[]) {
-	const nestedRows = await Promise.all(
-		relativePaths.map((relativePath) => readJsonlFile(repoPath, relativePath)),
+function readJsonlFilesEffect(
+	repoPath: string,
+	relativePaths: string[],
+): Effect.Effect<JsonRecord[], unknown> {
+	return Effect.gen(function* () {
+		const nestedRows = yield* Effect.forEach(
+			relativePaths,
+			(relativePath) => readJsonlFileEffect(repoPath, relativePath),
+			{ concurrency: "unbounded" },
+		);
+		return nestedRows.flat();
+	});
+}
+
+function readBackupImportRowsEffect(
+	resolvedRepoPath: string,
+	manifest: BackupManifest,
+): Effect.Effect<JsonRecord[][], unknown> {
+	const readRows = (predicate: (relativePath: string) => boolean) =>
+		readJsonlFilesEffect(
+			resolvedRepoPath,
+			rowsForManifestPath(manifest, predicate),
+		);
+
+	return Effect.all(
+		[
+			readRows((file) => file === "data/accounts.jsonl"),
+			readRows((file) => file === "data/profiles.jsonl"),
+			readRows((file) => file === "data/profile_affiliations.jsonl"),
+			readRows((file) => file === "data/profile_snapshots.jsonl"),
+			readRows((file) => file === "data/profile_bio_entities.jsonl"),
+			readRows((file) => file.startsWith("data/tweets/")),
+			readRows((file) => file.startsWith("data/collections/")),
+			readRows((file) => file.startsWith("data/timeline_edges/")),
+			readRows((file) => file === "data/dms/conversations.jsonl"),
+			readRows(
+				(file) =>
+					file.startsWith("data/dms/") &&
+					file !== "data/dms/conversations.jsonl",
+			),
+			readRows((file) => file === "data/moderation/blocks.jsonl"),
+			readRows((file) => file === "data/moderation/mutes.jsonl"),
+			readRows((file) => file === "data/actions/tweet_actions.jsonl"),
+			readRows((file) => file === "data/ai_scores.jsonl"),
+			readRows((file) => file === "data/links/url_expansions.jsonl"),
+			readRows((file) => file === "data/links/occurrences.jsonl"),
+			readRows((file) => file === "data/follow_snapshots.jsonl"),
+			readRows((file) => file === "data/follow_snapshot_members.jsonl"),
+			readRows((file) => file === "data/follow_edges.jsonl"),
+			readRows((file) => file === "data/follow_events.jsonl"),
+		],
+		{ concurrency: "unbounded" },
 	);
-	return nestedRows.flat();
 }
 
 function rowsForManifestPath(
@@ -1098,93 +1251,66 @@ function clearBackupImportData(db: Database) {
   `);
 }
 
-export async function importBackup({
+export function importBackupEffect({
 	repoPath,
-	db = getNativeDb({ seedDemoData: false }),
+	db: providedDb,
 	validate = true,
 	mode = "merge",
-}: {
-	repoPath: string;
-	db?: Database;
-	validate?: boolean;
-	mode?: BackupImportMode;
-}): Promise<BackupImportResult> {
-	const resolvedRepoPath = path.resolve(repoPath);
-	const manifest = await readManifest(resolvedRepoPath);
-	const validation = validate
-		? await validateBackup(resolvedRepoPath)
-		: undefined;
-	if (validation && !validation.ok) {
-		throw new Error(
-			`Backup validation failed: ${validation.errors.join("; ")}`,
-		);
-	}
-
-	const readRows = (predicate: (relativePath: string) => boolean) =>
-		readJsonlFiles(resolvedRepoPath, rowsForManifestPath(manifest, predicate));
-
-	const [
-		accounts,
-		profiles,
-		profileAffiliations,
-		profileSnapshots,
-		profileBioEntities,
-		tweets,
-		collections,
-		timelineEdges,
-		conversations,
-		messages,
-		blocks,
-		mutes,
-		actions,
-		scores,
-		urlExpansions,
-		linkOccurrences,
-		followSnapshots,
-		followSnapshotMembers,
-		followEdges,
-		followEvents,
-	] = await Promise.all([
-		readRows((file) => file === "data/accounts.jsonl"),
-		readRows((file) => file === "data/profiles.jsonl"),
-		readRows((file) => file === "data/profile_affiliations.jsonl"),
-		readRows((file) => file === "data/profile_snapshots.jsonl"),
-		readRows((file) => file === "data/profile_bio_entities.jsonl"),
-		readRows((file) => file.startsWith("data/tweets/")),
-		readRows((file) => file.startsWith("data/collections/")),
-		readRows((file) => file.startsWith("data/timeline_edges/")),
-		readRows((file) => file === "data/dms/conversations.jsonl"),
-		readRows(
-			(file) =>
-				file.startsWith("data/dms/") && file !== "data/dms/conversations.jsonl",
-		),
-		readRows((file) => file === "data/moderation/blocks.jsonl"),
-		readRows((file) => file === "data/moderation/mutes.jsonl"),
-		readRows((file) => file === "data/actions/tweet_actions.jsonl"),
-		readRows((file) => file === "data/ai_scores.jsonl"),
-		readRows((file) => file === "data/links/url_expansions.jsonl"),
-		readRows((file) => file === "data/links/occurrences.jsonl"),
-		readRows((file) => file === "data/follow_snapshots.jsonl"),
-		readRows((file) => file === "data/follow_snapshot_members.jsonl"),
-		readRows((file) => file === "data/follow_edges.jsonl"),
-		readRows((file) => file === "data/follow_events.jsonl"),
-	]);
-
-	db.transaction(() => {
-		if (mode === "replace") {
-			clearBackupImportData(db);
+}: BackupImportOptions): Effect.Effect<BackupImportResult, unknown> {
+	return Effect.gen(function* () {
+		const resolvedRepoPath = yield* trySync(() => path.resolve(repoPath));
+		const db =
+			providedDb ??
+			(yield* trySync(() => getNativeDb({ seedDemoData: false })));
+		const manifest = yield* readManifestEffect(resolvedRepoPath);
+		const validation = validate
+			? yield* validateBackupEffect(resolvedRepoPath)
+			: undefined;
+		if (validation && !validation.ok) {
+			return yield* Effect.fail(
+				new Error(`Backup validation failed: ${validation.errors.join("; ")}`),
+			);
 		}
-		const tweetFtsIds =
-			mode === "replace"
-				? new Set<string>()
-				: readFtsIds(db, "tweets_fts", "tweet_id");
-		const dmFtsIds =
-			mode === "replace"
-				? new Set<string>()
-				: readFtsIds(db, "dm_fts", "message_id");
-		insertRows(
-			db,
-			`
+
+		const [
+			accounts,
+			profiles,
+			profileAffiliations,
+			profileSnapshots,
+			profileBioEntities,
+			tweets,
+			collections,
+			timelineEdges,
+			conversations,
+			messages,
+			blocks,
+			mutes,
+			actions,
+			scores,
+			urlExpansions,
+			linkOccurrences,
+			followSnapshots,
+			followSnapshotMembers,
+			followEdges,
+			followEvents,
+		] = yield* readBackupImportRowsEffect(resolvedRepoPath, manifest);
+
+		const fingerprint = yield* trySync(() => {
+			db.transaction(() => {
+				if (mode === "replace") {
+					clearBackupImportData(db);
+				}
+				const tweetFtsIds =
+					mode === "replace"
+						? new Set<string>()
+						: readFtsIds(db, "tweets_fts", "tweet_id");
+				const dmFtsIds =
+					mode === "replace"
+						? new Set<string>()
+						: readFtsIds(db, "dm_fts", "message_id");
+				insertRows(
+					db,
+					`
       insert into accounts (id, name, handle, external_user_id, transport, is_default, created_at)
       values (?, ?, ?, ?, ?, ?, ?)
       on conflict(id) do update set
@@ -1195,20 +1321,20 @@ export async function importBackup({
         is_default = max(accounts.is_default, excluded.is_default),
         created_at = min(accounts.created_at, excluded.created_at)
       `,
-			accounts,
-			[
-				"id",
-				"name",
-				"handle",
-				"external_user_id",
-				"transport",
-				"is_default",
-				"created_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					accounts,
+					[
+						"id",
+						"name",
+						"handle",
+						"external_user_id",
+						"transport",
+						"is_default",
+						"created_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into profile_snapshots (
         profile_id, snapshot_hash, observed_at, last_seen_at, source, handle,
         display_name, bio, location, url, verified_type, followers_count,
@@ -1222,28 +1348,28 @@ export async function importBackup({
           else profile_snapshots.raw_json
         end
       `,
-			profileSnapshots,
-			[
-				"profile_id",
-				"snapshot_hash",
-				"observed_at",
-				"last_seen_at",
-				"source",
-				"handle",
-				"display_name",
-				"bio",
-				"location",
-				"url",
-				"verified_type",
-				"followers_count",
-				"following_count",
-				"affiliations_json",
-				"raw_json",
-			],
-		);
-		insertRows(
-			db,
-			`
+					profileSnapshots,
+					[
+						"profile_id",
+						"snapshot_hash",
+						"observed_at",
+						"last_seen_at",
+						"source",
+						"handle",
+						"display_name",
+						"bio",
+						"location",
+						"url",
+						"verified_type",
+						"followers_count",
+						"following_count",
+						"affiliations_json",
+						"raw_json",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into profile_bio_entities (
         profile_id, kind, value, source, is_active, first_seen_at, last_seen_at, raw_json
       ) values (?, ?, ?, coalesce(?, 'backup'), coalesce(?, 1), ?, ?, coalesce(?, '{}'))
@@ -1256,21 +1382,21 @@ export async function importBackup({
           else profile_bio_entities.raw_json
         end
       `,
-			profileBioEntities,
-			[
-				"profile_id",
-				"kind",
-				"value",
-				"source",
-				"is_active",
-				"first_seen_at",
-				"last_seen_at",
-				"raw_json",
-			],
-		);
-		insertRows(
-			db,
-			`
+					profileBioEntities,
+					[
+						"profile_id",
+						"kind",
+						"value",
+						"source",
+						"is_active",
+						"first_seen_at",
+						"last_seen_at",
+						"raw_json",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into profiles (
         id, handle, display_name, bio, followers_count, following_count,
         public_metrics_json, avatar_hue, avatar_url, location, url,
@@ -1301,28 +1427,28 @@ export async function importBackup({
         end,
         created_at = min(profiles.created_at, excluded.created_at)
       `,
-			profiles,
-			[
-				"id",
-				"handle",
-				"display_name",
-				"bio",
-				"followers_count",
-				"following_count",
-				"public_metrics_json",
-				"avatar_hue",
-				"avatar_url",
-				"location",
-				"url",
-				"verified_type",
-				"entities_json",
-				"raw_json",
-				"created_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					profiles,
+					[
+						"id",
+						"handle",
+						"display_name",
+						"bio",
+						"followers_count",
+						"following_count",
+						"public_metrics_json",
+						"avatar_hue",
+						"avatar_url",
+						"location",
+						"url",
+						"verified_type",
+						"entities_json",
+						"raw_json",
+						"created_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into profile_affiliations (
         subject_profile_id, organization_profile_id, organization_name,
         organization_handle, badge_url, url, label, source, is_active,
@@ -1343,26 +1469,26 @@ export async function importBackup({
         end,
         updated_at = excluded.updated_at
       `,
-			profileAffiliations,
-			[
-				"subject_profile_id",
-				"organization_profile_id",
-				"organization_name",
-				"organization_handle",
-				"badge_url",
-				"url",
-				"label",
-				"source",
-				"is_active",
-				"first_seen_at",
-				"last_seen_at",
-				"raw_json",
-				"updated_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					profileAffiliations,
+					[
+						"subject_profile_id",
+						"organization_profile_id",
+						"organization_name",
+						"organization_handle",
+						"badge_url",
+						"url",
+						"label",
+						"source",
+						"is_active",
+						"first_seen_at",
+						"last_seen_at",
+						"raw_json",
+						"updated_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into follow_snapshots (
         id, account_id, direction, source, status, page_count, result_count,
         started_at, completed_at, raw_meta_json
@@ -1381,23 +1507,23 @@ export async function importBackup({
           else follow_snapshots.raw_meta_json
         end
       `,
-			followSnapshots,
-			[
-				"id",
-				"account_id",
-				"direction",
-				"source",
-				"status",
-				"page_count",
-				"result_count",
-				"started_at",
-				"completed_at",
-				"raw_meta_json",
-			],
-		);
-		insertRows(
-			db,
-			`
+					followSnapshots,
+					[
+						"id",
+						"account_id",
+						"direction",
+						"source",
+						"status",
+						"page_count",
+						"result_count",
+						"started_at",
+						"completed_at",
+						"raw_meta_json",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into follow_snapshot_members (
         snapshot_id, profile_id, external_user_id, position
       ) values (?, ?, ?, coalesce(?, 0))
@@ -1405,12 +1531,12 @@ export async function importBackup({
         external_user_id = coalesce(nullif(excluded.external_user_id, ''), follow_snapshot_members.external_user_id),
         position = excluded.position
       `,
-			followSnapshotMembers,
-			["snapshot_id", "profile_id", "external_user_id", "position"],
-		);
-		insertRows(
-			db,
-			`
+					followSnapshotMembers,
+					["snapshot_id", "profile_id", "external_user_id", "position"],
+				);
+				insertRows(
+					db,
+					`
       insert into follow_edges (
         account_id, direction, profile_id, external_user_id, source, current,
         first_seen_at, last_seen_at, ended_at, updated_at
@@ -1430,23 +1556,23 @@ export async function importBackup({
         end,
         updated_at = max(follow_edges.updated_at, excluded.updated_at)
       `,
-			followEdges,
-			[
-				"account_id",
-				"direction",
-				"profile_id",
-				"external_user_id",
-				"source",
-				"current",
-				"first_seen_at",
-				"last_seen_at",
-				"ended_at",
-				"updated_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					followEdges,
+					[
+						"account_id",
+						"direction",
+						"profile_id",
+						"external_user_id",
+						"source",
+						"current",
+						"first_seen_at",
+						"last_seen_at",
+						"ended_at",
+						"updated_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into follow_events (
         id, account_id, direction, profile_id, external_user_id, kind, event_at,
         snapshot_id
@@ -1460,21 +1586,21 @@ export async function importBackup({
         event_at = coalesce(nullif(excluded.event_at, ''), follow_events.event_at),
         snapshot_id = coalesce(nullif(excluded.snapshot_id, ''), follow_events.snapshot_id)
       `,
-			followEvents,
-			[
-				"id",
-				"account_id",
-				"direction",
-				"profile_id",
-				"external_user_id",
-				"kind",
-				"event_at",
-				"snapshot_id",
-			],
-		);
-		insertRows(
-			db,
-			`
+					followEvents,
+					[
+						"id",
+						"account_id",
+						"direction",
+						"profile_id",
+						"external_user_id",
+						"kind",
+						"event_at",
+						"snapshot_id",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into tweets (
         id, account_id, author_profile_id, kind, text, created_at, is_replied,
         reply_to_id, like_count, media_count, bookmarked, liked, entities_json,
@@ -1506,37 +1632,37 @@ export async function importBackup({
         end,
         quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id)
       `,
-			tweets,
-			[
-				"id",
-				"account_id",
-				"author_profile_id",
-				"kind",
-				"text",
-				"created_at",
-				"is_replied",
-				"reply_to_id",
-				"like_count",
-				"media_count",
-				"bookmarked",
-				"liked",
-				"entities_json",
-				"media_json",
-				"quoted_tweet_id",
-			],
-		);
-		insertFtsRows(
-			db,
-			"tweets_fts",
-			"tweet_id",
-			tweets,
-			"id",
-			"text",
-			tweetFtsIds,
-		);
-		insertRows(
-			db,
-			`
+					tweets,
+					[
+						"id",
+						"account_id",
+						"author_profile_id",
+						"kind",
+						"text",
+						"created_at",
+						"is_replied",
+						"reply_to_id",
+						"like_count",
+						"media_count",
+						"bookmarked",
+						"liked",
+						"entities_json",
+						"media_json",
+						"quoted_tweet_id",
+					],
+				);
+				insertFtsRows(
+					db,
+					"tweets_fts",
+					"tweet_id",
+					tweets,
+					"id",
+					"text",
+					tweetFtsIds,
+				);
+				insertRows(
+					db,
+					`
       insert into tweet_collections (
         account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?)
@@ -1549,20 +1675,20 @@ export async function importBackup({
         end,
         updated_at = max(tweet_collections.updated_at, excluded.updated_at)
       `,
-			collections,
-			[
-				"account_id",
-				"tweet_id",
-				"kind",
-				"collected_at",
-				"source",
-				"raw_json",
-				"updated_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					collections,
+					[
+						"account_id",
+						"tweet_id",
+						"kind",
+						"collected_at",
+						"source",
+						"raw_json",
+						"updated_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into tweet_account_edges (
         account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
         source, raw_json, updated_at
@@ -1578,22 +1704,22 @@ export async function importBackup({
         end,
         updated_at = max(tweet_account_edges.updated_at, excluded.updated_at)
       `,
-			timelineEdges,
-			[
-				"account_id",
-				"tweet_id",
-				"kind",
-				"first_seen_at",
-				"last_seen_at",
-				"seen_count",
-				"source",
-				"raw_json",
-				"updated_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					timelineEdges,
+					[
+						"account_id",
+						"tweet_id",
+						"kind",
+						"first_seen_at",
+						"last_seen_at",
+						"seen_count",
+						"source",
+						"raw_json",
+						"updated_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into dm_conversations (
         id, account_id, participant_profile_id, title, last_message_at, unread_count, needs_reply
       ) values (?, ?, ?, ?, ?, ?, ?)
@@ -1605,20 +1731,20 @@ export async function importBackup({
         unread_count = max(dm_conversations.unread_count, excluded.unread_count),
         needs_reply = max(dm_conversations.needs_reply, excluded.needs_reply)
       `,
-			conversations,
-			[
-				"id",
-				"account_id",
-				"participant_profile_id",
-				"title",
-				"last_message_at",
-				"unread_count",
-				"needs_reply",
-			],
-		);
-		insertRows(
-			db,
-			`
+					conversations,
+					[
+						"id",
+						"account_id",
+						"participant_profile_id",
+						"title",
+						"last_message_at",
+						"unread_count",
+						"needs_reply",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into dm_messages (
         id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
       ) values (?, ?, ?, ?, ?, ?, ?, ?)
@@ -1631,22 +1757,30 @@ export async function importBackup({
         is_replied = max(dm_messages.is_replied, excluded.is_replied),
         media_count = max(dm_messages.media_count, excluded.media_count)
       `,
-			messages,
-			[
-				"id",
-				"conversation_id",
-				"sender_profile_id",
-				"text",
-				"created_at",
-				"direction",
-				"is_replied",
-				"media_count",
-			],
-		);
-		insertFtsRows(db, "dm_fts", "message_id", messages, "id", "text", dmFtsIds);
-		insertRows(
-			db,
-			`
+					messages,
+					[
+						"id",
+						"conversation_id",
+						"sender_profile_id",
+						"text",
+						"created_at",
+						"direction",
+						"is_replied",
+						"media_count",
+					],
+				);
+				insertFtsRows(
+					db,
+					"dm_fts",
+					"message_id",
+					messages,
+					"id",
+					"text",
+					dmFtsIds,
+				);
+				insertRows(
+					db,
+					`
       insert into url_expansions (
         short_url, expanded_url, final_url, status, expanded_tweet_id,
         expanded_handle, title, description, image_url, site_name, error, source,
@@ -1666,26 +1800,26 @@ export async function importBackup({
         source = excluded.source,
         updated_at = excluded.updated_at
       `,
-			urlExpansions,
-			[
-				"short_url",
-				"expanded_url",
-				"final_url",
-				"status",
-				"expanded_tweet_id",
-				"expanded_handle",
-				"title",
-				"description",
-				"image_url",
-				"site_name",
-				"error",
-				"source",
-				"updated_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					urlExpansions,
+					[
+						"short_url",
+						"expanded_url",
+						"final_url",
+						"status",
+						"expanded_tweet_id",
+						"expanded_handle",
+						"title",
+						"description",
+						"image_url",
+						"site_name",
+						"error",
+						"source",
+						"updated_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into link_occurrences (
         source_kind, source_id, source_position, short_url, account_id,
         conversation_id, direction, created_at
@@ -1696,45 +1830,45 @@ export async function importBackup({
         direction = excluded.direction,
         created_at = excluded.created_at
       `,
-			linkOccurrences,
-			[
-				"source_kind",
-				"source_id",
-				"source_position",
-				"short_url",
-				"account_id",
-				"conversation_id",
-				"direction",
-				"created_at",
-			],
-		);
-		insertRows(
-			db,
-			`
+					linkOccurrences,
+					[
+						"source_kind",
+						"source_id",
+						"source_position",
+						"short_url",
+						"account_id",
+						"conversation_id",
+						"direction",
+						"created_at",
+					],
+				);
+				insertRows(
+					db,
+					`
       insert into blocks (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
       on conflict(account_id, profile_id) do update set
         source = coalesce(nullif(excluded.source, ''), blocks.source),
         created_at = min(blocks.created_at, excluded.created_at)
       `,
-			blocks,
-			["account_id", "profile_id", "source", "created_at"],
-		);
-		insertRows(
-			db,
-			`
+					blocks,
+					["account_id", "profile_id", "source", "created_at"],
+				);
+				insertRows(
+					db,
+					`
       insert into mutes (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
       on conflict(account_id, profile_id) do update set
         source = coalesce(nullif(excluded.source, ''), mutes.source),
         created_at = min(mutes.created_at, excluded.created_at)
       `,
-			mutes,
-			["account_id", "profile_id", "source", "created_at"],
-		);
-		insertRows(
-			db,
-			`
+					mutes,
+					["account_id", "profile_id", "source", "created_at"],
+				);
+				insertRows(
+					db,
+					`
       insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at)
       values (?, ?, ?, ?, ?, ?)
       on conflict(id) do update set
@@ -1744,12 +1878,12 @@ export async function importBackup({
         body = coalesce(nullif(excluded.body, ''), tweet_actions.body),
         created_at = min(tweet_actions.created_at, excluded.created_at)
       `,
-			actions,
-			["id", "account_id", "tweet_id", "kind", "body", "created_at"],
-		);
-		insertRows(
-			db,
-			`
+					actions,
+					["id", "account_id", "tweet_id", "kind", "body", "created_at"],
+				);
+				insertRows(
+					db,
+					`
       insert into ai_scores (
         entity_kind, entity_id, model, score, summary, reasoning, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?)
@@ -1760,106 +1894,148 @@ export async function importBackup({
         reasoning = coalesce(nullif(excluded.reasoning, ''), ai_scores.reasoning),
         updated_at = max(ai_scores.updated_at, excluded.updated_at)
       `,
-			scores,
-			[
-				"entity_kind",
-				"entity_id",
-				"model",
-				"score",
-				"summary",
-				"reasoning",
-				"updated_at",
-			],
-		);
-	})();
+					scores,
+					[
+						"entity_kind",
+						"entity_id",
+						"model",
+						"score",
+						"summary",
+						"reasoning",
+						"updated_at",
+					],
+				);
+			})();
+			return getBackupDatabaseFingerprint(db);
+		});
 
-	return {
-		ok: true,
-		repoPath: resolvedRepoPath,
-		mode,
-		manifest,
-		...(validation ? { validation } : {}),
-		fingerprint: getBackupDatabaseFingerprint(db),
-	};
+		return {
+			ok: true,
+			repoPath: resolvedRepoPath,
+			mode,
+			manifest,
+			...(validation ? { validation } : {}),
+			fingerprint,
+		};
+	});
 }
 
-export async function syncBackup({
-	repoPath,
-	remote,
-	db = getNativeDb({ seedDemoData: false }),
-	message = "archive: sync birdclaw backup",
-}: {
+export function importBackup(
+	options: BackupImportOptions,
+): Promise<BackupImportResult> {
+	return runEffectPromise(importBackupEffect(options));
+}
+
+export interface SyncBackupOptions {
 	repoPath: string;
 	remote?: string;
 	db?: Database;
 	message?: string;
-}): Promise<BackupSyncResult> {
-	const resolvedRepoPath = path.resolve(repoPath);
-	await ensureBackupGitRepo({ repoPath: resolvedRepoPath, remote });
-	const pulled = await pullBackupGitRepo(resolvedRepoPath);
-	const manifestExists = existsSync(path.join(resolvedRepoPath, MANIFEST_PATH));
-	const importResult = manifestExists
-		? await importBackup({
-				repoPath: resolvedRepoPath,
-				db,
-				mode: "merge",
-			})
-		: undefined;
-	const exportResult = await exportBackup({
-		repoPath: resolvedRepoPath,
-		db,
-		commit: true,
-		push: true,
-		message,
-	});
-
-	return {
-		ok: true,
-		repoPath: resolvedRepoPath,
-		...(remote ? { remote } : {}),
-		pulled,
-		imported: Boolean(importResult),
-		...(importResult ? { importResult } : {}),
-		exportResult,
-	};
 }
 
-export async function updateBackupFromGit({
+export function syncBackupEffect({
 	repoPath,
 	remote,
-	db = getNativeDb({ seedDemoData: false }),
-}: {
+	message = "archive: sync birdclaw backup",
+	db,
+}: SyncBackupOptions): Effect.Effect<BackupSyncResult, unknown> {
+	return Effect.gen(function* () {
+		const resolvedRepoPath = path.resolve(repoPath);
+		const database =
+			db ?? (yield* trySync(() => getNativeDb({ seedDemoData: false })));
+		yield* ensureBackupGitRepoEffect({ repoPath: resolvedRepoPath, remote });
+		const pulled = yield* pullBackupGitRepoEffect(resolvedRepoPath);
+		const manifestExists = yield* trySync(() =>
+			existsSync(path.join(resolvedRepoPath, MANIFEST_PATH)),
+		);
+		const importResult = manifestExists
+			? yield* importBackupEffect({
+					repoPath: resolvedRepoPath,
+					db: database,
+					mode: "merge",
+				})
+			: undefined;
+		const exportResult = yield* exportBackupEffect({
+			repoPath: resolvedRepoPath,
+			db: database,
+			commit: true,
+			push: true,
+			message,
+		});
+
+		return {
+			ok: true,
+			repoPath: resolvedRepoPath,
+			...(remote ? { remote } : {}),
+			pulled,
+			imported: Boolean(importResult),
+			...(importResult ? { importResult } : {}),
+			exportResult,
+		};
+	});
+}
+
+export function syncBackup(
+	options: SyncBackupOptions,
+): Promise<BackupSyncResult> {
+	return runEffectPromise(syncBackupEffect(options));
+}
+
+export interface UpdateBackupFromGitOptions {
 	repoPath: string;
 	remote?: string;
 	db?: Database;
-}): Promise<{
+}
+
+export interface UpdateBackupFromGitResult {
 	ok: true;
 	repoPath: string;
 	remote?: string;
 	pulled: boolean;
 	imported: boolean;
 	importResult?: BackupImportResult;
-}> {
-	const resolvedRepoPath = path.resolve(repoPath);
-	await ensureBackupGitRepo({ repoPath: resolvedRepoPath, remote });
-	const pulled = await pullBackupGitRepo(resolvedRepoPath);
-	const manifestExists = existsSync(path.join(resolvedRepoPath, MANIFEST_PATH));
-	const importResult = manifestExists
-		? await importBackup({
-				repoPath: resolvedRepoPath,
-				db,
-				mode: "merge",
-			})
-		: undefined;
+}
 
-	return {
-		ok: true,
-		repoPath: resolvedRepoPath,
-		...(remote ? { remote } : {}),
-		pulled,
-		imported: Boolean(importResult),
-		...(importResult ? { importResult } : {}),
-	};
+export function updateBackupFromGitEffect({
+	repoPath,
+	remote,
+	db,
+}: UpdateBackupFromGitOptions): Effect.Effect<
+	UpdateBackupFromGitResult,
+	unknown
+> {
+	return Effect.gen(function* () {
+		const resolvedRepoPath = path.resolve(repoPath);
+		const database =
+			db ?? (yield* trySync(() => getNativeDb({ seedDemoData: false })));
+		yield* ensureBackupGitRepoEffect({ repoPath: resolvedRepoPath, remote });
+		const pulled = yield* pullBackupGitRepoEffect(resolvedRepoPath);
+		const manifestExists = yield* trySync(() =>
+			existsSync(path.join(resolvedRepoPath, MANIFEST_PATH)),
+		);
+		const importResult = manifestExists
+			? yield* importBackupEffect({
+					repoPath: resolvedRepoPath,
+					db: database,
+					mode: "merge",
+				})
+			: undefined;
+
+		return {
+			ok: true,
+			repoPath: resolvedRepoPath,
+			...(remote ? { remote } : {}),
+			pulled,
+			imported: Boolean(importResult),
+			...(importResult ? { importResult } : {}),
+		};
+	});
+}
+
+export function updateBackupFromGit(
+	options: UpdateBackupFromGitOptions,
+): Promise<UpdateBackupFromGitResult> {
+	return runEffectPromise(updateBackupFromGitEffect(options));
 }
 
 function readAutoSyncState(db: Database) {
@@ -1921,62 +2097,99 @@ function resolveAutoSyncConfig() {
 	};
 }
 
-export async function maybeAutoUpdateBackup(
+function autoSyncConfigError(error: unknown): BackupAutoUpdateResult {
+	return {
+		ok: false,
+		enabled: true,
+		skipped: false,
+		error: error instanceof Error ? error.message : String(error),
+	};
+}
+
+export function maybeAutoUpdateBackupEffect(
 	db?: Database,
-): Promise<BackupAutoUpdateResult> {
-	if (process.env.BIRDCLAW_BACKUP_AUTO_SYNC === "0") {
-		return {
-			ok: true,
-			enabled: false,
-			skipped: true,
-			reason: "disabled by BIRDCLAW_BACKUP_AUTO_SYNC=0",
-		};
-	}
-	const config = resolveAutoSyncConfig();
-	if (!config) {
-		return {
-			ok: true,
-			enabled: false,
-			skipped: true,
-			reason: "backup auto-sync is not configured",
-		};
-	}
+): Effect.Effect<BackupAutoUpdateResult, never> {
+	return Effect.gen(function* () {
+		if (process.env.BIRDCLAW_BACKUP_AUTO_SYNC === "0") {
+			return {
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "disabled by BIRDCLAW_BACKUP_AUTO_SYNC=0",
+			};
+		}
+		const configResult = yield* trySync(() => resolveAutoSyncConfig()).pipe(
+			Effect.map((config) => ({ ok: true as const, config })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (!configResult.ok) return autoSyncConfigError(configResult.error);
+		const { config } = configResult;
+		if (!config) {
+			return {
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "backup auto-sync is not configured",
+			};
+		}
 
-	const database = db ?? getNativeDb({ seedDemoData: false });
-	const state = readAutoSyncState(database);
-	const checkedAt = state?.checkedAt ? new Date(state.checkedAt).getTime() : 0;
-	const ageMs = Date.now() - checkedAt;
-	if (ageMs >= 0 && ageMs < config.staleAfterSeconds * 1000) {
-		return {
-			ok: true,
-			enabled: true,
-			skipped: true,
-			reason: "backup auto-sync is fresh",
-			repoPath: config.repoPath,
-			...(config.remote ? { remote: config.remote } : {}),
-		};
-	}
+		const database = yield* trySync(
+			() => db ?? getNativeDb({ seedDemoData: false }),
+		).pipe(Effect.orDie);
+		const state = yield* trySync(() => readAutoSyncState(database)).pipe(
+			Effect.catchAll(() => Effect.succeed(null)),
+		);
+		const checkedAt = state?.checkedAt
+			? new Date(state.checkedAt).getTime()
+			: 0;
+		const ageMs = Date.now() - checkedAt;
+		if (ageMs >= 0 && ageMs < config.staleAfterSeconds * 1000) {
+			return {
+				ok: true,
+				enabled: true,
+				skipped: true,
+				reason: "backup auto-sync is fresh",
+				repoPath: config.repoPath,
+				...(config.remote ? { remote: config.remote } : {}),
+			};
+		}
 
-	const now = new Date().toISOString();
-	try {
-		const result = await updateBackupFromGit({
+		const now = new Date().toISOString();
+		const result = yield* updateBackupFromGitEffect({
 			repoPath: config.repoPath,
 			remote: config.remote,
 			db: database,
-		});
-		writeAutoSyncState(database, { checkedAt: now, ok: true });
-		return {
-			ok: true,
-			enabled: true,
-			skipped: false,
-			repoPath: result.repoPath,
-			...(result.remote ? { remote: result.remote } : {}),
-			pulled: result.pulled,
-			imported: result.imported,
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		writeAutoSyncState(database, { checkedAt: now, ok: false, error: message });
+		}).pipe(
+			Effect.map((value) => ({ ok: true as const, value })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+
+		if (result.ok) {
+			yield* trySync(() =>
+				writeAutoSyncState(database, { checkedAt: now, ok: true }),
+			).pipe(Effect.orDie);
+			return {
+				ok: true,
+				enabled: true,
+				skipped: false,
+				repoPath: result.value.repoPath,
+				...(result.value.remote ? { remote: result.value.remote } : {}),
+				pulled: result.value.pulled,
+				imported: result.value.imported,
+			};
+		}
+
+		const message =
+			result.error instanceof Error
+				? result.error.message
+				: String(result.error);
+		yield* trySync(() =>
+			writeAutoSyncState(database, {
+				checkedAt: now,
+				ok: false,
+				error: message,
+			}),
+		).pipe(Effect.orDie);
 		return {
 			ok: false,
 			enabled: true,
@@ -1985,54 +2198,80 @@ export async function maybeAutoUpdateBackup(
 			...(config.remote ? { remote: config.remote } : {}),
 			error: message,
 		};
-	}
+	});
 }
 
-export async function maybeAutoSyncBackup(
+export function maybeAutoUpdateBackup(
 	db?: Database,
 ): Promise<BackupAutoUpdateResult> {
-	if (process.env.BIRDCLAW_BACKUP_AUTO_SYNC === "0") {
-		return {
-			ok: true,
-			enabled: false,
-			skipped: true,
-			reason: "disabled by BIRDCLAW_BACKUP_AUTO_SYNC=0",
-		};
-	}
-	const config = resolveAutoSyncConfig();
-	if (!config) {
-		return {
-			ok: true,
-			enabled: false,
-			skipped: true,
-			reason: "backup auto-sync is not configured",
-		};
-	}
-	const database = db ?? getNativeDb({ seedDemoData: false });
-	const now = new Date().toISOString();
-	try {
-		const result = await syncBackup({
+	return runEffectPromise(maybeAutoUpdateBackupEffect(db));
+}
+
+export function maybeAutoSyncBackupEffect(
+	db?: Database,
+): Effect.Effect<BackupAutoUpdateResult, never> {
+	return Effect.gen(function* () {
+		if (process.env.BIRDCLAW_BACKUP_AUTO_SYNC === "0") {
+			return {
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "disabled by BIRDCLAW_BACKUP_AUTO_SYNC=0",
+			};
+		}
+		const configResult = yield* trySync(() => resolveAutoSyncConfig()).pipe(
+			Effect.map((config) => ({ ok: true as const, config })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (!configResult.ok) return autoSyncConfigError(configResult.error);
+		const { config } = configResult;
+		if (!config) {
+			return {
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "backup auto-sync is not configured",
+			};
+		}
+		const database = yield* trySync(
+			() => db ?? getNativeDb({ seedDemoData: false }),
+		).pipe(Effect.orDie);
+		const now = new Date().toISOString();
+		const result = yield* syncBackupEffect({
 			repoPath: config.repoPath,
 			remote: config.remote,
 			db: database,
-		});
-		writeAutoSyncState(database, { checkedAt: now, ok: true });
-		return {
-			ok: true,
-			enabled: true,
-			skipped: false,
-			repoPath: result.repoPath,
-			...(result.remote ? { remote: result.remote } : {}),
-			pulled: result.pulled,
-			imported: result.imported,
-		};
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		writeAutoSyncState(database, {
-			checkedAt: now,
-			ok: false,
-			error: message,
-		});
+		}).pipe(
+			Effect.map((value) => ({ ok: true as const, value })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+
+		if (result.ok) {
+			yield* trySync(() =>
+				writeAutoSyncState(database, { checkedAt: now, ok: true }),
+			).pipe(Effect.orDie);
+			return {
+				ok: true,
+				enabled: true,
+				skipped: false,
+				repoPath: result.value.repoPath,
+				...(result.value.remote ? { remote: result.value.remote } : {}),
+				pulled: result.value.pulled,
+				imported: result.value.imported,
+			};
+		}
+
+		const message =
+			result.error instanceof Error
+				? result.error.message
+				: String(result.error);
+		yield* trySync(() =>
+			writeAutoSyncState(database, {
+				checkedAt: now,
+				ok: false,
+				error: message,
+			}),
+		).pipe(Effect.orDie);
 		return {
 			ok: false,
 			enabled: true,
@@ -2041,105 +2280,144 @@ export async function maybeAutoSyncBackup(
 			...(config.remote ? { remote: config.remote } : {}),
 			error: message,
 		};
-	}
+	});
 }
 
-export async function validateBackup(
+export function maybeAutoSyncBackup(
+	db?: Database,
+): Promise<BackupAutoUpdateResult> {
+	return runEffectPromise(maybeAutoSyncBackupEffect(db));
+}
+
+export function validateBackupEffect(
 	repoPath: string,
-): Promise<BackupValidationResult> {
-	const resolvedRepoPath = path.resolve(repoPath);
-	const errors: string[] = [];
-	let manifest: BackupManifest;
-	try {
-		manifest = await readManifest(resolvedRepoPath);
-	} catch (error) {
-		return {
-			ok: false,
-			repoPath: resolvedRepoPath,
-			files: [],
-			counts: {},
-			backupHash: "",
-			errors: [error instanceof Error ? error.message : String(error)],
-		};
-	}
+): Effect.Effect<BackupValidationResult, unknown> {
+	return Effect.gen(function* () {
+		const resolvedRepoPath = yield* trySync(() => path.resolve(repoPath));
+		const errors: string[] = [];
+		const manifestResult = yield* readManifestEffect(resolvedRepoPath).pipe(
+			Effect.match({
+				onFailure: (error) => ({ ok: false as const, error }),
+				onSuccess: (manifest) => ({ ok: true as const, manifest }),
+			}),
+		);
+		if (!manifestResult.ok) {
+			return {
+				ok: false,
+				repoPath: resolvedRepoPath,
+				files: [],
+				counts: {},
+				backupHash: "",
+				errors: [
+					manifestResult.error instanceof Error
+						? manifestResult.error.message
+						: String(manifestResult.error),
+				],
+			};
+		}
+		const { manifest } = manifestResult;
 
-	const results = await Promise.all(
-		manifest.files.map(async (expected) => {
-			const fileErrors: string[] = [];
-			let file: BackupFileManifest | undefined;
-			try {
-				const content = await fs.readFile(
-					path.join(resolvedRepoPath, expected.path),
-				);
-				const text = content.toString("utf8");
-				const rows = text.split("\n").filter((line) => line.length > 0);
-				for (const [index, line] of rows.entries()) {
-					try {
-						JSON.parse(line);
-					} catch (error) {
-						fileErrors.push(
-							`${expected.path}:${index + 1}: ${
-								error instanceof Error ? error.message : String(error)
-							}`,
-						);
+		const results = yield* Effect.forEach(
+			manifest.files,
+			(expected) =>
+				Effect.gen(function* () {
+					const fileErrors: string[] = [];
+					let file: BackupFileManifest | undefined;
+					const content = yield* tryPromise(() =>
+						fs.readFile(path.join(resolvedRepoPath, expected.path)),
+					).pipe(
+						Effect.match({
+							onFailure: (error) => {
+								fileErrors.push(
+									`${expected.path}: ${error instanceof Error ? error.message : String(error)}`,
+								);
+								return undefined;
+							},
+							onSuccess: (value) => value,
+						}),
+					);
+					if (content) {
+						const text = content.toString("utf8");
+						const rows = text.split("\n").filter((line) => line.length > 0);
+						for (const [index, line] of rows.entries()) {
+							const parseError = yield* trySync(() => JSON.parse(line)).pipe(
+								Effect.match({
+									onFailure: (error) => error,
+									onSuccess: () => undefined,
+								}),
+							);
+							if (parseError) {
+								fileErrors.push(
+									`${expected.path}:${index + 1}: ${
+										parseError instanceof Error
+											? parseError.message
+											: String(parseError)
+									}`,
+								);
+							}
+						}
+						file = {
+							path: expected.path,
+							rows: rows.length,
+							sha256: sha256(content),
+							bytes: content.byteLength,
+						};
 					}
-				}
-				file = {
-					path: expected.path,
-					rows: rows.length,
-					sha256: sha256(content),
-					bytes: content.byteLength,
-				};
-			} catch (error) {
-				fileErrors.push(
-					`${expected.path}: ${error instanceof Error ? error.message : String(error)}`,
+					return { file, errors: fileErrors };
+				}),
+			{ concurrency: "unbounded" },
+		);
+
+		const files: BackupFileManifest[] = [];
+		for (const result of results) {
+			errors.push(...result.errors);
+			if (result.file) {
+				files.push(result.file);
+			}
+		}
+
+		for (const expected of manifest.files) {
+			const file = files.find((entry) => entry.path === expected.path);
+			if (!file) {
+				continue;
+			}
+			if (file.rows !== expected.rows) {
+				errors.push(`${file.path}: row count ${file.rows} != ${expected.rows}`);
+			}
+			if (file.sha256 !== expected.sha256) {
+				errors.push(
+					`${file.path}: sha256 ${file.sha256} != ${expected.sha256}`,
 				);
 			}
-			return { file, errors: fileErrors };
-		}),
-	);
+			if (file.bytes !== expected.bytes) {
+				errors.push(`${file.path}: bytes ${file.bytes} != ${expected.bytes}`);
+			}
+		}
 
-	const files: BackupFileManifest[] = [];
-	for (const result of results) {
-		errors.push(...result.errors);
-		if (result.file) {
-			files.push(result.file);
+		const counts = computeCounts(files);
+		const backupHash = computeBackupHash(files);
+		if (backupHash !== manifest.backupHash) {
+			errors.push(`backup hash ${backupHash} != ${manifest.backupHash}`);
 		}
-	}
+		if (canonicalStringify(counts) !== canonicalStringify(manifest.counts)) {
+			errors.push("manifest counts do not match backup files");
+		}
 
-	for (const expected of manifest.files) {
-		const file = files.find((entry) => entry.path === expected.path);
-		if (!file) {
-			continue;
-		}
-		if (file.rows !== expected.rows) {
-			errors.push(`${file.path}: row count ${file.rows} != ${expected.rows}`);
-		}
-		if (file.sha256 !== expected.sha256) {
-			errors.push(`${file.path}: sha256 ${file.sha256} != ${expected.sha256}`);
-		}
-		if (file.bytes !== expected.bytes) {
-			errors.push(`${file.path}: bytes ${file.bytes} != ${expected.bytes}`);
-		}
-	}
+		return {
+			ok: errors.length === 0,
+			repoPath: resolvedRepoPath,
+			files,
+			counts,
+			backupHash,
+			errors,
+		};
+	});
+}
 
-	const counts = computeCounts(files);
-	const backupHash = computeBackupHash(files);
-	if (backupHash !== manifest.backupHash) {
-		errors.push(`backup hash ${backupHash} != ${manifest.backupHash}`);
-	}
-	if (canonicalStringify(counts) !== canonicalStringify(manifest.counts)) {
-		errors.push("manifest counts do not match backup files");
-	}
-
-	return {
-		ok: errors.length === 0,
-		repoPath: resolvedRepoPath,
-		files,
-		counts,
-		backupHash,
-		errors,
-	};
+export function validateBackup(
+	repoPath: string,
+): Promise<BackupValidationResult> {
+	return runEffectPromise(validateBackupEffect(repoPath));
 }
 
 export function getBackupDatabaseFingerprint(

--- a/src/lib/bird-actions.test.ts
+++ b/src/lib/bird-actions.test.ts
@@ -1,4 +1,8 @@
 // @vitest-environment node
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsyncMock = vi.fn();
@@ -22,6 +26,7 @@ describe("bird action transport wrapper", () => {
 		execFileAsyncMock.mockReset();
 		accessMock.mockReset();
 		delete process.env.BIRDCLAW_BIRD_COMMAND;
+		delete process.env.BIRDCLAW_CONFIG;
 		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
 	});
 
@@ -49,6 +54,44 @@ describe("bird action transport wrapper", () => {
 		expect(result).toEqual({
 			ok: true,
 			output: "✅ Blocked @sam; verified blocking=true",
+		});
+	});
+
+	it("exposes bird action helpers as Effect programs", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
+		execFileAsyncMock
+			.mockResolvedValueOnce({ stdout: "Blocked\n" })
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ blocking: true, muting: false }),
+			});
+
+		const { blockUserViaBirdEffect } = await import("./bird-actions");
+
+		await expect(
+			Effect.runPromise(blockUserViaBirdEffect("42")),
+		).resolves.toEqual({
+			ok: true,
+			output: "Blocked; verified blocking=true",
+		});
+	});
+
+	it("exposes bird profile lookup as an Effect program", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		execFileAsyncMock.mockResolvedValueOnce({
+			stdout: JSON.stringify({
+				user: { id: "42", username: "sam", followersCount: 1 },
+			}),
+		});
+
+		const { lookupProfileViaBirdEffect } = await import("./bird-actions");
+
+		await expect(
+			Effect.runPromise(lookupProfileViaBirdEffect("@sam")),
+		).resolves.toMatchObject({
+			id: "42",
+			username: "sam",
+			public_metrics: { followers_count: 1 },
 		});
 	});
 
@@ -84,6 +127,27 @@ describe("bird action transport wrapper", () => {
 		});
 	});
 
+	it("returns bird command config failures through the Effect error channel", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-actions-"));
+		const configPath = path.join(tempDir, "config.json");
+		writeFileSync(configPath, "{bad json", "utf8");
+		process.env.BIRDCLAW_CONFIG = configPath;
+		delete process.env.BIRDCLAW_BIRD_COMMAND;
+
+		try {
+			const { muteUserViaBird, lookupProfileViaBird } =
+				await import("./bird-actions");
+
+			await expect(muteUserViaBird("42")).resolves.toMatchObject({
+				ok: false,
+			});
+			await expect(lookupProfileViaBird("@sam")).resolves.toBeNull();
+			expect(execFileAsyncMock).not.toHaveBeenCalled();
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("skips live mutations when writes are disabled", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		process.env.BIRDCLAW_DISABLE_LIVE_WRITES = "1";
@@ -92,6 +156,22 @@ describe("bird action transport wrapper", () => {
 		const result = await muteUserViaBird("42");
 
 		expect(result).toEqual({
+			ok: true,
+			output: "live writes disabled",
+		});
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+	});
+
+	it("checks disabled live writes when deferred bird action effects run", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
+
+		const { muteUserViaBirdEffect } = await import("./bird-actions");
+		const effect = muteUserViaBirdEffect("42");
+
+		process.env.BIRDCLAW_DISABLE_LIVE_WRITES = "1";
+
+		await expect(Effect.runPromise(effect)).resolves.toEqual({
 			ok: true,
 			output: "live writes disabled",
 		});

--- a/src/lib/bird-actions.ts
+++ b/src/lib/bird-actions.ts
@@ -1,4 +1,9 @@
-import { runBirdCommand } from "./bird-command";
+import { Effect } from "effect";
+import {
+	BirdCommandExecutionError,
+	runBirdCommandEffect,
+} from "./bird-command";
+import { runEffectPromise } from "./effect-runtime";
 import type { XurlMentionUser } from "./types";
 
 function liveWritesDisabled() {
@@ -12,6 +17,9 @@ function stripAnsi(value: string) {
 
 function formatExecError(error: unknown, fallback: string) {
 	if (!(error instanceof Error)) {
+		return fallback;
+	}
+	if (error instanceof BirdCommandExecutionError && error.useFallbackMessage) {
 		return fallback;
 	}
 
@@ -38,18 +46,28 @@ function normalizeOutput(stdout?: string, stderr?: string) {
 	return stripAnsi(stdout || stderr || "ok").trim();
 }
 
-async function runBirdJsonCommand(args: string[]) {
-	const { stdout } = await runBirdCommand(args);
-	return JSON.parse(stripAnsi(stdout)) as Record<string, unknown>;
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
 }
 
-export async function readBirdStatusViaBird(query: string) {
-	try {
-		const payload = await runBirdJsonCommand(["status", query, "--json"]);
-		return payload;
-	} catch {
-		return null;
-	}
+function runBirdJsonCommandEffect(args: string[]) {
+	return Effect.gen(function* () {
+		const { stdout } = yield* runBirdCommandEffect(args);
+		return yield* Effect.try({
+			try: () => JSON.parse(stripAnsi(stdout)) as Record<string, unknown>,
+			catch: toError,
+		});
+	});
+}
+
+export function readBirdStatusViaBirdEffect(query: string) {
+	return runBirdJsonCommandEffect(["status", query, "--json"]).pipe(
+		Effect.catchAll(() => Effect.succeed(null)),
+	);
+}
+
+export function readBirdStatusViaBird(query: string) {
+	return runEffectPromise(readBirdStatusViaBirdEffect(query));
 }
 
 function toBirdLookupUser(payload: Record<string, unknown>): XurlMentionUser {
@@ -112,22 +130,27 @@ function toBirdLookupUser(payload: Record<string, unknown>): XurlMentionUser {
 	};
 }
 
-export async function lookupProfileViaBird(query: string) {
-	try {
-		const payload = await runBirdJsonCommand([
+export function lookupProfileViaBirdEffect(query: string) {
+	return Effect.gen(function* () {
+		const payload = yield* runBirdJsonCommandEffect([
 			"user",
 			query,
 			"-n",
 			"1",
 			"--json",
 		]);
-		return toBirdLookupUser(payload);
-	} catch {
-		return null;
-	}
+		return yield* Effect.try({
+			try: () => toBirdLookupUser(payload),
+			catch: toError,
+		});
+	}).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 
-async function runVerifiedBirdMutation({
+export function lookupProfileViaBird(query: string) {
+	return runEffectPromise(lookupProfileViaBirdEffect(query));
+}
+
+function runVerifiedBirdMutationEffect({
 	action,
 	query,
 	verifyField,
@@ -138,45 +161,52 @@ async function runVerifiedBirdMutation({
 	verifyField: "blocking" | "muting";
 	expectedValue: boolean;
 }) {
-	if (liveWritesDisabled()) {
-		return { ok: true, output: "live writes disabled" };
-	}
+	return Effect.gen(function* () {
+		if (liveWritesDisabled()) {
+			return { ok: true, output: "live writes disabled" };
+		}
 
-	let baseOutput = "";
-	try {
-		const { stdout, stderr } = await runBirdCommand([action, query]);
-		baseOutput = normalizeOutput(stdout, stderr);
-	} catch (error) {
+		const mutationResult = yield* runBirdCommandEffect([action, query]).pipe(
+			Effect.map(({ stdout, stderr }) => ({
+				ok: true as const,
+				output: normalizeOutput(stdout, stderr),
+			})),
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false as const,
+					output: formatExecError(error, `bird ${action} failed`),
+				}),
+			),
+		);
+		if (!mutationResult.ok) {
+			return mutationResult;
+		}
+
+		const status = yield* readBirdStatusViaBirdEffect(query);
+		if (!status || typeof status[verifyField] !== "boolean") {
+			return {
+				ok: false,
+				output: `${mutationResult.output}; bird status verify unavailable`,
+			};
+		}
+
+		const actualValue = Boolean(status[verifyField]);
+		if (actualValue !== expectedValue) {
+			return {
+				ok: false,
+				output: `${mutationResult.output}; bird status verify ${verifyField}=${String(actualValue)}`,
+			};
+		}
+
 		return {
-			ok: false,
-			output: formatExecError(error, `bird ${action} failed`),
+			ok: true,
+			output: `${mutationResult.output}; verified ${verifyField}=${String(actualValue)}`,
 		};
-	}
-
-	const status = await readBirdStatusViaBird(query);
-	if (!status || typeof status[verifyField] !== "boolean") {
-		return {
-			ok: false,
-			output: `${baseOutput}; bird status verify unavailable`,
-		};
-	}
-
-	const actualValue = Boolean(status[verifyField]);
-	if (actualValue !== expectedValue) {
-		return {
-			ok: false,
-			output: `${baseOutput}; bird status verify ${verifyField}=${String(actualValue)}`,
-		};
-	}
-
-	return {
-		ok: true,
-		output: `${baseOutput}; verified ${verifyField}=${String(actualValue)}`,
-	};
+	});
 }
 
-export async function blockUserViaBird(query: string) {
-	return runVerifiedBirdMutation({
+export function blockUserViaBirdEffect(query: string) {
+	return runVerifiedBirdMutationEffect({
 		action: "block",
 		query,
 		verifyField: "blocking",
@@ -184,8 +214,12 @@ export async function blockUserViaBird(query: string) {
 	});
 }
 
-export async function unblockUserViaBird(query: string) {
-	return runVerifiedBirdMutation({
+export function blockUserViaBird(query: string) {
+	return runEffectPromise(blockUserViaBirdEffect(query));
+}
+
+export function unblockUserViaBirdEffect(query: string) {
+	return runVerifiedBirdMutationEffect({
 		action: "unblock",
 		query,
 		verifyField: "blocking",
@@ -193,8 +227,12 @@ export async function unblockUserViaBird(query: string) {
 	});
 }
 
-export async function muteUserViaBird(query: string) {
-	return runVerifiedBirdMutation({
+export function unblockUserViaBird(query: string) {
+	return runEffectPromise(unblockUserViaBirdEffect(query));
+}
+
+export function muteUserViaBirdEffect(query: string) {
+	return runVerifiedBirdMutationEffect({
 		action: "mute",
 		query,
 		verifyField: "muting",
@@ -202,11 +240,19 @@ export async function muteUserViaBird(query: string) {
 	});
 }
 
-export async function unmuteUserViaBird(query: string) {
-	return runVerifiedBirdMutation({
+export function muteUserViaBird(query: string) {
+	return runEffectPromise(muteUserViaBirdEffect(query));
+}
+
+export function unmuteUserViaBirdEffect(query: string) {
+	return runVerifiedBirdMutationEffect({
 		action: "unmute",
 		query,
 		verifyField: "muting",
 		expectedValue: false,
 	});
+}
+
+export function unmuteUserViaBird(query: string) {
+	return runEffectPromise(unmuteUserViaBirdEffect(query));
 }

--- a/src/lib/bird-command.test.ts
+++ b/src/lib/bird-command.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execFileAsyncMock = vi.fn();
+const accessMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+	execFile: vi.fn(),
+}));
+
+vi.mock("node:util", () => ({
+	promisify: vi.fn(() => execFileAsyncMock),
+}));
+
+vi.mock("node:fs/promises", () => ({
+	access: accessMock,
+}));
+
+describe("bird command Effect boundary", () => {
+	afterEach(() => {
+		vi.resetModules();
+		execFileAsyncMock.mockReset();
+		accessMock.mockReset();
+		delete process.env.BIRDCLAW_BIRD_COMMAND;
+		delete process.env.BIRDCLAW_CONFIG;
+	});
+
+	it("returns a rejected promise instead of throwing synchronously on config parse failures", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-command-"));
+		const configPath = path.join(tempDir, "config.json");
+		writeFileSync(configPath, "{bad json", "utf8");
+		process.env.BIRDCLAW_CONFIG = configPath;
+		const { runBirdCommand } = await import("./bird-command");
+		let promise: Promise<unknown> | undefined;
+
+		expect(() => {
+			promise = runBirdCommand(["version"]);
+		}).not.toThrow();
+		await expect(promise).rejects.toThrow(/JSON/);
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+});

--- a/src/lib/bird-command.ts
+++ b/src/lib/bird-command.ts
@@ -3,9 +3,29 @@ import type { ExecFileOptions } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants } from "node:fs";
 import { promisify } from "node:util";
+import { Data, Effect } from "effect";
 import { getBirdCommand } from "./config";
+import { runEffectPromise } from "./effect-runtime";
 
 const execFileAsync = promisify(execFile);
+
+export class BirdCommandUnavailableError extends Data.TaggedError(
+	"BirdCommandUnavailableError",
+)<{
+	readonly message: string;
+	readonly command: string;
+	readonly cause?: unknown;
+}> {}
+
+export class BirdCommandExecutionError extends Data.TaggedError(
+	"BirdCommandExecutionError",
+)<{
+	readonly message: string;
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly useFallbackMessage?: boolean;
+	readonly cause?: unknown;
+}> {}
 
 function isPathCommand(command: string) {
 	return command.includes("/") || command.startsWith(".");
@@ -18,40 +38,93 @@ function formatBirdInstallHint(command: string) {
 	].join("\n");
 }
 
-async function assertBirdCommandAvailable(command: string) {
-	if (!isPathCommand(command)) {
-		return;
-	}
-
-	try {
-		await access(command, constants.X_OK);
-	} catch {
-		throw new Error(formatBirdInstallHint(command));
-	}
+function isUnavailableExecError(error: unknown) {
+	return (
+		error &&
+		typeof error === "object" &&
+		"code" in error &&
+		(error.code === "ENOENT" || error.code === "EACCES")
+	);
 }
 
-export async function runBirdCommand(
+function execFailureFromCause(command: string, cause: unknown) {
+	if (isUnavailableExecError(cause)) {
+		return new BirdCommandUnavailableError({
+			message: formatBirdInstallHint(command),
+			command,
+			cause,
+		});
+	}
+	if (cause instanceof Error) {
+		const output = cause as Error & {
+			stdout?: unknown;
+			stderr?: unknown;
+		};
+		return new BirdCommandExecutionError({
+			message: cause.message,
+			stdout: typeof output.stdout === "string" ? output.stdout : undefined,
+			stderr: typeof output.stderr === "string" ? output.stderr : undefined,
+			cause,
+		});
+	}
+	return new BirdCommandExecutionError({
+		message: "",
+		useFallbackMessage: true,
+		cause,
+	});
+}
+
+function assertBirdCommandAvailableEffect(command: string) {
+	if (!isPathCommand(command)) {
+		return Effect.void;
+	}
+
+	return Effect.tryPromise({
+		try: () => Promise.resolve(access(command, constants.X_OK)),
+		catch: (cause) =>
+			new BirdCommandUnavailableError({
+				message: formatBirdInstallHint(command),
+				command,
+				cause,
+			}),
+	}).pipe(Effect.asVoid);
+}
+
+function getBirdCommandEffect() {
+	return Effect.try({
+		try: () => getBirdCommand(),
+		catch: (cause) =>
+			cause instanceof Error ? cause : new Error(String(cause)),
+	});
+}
+
+export function runBirdCommandEffect(
+	args: string[],
+	options?: ExecFileOptions,
+): Effect.Effect<
+	{ stdout: string; stderr: string },
+	BirdCommandExecutionError | BirdCommandUnavailableError | Error
+> {
+	return Effect.gen(function* () {
+		const birdCommand = yield* getBirdCommandEffect();
+		yield* assertBirdCommandAvailableEffect(birdCommand);
+
+		const result = yield* Effect.tryPromise({
+			try: () =>
+				Promise.resolve(
+					options === undefined
+						? execFileAsync(birdCommand, args)
+						: execFileAsync(birdCommand, args, options),
+				),
+			catch: (cause) => execFailureFromCause(birdCommand, cause),
+		});
+		return result as { stdout: string; stderr: string };
+	});
+}
+
+export function runBirdCommand(
 	args: string[],
 	options?: ExecFileOptions,
 ): Promise<{ stdout: string; stderr: string }> {
-	const birdCommand = getBirdCommand();
-	await assertBirdCommandAvailable(birdCommand);
-
-	try {
-		const result =
-			options === undefined
-				? await execFileAsync(birdCommand, args)
-				: await execFileAsync(birdCommand, args, options);
-		return result as { stdout: string; stderr: string };
-	} catch (error) {
-		if (
-			error &&
-			typeof error === "object" &&
-			"code" in error &&
-			(error.code === "ENOENT" || error.code === "EACCES")
-		) {
-			throw new Error(formatBirdInstallHint(birdCommand));
-		}
-		throw error;
-	}
+	return runEffectPromise(runBirdCommandEffect(args, options));
 }

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
-import { writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsyncMock = vi.fn();
@@ -39,6 +42,26 @@ describe("bird transport wrapper", () => {
 		vi.resetModules();
 		execFileAsyncMock.mockReset();
 		delete process.env.BIRDCLAW_BIRD_COMMAND;
+		delete process.env.BIRDCLAW_CONFIG;
+	});
+
+	it("keeps config parse failures behind the Effect promise boundary", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-bird-"));
+		const configPath = path.join(tempDir, "config.json");
+		writeFileSync(configPath, "{bad json", "utf8");
+		process.env.BIRDCLAW_CONFIG = configPath;
+
+		const { runBirdJsonCommandEffect } = await import("./bird");
+		const { runEffectPromise } = await import("./effect-runtime");
+		let promise: Promise<unknown> | undefined;
+
+		expect(() => {
+			promise = runEffectPromise(runBirdJsonCommandEffect(["mentions"]));
+		}).not.toThrow();
+		await expect(promise).rejects.toThrow(/JSON/);
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+
+		rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	it("maps bird mentions json into xurl-compatible payloads", async () => {
@@ -113,6 +136,32 @@ describe("bird transport wrapper", () => {
 				next_token: null,
 			}),
 		});
+	});
+
+	it("keeps bird collection adapters lazy as Effect programs", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdStdoutOnce(
+			JSON.stringify([
+				{
+					id: "tweet_effect_1",
+					text: "lazy bird",
+					createdAt: "2026-05-01T00:00:00.000Z",
+					authorId: "42",
+					author: { username: "sam", name: "Sam" },
+				},
+			]),
+		);
+		const { listMentionsViaBirdEffect } = await import("./bird");
+
+		const effect = listMentionsViaBirdEffect({ maxResults: 3 });
+
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual(
+			expect.objectContaining({
+				data: [expect.objectContaining({ id: "tweet_effect_1" })],
+			}),
+		);
+		expectBirdCommandCall(1, ["mentions", "-n", "3", "--json"]);
 	});
 
 	it("maps mention fallbacks and empty mention payloads", async () => {

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -3,7 +3,9 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { Effect } from "effect";
 import { getBirdCommand } from "./config";
+import { runEffectPromise } from "./effect-runtime";
 import type {
 	XurlMentionData,
 	XurlFollowUsersResponse,
@@ -15,6 +17,7 @@ import type {
 
 const execFileAsync = promisify(execFile);
 const BIRD_JSON_MAX_BUFFER_BYTES = 512 * 1024 * 1024;
+const BIRD_STDOUT_REDIRECT_SCRIPT = 'out="$1"; shift; exec "$@" > "$out"';
 
 interface BirdTweetMedia {
 	type?: string;
@@ -223,23 +226,48 @@ function isUnsupportedBirdOptionError(error: unknown, option: string) {
 	return text.includes(option) && /unknown option|error:/i.test(text);
 }
 
-async function runBirdJsonCommand(args: string[], timeoutMs?: number) {
-	const tempDir = mkdtempSync(join(tmpdir(), "birdclaw-bird-"));
-	const stdoutPath = join(tempDir, "stdout.json");
-	const birdCommand = getBirdCommand();
-	try {
-		const shellScript = 'out="$1"; shift; exec "$@" > "$out"';
-		await execFileAsync(
-			"/bin/bash",
-			["-c", shellScript, "birdclaw-bird", stdoutPath, birdCommand, ...args],
-			{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
-		);
-		return readFileSync(stdoutPath, "utf8");
-	} catch (error) {
-		throw formatBirdCommandError(error, birdCommand);
-	} finally {
-		rmSync(tempDir, { recursive: true, force: true });
-	}
+function makeBirdStdoutTempEffect() {
+	return Effect.acquireRelease(
+		Effect.sync(() => {
+			const tempDir = mkdtempSync(join(tmpdir(), "birdclaw-bird-"));
+			return { tempDir, stdoutPath: join(tempDir, "stdout.json") };
+		}),
+		({ tempDir }) =>
+			Effect.sync(() => rmSync(tempDir, { recursive: true, force: true })),
+	);
+}
+
+export function runBirdJsonCommandEffect(args: string[], timeoutMs?: number) {
+	return Effect.scoped(
+		Effect.gen(function* () {
+			const birdCommand = yield* Effect.try({
+				try: () => getBirdCommand(),
+				catch: (error) =>
+					error instanceof Error ? error : new Error(String(error)),
+			});
+			const { stdoutPath } = yield* makeBirdStdoutTempEffect();
+			yield* Effect.tryPromise({
+				try: () =>
+					execFileAsync(
+						"/bin/bash",
+						[
+							"-c",
+							BIRD_STDOUT_REDIRECT_SCRIPT,
+							"birdclaw-bird",
+							stdoutPath,
+							birdCommand,
+							...args,
+						],
+						{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
+					),
+				catch: (error) => formatBirdCommandError(error, birdCommand),
+			});
+			return yield* Effect.try({
+				try: () => readFileSync(stdoutPath, "utf8"),
+				catch: (error) => error,
+			});
+		}),
+	);
 }
 
 function getBirdTweetItems(payload: unknown, command: string) {
@@ -352,23 +380,51 @@ function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
 	};
 }
 
-export async function listMentionsViaBird({
+function parseBirdJsonEffect(stdout: string) {
+	return Effect.try({
+		try: () => parseBirdJson(stdout),
+		catch: (error) => error,
+	});
+}
+
+function normalizeBirdTweetsPayloadEffect(payload: unknown, command: string) {
+	return Effect.try({
+		try: () => normalizeBirdTweets(getBirdTweetItems(payload, command)),
+		catch: (error) => error,
+	});
+}
+
+function normalizeBirdTweetItemEffect(payload: unknown, command: string) {
+	return Effect.try({
+		try: () => getBirdTweetItem(payload, command),
+		catch: (error) => error,
+	});
+}
+
+export function listMentionsViaBirdEffect({
 	maxResults,
 }: {
 	maxResults: number;
-}): Promise<XurlMentionsResponse> {
-	const stdout = await runBirdJsonCommand([
-		"mentions",
-		"-n",
-		String(maxResults),
-		"--json",
-	]);
-	const payload = parseBirdJson(stdout);
-
-	return normalizeBirdTweets(getBirdTweetItems(payload, "mentions"));
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return Effect.gen(function* () {
+		const stdout = yield* runBirdJsonCommandEffect([
+			"mentions",
+			"-n",
+			String(maxResults),
+			"--json",
+		]);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdTweetsPayloadEffect(payload, "mentions");
+	});
 }
 
-async function listTweetsViaBirdCommand({
+export function listMentionsViaBird(options: {
+	maxResults: number;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listMentionsViaBirdEffect(options));
+}
+
+function listTweetsViaBirdCommandEffect({
 	command,
 	maxResults,
 	all,
@@ -378,86 +434,114 @@ async function listTweetsViaBirdCommand({
 	maxResults: number;
 	all?: boolean;
 	maxPages?: number;
-}): Promise<XurlMentionsResponse> {
-	const args = [command, "-n", String(maxResults), "--json"];
-	if (all) {
-		args.push("--all");
-	}
-	if (maxPages !== undefined) {
-		args.push("--max-pages", String(maxPages));
-	}
-	const stdout = await runBirdJsonCommand(args);
-	const payload = parseBirdJson(stdout);
-
-	return normalizeBirdTweets(getBirdTweetItems(payload, command));
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return Effect.gen(function* () {
+		const args = [command, "-n", String(maxResults), "--json"];
+		if (all) {
+			args.push("--all");
+		}
+		if (maxPages !== undefined) {
+			args.push("--max-pages", String(maxPages));
+		}
+		const stdout = yield* runBirdJsonCommandEffect(args);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdTweetsPayloadEffect(payload, command);
+	});
 }
 
-export async function listLikedTweetsViaBird({
-	maxResults,
-	all,
-	maxPages,
-}: {
+export function listLikedTweetsViaBirdEffect(options: {
 	maxResults: number;
 	all?: boolean;
 	maxPages?: number;
-}): Promise<XurlMentionsResponse> {
-	return listTweetsViaBirdCommand({
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return listTweetsViaBirdCommandEffect({
 		command: "likes",
-		maxResults,
-		all,
-		maxPages,
+		...options,
 	});
 }
 
-export async function listBookmarkedTweetsViaBird({
-	maxResults,
-	all,
-	maxPages,
-}: {
+export function listLikedTweetsViaBird(options: {
 	maxResults: number;
 	all?: boolean;
 	maxPages?: number;
 }): Promise<XurlMentionsResponse> {
-	return listTweetsViaBirdCommand({
+	return runEffectPromise(listLikedTweetsViaBirdEffect(options));
+}
+
+export function listBookmarkedTweetsViaBirdEffect(options: {
+	maxResults: number;
+	all?: boolean;
+	maxPages?: number;
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return listTweetsViaBirdCommandEffect({
 		command: "bookmarks",
-		maxResults,
-		all,
-		maxPages,
+		...options,
 	});
 }
 
-export async function lookupTweetsByIdsViaBird(
+export function listBookmarkedTweetsViaBird(options: {
+	maxResults: number;
+	all?: boolean;
+	maxPages?: number;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listBookmarkedTweetsViaBirdEffect(options));
+}
+
+export function lookupTweetsByIdsViaBirdEffect(
+	ids: string[],
+): Effect.Effect<XurlTweetsResponse, unknown> {
+	if (ids.length === 0) {
+		return Effect.succeed({ data: [] });
+	}
+
+	return Effect.gen(function* () {
+		const tweets = yield* Effect.forEach(
+			ids,
+			(id) =>
+				Effect.gen(function* () {
+					const stdout = yield* runBirdJsonCommandEffect([
+						"read",
+						id,
+						"--json",
+					]);
+					const payload = yield* parseBirdJsonEffect(stdout);
+					return yield* normalizeBirdTweetItemEffect(payload, "read");
+				}),
+			{ concurrency: "unbounded" },
+		);
+		return normalizeBirdTweets(tweets);
+	});
+}
+
+export function lookupTweetsByIdsViaBird(
 	ids: string[],
 ): Promise<XurlTweetsResponse> {
-	if (ids.length === 0) {
-		return { data: [] };
-	}
-
-	const tweets = await Promise.all(
-		ids.map(async (id) => {
-			const stdout = await runBirdJsonCommand(["read", id, "--json"]);
-			return getBirdTweetItem(parseBirdJson(stdout), "read");
-		}),
-	);
-
-	return normalizeBirdTweets(tweets);
+	return runEffectPromise(lookupTweetsByIdsViaBirdEffect(ids));
 }
 
-export async function listHomeTimelineViaBird({
+export function listHomeTimelineViaBirdEffect({
 	maxResults,
 	following = true,
 }: {
 	maxResults: number;
 	following?: boolean;
-}): Promise<XurlMentionsResponse> {
-	const args = ["home", "-n", String(maxResults), "--json"];
-	if (following) {
-		args.push("--following");
-	}
-	const stdout = await runBirdJsonCommand(args);
-	const payload = parseBirdJson(stdout);
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return Effect.gen(function* () {
+		const args = ["home", "-n", String(maxResults), "--json"];
+		if (following) {
+			args.push("--following");
+		}
+		const stdout = yield* runBirdJsonCommandEffect(args);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdTweetsPayloadEffect(payload, "home");
+	});
+}
 
-	return normalizeBirdTweets(getBirdTweetItems(payload, "home"));
+export function listHomeTimelineViaBird(options: {
+	maxResults: number;
+	following?: boolean;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listHomeTimelineViaBirdEffect(options));
 }
 
 function normalizeBirdFollowUsers(
@@ -490,7 +574,18 @@ function normalizeBirdFollowUsers(
 	};
 }
 
-export async function listFollowUsersViaBird({
+function normalizeBirdFollowUsersEffect(
+	payload: unknown,
+	command: "followers" | "following",
+	maxResults: number,
+) {
+	return Effect.try({
+		try: () => normalizeBirdFollowUsers(payload, command, maxResults),
+		catch: (error) => error,
+	});
+}
+
+export function listFollowUsersViaBirdEffect({
 	direction,
 	userId,
 	maxResults,
@@ -502,24 +597,39 @@ export async function listFollowUsersViaBird({
 	maxResults: number;
 	all?: boolean;
 	maxPages?: number;
-}): Promise<XurlFollowUsersResponse> {
-	const args = [direction, "-n", String(maxResults), "--json"];
-	if (userId) {
-		args.push("--user", userId);
-	}
-	if (all) {
-		args.push("--all");
-	}
-	if (maxPages !== undefined) {
-		args.push("--max-pages", String(maxPages));
-	}
-	const stdout = await runBirdJsonCommand(args);
-	const payload = parseBirdJson(stdout);
-
-	return normalizeBirdFollowUsers(payload, direction, maxResults);
+}): Effect.Effect<XurlFollowUsersResponse, unknown> {
+	return Effect.gen(function* () {
+		const args = [direction, "-n", String(maxResults), "--json"];
+		if (userId) {
+			args.push("--user", userId);
+		}
+		if (all) {
+			args.push("--all");
+		}
+		if (maxPages !== undefined) {
+			args.push("--max-pages", String(maxPages));
+		}
+		const stdout = yield* runBirdJsonCommandEffect(args);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdFollowUsersEffect(
+			payload,
+			direction,
+			maxResults,
+		);
+	});
 }
 
-export async function listThreadViaBird({
+export function listFollowUsersViaBird(options: {
+	direction: "followers" | "following";
+	userId?: string;
+	maxResults: number;
+	all?: boolean;
+	maxPages?: number;
+}): Promise<XurlFollowUsersResponse> {
+	return runEffectPromise(listFollowUsersViaBirdEffect(options));
+}
+
+export function listThreadViaBirdEffect({
 	tweetId,
 	all,
 	maxPages,
@@ -529,75 +639,113 @@ export async function listThreadViaBird({
 	all?: boolean;
 	maxPages?: number;
 	timeoutMs?: number;
-}): Promise<XurlMentionsResponse> {
-	const args = ["thread", tweetId, "--json"];
-	if (all) {
-		args.push("--all");
-	}
-	if (maxPages !== undefined) {
-		args.push("--max-pages", String(maxPages));
-	}
-	const stdout = await runBirdJsonCommand(args, timeoutMs);
-	const payload = parseBirdJson(stdout);
-
-	return normalizeBirdTweets(getBirdTweetItems(payload, "thread"));
+}): Effect.Effect<XurlMentionsResponse, unknown> {
+	return Effect.gen(function* () {
+		const args = ["thread", tweetId, "--json"];
+		if (all) {
+			args.push("--all");
+		}
+		if (maxPages !== undefined) {
+			args.push("--max-pages", String(maxPages));
+		}
+		const stdout = yield* runBirdJsonCommandEffect(args, timeoutMs);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdTweetsPayloadEffect(payload, "thread");
+	});
 }
 
-export async function listDirectMessagesViaBird({
+export function listThreadViaBird(options: {
+	tweetId: string;
+	all?: boolean;
+	maxPages?: number;
+	timeoutMs?: number;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listThreadViaBirdEffect(options));
+}
+
+function normalizeBirdDmsPayloadEffect(payload: unknown) {
+	return Effect.try({
+		try: () => {
+			if (
+				!payload ||
+				typeof payload !== "object" ||
+				(payload as { success?: unknown }).success !== true ||
+				!Array.isArray(
+					(payload as { conversations?: unknown }).conversations,
+				) ||
+				!Array.isArray((payload as { events?: unknown }).events)
+			) {
+				throw new Error("bird dms returned unexpected JSON");
+			}
+
+			return payload as BirdDmsResponse;
+		},
+		catch: (error) => error,
+	});
+}
+
+export function listDirectMessagesViaBirdEffect({
 	maxResults,
 }: {
 	maxResults: number;
-}): Promise<BirdDmsResponse> {
-	const stdout = await runBirdJsonCommand([
-		"dms",
-		"-n",
-		String(maxResults),
-		"--json",
-	]);
-	const payload = parseBirdJson(stdout);
-	if (
-		!payload ||
-		typeof payload !== "object" ||
-		(payload as { success?: unknown }).success !== true ||
-		!Array.isArray((payload as { conversations?: unknown }).conversations) ||
-		!Array.isArray((payload as { events?: unknown }).events)
-	) {
-		throw new Error("bird dms returned unexpected JSON");
-	}
-
-	return payload as BirdDmsResponse;
+}): Effect.Effect<BirdDmsResponse, unknown> {
+	return Effect.gen(function* () {
+		const stdout = yield* runBirdJsonCommandEffect([
+			"dms",
+			"-n",
+			String(maxResults),
+			"--json",
+		]);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdDmsPayloadEffect(payload);
+	});
 }
 
-export async function lookupProfileViaBird(
-	usernameOrId: string,
-): Promise<XurlMentionUser | null> {
-	const target = usernameOrId.trim().replace(/^@/, "");
-	if (!target) {
-		return null;
-	}
+export function listDirectMessagesViaBird(options: {
+	maxResults: number;
+}): Promise<BirdDmsResponse> {
+	return runEffectPromise(listDirectMessagesViaBirdEffect(options));
+}
 
-	let stdout: string;
-	try {
-		stdout = await runBirdJsonCommand([
+export function lookupProfileViaBirdEffect(
+	usernameOrId: string,
+): Effect.Effect<XurlMentionUser | null, unknown> {
+	return Effect.gen(function* () {
+		const target = usernameOrId.trim().replace(/^@/, "");
+		if (!target) {
+			return null;
+		}
+
+		const stdout = yield* runBirdJsonCommandEffect([
 			"user",
 			target,
 			"--json",
 			"--profile-only",
-		]);
-	} catch (error) {
-		if (!isUnsupportedBirdOptionError(error, "--profile-only")) {
-			throw error;
-		}
-		stdout = await runBirdJsonCommand([
-			"user",
-			target,
-			"--json",
-			"--count",
-			"1",
-		]);
-	}
-	const payload = parseBirdJson(stdout) as BirdUserOverviewPayload;
-	return toXurlMentionUser(payload.user);
+		]).pipe(
+			Effect.catchAll((error) => {
+				if (!isUnsupportedBirdOptionError(error, "--profile-only")) {
+					return Effect.fail(error);
+				}
+				return runBirdJsonCommandEffect([
+					"user",
+					target,
+					"--json",
+					"--count",
+					"1",
+				]);
+			}),
+		);
+		const payload = (yield* parseBirdJsonEffect(
+			stdout,
+		)) as BirdUserOverviewPayload;
+		return toXurlMentionUser(payload.user);
+	});
+}
+
+export function lookupProfileViaBird(
+	usernameOrId: string,
+): Promise<XurlMentionUser | null> {
+	return runEffectPromise(lookupProfileViaBirdEffect(usernameOrId));
 }
 
 function toXurlMentionUser(
@@ -642,10 +790,11 @@ function toXurlMentionUser(
 	};
 }
 
-export async function lookupProfilesViaBird(
+export function lookupProfilesViaBirdEffect(
 	usernameOrIds: string[],
-): Promise<
-	Array<{ target: string; user: XurlMentionUser | null; error?: string }>
+): Effect.Effect<
+	Array<{ target: string; user: XurlMentionUser | null; error?: string }>,
+	unknown
 > {
 	const targets = Array.from(
 		new Set(
@@ -655,56 +804,72 @@ export async function lookupProfilesViaBird(
 		),
 	);
 	if (targets.length === 0) {
-		return [];
+		return Effect.succeed([]);
 	}
 
-	try {
-		const stdout = await runBirdJsonCommand(["profiles", ...targets, "--json"]);
-		const payload = parseBirdJson(stdout) as BirdProfilesPayload;
-		const users = (payload.users ?? [])
-			.map(toXurlMentionUser)
-			.filter((user): user is XurlMentionUser => Boolean(user));
-		const byTarget = new Map<string, XurlMentionUser>();
-		for (const user of users) {
-			byTarget.set(String(user.id), user);
-			byTarget.set(user.username.toLowerCase(), user);
-		}
-		const errors = new Map(
-			(payload.errors ?? []).map((item) => [
-				String(item.target ?? "")
-					.replace(/^@/, "")
-					.toLowerCase(),
-				item.error ?? "Unknown error",
-			]),
-		);
-		return targets.map((target) => ({
-			target,
-			user: byTarget.get(target.toLowerCase()) ?? null,
-			...(errors.has(target.toLowerCase())
-				? { error: errors.get(target.toLowerCase()) }
-				: {}),
-		}));
-	} catch (error) {
-		if (!isUnsupportedBirdOptionError(error, "profiles")) {
-			throw error;
-		}
-		return Promise.all(
-			targets.map(async (target) => {
-				try {
-					return { target, user: await lookupProfileViaBird(target) };
-				} catch (lookupError) {
-					return {
-						target,
-						user: null,
-						error:
-							lookupError instanceof Error
-								? lookupError.message
-								: String(lookupError),
-					};
+	return runBirdJsonCommandEffect(["profiles", ...targets, "--json"]).pipe(
+		Effect.flatMap((stdout) =>
+			Effect.gen(function* () {
+				const payload = (yield* parseBirdJsonEffect(
+					stdout,
+				)) as BirdProfilesPayload;
+				const users = (payload.users ?? [])
+					.map(toXurlMentionUser)
+					.filter((user): user is XurlMentionUser => Boolean(user));
+				const byTarget = new Map<string, XurlMentionUser>();
+				for (const user of users) {
+					byTarget.set(String(user.id), user);
+					byTarget.set(user.username.toLowerCase(), user);
 				}
+				const errors = new Map(
+					(payload.errors ?? []).map((item) => [
+						String(item.target ?? "")
+							.replace(/^@/, "")
+							.toLowerCase(),
+						item.error ?? "Unknown error",
+					]),
+				);
+				return targets.map((target) => ({
+					target,
+					user: byTarget.get(target.toLowerCase()) ?? null,
+					...(errors.has(target.toLowerCase())
+						? { error: errors.get(target.toLowerCase()) }
+						: {}),
+				}));
 			}),
-		);
-	}
+		),
+		Effect.catchAll((error) => {
+			if (!isUnsupportedBirdOptionError(error, "profiles")) {
+				return Effect.fail(error);
+			}
+			return Effect.forEach(
+				targets,
+				(target) =>
+					lookupProfileViaBirdEffect(target).pipe(
+						Effect.map((user) => ({ target, user })),
+						Effect.catchAll((lookupError) =>
+							Effect.succeed({
+								target,
+								user: null,
+								error:
+									lookupError instanceof Error
+										? lookupError.message
+										: String(lookupError),
+							}),
+						),
+					),
+				{ concurrency: "unbounded" },
+			);
+		}),
+	);
+}
+
+export function lookupProfilesViaBird(
+	usernameOrIds: string[],
+): Promise<
+	Array<{ target: string; user: XurlMentionUser | null; error?: string }>
+> {
+	return runEffectPromise(lookupProfilesViaBirdEffect(usernameOrIds));
 }
 
 export const __test__ = {

--- a/src/lib/blocklist.test.ts
+++ b/src/lib/blocklist.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const addBlockMock = vi.fn();
@@ -82,6 +83,27 @@ plain text should be ignored
 					error: "Profile not found: @beta",
 				},
 			],
+		});
+	});
+
+	it("exposes blocklist imports as Effect programs", async () => {
+		const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-blocklist-"));
+		tempRoots.push(tempRoot);
+		const filePath = path.join(tempRoot, "blocklist.txt");
+		writeFileSync(filePath, "@alpha\n");
+		addBlockMock.mockResolvedValueOnce({
+			ok: true,
+			blockedAt: "2026-03-09T00:00:00.000Z",
+			profile: { handle: "alpha" },
+			transport: { ok: true, output: "blocked" },
+		});
+		const { importBlocklistEffect } = await import("./blocklist");
+
+		await expect(
+			Effect.runPromise(importBlocklistEffect("acct_primary", filePath)),
+		).resolves.toMatchObject({
+			ok: true,
+			blockedCount: 1,
 		});
 	});
 });

--- a/src/lib/blocklist.ts
+++ b/src/lib/blocklist.ts
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
+import { Effect } from "effect";
 import { addBlock } from "./blocks";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 
 export interface BlocklistImportItem {
 	query: string;
@@ -76,14 +78,31 @@ export function parseBlocklistText(text: string) {
 	return items;
 }
 
-export async function importBlocklist(accountId: string, filePath: string) {
-	const text = await readFile(filePath, "utf8");
-	const queries = parseBlocklistText(text);
-	const items: BlocklistImportItem[] = [];
+export function importBlocklistEffect(accountId: string, filePath: string) {
+	return Effect.gen(function* () {
+		const text = yield* tryPromise(() => readFile(filePath, "utf8"));
+		const queries = parseBlocklistText(text);
+		const items: BlocklistImportItem[] = [];
 
-	for (const query of queries) {
-		try {
-			const result = await addBlock(accountId, query);
+		for (const query of queries) {
+			const blocked = yield* tryPromise(() => addBlock(accountId, query)).pipe(
+				Effect.map((result) => ({ ok: true as const, result })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ ok: false as const, error }),
+				),
+			);
+			if (!blocked.ok) {
+				items.push({
+					query,
+					ok: false,
+					error:
+						blocked.error instanceof Error
+							? blocked.error.message
+							: "block failed",
+				});
+				continue;
+			}
+			const { result } = blocked;
 			if (!result.ok) {
 				items.push({
 					query,
@@ -98,22 +117,20 @@ export async function importBlocklist(accountId: string, filePath: string) {
 				blockedAt: result.blockedAt,
 				handle: result.profile.handle,
 			});
-		} catch (error) {
-			items.push({
-				query,
-				ok: false,
-				error: error instanceof Error ? error.message : "block failed",
-			});
 		}
-	}
 
-	return {
-		ok: items.every((item) => item.ok),
-		accountId,
-		path: filePath,
-		requestedCount: queries.length,
-		blockedCount: items.filter((item) => item.ok).length,
-		failedCount: items.filter((item) => !item.ok).length,
-		items,
-	} satisfies BlocklistImportResult;
+		return {
+			ok: items.every((item) => item.ok),
+			accountId,
+			path: filePath,
+			requestedCount: queries.length,
+			blockedCount: items.filter((item) => item.ok).length,
+			failedCount: items.filter((item) => !item.ok).length,
+			items,
+		} satisfies BlocklistImportResult;
+	});
+}
+
+export function importBlocklist(accountId: string, filePath: string) {
+	return runEffectPromise(importBlocklistEffect(accountId, filePath));
 }

--- a/src/lib/blocks-write.ts
+++ b/src/lib/blocks-write.ts
@@ -1,118 +1,165 @@
+import { Effect } from "effect";
 import { runModerationAction } from "./actions-transport";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import {
 	deleteModerationRow,
 	type ModerationActionOptions,
-	resolveModerationTarget,
+	resolveModerationTargetEffect,
 	writeModerationRow,
 } from "./moderation-write";
 
-export async function addBlock(
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: (error) =>
+			error instanceof Error ? error : new Error(String(error)),
+	});
+}
+
+export function addBlockEffect(
 	accountId: string,
 	query: string,
 	options: ModerationActionOptions = {},
 ) {
-	const { db, resolved, resolvedAccountId, actionQuery } =
-		await resolveModerationTarget({
-			accountId,
-			query,
-			selfActionError: "Cannot block the current account",
-		});
-	const transport = await runModerationAction({
-		action: "block",
-		query: actionQuery,
-		targetUserId: resolved.externalUserId ?? undefined,
-		transport: options.transport,
-	});
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId, actionQuery } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot block the current account",
+			});
+		const transport = yield* tryPromise(() =>
+			runModerationAction({
+				action: "block",
+				query: actionQuery,
+				targetUserId: resolved.externalUserId ?? undefined,
+				transport: options.transport,
+			}),
+		);
 
-	if (!transport.ok) {
+		if (!transport.ok) {
+			return {
+				ok: false,
+				action: "block",
+				accountId: resolvedAccountId,
+				profile: resolved.profile,
+				transport,
+			};
+		}
+
+		const blockedAt = new Date().toISOString();
+		yield* trySync(() =>
+			writeModerationRow(
+				db,
+				"blocks",
+				resolvedAccountId,
+				resolved.profile.id,
+				blockedAt,
+			),
+		);
+
 		return {
-			ok: false,
+			ok: true,
 			action: "block",
 			accountId: resolvedAccountId,
+			blockedAt,
 			profile: resolved.profile,
 			transport,
 		};
-	}
-
-	const blockedAt = new Date().toISOString();
-	writeModerationRow(
-		db,
-		"blocks",
-		resolvedAccountId,
-		resolved.profile.id,
-		blockedAt,
-	);
-
-	return {
-		ok: true,
-		action: "block",
-		accountId: resolvedAccountId,
-		blockedAt,
-		profile: resolved.profile,
-		transport,
-	};
-}
-
-export async function recordBlock(accountId: string, query: string) {
-	const { db, resolved, resolvedAccountId } = await resolveModerationTarget({
-		accountId,
-		query,
-		selfActionError: "Cannot block the current account",
 	});
-
-	const blockedAt = new Date().toISOString();
-	writeModerationRow(
-		db,
-		"blocks",
-		resolvedAccountId,
-		resolved.profile.id,
-		blockedAt,
-	);
-
-	return {
-		ok: true,
-		action: "record-block",
-		accountId: resolvedAccountId,
-		blockedAt,
-		profile: resolved.profile,
-	};
 }
 
-export async function removeBlock(
+export function addBlock(
 	accountId: string,
 	query: string,
 	options: ModerationActionOptions = {},
 ) {
-	const { db, resolved, resolvedAccountId, actionQuery } =
-		await resolveModerationTarget({
-			accountId,
-			query,
-			selfActionError: "Cannot block the current account",
-		});
-	const transport = await runModerationAction({
-		action: "unblock",
-		query: actionQuery,
-		targetUserId: resolved.externalUserId ?? undefined,
-		transport: options.transport,
-	});
+	return runEffectPromise(addBlockEffect(accountId, query, options));
+}
 
-	if (!transport.ok) {
+export function recordBlockEffect(accountId: string, query: string) {
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot block the current account",
+			});
+
+		const blockedAt = new Date().toISOString();
+		yield* trySync(() =>
+			writeModerationRow(
+				db,
+				"blocks",
+				resolvedAccountId,
+				resolved.profile.id,
+				blockedAt,
+			),
+		);
+
 		return {
-			ok: false,
+			ok: true,
+			action: "record-block",
+			accountId: resolvedAccountId,
+			blockedAt,
+			profile: resolved.profile,
+		};
+	});
+}
+
+export function recordBlock(accountId: string, query: string) {
+	return runEffectPromise(recordBlockEffect(accountId, query));
+}
+
+export function removeBlockEffect(
+	accountId: string,
+	query: string,
+	options: ModerationActionOptions = {},
+) {
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId, actionQuery } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot block the current account",
+			});
+		const transport = yield* tryPromise(() =>
+			runModerationAction({
+				action: "unblock",
+				query: actionQuery,
+				targetUserId: resolved.externalUserId ?? undefined,
+				transport: options.transport,
+			}),
+		);
+
+		if (!transport.ok) {
+			return {
+				ok: false,
+				action: "unblock",
+				accountId: resolvedAccountId,
+				profile: resolved.profile,
+				transport,
+			};
+		}
+
+		yield* trySync(() =>
+			deleteModerationRow(db, "blocks", resolvedAccountId, resolved.profile.id),
+		);
+
+		return {
+			ok: true,
 			action: "unblock",
 			accountId: resolvedAccountId,
 			profile: resolved.profile,
 			transport,
 		};
-	}
+	});
+}
 
-	deleteModerationRow(db, "blocks", resolvedAccountId, resolved.profile.id);
-
-	return {
-		ok: true,
-		action: "unblock",
-		accountId: resolvedAccountId,
-		profile: resolved.profile,
-		transport,
-	};
+export function removeBlock(
+	accountId: string,
+	query: string,
+	options: ModerationActionOptions = {},
+) {
+	return runEffectPromise(removeBlockEffect(accountId, query, options));
 }

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -114,6 +115,23 @@ describe("blocklist", () => {
 				public_metrics: { followers_count: 632000 },
 			},
 		]);
+	});
+
+	it("builds block write effects lazily", async () => {
+		setupTempHome();
+		const { addBlockEffect } = await import("./blocks");
+
+		const effect = addBlockEffect("acct_primary", "@amelia");
+
+		expect(mocks.lookupUsersByHandles).not.toHaveBeenCalled();
+		expect(mocks.blockUserViaBird).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			action: "block",
+			accountId: "acct_primary",
+		});
+		expect(mocks.lookupUsersByHandles).toHaveBeenCalledWith(["amelia"]);
+		expect(mocks.blockUserViaBird).toHaveBeenCalledWith("7");
 	});
 
 	it("blocks, lists, searches, and unblocks profiles", async () => {
@@ -314,6 +332,33 @@ describe("blocklist", () => {
 		expect(
 			listed.find((item) => item.profile.handle === "amelia")?.source,
 		).toBe("manual");
+	});
+
+	it("exposes remote block sync as an Effect program", async () => {
+		setupTempHome();
+		mocks.listBlockedUsers.mockResolvedValueOnce({
+			items: [
+				{
+					id: "8",
+					username: "avawires",
+					name: "Ava Wires",
+					description: "Infra reporter",
+					profile_image_url:
+						"https://pbs.twimg.com/profile_images/8/avatar_bigger.jpg",
+					public_metrics: { followers_count: 632000 },
+				},
+			],
+			nextToken: null,
+		});
+		const { syncBlocksEffect } = await import("./blocks");
+
+		await expect(
+			Effect.runPromise(syncBlocksEffect("acct_primary")),
+		).resolves.toMatchObject({
+			ok: true,
+			synced: true,
+			syncedCount: 1,
+		});
 	});
 
 	it("skips remote sync when the authenticated xurl account does not match", async () => {

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1,5 +1,7 @@
+import { Effect } from "effect";
 import type { Database } from "./sqlite";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import {
 	getAccountHandle,
 	getDefaultAccountId,
@@ -9,10 +11,28 @@ import type { BlockItem, BlockListResponse, BlockSearchItem } from "./types";
 import { upsertProfileFromXUser } from "./x-profile";
 import { listBlockedUsers, lookupAuthenticatedUser } from "./xurl";
 
-export { addBlock, recordBlock, removeBlock } from "./blocks-write";
+export {
+	addBlock,
+	addBlockEffect,
+	recordBlock,
+	recordBlockEffect,
+	removeBlock,
+	removeBlockEffect,
+} from "./blocks-write";
 
 function remoteBlockSyncDisabled() {
 	return process.env.BIRDCLAW_DISABLE_LIVE_WRITES === "1";
+}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 function upsertRemoteBlock(
@@ -206,116 +226,126 @@ export function getBlocksResponse({
 	};
 }
 
-export async function syncBlocks(accountId: string) {
-	const db = getNativeDb();
-	const resolvedAccountId = accountId || getDefaultAccountId(db);
-	const blockedAt = new Date().toISOString();
-	const remoteProfileIds: string[] = [];
+export function syncBlocksEffect(accountId: string) {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccountId = accountId || getDefaultAccountId(db);
+		const blockedAt = new Date().toISOString();
+		const remoteProfileIds: string[] = [];
 
-	if (remoteBlockSyncDisabled()) {
-		return {
-			ok: true,
-			accountId: resolvedAccountId,
-			synced: false,
-			syncedCount: 0,
-			transport: {
+		if (remoteBlockSyncDisabled()) {
+			return {
 				ok: true,
-				output: "remote block sync disabled in test mode",
-			},
-		};
-	}
-
-	try {
-		const me = await lookupAuthenticatedUser();
-		const sourceUserId =
-			typeof me?.id === "string" && me.id.length > 0 ? me.id : null;
-		const sourceUsername =
-			typeof me?.username === "string" ? me.username.replace(/^@/, "") : "";
-		const accountHandle = getAccountHandle(db, resolvedAccountId);
-
-		if (!sourceUserId) {
-			return {
-				ok: false,
 				accountId: resolvedAccountId,
 				synced: false,
 				syncedCount: 0,
 				transport: {
-					ok: false,
-					output:
-						"xurl block sync unavailable without an authenticated account",
+					ok: true,
+					output: "remote block sync disabled in test mode",
 				},
 			};
 		}
 
-		if (accountHandle && sourceUsername && accountHandle !== sourceUsername) {
-			return {
-				ok: false,
-				accountId: resolvedAccountId,
-				synced: false,
-				syncedCount: 0,
-				transport: {
+		return yield* Effect.gen(function* () {
+			const me = yield* tryPromise(() => lookupAuthenticatedUser()).pipe(
+				Effect.mapError(toError),
+			);
+			const sourceUserId =
+				typeof me?.id === "string" && me.id.length > 0 ? me.id : null;
+			const sourceUsername =
+				typeof me?.username === "string" ? me.username.replace(/^@/, "") : "";
+			const accountHandle = getAccountHandle(db, resolvedAccountId);
+
+			if (!sourceUserId) {
+				return {
 					ok: false,
-					output: `xurl is authenticated as @${sourceUsername}, not @${accountHandle}`,
-				},
-			};
-		}
+					accountId: resolvedAccountId,
+					synced: false,
+					syncedCount: 0,
+					transport: {
+						ok: false,
+						output:
+							"xurl block sync unavailable without an authenticated account",
+					},
+				};
+			}
 
-		let nextToken: string | null = null;
-		let pageCount = 0;
+			if (accountHandle && sourceUsername && accountHandle !== sourceUsername) {
+				return {
+					ok: false,
+					accountId: resolvedAccountId,
+					synced: false,
+					syncedCount: 0,
+					transport: {
+						ok: false,
+						output: `xurl is authenticated as @${sourceUsername}, not @${accountHandle}`,
+					},
+				};
+			}
 
-		do {
-			const page = await listBlockedUsers(sourceUserId, nextToken ?? undefined);
-			const mergeRemotePage = db.transaction(() => {
-				for (const user of page.items) {
-					const resolved = upsertProfileFromXUser(db, user);
-					remoteProfileIds.push(resolved.profile.id);
-					upsertRemoteBlock(
-						db,
-						resolvedAccountId,
-						resolved.profile.id,
-						blockedAt,
-					);
-				}
+			let nextToken: string | null = null;
+			let pageCount = 0;
+
+			do {
+				const page = yield* tryPromise(() =>
+					listBlockedUsers(sourceUserId, nextToken ?? undefined),
+				).pipe(Effect.mapError(toError));
+				yield* trySync(() => {
+					const mergeRemotePage = db.transaction(() => {
+						for (const user of page.items) {
+							const resolved = upsertProfileFromXUser(db, user);
+							remoteProfileIds.push(resolved.profile.id);
+							upsertRemoteBlock(
+								db,
+								resolvedAccountId,
+								resolved.profile.id,
+								blockedAt,
+							);
+						}
+					});
+					mergeRemotePage();
+				});
+				nextToken = page.nextToken;
+				pageCount += 1;
+			} while (nextToken && pageCount < 20);
+
+			yield* trySync(() => {
+				const pruneMergedBlocks = db.transaction(() => {
+					pruneRemoteBlocks(db, resolvedAccountId, remoteProfileIds);
+				});
+				pruneMergedBlocks();
 			});
-			mergeRemotePage();
-			nextToken = page.nextToken;
-			pageCount += 1;
-		} while (nextToken && pageCount < 20);
 
-		const pruneMergedBlocks = db.transaction(() => {
-			pruneRemoteBlocks(db, resolvedAccountId, remoteProfileIds);
-		});
-		pruneMergedBlocks();
-
-		return {
-			ok: true,
-			accountId: resolvedAccountId,
-			synced: true,
-			syncedCount: remoteProfileIds.length,
-			transport: {
+			return {
 				ok: true,
-				output: `synced ${remoteProfileIds.length} remote blocks`,
-			},
-		};
-	} catch (error) {
-		return {
-			ok: false,
-			accountId: resolvedAccountId,
-			synced: remoteProfileIds.length > 0,
-			syncedCount: remoteProfileIds.length,
-			transport: {
-				ok: false,
-				output:
-					remoteProfileIds.length > 0
-						? `partial block sync after ${remoteProfileIds.length} profiles: ${
-								error instanceof Error
-									? error.message
-									: "xurl block sync failed"
-							}`
-						: error instanceof Error
-							? error.message
-							: "xurl block sync failed",
-			},
-		};
-	}
+				accountId: resolvedAccountId,
+				synced: true,
+				syncedCount: remoteProfileIds.length,
+				transport: {
+					ok: true,
+					output: `synced ${remoteProfileIds.length} remote blocks`,
+				},
+			};
+		}).pipe(
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false,
+					accountId: resolvedAccountId,
+					synced: remoteProfileIds.length > 0,
+					syncedCount: remoteProfileIds.length,
+					transport: {
+						ok: false,
+						output:
+							remoteProfileIds.length > 0
+								? `partial block sync after ${remoteProfileIds.length} profiles: ${error.message}`
+								: error.message,
+					},
+				}),
+			),
+		);
+	});
+}
+
+export function syncBlocks(accountId: string) {
+	return runEffectPromise(syncBlocksEffect(accountId));
 }

--- a/src/lib/bookmark-sync-job.test.ts
+++ b/src/lib/bookmark-sync-job.test.ts
@@ -3,11 +3,14 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	buildBookmarkSyncLaunchAgentPlist,
 	installBookmarkSyncLaunchAgent,
+	installBookmarkSyncLaunchAgentEffect,
 	runBookmarkSyncJob,
+	runBookmarkSyncJobEffect,
 } from "./bookmark-sync-job";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -28,6 +31,11 @@ Object.defineProperty(
 vi.mock("./timeline-collections-live", () => ({
 	syncTimelineCollection: (...args: unknown[]) =>
 		syncTimelineCollectionMock(...args),
+	syncTimelineCollectionEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncTimelineCollectionMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./backup", async (importOriginal) => {
@@ -36,6 +44,11 @@ vi.mock("./backup", async (importOriginal) => {
 		...actual,
 		maybeAutoSyncBackup: (...args: unknown[]) =>
 			maybeAutoSyncBackupMock(...args),
+		maybeAutoSyncBackupEffect: (...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => maybeAutoSyncBackupMock(...args),
+				catch: (error) => error,
+			}),
 	};
 });
 
@@ -64,6 +77,36 @@ afterEach(() => {
 });
 
 describe("bookmark sync job", () => {
+	it("builds bookmark sync jobs lazily as Effect programs", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-job-lazy-");
+		resetBirdclawPathsForTests();
+		const logPath = path.join(process.env.BIRDCLAW_HOME, "audit.jsonl");
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "xurl",
+			kind: "bookmarks",
+			accountId: "acct_primary",
+			count: 1,
+			payload: { data: [] },
+		});
+		maybeAutoSyncBackupMock.mockResolvedValue({
+			ok: true,
+			enabled: false,
+			skipped: true,
+		});
+
+		const effect = runBookmarkSyncJobEffect({ logPath, limit: 5 });
+
+		expect(existsSync(logPath)).toBe(false);
+		expect(syncTimelineCollectionMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			sync: { count: 1 },
+		});
+		expect(syncTimelineCollectionMock).toHaveBeenCalledTimes(1);
+		expect(readFileSync(logPath, "utf8")).toContain('"ok":true');
+	});
+
 	it("writes a successful JSONL audit entry", async () => {
 		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-job-");
 		resetBirdclawPathsForTests();
@@ -186,6 +229,31 @@ describe("bookmark sync job", () => {
 		expect(existsSync(result.plistPath)).toBe(true);
 		expect(execFileAsyncMock).not.toHaveBeenCalled();
 		expect(getNativeDb({ seedDemoData: false })).toBeTruthy();
+	});
+
+	it("builds launchd install effects lazily", async () => {
+		process.env.BIRDCLAW_HOME = makeTempDir("birdclaw-launchd-lazy-home-");
+		resetBirdclawPathsForTests();
+		const launchAgentsDir = makeTempDir("birdclaw-launchagents-lazy-");
+		const effect = installBookmarkSyncLaunchAgentEffect({
+			launchAgentsDir,
+			program: "/opt/homebrew/bin/birdclaw",
+			load: false,
+		});
+
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+		expect(
+			existsSync(
+				path.join(
+					launchAgentsDir,
+					"com.steipete.birdclaw.bookmarks-sync.plist",
+				),
+			),
+		).toBe(false);
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			loaded: false,
+		});
 	});
 
 	it("can source an env file before running the launchd command", () => {

--- a/src/lib/bookmark-sync-job.ts
+++ b/src/lib/bookmark-sync-job.ts
@@ -3,12 +3,17 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { Effect } from "effect";
 import type { Database } from "./sqlite";
-import { maybeAutoSyncBackup, type BackupAutoUpdateResult } from "./backup";
+import {
+	maybeAutoSyncBackupEffect,
+	type BackupAutoUpdateResult,
+} from "./backup";
 import { ensureBirdclawDirs, getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import {
-	syncTimelineCollection,
+	syncTimelineCollectionEffect,
 	type TimelineCollectionMode,
 } from "./timeline-collections-live";
 
@@ -124,53 +129,98 @@ function countBookmarks(db: Database) {
 	return row.count;
 }
 
-async function appendAuditEntry(
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+function appendAuditEntryEffect(
 	logPath: string,
 	entry: BookmarkSyncAuditEntry,
 ) {
-	await fs.mkdir(path.dirname(logPath), { recursive: true });
-	await fs.appendFile(logPath, `${JSON.stringify(entry)}\n`, "utf8");
+	return Effect.gen(function* () {
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(logPath), { recursive: true }),
+		);
+		yield* tryPromise(() =>
+			fs.appendFile(logPath, `${JSON.stringify(entry)}\n`, "utf8"),
+		);
+	});
 }
 
 function messageFromError(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
 }
 
-async function acquireLock(lockPath: string) {
-	await fs.mkdir(path.dirname(lockPath), { recursive: true });
-	try {
-		const handle = await fs.open(lockPath, "wx");
-		await handle.writeFile(
-			`${JSON.stringify({
-				pid: process.pid,
-				host: os.hostname(),
-				startedAt: new Date().toISOString(),
-			})}\n`,
-			"utf8",
+function isFileExistsError(error: unknown) {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "EEXIST"
+	);
+}
+
+function acquireLockEffect(
+	lockPath: string,
+): Effect.Effect<(() => Effect.Effect<void, never>) | undefined, unknown> {
+	return Effect.gen(function* () {
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(lockPath), { recursive: true }),
 		);
-		await handle.close();
-		return async () => {
-			await fs.rm(lockPath, { force: true });
-		};
-	} catch (error) {
-		if (
-			typeof error === "object" &&
-			error !== null &&
-			"code" in error &&
-			error.code === "EEXIST"
-		) {
-			const stats = await fs.stat(lockPath).catch(() => undefined);
+		const handleResult = yield* tryPromise(() => fs.open(lockPath, "wx")).pipe(
+			Effect.map((handle) => ({ handle, ok: true as const })),
+			Effect.catchAll((error) => {
+				if (isFileExistsError(error)) {
+					return Effect.succeed({ error, ok: false as const });
+				}
+				return Effect.fail(error);
+			}),
+		);
+
+		if (!handleResult.ok) {
+			const stats = yield* tryPromise(() => fs.stat(lockPath)).pipe(
+				Effect.catchAll(() => Effect.succeed(undefined)),
+			);
 			if (stats && Date.now() - stats.mtimeMs > DEFAULT_LOCK_STALE_MS) {
-				await fs.rm(lockPath, { force: true });
-				return acquireLock(lockPath);
+				yield* tryPromise(() => fs.rm(lockPath, { force: true }));
+				return yield* acquireLockEffect(lockPath);
 			}
 			return undefined;
 		}
-		throw error;
-	}
+
+		const { handle } = handleResult;
+		yield* tryPromise(() =>
+			handle.writeFile(
+				`${JSON.stringify({
+					pid: process.pid,
+					host: os.hostname(),
+					startedAt: new Date().toISOString(),
+				})}\n`,
+				"utf8",
+			),
+		).pipe(
+			Effect.ensuring(
+				tryPromise(() => handle.close()).pipe(
+					Effect.catchAll(() => Effect.void),
+				),
+			),
+		);
+		return () =>
+			tryPromise(() => fs.rm(lockPath, { force: true })).pipe(
+				Effect.asVoid,
+				Effect.catchAll(() => Effect.void),
+			);
+	});
 }
 
-export async function runBookmarkSyncJob({
+export function runBookmarkSyncJobEffect({
 	account,
 	mode = "auto",
 	limit = DEFAULT_BOOKMARK_SYNC_LIMIT,
@@ -181,107 +231,127 @@ export async function runBookmarkSyncJob({
 	logPath,
 	lockPath,
 	db,
-}: BookmarkSyncJobOptions = {}): Promise<BookmarkSyncAuditEntry> {
-	ensureBirdclawDirs();
-	const database = db ?? getNativeDb({ seedDemoData: false });
-	const resolvedLogPath = resolvePath(
-		logPath ?? getDefaultBookmarkSyncAuditLogPath(),
-	);
-	const resolvedLockPath = resolvePath(
-		lockPath ?? getDefaultBookmarkSyncLockPath(),
-	);
-	const effectiveAll = all ?? maxPages !== undefined;
-	const started = Date.now();
-	const startedAt = new Date(started).toISOString();
-	const before = { bookmarks: countBookmarks(database) };
-	const options = {
-		...(account ? { account } : {}),
-		mode,
-		limit,
-		all: effectiveAll,
-		...(maxPages === undefined ? {} : { maxPages }),
-		refresh,
-		...(cacheTtlMs === undefined ? {} : { cacheTtlMs }),
-	};
-
-	const releaseLock = await acquireLock(resolvedLockPath);
-	if (!releaseLock) {
-		const finished = Date.now();
-		const entry: BookmarkSyncAuditEntry = {
-			job: "bookmarks-sync",
-			ok: true,
-			startedAt,
-			finishedAt: new Date(finished).toISOString(),
-			durationMs: finished - started,
-			host: os.hostname(),
-			pid: process.pid,
-			options,
-			before,
-			after: before,
-			added: 0,
-			skipped: "already-running",
-		};
-		await appendAuditEntry(resolvedLogPath, entry);
-		return entry;
-	}
-
-	try {
-		const sync = await syncTimelineCollection({
-			kind: "bookmarks",
-			account,
+}: BookmarkSyncJobOptions = {}): Effect.Effect<
+	BookmarkSyncAuditEntry,
+	unknown
+> {
+	return Effect.gen(function* () {
+		yield* trySync(() => ensureBirdclawDirs());
+		const database =
+			db ?? (yield* trySync(() => getNativeDb({ seedDemoData: false })));
+		const resolvedLogPath = yield* trySync(() =>
+			resolvePath(logPath ?? getDefaultBookmarkSyncAuditLogPath()),
+		);
+		const resolvedLockPath = yield* trySync(() =>
+			resolvePath(lockPath ?? getDefaultBookmarkSyncLockPath()),
+		);
+		const effectiveAll = all ?? maxPages !== undefined;
+		const started = Date.now();
+		const startedAt = new Date(started).toISOString();
+		const before = yield* trySync(() => ({
+			bookmarks: countBookmarks(database),
+		}));
+		const options = {
+			...(account ? { account } : {}),
 			mode,
 			limit,
 			all: effectiveAll,
-			maxPages,
+			...(maxPages === undefined ? {} : { maxPages }),
 			refresh,
-			cacheTtlMs,
-		});
-		const backup = await maybeAutoSyncBackup(database);
-		const finished = Date.now();
-		const after = { bookmarks: countBookmarks(database) };
-		const entry: BookmarkSyncAuditEntry = {
-			job: "bookmarks-sync",
-			ok: true,
-			startedAt,
-			finishedAt: new Date(finished).toISOString(),
-			durationMs: finished - started,
-			host: os.hostname(),
-			pid: process.pid,
-			options,
-			before,
-			after,
-			added: Math.max(0, after.bookmarks - before.bookmarks),
-			sync: {
-				source: sync.source,
-				count: sync.count,
-				accountId: sync.accountId,
-			},
-			backup,
+			...(cacheTtlMs === undefined ? {} : { cacheTtlMs }),
 		};
-		await appendAuditEntry(resolvedLogPath, entry);
-		return entry;
-	} catch (error) {
-		const finished = Date.now();
-		const after = { bookmarks: countBookmarks(database) };
-		const entry: BookmarkSyncAuditEntry = {
-			job: "bookmarks-sync",
-			ok: false,
-			startedAt,
-			finishedAt: new Date(finished).toISOString(),
-			durationMs: finished - started,
-			host: os.hostname(),
-			pid: process.pid,
-			options,
-			before,
-			after,
-			added: Math.max(0, after.bookmarks - before.bookmarks),
-			error: messageFromError(error),
-		};
-		await appendAuditEntry(resolvedLogPath, entry);
-		return entry;
-	} finally {
-		await releaseLock();
-	}
+
+		const releaseLock = yield* acquireLockEffect(resolvedLockPath);
+		if (!releaseLock) {
+			const finished = Date.now();
+			const entry: BookmarkSyncAuditEntry = {
+				job: "bookmarks-sync",
+				ok: true,
+				startedAt,
+				finishedAt: new Date(finished).toISOString(),
+				durationMs: finished - started,
+				host: os.hostname(),
+				pid: process.pid,
+				options,
+				before,
+				after: before,
+				added: 0,
+				skipped: "already-running",
+			};
+			yield* appendAuditEntryEffect(resolvedLogPath, entry);
+			return entry;
+		}
+
+		return yield* Effect.gen(function* () {
+			const result = yield* Effect.gen(function* () {
+				const sync = yield* syncTimelineCollectionEffect({
+					kind: "bookmarks",
+					account,
+					mode,
+					limit,
+					all: effectiveAll,
+					maxPages,
+					refresh,
+					cacheTtlMs,
+				});
+				const backup = yield* maybeAutoSyncBackupEffect(database);
+				const finished = Date.now();
+				const after = yield* trySync(() => ({
+					bookmarks: countBookmarks(database),
+				}));
+				return {
+					job: "bookmarks-sync",
+					ok: true,
+					startedAt,
+					finishedAt: new Date(finished).toISOString(),
+					durationMs: finished - started,
+					host: os.hostname(),
+					pid: process.pid,
+					options,
+					before,
+					after,
+					added: Math.max(0, after.bookmarks - before.bookmarks),
+					sync: {
+						source: sync.source,
+						count: sync.count,
+						accountId: sync.accountId,
+					},
+					backup,
+				} satisfies BookmarkSyncAuditEntry;
+			}).pipe(
+				Effect.catchAll((error) =>
+					Effect.gen(function* () {
+						const finished = Date.now();
+						const after = yield* trySync(() => ({
+							bookmarks: countBookmarks(database),
+						}));
+						return {
+							job: "bookmarks-sync",
+							ok: false,
+							startedAt,
+							finishedAt: new Date(finished).toISOString(),
+							durationMs: finished - started,
+							host: os.hostname(),
+							pid: process.pid,
+							options,
+							before,
+							after,
+							added: Math.max(0, after.bookmarks - before.bookmarks),
+							error: messageFromError(error),
+						} satisfies BookmarkSyncAuditEntry;
+					}),
+				),
+			);
+			yield* appendAuditEntryEffect(resolvedLogPath, result);
+			return result;
+		}).pipe(Effect.ensuring(releaseLock()));
+	});
+}
+
+export function runBookmarkSyncJob(
+	options: BookmarkSyncJobOptions = {},
+): Promise<BookmarkSyncAuditEntry> {
+	return runEffectPromise(runBookmarkSyncJobEffect(options));
 }
 
 function xmlEscape(value: string) {
@@ -409,38 +479,58 @@ export function buildBookmarkSyncLaunchAgentPlist(
 	};
 }
 
-export async function installBookmarkSyncLaunchAgent(
+export function installBookmarkSyncLaunchAgentEffect(
+	options: BookmarkSyncLaunchAgentOptions = {},
+): Effect.Effect<BookmarkSyncLaunchAgentInstallResult, unknown> {
+	return Effect.gen(function* () {
+		yield* trySync(() => ensureBirdclawDirs());
+		const agent = yield* trySync(() =>
+			buildBookmarkSyncLaunchAgentPlist(options),
+		);
+		const launchAgentsDir = yield* trySync(() =>
+			resolvePath(options.launchAgentsDir ?? "~/Library/LaunchAgents"),
+		);
+		const plistPath = path.join(launchAgentsDir, `${agent.label}.plist`);
+		yield* tryPromise(() => fs.mkdir(launchAgentsDir, { recursive: true }));
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(agent.logPath), { recursive: true }),
+		);
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(agent.stdoutPath), { recursive: true }),
+		);
+		yield* tryPromise(() =>
+			fs.mkdir(path.dirname(agent.stderrPath), { recursive: true }),
+		);
+		yield* tryPromise(() => fs.writeFile(plistPath, agent.plist, "utf8"));
+
+		let loaded = false;
+		if (options.load !== false) {
+			yield* tryPromise(() =>
+				execFileAsync("launchctl", ["unload", plistPath]),
+			).pipe(Effect.catchAll(() => Effect.void));
+			yield* tryPromise(() =>
+				execFileAsync("launchctl", ["load", "-w", plistPath]),
+			);
+			loaded = true;
+		}
+
+		return {
+			ok: true,
+			label: agent.label,
+			plistPath,
+			loaded,
+			programArguments: agent.programArguments,
+			logPath: agent.logPath,
+			stdoutPath: agent.stdoutPath,
+			stderrPath: agent.stderrPath,
+			intervalSeconds: agent.intervalSeconds,
+			...(agent.envFile ? { envFile: agent.envFile } : {}),
+		};
+	});
+}
+
+export function installBookmarkSyncLaunchAgent(
 	options: BookmarkSyncLaunchAgentOptions = {},
 ): Promise<BookmarkSyncLaunchAgentInstallResult> {
-	ensureBirdclawDirs();
-	const agent = buildBookmarkSyncLaunchAgentPlist(options);
-	const launchAgentsDir = resolvePath(
-		options.launchAgentsDir ?? "~/Library/LaunchAgents",
-	);
-	const plistPath = path.join(launchAgentsDir, `${agent.label}.plist`);
-	await fs.mkdir(launchAgentsDir, { recursive: true });
-	await fs.mkdir(path.dirname(agent.logPath), { recursive: true });
-	await fs.mkdir(path.dirname(agent.stdoutPath), { recursive: true });
-	await fs.mkdir(path.dirname(agent.stderrPath), { recursive: true });
-	await fs.writeFile(plistPath, agent.plist, "utf8");
-
-	let loaded = false;
-	if (options.load !== false) {
-		await execFileAsync("launchctl", ["unload", plistPath]).catch(() => {});
-		await execFileAsync("launchctl", ["load", "-w", plistPath]);
-		loaded = true;
-	}
-
-	return {
-		ok: true,
-		label: agent.label,
-		plistPath,
-		loaded,
-		programArguments: agent.programArguments,
-		logPath: agent.logPath,
-		stdoutPath: agent.stdoutPath,
-		stderrPath: agent.stderrPath,
-		intervalSeconds: agent.intervalSeconds,
-		...(agent.envFile ? { envFile: agent.envFile } : {}),
-	};
+	return runEffectPromise(installBookmarkSyncLaunchAgentEffect(options));
 }

--- a/src/lib/conversation-surface.test.tsx
+++ b/src/lib/conversation-surface.test.tsx
@@ -5,9 +5,11 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	ConversationSurfaceScope,
+	loadConversationEffect,
 	resetConversationSurface,
 	useConversationSurface,
 } from "./conversation-surface";
@@ -86,6 +88,50 @@ describe("conversation surface", () => {
 		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
 		expect(screen.getByTestId("open")).toHaveTextContent("open");
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the original in-flight load locked across duplicate open attempts", async () => {
+		let resolvePending!: (value: ConversationResponse) => void;
+		const pending = new Promise<ConversationResponse>((resolve) => {
+			resolvePending = resolve;
+		});
+		const fetchMock = vi.fn().mockReturnValue(pending);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<ConversationSurfaceScope>
+				<Probe tweetId="tweet_1" />
+			</ConversationSurfaceScope>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "prefetch" }));
+		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+		fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		resolvePending({
+			ok: true,
+			json: async () => ({ items: [tweet], ok: true }),
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("status")).toHaveTextContent("ready");
+		});
+	});
+
+	it("exposes conversation loading as a lazy Effect program", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ items: [tweet], ok: true }),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const effect = loadConversationEffect("tweet_1");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toBeUndefined();
+		expect(fetchMock).toHaveBeenCalledWith("/api/conversation?tweetId=tweet_1");
 	});
 
 	it("stores load errors and ignores results after reset", async () => {

--- a/src/lib/conversation-surface.ts
+++ b/src/lib/conversation-surface.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { ReactNode } from "react";
+import { Effect } from "effect";
 import type { EmbeddedTweet } from "#/lib/types";
+import { runEffectPromise } from "./effect-runtime";
 
 type ConversationStatus = "idle" | "loading" | "ready" | "error";
 
@@ -60,53 +62,80 @@ function getSnapshot() {
 	return snapshot;
 }
 
-async function loadConversation(tweetId: string) {
-	const current = snapshot.records.get(tweetId);
-	if (current?.status === "ready" || inFlight.has(tweetId)) {
-		return;
-	}
-
-	const loadGeneration = generation;
-	inFlight.add(tweetId);
-	updateRecord(tweetId, {
-		error: null,
-		items: current?.items ?? [],
-		status: "loading",
-	});
-
-	try {
-		const response = await fetch(
-			`/api/conversation?tweetId=${encodeURIComponent(tweetId)}`,
-		);
-		const data = (await response.json()) as {
+function fetchConversationItemsEffect(tweetId: string) {
+	return Effect.gen(function* () {
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				fetch(`/api/conversation?tweetId=${encodeURIComponent(tweetId)}`),
+			catch: (error) => error,
+		});
+		const data = (yield* Effect.tryPromise({
+			try: () => response.json(),
+			catch: (error) => error,
+		})) as {
 			error?: string;
 			items?: EmbeddedTweet[];
 			ok?: boolean;
 		};
 		if (!response.ok || data.ok === false) {
-			throw new Error(data.error ?? "Conversation unavailable");
+			return yield* Effect.fail(
+				new Error(data.error ?? "Conversation unavailable"),
+			);
 		}
-		if (loadGeneration !== generation) {
+		return (data.items ?? []).filter(Boolean);
+	});
+}
+
+export function loadConversationEffect(
+	tweetId: string,
+): Effect.Effect<void, never> {
+	return Effect.gen(function* () {
+		const current = snapshot.records.get(tweetId);
+		if (current?.status === "ready" || inFlight.has(tweetId)) {
 			return;
 		}
-		updateRecord(tweetId, {
-			error: null,
-			items: (data.items ?? []).filter(Boolean),
-			status: "ready",
-		});
-	} catch (error) {
-		if (loadGeneration !== generation) {
-			return;
-		}
-		updateRecord(tweetId, {
-			error:
-				error instanceof Error ? error.message : "Conversation unavailable",
-			items: [],
-			status: "error",
-		});
-	} finally {
-		inFlight.delete(tweetId);
-	}
+
+		const loadGeneration = generation;
+		inFlight.add(tweetId);
+		yield* Effect.gen(function* () {
+			updateRecord(tweetId, {
+				error: null,
+				items: current?.items ?? [],
+				status: "loading",
+			});
+
+			const result = yield* fetchConversationItemsEffect(tweetId).pipe(
+				Effect.match({
+					onFailure: (error) => ({ error, ok: false as const }),
+					onSuccess: (items) => ({ items, ok: true as const }),
+				}),
+			);
+
+			if (loadGeneration !== generation) {
+				return;
+			}
+			if (result.ok) {
+				updateRecord(tweetId, {
+					error: null,
+					items: result.items,
+					status: "ready",
+				});
+			} else {
+				updateRecord(tweetId, {
+					error:
+						result.error instanceof Error
+							? result.error.message
+							: "Conversation unavailable",
+					items: [],
+					status: "error",
+				});
+			}
+		}).pipe(Effect.ensuring(Effect.sync(() => inFlight.delete(tweetId))));
+	});
+}
+
+function loadConversation(tweetId: string) {
+	return runEffectPromise(loadConversationEffect(tweetId));
 }
 
 export function retainConversationSurfaceScope() {

--- a/src/lib/dms-live.test.ts
+++ b/src/lib/dms-live.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getConversationThread, listDmConversations } from "./queries";
@@ -9,10 +10,18 @@ import { resetDatabaseForTests } from "./db";
 
 const listDirectMessagesViaBirdMock = vi.fn();
 
-vi.mock("./bird", () => ({
-	listDirectMessagesViaBird: (...args: unknown[]) =>
-		listDirectMessagesViaBirdMock(...args),
-}));
+vi.mock("./bird", async () => {
+	const { Effect } = await import("effect");
+	return {
+		listDirectMessagesViaBird: (...args: unknown[]) =>
+			listDirectMessagesViaBirdMock(...args),
+		listDirectMessagesViaBirdEffect: (...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => listDirectMessagesViaBirdMock(...args),
+				catch: (error) => error,
+			}),
+	};
+});
 
 const tempDirs: string[] = [];
 
@@ -36,6 +45,31 @@ describe("cached live DMs", () => {
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("keeps cached DM sync effects lazy", async () => {
+		makeTempHome();
+		listDirectMessagesViaBirdMock.mockResolvedValueOnce({
+			success: true,
+			conversations: [],
+			events: [],
+		});
+		const { syncDirectMessagesViaCachedBirdEffect } =
+			await import("./dms-live");
+
+		const effect = syncDirectMessagesViaCachedBirdEffect({
+			account: "acct_primary",
+			limit: 5,
+			refresh: true,
+		});
+
+		expect(listDirectMessagesViaBirdMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			source: "bird",
+			conversations: 0,
+			messages: 0,
+		});
+		expect(listDirectMessagesViaBirdMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("fetches bird DMs, caches them, and syncs them into the local store", async () => {

--- a/src/lib/dms-live.ts
+++ b/src/lib/dms-live.ts
@@ -1,16 +1,25 @@
+import { Effect } from "effect";
 import type { Database } from "./sqlite";
 import {
 	type BirdDmConversation,
 	type BirdDmEvent,
 	type BirdDmUser,
-	listDirectMessagesViaBird,
+	listDirectMessagesViaBirdEffect,
 } from "./bird";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type { XurlMentionUser } from "./types";
 import { upsertProfileFromXUser } from "./x-profile";
 
 export const DEFAULT_DMS_CACHE_TTL_MS = 2 * 60_000;
+
+export interface SyncDirectMessagesViaCachedBirdOptions {
+	account?: string;
+	limit?: number;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+}
 
 function parseCacheTtlMs(value?: number) {
 	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
@@ -230,50 +239,62 @@ function mergeDirectMessagesIntoLocalStore(
 	})();
 }
 
-export async function syncDirectMessagesViaCachedBird({
+export function syncDirectMessagesViaCachedBirdEffect({
 	account,
 	limit = 20,
 	refresh = false,
 	cacheTtlMs,
-}: {
-	account?: string;
-	limit?: number;
-	refresh?: boolean;
-	cacheTtlMs?: number;
-}) {
-	assertBirdLimit(limit);
-	const db = getNativeDb();
-	const resolvedAccount = resolveAccount(db, account);
-	const cacheKey = `dms:bird:${resolvedAccount.accountId}:${String(limit)}`;
-	const ttlMs = parseCacheTtlMs(cacheTtlMs);
-	const cached = readSyncCache<{
-		conversations: BirdDmConversation[];
-		events: BirdDmEvent[];
-	}>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
+}: SyncDirectMessagesViaCachedBirdOptions = {}): Effect.Effect<
+	{
+		ok: true;
+		source: "bird" | "cache";
+		accountId: string;
+		conversations: number;
+		messages: number;
+	},
+	unknown
+> {
+	return Effect.gen(function* () {
+		assertBirdLimit(limit);
+		const db = getNativeDb();
+		const resolvedAccount = resolveAccount(db, account);
+		const cacheKey = `dms:bird:${resolvedAccount.accountId}:${String(limit)}`;
+		const ttlMs = parseCacheTtlMs(cacheTtlMs);
+		const cached = readSyncCache<{
+			conversations: BirdDmConversation[];
+			events: BirdDmEvent[];
+		}>(cacheKey, db);
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
 
-	const payload =
-		!refresh && cached && cacheAgeMs <= ttlMs
-			? cached.value
-			: await listDirectMessagesViaBird({ maxResults: limit });
+		const payload =
+			!refresh && cached && cacheAgeMs <= ttlMs
+				? cached.value
+				: yield* listDirectMessagesViaBirdEffect({ maxResults: limit });
 
-	mergeDirectMessagesIntoLocalStore(
-		db,
-		resolvedAccount.accountId,
-		resolvedAccount.username,
-		payload,
-	);
-	if (!cached || refresh || cacheAgeMs > ttlMs) {
-		writeSyncCache(cacheKey, payload, db);
-	}
+		mergeDirectMessagesIntoLocalStore(
+			db,
+			resolvedAccount.accountId,
+			resolvedAccount.username,
+			payload,
+		);
+		if (!cached || refresh || cacheAgeMs > ttlMs) {
+			writeSyncCache(cacheKey, payload, db);
+		}
 
-	return {
-		ok: true,
-		source: cached && !refresh && cacheAgeMs <= ttlMs ? "cache" : "bird",
-		accountId: resolvedAccount.accountId,
-		conversations: payload.conversations.length,
-		messages: payload.events.length,
-	};
+		return {
+			ok: true,
+			source: cached && !refresh && cacheAgeMs <= ttlMs ? "cache" : "bird",
+			accountId: resolvedAccount.accountId,
+			conversations: payload.conversations.length,
+			messages: payload.events.length,
+		} as const;
+	});
+}
+
+export function syncDirectMessagesViaCachedBird(
+	options: SyncDirectMessagesViaCachedBirdOptions = {},
+) {
+	return runEffectPromise(syncDirectMessagesViaCachedBirdEffect(options));
 }

--- a/src/lib/effect-runtime.test.ts
+++ b/src/lib/effect-runtime.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
+
+describe("effect runtime boundary", () => {
+	it("throws original promise errors instead of UnknownException wrappers", async () => {
+		const original = Object.assign(new Error("socket reset"), {
+			code: "ECONNRESET",
+		});
+
+		let rejected: unknown;
+		try {
+			await runEffectPromise(tryPromise(() => Promise.reject(original)));
+		} catch (error) {
+			rejected = error;
+		}
+
+		expect(rejected).toBe(original);
+		expect(String(rejected)).not.toContain("UnknownException");
+	});
+});

--- a/src/lib/effect-runtime.ts
+++ b/src/lib/effect-runtime.ts
@@ -1,0 +1,21 @@
+import { Cause, Effect, Exit, Option } from "effect";
+
+export function tryPromise<A>(
+	try_: () => PromiseLike<A>,
+): Effect.Effect<A, unknown> {
+	return Effect.tryPromise({
+		try: try_,
+		catch: (cause) => cause,
+	});
+}
+
+export function runEffectPromise<A, E>(
+	effect: Effect.Effect<A, E>,
+): Promise<A> {
+	return Effect.runPromiseExit(effect).then((exit) => {
+		if (Exit.isSuccess(exit)) return exit.value;
+		const failure = Cause.failureOption(exit.cause);
+		if (Option.isSome(failure)) throw failure.value;
+		throw Cause.squash(exit.cause);
+	});
+}

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -14,6 +15,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	listFollowUsersViaBird: mocks.listFollowUsersViaBird,
+	listFollowUsersViaBirdEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listFollowUsersViaBird(options),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./xurl", () => ({
@@ -118,6 +124,31 @@ describe("follow graph sync and cache-only queries", () => {
 			all: true,
 			maxPages: undefined,
 		});
+		expect(mocks.listFollowUsersViaXurl).not.toHaveBeenCalled();
+	});
+
+	it("builds live sync effects lazily", async () => {
+		setupTempHome();
+		mocks.listFollowUsersViaBird.mockReset();
+		mocks.listFollowUsersViaBird.mockResolvedValueOnce({
+			data: [user("1", "alice", 100)],
+			meta: { result_count: 1, page_count: 1, next_token: null },
+		});
+		const { syncFollowGraphEffect } = await import("./follow-graph");
+
+		const effect = syncFollowGraphEffect({
+			direction: "followers",
+			yes: true,
+			refresh: true,
+		});
+
+		expect(mocks.listFollowUsersViaBird).not.toHaveBeenCalled();
+		expect(await Effect.runPromise(effect)).toMatchObject({
+			ok: true,
+			source: "bird",
+			count: 1,
+		});
+		expect(mocks.listFollowUsersViaBird).toHaveBeenCalledTimes(1);
 		expect(mocks.listFollowUsersViaXurl).not.toHaveBeenCalled();
 	});
 

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
-import { listFollowUsersViaBird } from "./bird";
+import { listFollowUsersViaBirdEffect } from "./bird";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { Database } from "./sqlite";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type {
@@ -37,6 +39,17 @@ export interface SyncFollowGraphOptions {
 
 type FollowGraphSyncMode = "auto" | "bird" | "xurl";
 type FollowGraphLiveSource = "bird" | "xurl";
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
 
 interface ResolvedAccount {
 	accountId: string;
@@ -238,7 +251,7 @@ function mergePages(
 	};
 }
 
-async function fetchFollowGraphViaXurl({
+function fetchFollowGraphViaXurlEffect({
 	direction,
 	username,
 	userId,
@@ -252,37 +265,41 @@ async function fetchFollowGraphViaXurl({
 	limit: number;
 	maxPages?: number;
 	maxResources?: number;
-}): Promise<MergedFollowPayload> {
-	const pages: XurlFollowUsersResponse[] = [];
-	let nextToken: string | undefined;
-	let pageCount = 0;
-	let collectedCount = 0;
+}): Effect.Effect<MergedFollowPayload, unknown> {
+	return Effect.gen(function* () {
+		const pages: XurlFollowUsersResponse[] = [];
+		let nextToken: string | undefined;
+		let pageCount = 0;
+		let collectedCount = 0;
 
-	do {
-		const payload = await listFollowUsersViaXurl({
-			direction,
-			username,
-			userId,
-			maxResults: limit,
-			paginationToken: nextToken,
-		});
-		pages.push(payload);
-		collectedCount += payload.data.length;
-		nextToken =
-			typeof payload.meta?.next_token === "string"
-				? String(payload.meta.next_token)
-				: undefined;
-		pageCount += 1;
-	} while (
-		nextToken &&
-		(maxPages === undefined || pageCount < maxPages) &&
-		(maxResources === undefined || collectedCount < maxResources)
-	);
+		do {
+			const payload = yield* tryPromise(() =>
+				listFollowUsersViaXurl({
+					direction,
+					username,
+					userId,
+					maxResults: limit,
+					paginationToken: nextToken,
+				}),
+			);
+			pages.push(payload);
+			collectedCount += payload.data.length;
+			nextToken =
+				typeof payload.meta?.next_token === "string"
+					? String(payload.meta.next_token)
+					: undefined;
+			pageCount += 1;
+		} while (
+			nextToken &&
+			(maxPages === undefined || pageCount < maxPages) &&
+			(maxResources === undefined || collectedCount < maxResources)
+		);
 
-	return mergePages(pages, nextToken, maxResources);
+		return mergePages(pages, nextToken, maxResources);
+	});
 }
 
-async function fetchFollowGraphViaBird({
+function fetchFollowGraphViaBirdEffect({
 	direction,
 	userId,
 	limit,
@@ -294,32 +311,34 @@ async function fetchFollowGraphViaBird({
 	limit: number;
 	maxPages?: number;
 	maxResources?: number;
-}): Promise<MergedFollowPayload> {
-	const birdLimit = Math.min(limit, BIRD_FOLLOW_PAGE_LIMIT);
-	const cappedMaxPages =
-		maxResources === undefined
-			? maxPages
-			: Math.min(
-					maxPages ?? Number.POSITIVE_INFINITY,
-					Math.ceil(maxResources / birdLimit),
-				);
-	const payload = await listFollowUsersViaBird({
-		direction,
-		userId,
-		maxResults: Math.min(birdLimit, maxResources ?? birdLimit),
-		all: true,
-		maxPages: Number.isFinite(cappedMaxPages) ? cappedMaxPages : undefined,
+}): Effect.Effect<MergedFollowPayload, unknown> {
+	return Effect.gen(function* () {
+		const birdLimit = Math.min(limit, BIRD_FOLLOW_PAGE_LIMIT);
+		const cappedMaxPages =
+			maxResources === undefined
+				? maxPages
+				: Math.min(
+						maxPages ?? Number.POSITIVE_INFINITY,
+						Math.ceil(maxResources / birdLimit),
+					);
+		const payload = yield* listFollowUsersViaBirdEffect({
+			direction,
+			userId,
+			maxResults: Math.min(birdLimit, maxResources ?? birdLimit),
+			all: true,
+			maxPages: Number.isFinite(cappedMaxPages) ? cappedMaxPages : undefined,
+		});
+		return mergePages(
+			[payload],
+			typeof payload.meta?.next_token === "string"
+				? String(payload.meta.next_token)
+				: undefined,
+			maxResources,
+		);
 	});
-	return mergePages(
-		[payload],
-		typeof payload.meta?.next_token === "string"
-			? String(payload.meta.next_token)
-			: undefined,
-		maxResources,
-	);
 }
 
-async function fetchFollowGraph({
+function fetchFollowGraphEffect({
 	mode,
 	direction,
 	username,
@@ -335,49 +354,27 @@ async function fetchFollowGraph({
 	limit: number;
 	maxPages?: number;
 	maxResources?: number;
-}): Promise<{ source: FollowGraphLiveSource; payload: MergedFollowPayload }> {
-	if (mode === "bird") {
-		return {
-			source: "bird",
-			payload: await fetchFollowGraphViaBird({
-				direction,
-				userId,
-				limit,
-				maxPages,
-				maxResources,
-			}),
-		};
-	}
-	if (mode === "xurl") {
-		return {
-			source: "xurl",
-			payload: await fetchFollowGraphViaXurl({
-				direction,
-				username,
-				userId,
-				limit,
-				maxPages,
-				maxResources,
-			}),
-		};
-	}
-
-	try {
-		return {
-			source: "bird",
-			payload: await fetchFollowGraphViaBird({
-				direction,
-				userId,
-				limit,
-				maxPages,
-				maxResources,
-			}),
-		};
-	} catch (birdError) {
-		try {
+}): Effect.Effect<
+	{ source: FollowGraphLiveSource; payload: MergedFollowPayload },
+	unknown
+> {
+	return Effect.gen(function* () {
+		if (mode === "bird") {
+			return {
+				source: "bird",
+				payload: yield* fetchFollowGraphViaBirdEffect({
+					direction,
+					userId,
+					limit,
+					maxPages,
+					maxResources,
+				}),
+			};
+		}
+		if (mode === "xurl") {
 			return {
 				source: "xurl",
-				payload: await fetchFollowGraphViaXurl({
+				payload: yield* fetchFollowGraphViaXurlEffect({
 					direction,
 					username,
 					userId,
@@ -386,14 +383,51 @@ async function fetchFollowGraph({
 					maxResources,
 				}),
 			};
-		} catch (xurlError) {
-			throw new Error(
-				`follow graph sync failed via bird and xurl: bird: ${errorMessage(
-					birdError,
-				)}; xurl: ${errorMessage(xurlError)}`,
-			);
 		}
-	}
+
+		const birdResult = yield* fetchFollowGraphViaBirdEffect({
+			direction,
+			userId,
+			limit,
+			maxPages,
+			maxResources,
+		}).pipe(
+			Effect.map((payload) => ({ ok: true as const, payload })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (birdResult.ok) {
+			return {
+				source: "bird",
+				payload: birdResult.payload,
+			};
+		}
+
+		const xurlResult = yield* fetchFollowGraphViaXurlEffect({
+			direction,
+			username,
+			userId,
+			limit,
+			maxPages,
+			maxResources,
+		}).pipe(
+			Effect.map((payload) => ({ ok: true as const, payload })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (xurlResult.ok) {
+			return {
+				source: "xurl",
+				payload: xurlResult.payload,
+			};
+		}
+
+		return yield* Effect.fail(
+			new Error(
+				`follow graph sync failed via bird and xurl: bird: ${errorMessage(
+					birdResult.error,
+				)}; xurl: ${errorMessage(xurlResult.error)}`,
+			),
+		);
+	});
 }
 
 function getExistingEdges(
@@ -620,98 +654,108 @@ function errorMessage(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
 }
 
-export async function syncFollowGraph(options: SyncFollowGraphOptions) {
-	const db = getNativeDb();
-	const mode = parseMode(options.mode);
-	const limit = parseLimit(options.limit);
-	const maxPages = parseOptionalPositiveInteger(
-		"--max-pages",
-		options.maxPages,
-	);
-	const maxResources = parseOptionalPositiveInteger(
-		"--max-resources",
-		options.maxResources,
-	);
-	const cacheTtlMs = parseCacheTtlMs(options.cacheTtlMs);
-	const account = resolveAccount(db, options.account);
-	const cacheKey = buildCacheKey({
-		direction: options.direction,
-		accountId: account.accountId,
-		mode,
-		limit,
-		maxPages,
-		maxResources,
-	});
-
-	if (!options.yes) {
-		return makeDryRunResponse({
-			db,
-			account,
+export function syncFollowGraphEffect(options: SyncFollowGraphOptions) {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const mode = yield* trySync(() => parseMode(options.mode));
+		const limit = yield* trySync(() => parseLimit(options.limit));
+		const maxPages = yield* trySync(() =>
+			parseOptionalPositiveInteger("--max-pages", options.maxPages),
+		);
+		const maxResources = yield* trySync(() =>
+			parseOptionalPositiveInteger("--max-resources", options.maxResources),
+		);
+		const cacheTtlMs = parseCacheTtlMs(options.cacheTtlMs);
+		const account = yield* trySync(() => resolveAccount(db, options.account));
+		const cacheKey = buildCacheKey({
 			direction: options.direction,
+			accountId: account.accountId,
 			mode,
 			limit,
 			maxPages,
 			maxResources,
-			cacheKey,
-			cacheTtlMs,
 		});
-	}
 
-	const cached = readSyncCache<MergedFollowPayload>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
-	const useCache = Boolean(
-		!options.refresh && cached && cacheAgeMs <= cacheTtlMs,
-	);
+		if (!options.yes) {
+			return yield* trySync(() =>
+				makeDryRunResponse({
+					db,
+					account,
+					direction: options.direction,
+					mode,
+					limit,
+					maxPages,
+					maxResources,
+					cacheKey,
+					cacheTtlMs,
+				}),
+			);
+		}
 
-	const liveResult = useCache
-		? undefined
-		: await fetchFollowGraph({
-				mode,
+		const cached = yield* trySync(() =>
+			readSyncCache<MergedFollowPayload>(cacheKey, db),
+		);
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
+		const useCache = Boolean(
+			!options.refresh && cached && cacheAgeMs <= cacheTtlMs,
+		);
+
+		const liveResult = useCache
+			? undefined
+			: yield* fetchFollowGraphEffect({
+					mode,
+					direction: options.direction,
+					username: account.username,
+					userId: account.externalUserId,
+					limit,
+					maxPages,
+					maxResources,
+				});
+		const payload = useCache ? cached!.value : liveResult!.payload;
+
+		if (!useCache) {
+			yield* trySync(() => writeSyncCache(cacheKey, payload, db));
+		}
+
+		const mergeResult = yield* trySync(() =>
+			mergeFollowPayloadIntoLocalStore({
+				db,
+				accountId: account.accountId,
 				direction: options.direction,
-				username: account.username,
-				userId: account.externalUserId,
-				limit,
-				maxPages,
-				maxResources,
-			});
-	const payload = useCache ? cached!.value : liveResult!.payload;
+				payload,
+				source: useCache ? "cache" : liveResult!.source,
+			}),
+		);
 
-	if (!useCache) {
-		writeSyncCache(cacheKey, payload, db);
-	}
-
-	const mergeResult = mergeFollowPayloadIntoLocalStore({
-		db,
-		accountId: account.accountId,
-		direction: options.direction,
-		payload,
-		source: useCache ? "cache" : liveResult!.source,
+		return {
+			ok: true,
+			dryRun: false,
+			source: useCache ? "cache" : liveResult!.source,
+			mode,
+			direction: options.direction,
+			accountId: account.accountId,
+			status: mergeResult.status,
+			count: mergeResult.count,
+			pageCount: mergeResult.pageCount,
+			snapshotId: mergeResult.snapshotId,
+			partial: mergeResult.status === "incomplete",
+			cache: {
+				key: cacheKey,
+				reused: useCache,
+				updatedAt: useCache ? cached?.updatedAt : new Date().toISOString(),
+			},
+			warning:
+				mergeResult.status === "incomplete" && !options.allowPartial
+					? "Snapshot is incomplete because a page/resource cap stopped pagination. It was recorded but not used for churn events."
+					: undefined,
+		};
 	});
+}
 
-	return {
-		ok: true,
-		dryRun: false,
-		source: useCache ? "cache" : liveResult!.source,
-		mode,
-		direction: options.direction,
-		accountId: account.accountId,
-		status: mergeResult.status,
-		count: mergeResult.count,
-		pageCount: mergeResult.pageCount,
-		snapshotId: mergeResult.snapshotId,
-		partial: mergeResult.status === "incomplete",
-		cache: {
-			key: cacheKey,
-			reused: useCache,
-			updatedAt: useCache ? cached?.updatedAt : new Date().toISOString(),
-		},
-		warning:
-			mergeResult.status === "incomplete" && !options.allowPartial
-				? "Snapshot is incomplete because a page/resource cap stopped pagination. It was recorded but not used for churn events."
-				: undefined,
-	};
+export function syncFollowGraph(options: SyncFollowGraphOptions) {
+	return runEffectPromise(syncFollowGraphEffect(options));
 }
 
 function toGraphProfile(row: Record<string, unknown>): FollowGraphProfile {

--- a/src/lib/inbox.test.ts
+++ b/src/lib/inbox.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -9,9 +10,14 @@ import { listInboxItems, scoreInbox } from "./inbox";
 
 const scoreMock = vi.fn();
 
-vi.mock("./openai", () => ({
-	scoreInboxItemWithOpenAI: (...args: unknown[]) => scoreMock(...args),
-}));
+vi.mock("./openai", async () => {
+	const { Effect } = await import("effect");
+	return {
+		scoreInboxItemWithOpenAI: (...args: unknown[]) => scoreMock(...args),
+		scoreInboxItemWithOpenAIEffect: (...args: unknown[]) =>
+			Effect.tryPromise(() => scoreMock(...args)),
+	};
+});
 
 const tempRoots: string[] = [];
 
@@ -103,6 +109,24 @@ describe("inbox", () => {
 			score: 66,
 			summary: "Worth it",
 			reasoning: "Specific ask",
+		});
+	});
+
+	it("exposes inbox scoring as a lazy Effect program", async () => {
+		setupTempHome();
+		scoreMock.mockResolvedValue({
+			model: "gpt-test",
+			score: 66,
+			summary: "Worth it",
+			reasoning: "Specific ask",
+		});
+		const { scoreInboxEffect } = await import("./inbox");
+
+		const effect = scoreInboxEffect({ kind: "mentions", limit: 1 });
+		expect(scoreMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			scored: 1,
 		});
 	});
 });

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -1,5 +1,7 @@
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
-import { scoreInboxItemWithOpenAI } from "./openai";
+import { runEffectPromise } from "./effect-runtime";
+import { scoreInboxItemWithOpenAIEffect } from "./openai";
 import { listDmConversations, listTimelineItems } from "./queries";
 import type { InboxItem, InboxQuery, InboxResponse } from "./types";
 
@@ -151,30 +153,44 @@ export function listInboxItems({
 	};
 }
 
-export async function scoreInbox({
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+export function scoreInboxEffect({
 	kind = "mixed",
 	limit = 8,
 }: Pick<InboxQuery, "kind" | "limit"> = {}) {
-	const db = getNativeDb();
-	const items = listInboxItems({ kind, limit }).items;
-	const results = [];
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const items = yield* trySync(() => listInboxItems({ kind, limit }).items);
+		const results = [];
 
-	for (const item of items) {
-		const scored = await scoreInboxItemWithOpenAI({
-			entityKind: item.entityKind,
-			title: item.title,
-			text: item.text,
-			influenceScore: item.influenceScore,
-			participant: {
-				handle: item.participant.handle,
-				displayName: item.participant.displayName,
-				bio: item.participant.bio,
-				followersCount: item.participant.followersCount,
-			},
-		});
+		for (const item of items) {
+			const scored = yield* scoreInboxItemWithOpenAIEffect({
+				entityKind: item.entityKind,
+				title: item.title,
+				text: item.text,
+				influenceScore: item.influenceScore,
+				participant: {
+					handle: item.participant.handle,
+					displayName: item.participant.displayName,
+					bio: item.participant.bio,
+					followersCount: item.participant.followersCount,
+				},
+			});
 
-		db.prepare(
-			`
+			yield* trySync(() =>
+				db
+					.prepare(
+						`
       insert into ai_scores (
         entity_kind, entity_id, model, score, summary, reasoning, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?)
@@ -185,26 +201,33 @@ export async function scoreInbox({
         reasoning = excluded.reasoning,
         updated_at = excluded.updated_at
       `,
-		).run(
-			item.entityKind,
-			item.entityId,
-			scored.model,
-			scored.score,
-			scored.summary,
-			scored.reasoning,
-			new Date().toISOString(),
-		);
+					)
+					.run(
+						item.entityKind,
+						item.entityId,
+						scored.model,
+						scored.score,
+						scored.summary,
+						scored.reasoning,
+						new Date().toISOString(),
+					),
+			);
 
-		results.push({
-			id: item.id,
-			score: scored.score,
-			source: "openai",
-		});
-	}
+			results.push({
+				id: item.id,
+				score: scored.score,
+				source: "openai",
+			});
+		}
 
-	return {
-		ok: true,
-		scored: results.length,
-		items: results,
-	};
+		return {
+			ok: true,
+			scored: results.length,
+			items: results,
+		};
+	});
+}
+
+export function scoreInbox(options: Pick<InboxQuery, "kind" | "limit"> = {}) {
+	return runEffectPromise(scoreInboxEffect(options));
 }

--- a/src/lib/link-index.test.ts
+++ b/src/lib/link-index.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -333,6 +334,31 @@ describe("link index", () => {
 		});
 		expect(fetchImpl).not.toHaveBeenCalled();
 		expect(searchLinks("vibecoder")).toHaveLength(1);
+	});
+
+	it("keeps backfill effects lazy until run", async () => {
+		const db = insertAccountFixture();
+		insertDmConversation(db);
+		insertDmMessage(db, { id: "dm_msg_1", text: "https://t.co/lazy" });
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			url: "https://x.com/codetaur/status/777",
+		} as Response);
+		const { backfillLinkIndexEffect } = await import("./link-index");
+
+		const effect = backfillLinkIndexEffect({ fetchImpl, source: "dm" });
+
+		expect(fetchImpl).not.toHaveBeenCalled();
+		expect(
+			db.prepare("select count(*) as count from link_occurrences").get(),
+		).toEqual({ count: 0 });
+
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			occurrences: 1,
+			networkExpansions: 1,
+		});
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 
 	it("retries failed expansion rows on normal backfills", async () => {

--- a/src/lib/link-index.ts
+++ b/src/lib/link-index.ts
@@ -1,4 +1,6 @@
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { Database } from "./sqlite";
 import {
 	normalizeUrlExpansionForIndex,
@@ -246,11 +248,19 @@ function rebuildOccurrences(
 	return { occurrences, entityExpansions };
 }
 
-async function expandWithConcurrency(
+function expandWithConcurrencyEffect(
 	db: Database,
 	urls: string[],
 	options: LinkBackfillOptions,
-) {
+): Effect.Effect<
+	{
+		networkExpansions: number;
+		cacheExpansions: number;
+		misses: number;
+		errors: number;
+	},
+	unknown
+> {
 	const concurrency = Math.max(
 		1,
 		Math.min(options.concurrency ?? DEFAULT_EXPAND_CONCURRENCY, 64),
@@ -261,62 +271,57 @@ async function expandWithConcurrency(
 		misses: 0,
 		errors: 0,
 	};
-	let nextIndex = 0;
 
-	async function worker() {
-		for (;;) {
-			const index = nextIndex++;
-			const url = urls[index];
-			if (!url) {
-				return;
-			}
-			const result = (
-				await expandUrls([url], {
+	return Effect.forEach(
+		urls,
+		(url) =>
+			tryPromise(() =>
+				expandUrls([url], {
 					refresh: options.refresh,
 					fetchImpl: options.fetchImpl,
 					timeoutMs: options.timeoutMs,
-				})
-			)[0]!;
-			if (result.source === "network") {
-				counts.networkExpansions++;
-			} else {
-				counts.cacheExpansions++;
-			}
-			if (result.status === "miss") {
-				counts.misses++;
-			}
-			if (result.status === "error") {
-				counts.errors++;
-			}
-			upsertUrlExpansion(db, normalizeUrlExpansionForIndex(result));
-		}
-	}
-
-	await Promise.all(
-		Array.from({ length: Math.min(concurrency, urls.length) }, () => worker()),
-	);
-	return counts;
+				}),
+			).pipe(
+				Effect.map((results) => {
+					const result = results[0]!;
+					if (result.source === "network") {
+						counts.networkExpansions++;
+					} else {
+						counts.cacheExpansions++;
+					}
+					if (result.status === "miss") {
+						counts.misses++;
+					}
+					if (result.status === "error") {
+						counts.errors++;
+					}
+					upsertUrlExpansion(db, normalizeUrlExpansionForIndex(result));
+				}),
+			),
+		{ concurrency },
+	).pipe(Effect.as(counts));
 }
 
-export async function backfillLinkIndex(
+export function backfillLinkIndexEffect(
 	options: LinkBackfillOptions = {},
-): Promise<LinkBackfillResult> {
-	const db = getNativeDb({ seedDemoData: false });
-	const { occurrences, entityExpansions } = rebuildOccurrences(
-		db,
-		Boolean(options.includeAllUrls),
-		options.source,
-	);
-	const limit =
-		typeof options.limit === "number" && Number.isFinite(options.limit)
-			? Math.max(0, Math.trunc(options.limit))
-			: undefined;
-	const needsExpansionClause = options.refresh
-		? "1 = 1"
-		: "(e.short_url is null or e.status in ('error', 'miss'))";
+): Effect.Effect<LinkBackfillResult, unknown> {
+	return Effect.gen(function* () {
+		const db = getNativeDb({ seedDemoData: false });
+		const { occurrences, entityExpansions } = rebuildOccurrences(
+			db,
+			Boolean(options.includeAllUrls),
+			options.source,
+		);
+		const limit =
+			typeof options.limit === "number" && Number.isFinite(options.limit)
+				? Math.max(0, Math.trunc(options.limit))
+				: undefined;
+		const needsExpansionClause = options.refresh
+			? "1 = 1"
+			: "(e.short_url is null or e.status in ('error', 'miss'))";
 
-	const urlsToExpand = db
-		.prepare(`
+		const urlsToExpand = db
+			.prepare(`
     select distinct o.short_url
     from link_occurrences o
     left join url_expansions e on e.short_url = o.short_url
@@ -325,43 +330,50 @@ export async function backfillLinkIndex(
     order by o.short_url
     ${limit === undefined ? "" : "limit ?"}
   `)
-		.all(
-			...(options.source ? [options.source] : []),
-			...(limit === undefined ? [] : [limit]),
-		) as Array<{
-		short_url: string;
-	}>;
+			.all(
+				...(options.source ? [options.source] : []),
+				...(limit === undefined ? [] : [limit]),
+			) as Array<{
+			short_url: string;
+		}>;
 
-	const expansionCounts = await expandWithConcurrency(
-		db,
-		urlsToExpand.map((row) => row.short_url),
-		options,
-	);
+		const expansionCounts = yield* expandWithConcurrencyEffect(
+			db,
+			urlsToExpand.map((row) => row.short_url),
+			options,
+		);
 
-	const uniqueUrls = db
-		.prepare(`
+		const uniqueUrls = db
+			.prepare(`
     select count(distinct short_url) as count
     from link_occurrences
     ${options.source ? "where source_kind = ?" : ""}
   `)
-		.get(...(options.source ? [options.source] : [])) as { count: number };
-	const remaining = db
-		.prepare(`
+			.get(...(options.source ? [options.source] : [])) as { count: number };
+		const remaining = db
+			.prepare(`
     select count(distinct o.short_url) as count
     from link_occurrences o
     left join url_expansions e on e.short_url = o.short_url
     where (e.short_url is null or e.status in ('error', 'miss'))
       ${options.source ? "and o.source_kind = ?" : ""}
   `)
-		.get(...(options.source ? [options.source] : [])) as { count: number };
+			.get(...(options.source ? [options.source] : [])) as { count: number };
 
-	return {
-		occurrences,
-		uniqueUrls: Number(uniqueUrls.count),
-		entityExpansions,
-		...expansionCounts,
-		remainingUnexpanded: Number(remaining.count),
-	};
+		return {
+			occurrences,
+			uniqueUrls: Number(uniqueUrls.count),
+			entityExpansions,
+			...expansionCounts,
+			remainingUnexpanded: Number(remaining.count),
+		};
+	});
+}
+
+export function backfillLinkIndex(
+	options: LinkBackfillOptions = {},
+): Promise<LinkBackfillResult> {
+	return runEffectPromise(backfillLinkIndexEffect(options));
 }
 
 function likePattern(value: string) {

--- a/src/lib/link-preview-metadata.test.ts
+++ b/src/lib/link-preview-metadata.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -9,7 +10,9 @@ import {
 	__test__,
 	extractLinkPreviewMetadata,
 	fetchLinkPreviewMetadata,
+	fetchLinkPreviewMetadataEffect,
 	getOrFetchLinkPreview,
+	getOrFetchLinkPreviewEffect,
 } from "./link-preview-metadata";
 
 const tempDirs: string[] = [];
@@ -62,6 +65,15 @@ describe("link preview metadata", () => {
 		);
 	});
 
+	it("keeps malformed numeric HTML entities as text", () => {
+		const metadata = extractLinkPreviewMetadata(
+			"<title>&#999999999999; Demo</title>",
+			"https://example.com/",
+		);
+
+		expect(metadata.title).toBe("&#999999999999; Demo");
+	});
+
 	it("treats direct image responses as image previews", async () => {
 		const fetchImpl = vi.fn().mockResolvedValue({
 			ok: true,
@@ -78,6 +90,27 @@ describe("link preview metadata", () => {
 			siteName: "example.com",
 			title: "example.com",
 		});
+	});
+
+	it("keeps link preview fetch effects lazy", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			url: "https://example.com/card.png",
+			headers: new Headers({ "content-type": "image/png" }),
+			text: vi.fn(),
+		});
+
+		const effect = fetchLinkPreviewMetadataEffect(
+			"https://example.com/card.png",
+			{ fetchImpl },
+		);
+
+		expect(fetchImpl).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			imageUrl: "https://example.com/card.png",
+		});
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 
 	it("persists fetched previews on url expansions", async () => {
@@ -118,5 +151,31 @@ describe("link preview metadata", () => {
 			title: "Peekaboo",
 			image_url: "https://peekaboo.sh/og.png",
 		});
+	});
+
+	it("keeps cached-preview effects lazy until run", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-preview-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+		resetBirdclawPathsForTests();
+		resetDatabaseForTests();
+
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			url: "https://example.com/",
+			headers: new Headers({ "content-type": "text/html" }),
+			text: vi.fn().mockResolvedValue("<title>Example</title>"),
+		});
+
+		const effect = getOrFetchLinkPreviewEffect("https://example.com/", {
+			fetchImpl,
+		});
+		expect(fetchImpl).not.toHaveBeenCalled();
+
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			title: "Example",
+		});
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/link-preview-metadata.ts
+++ b/src/lib/link-preview-metadata.ts
@@ -1,4 +1,6 @@
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { Database } from "./sqlite";
 import {
 	normalizeUrlExpansionForIndex,
@@ -44,13 +46,21 @@ function cleanText(value: string | null | undefined) {
 	return cleaned.length > 0 ? cleaned : null;
 }
 
+function decodeCodePoint(value: number, fallback: string) {
+	try {
+		return String.fromCodePoint(value);
+	} catch {
+		return fallback;
+	}
+}
+
 function decodeHtmlEntities(value: string) {
 	return value
-		.replace(/&#(\d+);/g, (_, code: string) =>
-			String.fromCodePoint(Number(code)),
+		.replace(/&#(\d+);/g, (entity: string, code: string) =>
+			decodeCodePoint(Number(code), entity),
 		)
-		.replace(/&#x([a-f0-9]+);/gi, (_, code: string) =>
-			String.fromCodePoint(Number.parseInt(code, 16)),
+		.replace(/&#x([a-f0-9]+);/gi, (entity: string, code: string) =>
+			decodeCodePoint(Number.parseInt(code, 16), entity),
 		)
 		.replace(/&amp;/g, "&")
 		.replace(/&lt;/g, "<")
@@ -183,10 +193,10 @@ export function extractLinkPreviewMetadata(
 	};
 }
 
-export async function fetchLinkPreviewMetadata(
+export function fetchLinkPreviewMetadataEffect(
 	url: string,
 	options: Pick<GetLinkPreviewOptions, "fetchImpl" | "timeoutMs"> = {},
-): Promise<LinkPreviewMetadata> {
+): Effect.Effect<LinkPreviewMetadata> {
 	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
 	const timeoutMs = options.timeoutMs ?? FETCH_TIMEOUT_MS;
 	const headers = {
@@ -197,16 +207,18 @@ export async function fetchLinkPreviewMetadata(
 		"accept-language": "en-US,en;q=0.9",
 	} satisfies HeadersInit;
 
-	try {
-		const response = await fetchImpl(url, {
-			headers,
-			redirect: "follow",
-			signal: AbortSignal.timeout(timeoutMs),
-		});
+	return Effect.gen(function* () {
+		const response = yield* tryPromise(() =>
+			fetchImpl(url, {
+				headers,
+				redirect: "follow",
+				signal: AbortSignal.timeout(timeoutMs),
+			}),
+		);
 		const finalUrl = response.url || url;
 		const contentType = response.headers.get("content-type") ?? "";
 		if (!response.ok) {
-			throw new Error(`HTTP ${response.status}`);
+			return yield* Effect.fail(new Error(`HTTP ${response.status}`));
 		}
 		if (contentType.toLowerCase().startsWith("image/")) {
 			return {
@@ -215,20 +227,33 @@ export async function fetchLinkPreviewMetadata(
 				description: null,
 				imageUrl: finalUrl,
 				siteName: hostLabel(finalUrl),
-			};
+			} satisfies LinkPreviewMetadata;
 		}
-		const html = (await response.text()).slice(0, MAX_HTML_CHARS);
-		return extractLinkPreviewMetadata(html, finalUrl);
-	} catch (error) {
-		return {
-			url,
-			title: hostLabel(url),
-			description: null,
-			imageUrl: youtubeThumbnail(url),
-			siteName: hostLabel(url),
-			error: error instanceof Error ? error.message : String(error),
-		};
-	}
+		const content = yield* tryPromise(() => response.text());
+		return yield* Effect.try({
+			try: () =>
+				extractLinkPreviewMetadata(content.slice(0, MAX_HTML_CHARS), finalUrl),
+			catch: (error) => error,
+		});
+	}).pipe(
+		Effect.catchAll((error) =>
+			Effect.succeed({
+				url,
+				title: hostLabel(url),
+				description: null,
+				imageUrl: youtubeThumbnail(url),
+				siteName: hostLabel(url),
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		),
+	);
+}
+
+export function fetchLinkPreviewMetadata(
+	url: string,
+	options: Pick<GetLinkPreviewOptions, "fetchImpl" | "timeoutMs"> = {},
+): Promise<LinkPreviewMetadata> {
+	return runEffectPromise(fetchLinkPreviewMetadataEffect(url, options));
 }
 
 function readCachedPreview(
@@ -310,22 +335,31 @@ function persistPreview(
 	);
 }
 
-export async function getOrFetchLinkPreview(
+export function getOrFetchLinkPreviewEffect(
+	url: string,
+	options: GetLinkPreviewOptions = {},
+): Effect.Effect<LinkPreviewMetadata> {
+	return Effect.gen(function* () {
+		const db = getNativeDb({ seedDemoData: false });
+		const cached = readCachedPreview(db, url, options.shortUrl);
+		if (cached && hasUsefulPreview(cached) && !options.refresh) {
+			return rowToPreview(cached);
+		}
+
+		const preview = yield* fetchLinkPreviewMetadataEffect(
+			cached?.final_url || cached?.expanded_url || url,
+			options,
+		);
+		persistPreview(db, url, options.shortUrl, cached, preview);
+		return preview;
+	});
+}
+
+export function getOrFetchLinkPreview(
 	url: string,
 	options: GetLinkPreviewOptions = {},
 ): Promise<LinkPreviewMetadata> {
-	const db = getNativeDb({ seedDemoData: false });
-	const cached = readCachedPreview(db, url, options.shortUrl);
-	if (cached && hasUsefulPreview(cached) && !options.refresh) {
-		return rowToPreview(cached);
-	}
-
-	const preview = await fetchLinkPreviewMetadata(
-		cached?.final_url || cached?.expanded_url || url,
-		options,
-	);
-	persistPreview(db, url, options.shortUrl, cached, preview);
-	return preview;
+	return runEffectPromise(getOrFetchLinkPreviewEffect(url, options));
 }
 
 export const __test__ = {

--- a/src/lib/media-fetch.test.ts
+++ b/src/lib/media-fetch.test.ts
@@ -182,6 +182,30 @@ describe("media fetch", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("preserves filesystem errors while storing fetched media", async () => {
+		const root = home();
+		const mediaDir = path.join(root, "media", "originals");
+		mkdirSync(mediaDir, { recursive: true });
+		insertTweet("tweet_1", [pbs("demo")]);
+
+		let thrown: unknown;
+		try {
+			await fetchTweetMedia({
+				fetchImpl: async () => {
+					mkdirSync(path.join(mediaDir, "demo.jpg"), { recursive: true });
+					return new Response(new Uint8Array([1, 2, 3]));
+				},
+				pacingMs: 0,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect(String(thrown)).not.toMatch(/UnknownException|unknown error/i);
+		expect((thrown as Error).message).toMatch(/EISDIR|directory|rename/i);
+	});
+
 	it("reuses archive bytes before fetching from the CDN", async () => {
 		const root = home();
 		const archiveFile = archiveTweetFile(root, "tweet_1", "demo");

--- a/src/lib/media-fetch.ts
+++ b/src/lib/media-fetch.ts
@@ -14,8 +14,10 @@ import {
 } from "node:fs";
 import { appendFile, copyFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { Effect } from "effect";
 import { getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 
 type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 type Row = { id: string; media_json: string };
@@ -98,6 +100,24 @@ const packageVersion = (
 
 function defaultSleep(ms: number) {
 	return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function toMediaError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function tryMediaSync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toMediaError,
+	});
+}
+
+function tryMediaPromise<T>(try_: () => Promise<T>) {
+	return Effect.tryPromise({
+		try: try_,
+		catch: toMediaError,
+	});
 }
 
 function fileSize(filePath: string) {
@@ -454,24 +474,26 @@ function archivePathFor(item: Candidate, mediaOriginalsDir: string) {
 	);
 }
 
-async function reuseFromArchive(
+function reuseFromArchiveEffect(
 	item: Candidate,
 	mediaOriginalsDir: string,
 	maxBytes: number,
-) {
-	const archivePath = archivePathFor(item, mediaOriginalsDir);
-	if (!archivePath || !existsSync(archivePath)) return null;
-	const bytes = fileSize(archivePath);
-	if (bytes > maxBytes) return fail(item, "max-bytes");
-	await copyFile(archivePath, item.tmpPath);
-	await rename(item.tmpPath, item.path);
-	return {
-		fetched: 1,
-		bytes,
-		rateLimited: false,
-		kind: item.kind,
-		reusedFromArchive: true,
-	} satisfies FetchOneResult;
+): Effect.Effect<FetchOneResult | null, Error> {
+	return Effect.gen(function* () {
+		const archivePath = archivePathFor(item, mediaOriginalsDir);
+		if (!archivePath || !existsSync(archivePath)) return null;
+		const bytes = fileSize(archivePath);
+		if (bytes > maxBytes) return fail(item, "max-bytes");
+		yield* tryMediaPromise(() => copyFile(archivePath, item.tmpPath));
+		yield* tryMediaPromise(() => rename(item.tmpPath, item.path));
+		return {
+			fetched: 1,
+			bytes,
+			rateLimited: false,
+			kind: item.kind,
+			reusedFromArchive: true,
+		} satisfies FetchOneResult;
+	});
 }
 
 function contentLength(response: Response) {
@@ -486,49 +508,61 @@ function contentRangeTotal(response: Response) {
 	return total ? Number(total) : null;
 }
 
-async function writeResponseBody(
+function writeResponseBodyEffect(
 	response: Response,
 	tmpPath: string,
 	append: boolean,
 	maxBytes: number,
 	initialBytes: number,
-) {
-	if (!response.body) throw new Error("missing response body");
-	let bytes = 0;
-	if (!append) {
-		await writeFile(tmpPath, Buffer.alloc(0));
-	}
-	const reader = response.body.getReader();
-	try {
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) {
-				break;
+): Effect.Effect<number, Error> {
+	return Effect.gen(function* () {
+		if (!response.body)
+			return yield* Effect.fail(new Error("missing response body"));
+		let bytes = 0;
+		if (!append) {
+			yield* tryMediaPromise(() => writeFile(tmpPath, Buffer.alloc(0)));
+		}
+		const reader = response.body.getReader();
+		const result = yield* Effect.gen(function* () {
+			for (;;) {
+				const { done, value } = yield* tryMediaPromise(() => reader.read());
+				if (done) {
+					break;
+				}
+				const chunk = Buffer.from(value);
+				bytes += chunk.length;
+				if (initialBytes + bytes > maxBytes) {
+					yield* tryMediaPromise(() => rm(tmpPath, { force: true })).pipe(
+						Effect.catchAll(() => Effect.void),
+					);
+					return yield* Effect.fail(new Error("max-bytes"));
+				}
+				yield* tryMediaPromise(() => appendFile(tmpPath, chunk));
 			}
-			const chunk = Buffer.from(value);
-			bytes += chunk.length;
-			if (initialBytes + bytes > maxBytes) {
-				throw new Error("max-bytes");
-			}
-			await appendFile(tmpPath, chunk);
-		}
-	} catch (error) {
-		if (error instanceof Error && error.message === "max-bytes") {
-			await rm(tmpPath, { force: true });
-		}
-		try {
-			await reader.cancel(error);
-		} catch {
-			// The stream may already be errored; preserving the original failure matters.
-		}
-		throw error;
-	} finally {
-		reader.releaseLock();
-	}
-	return bytes;
+			return bytes;
+		}).pipe(
+			Effect.map((writtenBytes) => ({ ok: true as const, writtenBytes })),
+			Effect.catchAll((error) =>
+				Effect.gen(function* () {
+					if (error.message === "max-bytes") {
+						yield* tryMediaPromise(() => rm(tmpPath, { force: true })).pipe(
+							Effect.catchAll(() => Effect.void),
+						);
+					}
+					yield* tryMediaPromise(() => reader.cancel(error)).pipe(
+						Effect.catchAll(() => Effect.void),
+					);
+					return { error, ok: false as const };
+				}),
+			),
+			Effect.ensuring(Effect.sync(() => reader.releaseLock())),
+		);
+		if (!result.ok) return yield* Effect.fail(result.error);
+		return result.writtenBytes;
+	});
 }
 
-async function fetchOne({
+function fetchOneEffect({
 	item,
 	fetchImpl,
 	sleep,
@@ -542,74 +576,85 @@ async function fetchOne({
 	retryMax: number;
 	userAgent: string;
 	maxBytes: number;
-}): Promise<FetchOneResult> {
-	let rateLimited = false;
-	for (let attempt = 0; attempt <= retryMax; attempt += 1) {
-		const partialBytes = item.kind === "image" ? 0 : fileSize(item.tmpPath);
-		if (partialBytes > maxBytes) {
-			await rm(item.tmpPath, { force: true });
-			return fail(item, "max-bytes");
-		}
-		let response: Response;
-		try {
-			response = await fetchImpl(item.url, {
-				headers: {
-					"user-agent": userAgent,
-					...(partialBytes > 0 ? { range: `bytes=${partialBytes}-` } : {}),
-				},
-			});
-		} catch (error) {
-			return fail(
-				item,
-				error instanceof Error ? error.message : String(error),
-				rateLimited,
-			);
-		}
-		if (response.status === 429) {
-			rateLimited = true;
-			if (attempt < retryMax) {
-				await sleep(1000 * 2 ** attempt);
-				continue;
+}): Effect.Effect<FetchOneResult, Error> {
+	return Effect.gen(function* () {
+		let rateLimited = false;
+		for (let attempt = 0; attempt <= retryMax; attempt += 1) {
+			const partialBytes = item.kind === "image" ? 0 : fileSize(item.tmpPath);
+			if (partialBytes > maxBytes) {
+				yield* tryMediaPromise(() => rm(item.tmpPath, { force: true })).pipe(
+					Effect.catchAll(() => Effect.void),
+				);
+				return fail(item, "max-bytes");
 			}
-			return fail(item, "429", true);
-		}
-		if (!response.ok && response.status !== 206) {
-			return fail(item, String(response.status), rateLimited);
-		}
+			const responseResult = yield* tryMediaPromise(() =>
+				fetchImpl(item.url, {
+					headers: {
+						"user-agent": userAgent,
+						...(partialBytes > 0 ? { range: `bytes=${partialBytes}-` } : {}),
+					},
+				}),
+			).pipe(
+				Effect.map((response) => ({ ok: true as const, response })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ error, ok: false as const }),
+				),
+			);
+			if (!responseResult.ok) {
+				return fail(item, responseResult.error.message, rateLimited);
+			}
+			const { response } = responseResult;
+			if (response.status === 429) {
+				rateLimited = true;
+				if (attempt < retryMax) {
+					yield* tryMediaPromise(() => sleep(1000 * 2 ** attempt)).pipe(
+						Effect.catchAll(() => Effect.void),
+					);
+					continue;
+				}
+				return fail(item, "429", true);
+			}
+			if (!response.ok && response.status !== 206) {
+				return fail(item, String(response.status), rateLimited);
+			}
 
-		const expectedTotal =
-			contentRangeTotal(response) ??
-			(contentLength(response) ?? 0) +
-				(response.status === 206 ? partialBytes : 0);
-		if (expectedTotal > maxBytes) {
-			await rm(item.tmpPath, { force: true });
-			return fail(item, "max-bytes");
-		}
+			const expectedTotal =
+				contentRangeTotal(response) ??
+				(contentLength(response) ?? 0) +
+					(response.status === 206 ? partialBytes : 0);
+			if (expectedTotal > maxBytes) {
+				yield* tryMediaPromise(() => rm(item.tmpPath, { force: true })).pipe(
+					Effect.catchAll(() => Effect.void),
+				);
+				return fail(item, "max-bytes");
+			}
 
-		const append = partialBytes > 0 && response.status === 206;
-		let bytes = 0;
-		try {
-			bytes = await writeResponseBody(
+			const append = partialBytes > 0 && response.status === 206;
+			const bytesResult = yield* writeResponseBodyEffect(
 				response,
 				item.tmpPath,
 				append,
 				maxBytes,
 				append ? partialBytes : 0,
+			).pipe(
+				Effect.map((bytes) => ({ bytes, ok: true as const })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ error, ok: false as const }),
+				),
 			);
-		} catch (error) {
-			if (error instanceof Error && error.message === "max-bytes") {
-				return fail(item, "max-bytes", rateLimited);
+			if (!bytesResult.ok) {
+				return fail(item, bytesResult.error.message, rateLimited);
 			}
-			return fail(
-				item,
-				error instanceof Error ? error.message : String(error),
+			yield* tryMediaPromise(() => rename(item.tmpPath, item.path));
+			return {
+				fetched: 1,
+				bytes: bytesResult.bytes,
 				rateLimited,
-			);
+				kind: item.kind,
+			};
 		}
-		await rename(item.tmpPath, item.path);
-		return { fetched: 1, bytes, rateLimited, kind: item.kind };
-	}
-	return fail(item, "retry exhausted", rateLimited);
+		return fail(item, "retry exhausted", rateLimited);
+	});
 }
 
 function applyFetched(result: MediaFetchResult, fetched: FetchOneResult) {
@@ -632,7 +677,7 @@ function applyFetched(result: MediaFetchResult, fetched: FetchOneResult) {
 	if (fetched.failure) result.failures.push(fetched.failure);
 }
 
-async function runGroup(
+function runGroupEffect(
 	items: Candidate[],
 	parallel: number,
 	pacingMs: number,
@@ -640,127 +685,155 @@ async function runGroup(
 	sleep: (ms: number) => Promise<void>,
 	worker: (item: Candidate) => Promise<void>,
 ) {
-	let next = 0;
 	let lastStart: number | null = null;
 	let pace = Promise.resolve();
-	const runPaced = async (item: Candidate) => {
+	const pacedItems = items.map((item) => {
 		const previous = pace;
 		let release = () => {};
 		pace = new Promise<void>((resolve) => {
 			release = resolve;
 		});
-		await previous;
-		let work: Promise<void>;
-		try {
-			const waitMs =
-				lastStart !== null ? Math.max(0, lastStart + pacingMs - now()) : 0;
-			if (waitMs > 0) await sleep(waitMs);
-			lastStart = now();
-			work = worker(item);
-		} finally {
-			release();
-		}
-		await work;
-	};
-	await Promise.all(
-		Array.from({ length: Math.min(parallel, items.length) }, async () => {
-			for (;;) {
-				const item = items[next++];
-				if (!item) return;
-				await runPaced(item);
-			}
-		}),
-	);
+		return { item, previous, release };
+	});
+	const runPaced = ({
+		item,
+		previous,
+		release,
+	}: {
+		item: Candidate;
+		previous: Promise<void>;
+		release: () => void;
+	}) =>
+		tryMediaPromise(() =>
+			previous.then(() => {
+				const waitMs =
+					lastStart !== null ? Math.max(0, lastStart + pacingMs - now()) : 0;
+				const wait = waitMs > 0 ? sleep(waitMs) : Promise.resolve();
+				return wait.then(
+					() => {
+						let work: Promise<void>;
+						try {
+							lastStart = now();
+							work = worker(item);
+						} finally {
+							release();
+						}
+						return work;
+					},
+					(error: unknown) => {
+						release();
+						throw error;
+					},
+				);
+			}),
+		);
+	return Effect.forEach(pacedItems, runPaced, {
+		concurrency: Math.min(parallel, items.length),
+		discard: true,
+	});
 }
 
-export async function fetchTweetMedia(options: MediaFetchOptions = {}) {
-	const now = options.now ?? Date.now;
-	const startedAt = now();
-	const sleep = options.sleep ?? defaultSleep;
-	const fetchImpl = options.fetchImpl ?? fetch;
-	const retryMax = Math.max(0, Math.floor(options.retryMax ?? 3));
-	const parallel = Math.min(5, Math.max(1, Math.floor(options.parallel ?? 1)));
-	const pacingMs = Math.max(0, Math.floor(options.pacingMs ?? 250));
-	const videoPacingMs = Math.max(
-		0,
-		Math.floor(options.videoPacingMs ?? pacingMs),
-	);
-	const maxBytes = Math.max(
-		0,
-		Math.floor(options.maxBytes ?? DEFAULT_MAX_BYTES),
-	);
-	const userAgent =
-		options.userAgent ??
-		`birdclaw/${packageVersion ?? "0.0.0"} (https://github.com/steipete/birdclaw)`;
-	const { mediaOriginalsDir } = getBirdclawPaths();
-	mkdirSync(mediaOriginalsDir, { recursive: true });
+export function fetchTweetMedia(options: MediaFetchOptions = {}) {
+	return runEffectPromise(fetchTweetMediaEffect(options));
+}
 
-	const { candidates, skipped_cached, would_fetch } = collect(
-		options,
-		mediaOriginalsDir,
-	);
-	const result: MediaFetchResult = {
-		ok: true,
-		fetched: 0,
-		images_fetched: 0,
-		videos_fetched: 0,
-		gifs_fetched: 0,
-		reused_from_archive: 0,
-		skipped_cached,
-		failed: 0,
-		rate_limited: 0,
-		bytes: 0,
-		image_bytes: 0,
-		video_bytes: 0,
-		gif_bytes: 0,
-		duration_ms: 0,
-		failures: [],
-		...(options.dryRun ? { dry_run: true as const, would_fetch } : {}),
-	};
+export function fetchTweetMediaEffect(options: MediaFetchOptions = {}) {
+	return Effect.gen(function* () {
+		const now = options.now ?? Date.now;
+		const startedAt = now();
+		const sleep = options.sleep ?? defaultSleep;
+		const fetchImpl = options.fetchImpl ?? fetch;
+		const retryMax = Math.max(0, Math.floor(options.retryMax ?? 3));
+		const parallel = Math.min(
+			5,
+			Math.max(1, Math.floor(options.parallel ?? 1)),
+		);
+		const pacingMs = Math.max(0, Math.floor(options.pacingMs ?? 250));
+		const videoPacingMs = Math.max(
+			0,
+			Math.floor(options.videoPacingMs ?? pacingMs),
+		);
+		const maxBytes = Math.max(
+			0,
+			Math.floor(options.maxBytes ?? DEFAULT_MAX_BYTES),
+		);
+		const userAgent =
+			options.userAgent ??
+			`birdclaw/${packageVersion ?? "0.0.0"} (https://github.com/steipete/birdclaw)`;
+		const { mediaOriginalsDir } = getBirdclawPaths();
+		yield* tryMediaSync(() =>
+			mkdirSync(mediaOriginalsDir, { recursive: true }),
+		);
 
-	if (!options.dryRun) {
-		const httpCandidates: Candidate[] = [];
-		for (const item of candidates) {
-			const reused = await reuseFromArchive(item, mediaOriginalsDir, maxBytes);
-			if (reused) {
-				applyFetched(result, reused);
-			} else {
-				httpCandidates.push(item);
-			}
-		}
-		const fetchCandidate = async (item: Candidate) =>
-			applyFetched(
-				result,
-				await fetchOne({
+		const { candidates, skipped_cached, would_fetch } = yield* tryMediaSync(
+			() => collect(options, mediaOriginalsDir),
+		);
+		const result: MediaFetchResult = {
+			ok: true,
+			fetched: 0,
+			images_fetched: 0,
+			videos_fetched: 0,
+			gifs_fetched: 0,
+			reused_from_archive: 0,
+			skipped_cached,
+			failed: 0,
+			rate_limited: 0,
+			bytes: 0,
+			image_bytes: 0,
+			video_bytes: 0,
+			gif_bytes: 0,
+			duration_ms: 0,
+			failures: [],
+			...(options.dryRun ? { dry_run: true as const, would_fetch } : {}),
+		};
+
+		if (!options.dryRun) {
+			const httpCandidates: Candidate[] = [];
+			for (const item of candidates) {
+				const reused = yield* reuseFromArchiveEffect(
 					item,
-					fetchImpl,
-					sleep,
-					retryMax,
-					userAgent,
+					mediaOriginalsDir,
 					maxBytes,
-				}),
+				);
+				if (reused) {
+					applyFetched(result, reused);
+				} else {
+					httpCandidates.push(item);
+				}
+			}
+			const fetchCandidate = (item: Candidate) =>
+				runEffectPromise(
+					fetchOneEffect({
+						item,
+						fetchImpl,
+						sleep,
+						retryMax,
+						userAgent,
+						maxBytes,
+					}).pipe(Effect.map((fetched) => applyFetched(result, fetched))),
+				);
+			yield* runGroupEffect(
+				httpCandidates.filter((item) => item.kind === "image"),
+				parallel,
+				pacingMs,
+				now,
+				sleep,
+				fetchCandidate,
 			);
-		await runGroup(
-			httpCandidates.filter((item) => item.kind === "image"),
-			parallel,
-			pacingMs,
-			now,
-			sleep,
-			fetchCandidate,
-		);
-		await runGroup(
-			httpCandidates.filter((item) => item.kind !== "image"),
-			1,
-			videoPacingMs,
-			now,
-			sleep,
-			fetchCandidate,
-		);
-	}
+			yield* runGroupEffect(
+				httpCandidates.filter((item) => item.kind !== "image"),
+				1,
+				videoPacingMs,
+				now,
+				sleep,
+				fetchCandidate,
+			);
+		}
 
-	result.failed = result.failures.length;
-	result.duration_ms = Math.max(0, Math.round(now() - startedAt));
-	return result;
+		result.failed = result.failures.length;
+		result.duration_ms = Math.max(0, Math.round(now() - startedAt));
+		return result;
+	});
 }
 
 export function formatMediaFetchResult(result: MediaFetchResult) {

--- a/src/lib/mention-threads-live.test.ts
+++ b/src/lib/mention-threads-live.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -15,11 +16,29 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	listThreadViaBird: mocks.listThreadViaBird,
+	listThreadViaBirdEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listThreadViaBird(options),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./xurl", () => ({
 	searchRecentByConversationId: mocks.searchRecentByConversationId,
+	searchRecentByConversationIdEffect: (
+		conversationId: string,
+		options: unknown,
+	) =>
+		Effect.tryPromise({
+			try: () => mocks.searchRecentByConversationId(conversationId, options),
+			catch: (error) => error,
+		}),
 	getTweetById: mocks.getTweetById,
+	getTweetByIdEffect: (id: string, options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.getTweetById(id, options),
+			catch: (error) => error,
+		}),
 }));
 
 const tempRoots: string[] = [];
@@ -94,6 +113,49 @@ afterEach(() => {
 });
 
 describe("mention thread sync", () => {
+	it("builds mention thread sync effects lazily", async () => {
+		setupTempHome();
+		const { syncMentionThreadsEffect } = await import("./mention-threads-live");
+
+		const effect = syncMentionThreadsEffect({
+			limit: 1,
+			delayMs: 0,
+			timeoutMs: 5000,
+		});
+
+		expect(mocks.listThreadViaBird).not.toHaveBeenCalled();
+		mocks.listThreadViaBird.mockResolvedValue({
+			data: [
+				{
+					id: "mention_1",
+					author_id: "42",
+					text: "mention text",
+					created_at: "2026-05-04T07:00:00.000Z",
+				},
+			],
+			meta: { result_count: 1 },
+		});
+
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			source: "bird",
+			threads: 1,
+		});
+		expect(mocks.listThreadViaBird).toHaveBeenCalledTimes(1);
+	});
+
+	it("validates mention thread sync effects only when run", async () => {
+		setupTempHome();
+		const { syncMentionThreadsEffect } = await import("./mention-threads-live");
+
+		const effect = syncMentionThreadsEffect({ limit: 0 });
+
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"--limit must be at least 1",
+		);
+		expect(mocks.listThreadViaBird).not.toHaveBeenCalled();
+	});
+
 	it("fetches recent mention threads with timeout and stores conversation context", async () => {
 		setupTempHome();
 		mocks.listThreadViaBird.mockResolvedValue({
@@ -343,6 +405,53 @@ describe("mention thread sync", () => {
 			media_count: 0,
 			author_profile_id: "profile_user_77",
 		});
+	});
+
+	it("keeps merge failures isolated to the current mention", async () => {
+		setupTempHome();
+		insertMention("mention_2", "second mention", "2026-05-04T08:00:00.000Z");
+		mocks.listThreadViaBird
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "bad_thread_row",
+						author_id: "42",
+						text: null,
+						created_at: "2026-05-04T08:00:00.000Z",
+					},
+				],
+				meta: { result_count: 1 },
+			})
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "mention_1",
+						author_id: "42",
+						text: "good thread row",
+						created_at: "2026-05-04T07:00:00.000Z",
+					},
+				],
+				meta: { result_count: 1 },
+			});
+		const { syncMentionThreads } = await import("./mention-threads-live");
+
+		const result = await syncMentionThreads({
+			limit: 2,
+			delayMs: 0,
+			timeoutMs: 5000,
+		});
+
+		expect(result).toMatchObject({
+			threads: 2,
+			succeeded: 1,
+			failed: 1,
+			mergedTweets: 1,
+		});
+		expect(result.failures[0]).toMatchObject({
+			tweetId: "mention_2",
+			ok: false,
+		});
+		expect(mocks.listThreadViaBird).toHaveBeenCalledTimes(2);
 	});
 
 	it("fetches xurl conversation search results and writes thread context edges", async () => {

--- a/src/lib/mention-threads-live.ts
+++ b/src/lib/mention-threads-live.ts
@@ -1,6 +1,8 @@
 import type { Database } from "./sqlite";
-import { listThreadViaBird } from "./bird";
+import { Effect } from "effect";
+import { listThreadViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import type {
 	XurlMentionData,
@@ -11,7 +13,7 @@ import type {
 } from "./types";
 import { upsertTweetAccountEdge } from "./tweet-account-edges";
 import { ensureStubProfileForXUser, upsertProfileFromXUser } from "./x-profile";
-import { getTweetById, searchRecentByConversationId } from "./xurl";
+import { getTweetByIdEffect, searchRecentByConversationIdEffect } from "./xurl";
 
 const DEFAULT_LIMIT = 30;
 const DEFAULT_DELAY_MS = 1500;
@@ -21,12 +23,30 @@ const DEFAULT_FALLBACK_DEPTH = 12;
 const MAX_XURL_SEARCH_RESULTS = 100;
 
 export type MentionThreadsMode = "bird" | "xurl";
+export interface SyncMentionThreadsOptions {
+	account?: string;
+	mode?: string;
+	limit?: number;
+	delayMs?: number;
+	timeoutMs?: number;
+	all?: boolean;
+	maxPages?: number;
+}
 
 interface LocalMention {
 	id: string;
 	replyToId?: string;
 	conversationId?: string;
 	rawTweet?: XurlMentionData;
+}
+interface ThreadFetchResult {
+	strategy: string;
+	payload: XurlMentionsResponse;
+	pages?: number;
+	fallbackDepth?: number;
+	generalReadTweets: number;
+	truncated?: boolean;
+	warnings: string[];
 }
 
 function assertPositiveInteger(value: number, name: string) {
@@ -54,8 +74,15 @@ function parseMode(value: string | undefined): MentionThreadsMode {
 	return mode;
 }
 
-function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 function getRemainingThreadTimeoutMs(
@@ -341,7 +368,7 @@ function mergeMentionThreadIntoLocalStore({
 	})();
 }
 
-async function fetchConversationViaRecentSearch({
+function fetchConversationViaRecentSearchEffect({
 	conversationId,
 	all,
 	maxPages,
@@ -354,39 +381,46 @@ async function fetchConversationViaRecentSearch({
 	timeoutMs: number;
 	deadlineMs: number;
 }) {
-	const pages: XurlTweetsResponse[] = [];
-	let nextToken: string | undefined;
-	let pageCount = 0;
+	return Effect.gen(function* () {
+		const pages: XurlTweetsResponse[] = [];
+		let nextToken: string | undefined;
+		let pageCount = 0;
 
-	do {
-		const payload = await searchRecentByConversationId(conversationId, {
-			maxResults: MAX_XURL_SEARCH_RESULTS,
-			paginationToken: nextToken,
-			timeoutMs: getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
-		});
-		pages.push(payload);
-		nextToken =
-			typeof payload.meta?.next_token === "string"
-				? payload.meta.next_token
-				: undefined;
-		pageCount += 1;
-	} while (
-		(all || maxPages !== undefined) &&
-		nextToken &&
-		(maxPages === undefined || pageCount < maxPages)
-	);
+		do {
+			const payload = yield* searchRecentByConversationIdEffect(
+				conversationId,
+				{
+					maxResults: MAX_XURL_SEARCH_RESULTS,
+					paginationToken: nextToken,
+					timeoutMs: yield* trySync(() =>
+						getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
+					),
+				},
+			);
+			pages.push(payload);
+			nextToken =
+				typeof payload.meta?.next_token === "string"
+					? payload.meta.next_token
+					: undefined;
+			pageCount += 1;
+		} while (
+			(all || maxPages !== undefined) &&
+			nextToken &&
+			(maxPages === undefined || pageCount < maxPages)
+		);
 
-	const payload = mergePayloads(pages);
-	const paginationRequested = all || maxPages !== undefined;
-	return {
-		payload,
-		pages: pageCount,
-		truncated: paginationRequested && Boolean(nextToken),
-		generalReadTweets: payload.data.length,
-	};
+		const payload = mergePayloads(pages);
+		const paginationRequested = all || maxPages !== undefined;
+		return {
+			payload,
+			pages: pageCount,
+			truncated: paginationRequested && Boolean(nextToken),
+			generalReadTweets: payload.data.length,
+		};
+	});
 }
 
-async function fetchParentChainViaXurl({
+function fetchParentChainViaXurlEffect({
 	mention,
 	maxDepth,
 	timeoutMs,
@@ -397,76 +431,82 @@ async function fetchParentChainViaXurl({
 	timeoutMs: number;
 	deadlineMs: number;
 }) {
-	const pages: XurlTweetsResponse[] = [];
-	const warnings: string[] = [];
-	const seenTweetIds = new Set([mention.id]);
-	let nextParentId = mention.replyToId;
-	let fallbackDepth = 0;
-	let generalReadTweets = 0;
+	return Effect.gen(function* () {
+		const pages: XurlTweetsResponse[] = [];
+		const warnings: string[] = [];
+		const seenTweetIds = new Set([mention.id]);
+		let nextParentId = mention.replyToId;
+		let fallbackDepth = 0;
+		let generalReadTweets = 0;
 
-	const rawAnchorPayload =
-		mention.rawTweet && mention.rawTweet.id === mention.id
-			? ({ data: [mention.rawTweet] } satisfies XurlTweetsResponse)
-			: undefined;
-	let shouldUseRawAnchor = Boolean(rawAnchorPayload);
+		const rawAnchorPayload =
+			mention.rawTweet && mention.rawTweet.id === mention.id
+				? ({ data: [mention.rawTweet] } satisfies XurlTweetsResponse)
+				: undefined;
+		let shouldUseRawAnchor = Boolean(rawAnchorPayload);
 
-	if (!nextParentId) {
-		const anchorPayload = await getTweetById(mention.id, {
-			timeoutMs: getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
-		});
-		pages.push(anchorPayload);
-		generalReadTweets += anchorPayload.data.length;
-		const anchorTweet = anchorPayload.data[0];
-		if (anchorTweet) {
-			shouldUseRawAnchor = false;
-			seenTweetIds.add(anchorTweet.id);
-			nextParentId = anchorTweet.in_reply_to_user_id
-				? getReplyToId(anchorTweet)
+		if (!nextParentId) {
+			const anchorPayload = yield* getTweetByIdEffect(mention.id, {
+				timeoutMs: yield* trySync(() =>
+					getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
+				),
+			});
+			pages.push(anchorPayload);
+			generalReadTweets += anchorPayload.data.length;
+			const anchorTweet = anchorPayload.data[0];
+			if (anchorTweet) {
+				shouldUseRawAnchor = false;
+				seenTweetIds.add(anchorTweet.id);
+				nextParentId = anchorTweet.in_reply_to_user_id
+					? getReplyToId(anchorTweet)
+					: undefined;
+			}
+		}
+
+		if (shouldUseRawAnchor && rawAnchorPayload) {
+			pages.unshift(rawAnchorPayload);
+		}
+
+		while (nextParentId) {
+			if (fallbackDepth >= maxDepth) {
+				warnings.push(
+					`fallback parent-chain depth cap reached for ${mention.id} after ${maxDepth} hops`,
+				);
+				break;
+			}
+			if (seenTweetIds.has(nextParentId)) {
+				warnings.push(
+					`fallback parent-chain cycle detected for ${mention.id} at ${nextParentId}`,
+				);
+				break;
+			}
+
+			fallbackDepth += 1;
+			const parentPayload = yield* getTweetByIdEffect(nextParentId, {
+				timeoutMs: yield* trySync(() =>
+					getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
+				),
+			});
+			pages.push(parentPayload);
+			generalReadTweets += parentPayload.data.length;
+			const parentTweet = parentPayload.data[0];
+			if (!parentTweet) {
+				break;
+			}
+			seenTweetIds.add(parentTweet.id);
+			nextParentId = parentTweet.in_reply_to_user_id
+				? getReplyToId(parentTweet)
 				: undefined;
 		}
-	}
 
-	if (shouldUseRawAnchor && rawAnchorPayload) {
-		pages.unshift(rawAnchorPayload);
-	}
-
-	while (nextParentId) {
-		if (fallbackDepth >= maxDepth) {
-			warnings.push(
-				`fallback parent-chain depth cap reached for ${mention.id} after ${maxDepth} hops`,
-			);
-			break;
-		}
-		if (seenTweetIds.has(nextParentId)) {
-			warnings.push(
-				`fallback parent-chain cycle detected for ${mention.id} at ${nextParentId}`,
-			);
-			break;
-		}
-
-		fallbackDepth += 1;
-		const parentPayload = await getTweetById(nextParentId, {
-			timeoutMs: getRemainingThreadTimeoutMs(deadlineMs, timeoutMs),
-		});
-		pages.push(parentPayload);
-		generalReadTweets += parentPayload.data.length;
-		const parentTweet = parentPayload.data[0];
-		if (!parentTweet) {
-			break;
-		}
-		seenTweetIds.add(parentTweet.id);
-		nextParentId = parentTweet.in_reply_to_user_id
-			? getReplyToId(parentTweet)
-			: undefined;
-	}
-
-	const payload = mergePayloads(pages);
-	return {
-		payload,
-		fallbackDepth,
-		warnings,
-		generalReadTweets,
-	};
+		const payload = mergePayloads(pages);
+		return {
+			payload,
+			fallbackDepth,
+			warnings,
+			generalReadTweets,
+		};
+	});
 }
 
 function findMissingAncestorId(
@@ -505,7 +545,7 @@ function findMissingAncestorId(
 	return undefined;
 }
 
-async function fetchThreadContextViaXurl({
+function fetchThreadContextViaXurlEffect({
 	mention,
 	all,
 	maxPages,
@@ -518,98 +558,100 @@ async function fetchThreadContextViaXurl({
 	maxFallbackDepth: number;
 	timeoutMs: number;
 }) {
-	const deadlineMs = Date.now() + timeoutMs;
-	if (!mention.conversationId) {
-		if (mention.replyToId) {
-			const fallback = await fetchParentChainViaXurl({
-				mention,
-				maxDepth: maxFallbackDepth,
-				timeoutMs,
-				deadlineMs,
-			});
+	return Effect.gen(function* () {
+		const deadlineMs = Date.now() + timeoutMs;
+		if (!mention.conversationId) {
+			if (mention.replyToId) {
+				const fallback = yield* fetchParentChainViaXurlEffect({
+					mention,
+					maxDepth: maxFallbackDepth,
+					timeoutMs,
+					deadlineMs,
+				});
+				return {
+					strategy: "parent_walk" as const,
+					pages: 0,
+					truncated: false,
+					payload: fallback.payload,
+					fallbackDepth: fallback.fallbackDepth,
+					generalReadTweets: fallback.generalReadTweets,
+					warnings: [
+						`missing conversation_id for ${mention.id}; used parent walk`,
+						...fallback.warnings,
+					],
+				};
+			}
 			return {
-				strategy: "parent_walk" as const,
+				strategy: "skipped:no_conversation_id" as const,
+				payload: { data: [] } satisfies XurlMentionsResponse,
 				pages: 0,
+				fallbackDepth: 0,
+				generalReadTweets: 0,
+				warnings: [`skipped ${mention.id}: missing conversation_id`],
 				truncated: false,
-				payload: fallback.payload,
-				fallbackDepth: fallback.fallbackDepth,
-				generalReadTweets: fallback.generalReadTweets,
-				warnings: [
-					`missing conversation_id for ${mention.id}; used parent walk`,
-					...fallback.warnings,
-				],
 			};
 		}
-		return {
-			strategy: "skipped:no_conversation_id" as const,
-			payload: { data: [] } satisfies XurlMentionsResponse,
-			pages: 0,
-			fallbackDepth: 0,
-			generalReadTweets: 0,
-			warnings: [`skipped ${mention.id}: missing conversation_id`],
-			truncated: false,
-		};
-	}
 
-	const search = await fetchConversationViaRecentSearch({
-		conversationId: mention.conversationId,
-		all,
-		maxPages,
-		timeoutMs,
-		deadlineMs,
-	});
-	if (search.payload.data.length > 0) {
-		const missingAncestorId = findMissingAncestorId(mention, search.payload);
-		if (missingAncestorId) {
-			const fallback = await fetchParentChainViaXurl({
-				mention,
-				maxDepth: maxFallbackDepth,
-				timeoutMs,
-				deadlineMs,
-			});
+		const search = yield* fetchConversationViaRecentSearchEffect({
+			conversationId: mention.conversationId,
+			all,
+			maxPages,
+			timeoutMs,
+			deadlineMs,
+		});
+		if (search.payload.data.length > 0) {
+			const missingAncestorId = findMissingAncestorId(mention, search.payload);
+			if (missingAncestorId) {
+				const fallback = yield* fetchParentChainViaXurlEffect({
+					mention,
+					maxDepth: maxFallbackDepth,
+					timeoutMs,
+					deadlineMs,
+				});
+				return {
+					strategy: "conversation_search+parent_walk" as const,
+					pages: search.pages,
+					truncated: search.truncated,
+					payload: mergePayloads([search.payload, fallback.payload]),
+					fallbackDepth: fallback.fallbackDepth,
+					generalReadTweets:
+						search.generalReadTweets + fallback.generalReadTweets,
+					warnings: [
+						`recent search missed ancestor ${missingAncestorId} for conversation ${mention.conversationId}; used parent walk`,
+						...fallback.warnings,
+					],
+				};
+			}
 			return {
-				strategy: "conversation_search+parent_walk" as const,
-				pages: search.pages,
-				truncated: search.truncated,
-				payload: mergePayloads([search.payload, fallback.payload]),
-				fallbackDepth: fallback.fallbackDepth,
-				generalReadTweets:
-					search.generalReadTweets + fallback.generalReadTweets,
-				warnings: [
-					`recent search missed ancestor ${missingAncestorId} for conversation ${mention.conversationId}; used parent walk`,
-					...fallback.warnings,
-				],
+				strategy: "conversation_search" as const,
+				fallbackDepth: 0,
+				warnings: [] as string[],
+				...search,
 			};
 		}
-		return {
-			strategy: "conversation_search" as const,
-			fallbackDepth: 0,
-			warnings: [] as string[],
-			...search,
-		};
-	}
 
-	const fallback = await fetchParentChainViaXurl({
-		mention,
-		maxDepth: maxFallbackDepth,
-		timeoutMs,
-		deadlineMs,
+		const fallback = yield* fetchParentChainViaXurlEffect({
+			mention,
+			maxDepth: maxFallbackDepth,
+			timeoutMs,
+			deadlineMs,
+		});
+		return {
+			strategy: "parent_walk" as const,
+			pages: search.pages,
+			truncated: search.truncated,
+			payload: fallback.payload,
+			fallbackDepth: fallback.fallbackDepth,
+			generalReadTweets: search.generalReadTweets + fallback.generalReadTweets,
+			warnings: [
+				`recent search returned no tweets for conversation ${mention.conversationId}; used parent walk`,
+				...fallback.warnings,
+			],
+		};
 	});
-	return {
-		strategy: "parent_walk" as const,
-		pages: search.pages,
-		truncated: search.truncated,
-		payload: fallback.payload,
-		fallbackDepth: fallback.fallbackDepth,
-		generalReadTweets: search.generalReadTweets + fallback.generalReadTweets,
-		warnings: [
-			`recent search returned no tweets for conversation ${mention.conversationId}; used parent walk`,
-			...fallback.warnings,
-		],
-	};
 }
 
-export async function syncMentionThreads({
+export function syncMentionThreadsEffect({
 	account,
 	mode = DEFAULT_MODE,
 	limit = DEFAULT_LIMIT,
@@ -617,84 +659,111 @@ export async function syncMentionThreads({
 	timeoutMs = DEFAULT_TIMEOUT_MS,
 	all = false,
 	maxPages,
-}: {
-	account?: string;
-	mode?: string;
-	limit?: number;
-	delayMs?: number;
-	timeoutMs?: number;
-	all?: boolean;
-	maxPages?: number;
-}) {
-	const parsedMode = parseMode(mode);
-	const parsedLimit = assertPositiveInteger(limit, "--limit");
-	const parsedDelayMs = parseNonNegativeInteger(delayMs, "--delay-ms") ?? 0;
-	const parsedTimeoutMs = assertPositiveInteger(timeoutMs, "--timeout-ms");
-	const parsedMaxPages = parseNonNegativeInteger(maxPages, "--max-pages");
-	const db = getNativeDb();
-	const resolvedAccount = resolveAccount(db, account);
-	const mentions = listRecentMentions(
-		db,
-		resolvedAccount.accountId,
-		parsedLimit,
-	);
-	const mentionIds = mentions.map((mention) => mention.id);
-	const mentionIdSet = new Set(mentionIds);
-	const results: Array<{
-		tweetId: string;
-		conversationId?: string | null;
-		ok: boolean;
-		count: number;
-		strategy?: string;
-		pages?: number;
-		fallbackDepth?: number;
-		truncated?: boolean;
-		warnings?: string[];
-		error?: string;
-	}> = [];
-	let mergedTweets = 0;
-	let generalReadTweets = 0;
-	const uniqueTweetIds = new Set<string>();
-	const warnings: string[] = [];
+}: SyncMentionThreadsOptions) {
+	return Effect.gen(function* () {
+		const parsedMode = yield* trySync(() => parseMode(mode));
+		const parsedLimit = yield* trySync(() =>
+			assertPositiveInteger(limit, "--limit"),
+		);
+		const parsedDelayMs =
+			(yield* trySync(() => parseNonNegativeInteger(delayMs, "--delay-ms"))) ??
+			0;
+		const parsedTimeoutMs = yield* trySync(() =>
+			assertPositiveInteger(timeoutMs, "--timeout-ms"),
+		);
+		const parsedMaxPages = yield* trySync(() =>
+			parseNonNegativeInteger(maxPages, "--max-pages"),
+		);
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccount = yield* trySync(() => resolveAccount(db, account));
+		const mentions = yield* trySync(() =>
+			listRecentMentions(db, resolvedAccount.accountId, parsedLimit),
+		);
+		const mentionIds = mentions.map((mention) => mention.id);
+		const mentionIdSet = new Set(mentionIds);
+		const results: Array<{
+			tweetId: string;
+			conversationId?: string | null;
+			ok: boolean;
+			count: number;
+			strategy?: string;
+			pages?: number;
+			fallbackDepth?: number;
+			truncated?: boolean;
+			warnings?: string[];
+			error?: string;
+		}> = [];
+		let mergedTweets = 0;
+		let generalReadTweets = 0;
+		const uniqueTweetIds = new Set<string>();
+		const warnings: string[] = [];
 
-	for (const [index, mention] of mentions.entries()) {
-		if (index > 0 && parsedDelayMs > 0) {
-			await sleep(parsedDelayMs);
-		}
-		try {
-			const fetchResult =
+		for (const [index, mention] of mentions.entries()) {
+			if (index > 0 && parsedDelayMs > 0) {
+				yield* Effect.sleep(parsedDelayMs);
+			}
+			const fetchEffect: Effect.Effect<ThreadFetchResult, unknown, never> =
 				parsedMode === "bird"
-					? {
-							strategy: "bird" as const,
-							payload: await listThreadViaBird({
-								tweetId: mention.id,
-								all,
-								maxPages: parsedMaxPages,
-								timeoutMs: parsedTimeoutMs,
-							}),
-							pages: undefined,
-							fallbackDepth: undefined,
-							generalReadTweets: 0,
-							truncated: undefined,
-							warnings: [] as string[],
-						}
-					: await fetchThreadContextViaXurl({
+					? listThreadViaBirdEffect({
+							tweetId: mention.id,
+							all,
+							maxPages: parsedMaxPages,
+							timeoutMs: parsedTimeoutMs,
+						}).pipe(
+							Effect.map((payload) => ({
+								strategy: "bird" as const,
+								payload,
+								pages: undefined,
+								fallbackDepth: undefined,
+								generalReadTweets: 0,
+								truncated: undefined,
+								warnings: [] as string[],
+							})),
+						)
+					: fetchThreadContextViaXurlEffect({
 							mention,
 							all,
 							maxPages: parsedMaxPages,
 							maxFallbackDepth: DEFAULT_FALLBACK_DEPTH,
 							timeoutMs: parsedTimeoutMs,
 						});
+			const fetched = yield* fetchEffect.pipe(
+				Effect.flatMap((fetchResult) =>
+					trySync(() =>
+						mergeMentionThreadIntoLocalStore({
+							db,
+							accountId: resolvedAccount.accountId,
+							accountHandle: resolvedAccount.handle,
+							mentionIds: mentionIdSet,
+							payload: fetchResult.payload,
+							source: parsedMode,
+							writeThreadContextEdges: parsedMode === "xurl",
+						}),
+					).pipe(Effect.as(fetchResult)),
+				),
+				Effect.map((fetchResult) => ({ ok: true as const, fetchResult })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ ok: false as const, error }),
+				),
+			);
+
+			if (!fetched.ok) {
+				results.push({
+					tweetId: mention.id,
+					conversationId: mention.conversationId ?? null,
+					ok: false,
+					count: 0,
+					strategy: parsedMode,
+					error:
+						fetched.error instanceof Error
+							? fetched.error.message
+							: String(fetched.error),
+				});
+				continue;
+			}
+
+			const { fetchResult } = fetched;
 			const { payload } = fetchResult;
-			mergeMentionThreadIntoLocalStore({
-				db,
-				accountId: resolvedAccount.accountId,
-				accountHandle: resolvedAccount.handle,
-				mentionIds: mentionIdSet,
-				payload,
-				source: parsedMode,
-				writeThreadContextEdges: parsedMode === "xurl",
-			});
 			for (const tweet of payload.data) {
 				uniqueTweetIds.add(tweet.id);
 			}
@@ -713,47 +782,42 @@ export async function syncMentionThreads({
 				warnings:
 					fetchResult.warnings.length > 0 ? fetchResult.warnings : undefined,
 			});
-		} catch (error) {
-			results.push({
-				tweetId: mention.id,
-				conversationId: mention.conversationId ?? null,
-				ok: false,
-				count: 0,
-				strategy: parsedMode,
-				error: error instanceof Error ? error.message : String(error),
-			});
 		}
-	}
 
-	const failures = results.filter((item) => !item.ok);
-	const skipped = results.filter((item) =>
-		item.strategy?.startsWith("skipped:"),
-	);
-	const partial = results.some((item) => item.truncated === true);
-	return {
-		ok: true,
-		source: parsedMode,
-		accountId: resolvedAccount.accountId,
-		mentions: mentionIds.length,
-		threads: results.length,
-		succeeded: results.length - failures.length - skipped.length,
-		skipped: skipped.length,
-		failed: failures.length,
-		mergedTweets,
-		uniqueTweets: uniqueTweetIds.size,
-		generalReadTweets: parsedMode === "xurl" ? generalReadTweets : 0,
-		partial,
-		options: {
-			mode: parsedMode,
-			limit: parsedLimit,
-			delayMs: parsedDelayMs,
-			timeoutMs: parsedTimeoutMs,
-			all,
-			maxPages: parsedMaxPages ?? null,
-			maxFallbackDepth: DEFAULT_FALLBACK_DEPTH,
-		},
-		results,
-		failures,
-		warnings,
-	};
+		const failures = results.filter((item) => !item.ok);
+		const skipped = results.filter((item) =>
+			item.strategy?.startsWith("skipped:"),
+		);
+		const partial = results.some((item) => item.truncated === true);
+		return {
+			ok: true,
+			source: parsedMode,
+			accountId: resolvedAccount.accountId,
+			mentions: mentionIds.length,
+			threads: results.length,
+			succeeded: results.length - failures.length - skipped.length,
+			skipped: skipped.length,
+			failed: failures.length,
+			mergedTweets,
+			uniqueTweets: uniqueTweetIds.size,
+			generalReadTweets: parsedMode === "xurl" ? generalReadTweets : 0,
+			partial,
+			options: {
+				mode: parsedMode,
+				limit: parsedLimit,
+				delayMs: parsedDelayMs,
+				timeoutMs: parsedTimeoutMs,
+				all,
+				maxPages: parsedMaxPages ?? null,
+				maxFallbackDepth: DEFAULT_FALLBACK_DEPTH,
+			},
+			results,
+			failures,
+			warnings,
+		};
+	});
+}
+
+export function syncMentionThreads(options: SyncMentionThreadsOptions) {
+	return runEffectPromise(syncMentionThreadsEffect(options));
 }

--- a/src/lib/mentions-live.test.ts
+++ b/src/lib/mentions-live.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -11,9 +12,18 @@ const listMentionsViaBirdMock = vi.fn();
 const listMentionsViaXurlMock = vi.fn();
 const lookupUsersByHandlesMock = vi.fn();
 
-vi.mock("./bird", () => ({
-	listMentionsViaBird: (...args: unknown[]) => listMentionsViaBirdMock(...args),
-}));
+vi.mock("./bird", async () => {
+	const { Effect } = await import("effect");
+	return {
+		listMentionsViaBird: (...args: unknown[]) =>
+			listMentionsViaBirdMock(...args),
+		listMentionsViaBirdEffect: (...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => listMentionsViaBirdMock(...args),
+				catch: (error) => error,
+			}),
+	};
+});
 
 vi.mock("./xurl", () => ({
 	listMentionsViaXurl: (...args: unknown[]) => listMentionsViaXurlMock(...args),
@@ -92,6 +102,53 @@ describe("cached live mentions", () => {
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("builds mention sync effects lazily", async () => {
+		makeTempHome();
+		insertLocalMentionBaseline();
+		const { syncMentionsEffect } = await import("./mentions-live");
+
+		const effect = syncMentionsEffect({
+			mode: "xurl",
+			limit: 5,
+			refresh: true,
+		});
+
+		expect(listMentionsViaXurlMock).not.toHaveBeenCalled();
+		listMentionsViaXurlMock.mockResolvedValueOnce({
+			data: [
+				{
+					id: "tweet_lazy_mention",
+					author_id: "42",
+					text: "lazy mention",
+					created_at: "2026-03-09T02:00:00.000Z",
+				},
+			],
+			includes: {
+				users: [{ id: "42", username: "sam", name: "Sam" }],
+			},
+			meta: { result_count: 1 },
+		});
+
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 1,
+		});
+		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("validates mention sync effects only when run", async () => {
+		makeTempHome();
+		const { syncMentionsEffect } = await import("./mentions-live");
+
+		const effect = syncMentionsEffect({ mode: "xurl", limit: 4 });
+
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"xurl mode requires --limit between 5 and 100",
+		);
+		expect(listMentionsViaXurlMock).not.toHaveBeenCalled();
 	});
 
 	it("fetches live mentions, caches them, and syncs them into the local timeline", async () => {
@@ -1564,6 +1621,76 @@ describe("cached live mentions", () => {
 					id: "tweet_live_4",
 					author_id: "11",
 					text: "Old but still useful",
+					created_at: "2026-03-09T02:03:00.000Z",
+				},
+			],
+			includes: {
+				users: [{ id: "11", username: "des", name: "Des" }],
+			},
+			meta: {
+				result_count: 1,
+				page_count: 1,
+				next_token: null,
+			},
+		});
+		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back to stale cache when live merge fails", async () => {
+		makeTempHome();
+		listMentionsViaXurlMock.mockResolvedValueOnce({
+			data: [
+				{
+					id: "tweet_live_cached_before_merge_error",
+					author_id: "11",
+					text: "Cached before merge error",
+					created_at: "2026-03-09T02:03:00.000Z",
+				},
+			],
+			includes: {
+				users: [{ id: "11", username: "des", name: "Des" }],
+			},
+			meta: {
+				result_count: 1,
+				page_count: 1,
+				next_token: null,
+			},
+		});
+		const { exportMentionsViaCachedXurl } = await import("./mentions-live");
+
+		await exportMentionsViaCachedXurl({
+			account: "acct_primary",
+			limit: 5,
+			refresh: true,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		listMentionsViaXurlMock.mockResolvedValueOnce({
+			data: [
+				{
+					id: null,
+					author_id: "11",
+					text: "bad live row",
+					created_at: "2026-03-09T02:04:00.000Z",
+				},
+			],
+			includes: {
+				users: [{ id: "11", username: "des", name: "Des" }],
+			},
+			meta: { result_count: 1 },
+		});
+
+		const payload = await exportMentionsViaCachedXurl({
+			account: "acct_primary",
+			limit: 5,
+			cacheTtlMs: 0,
+		});
+
+		expect(payload).toEqual({
+			data: [
+				{
+					id: "tweet_live_cached_before_merge_error",
+					author_id: "11",
+					text: "Cached before merge error",
 					created_at: "2026-03-09T02:03:00.000Z",
 				},
 			],

--- a/src/lib/mentions-live.ts
+++ b/src/lib/mentions-live.ts
@@ -1,7 +1,9 @@
 import type { Database } from "./sqlite";
-import { listMentionsViaBird } from "./bird";
+import { Effect } from "effect";
+import { listMentionsViaBirdEffect } from "./bird";
 import type { MentionsDataSource } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { serializeMentionItemsAsXurlCompatible } from "./mentions-export";
 import { listTimelineItems } from "./queries";
@@ -22,6 +24,27 @@ export const DEFAULT_MENTIONS_CACHE_TTL_MS = 2 * 60_000;
 const MIN_XURL_MENTIONS_LIMIT = 5;
 const MAX_XURL_MENTIONS_LIMIT = 100;
 type MentionSyncMode = Exclude<MentionsDataSource, "birdclaw">;
+export interface SyncMentionsOptions {
+	account?: string;
+	mode?: string;
+	limit?: number;
+	maxPages?: number;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+	sinceId?: string;
+	startTime?: string;
+}
+interface ExportMentionsViaCachedLiveSourceOptions {
+	mode: MentionsDataSource;
+	account?: string;
+	search?: string;
+	replyFilter?: ReplyFilter;
+	limit?: number;
+	all?: boolean;
+	maxPages?: number;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+}
 type MentionScanBoundary =
 	| { kind: "auto" }
 	| { kind: "since"; sinceId: string }
@@ -42,6 +65,17 @@ interface MentionCursorValue extends XurlMentionsResponse {
 }
 interface MentionHighWaterValue {
 	sinceId: string;
+}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 function getMentionsFetchModeKey({
@@ -655,7 +689,7 @@ function mergeMentionPayloads(
 	};
 }
 
-async function fetchMentionsViaXurl({
+function fetchMentionsViaXurlEffect({
 	resolvedAccount,
 	limit,
 	all,
@@ -672,43 +706,51 @@ async function fetchMentionsViaXurl({
 	startPaginationToken?: string;
 	startTime?: string;
 }) {
-	const [accountUser] = await lookupUsersByHandles([resolvedAccount.username]);
-	if (!accountUser?.id) {
-		throw new Error(
-			`Could not resolve Twitter user id for @${resolvedAccount.username}`,
+	return Effect.gen(function* () {
+		const [accountUser] = yield* tryPromise(() =>
+			lookupUsersByHandles([resolvedAccount.username]),
 		);
-	}
+		if (!accountUser?.id) {
+			return yield* Effect.fail(
+				new Error(
+					`Could not resolve Twitter user id for @${resolvedAccount.username}`,
+				),
+			);
+		}
 
-	const pages: XurlMentionsResponse[] = [];
-	let nextToken: string | undefined = startPaginationToken;
-	let pageCount = 0;
-	do {
-		const payload = await listMentionsViaXurl({
-			maxResults: limit,
-			username: resolvedAccount.username,
-			userId: String(accountUser.id),
-			paginationToken: nextToken,
-			...(sinceId ? { sinceId } : {}),
-			...(startTime ? { startTime } : {}),
-		});
-		pages.push(payload);
-		const metaNextToken =
-			typeof payload.meta?.next_token === "string"
-				? payload.meta.next_token
-				: undefined;
-		nextToken = metaNextToken;
-		pageCount += 1;
-	} while (
-		all &&
-		nextToken &&
-		(parsedMaxPages === null || pageCount < parsedMaxPages)
-	);
+		const pages: XurlMentionsResponse[] = [];
+		let nextToken: string | undefined = startPaginationToken;
+		let pageCount = 0;
+		do {
+			const payload = yield* tryPromise(() =>
+				listMentionsViaXurl({
+					maxResults: limit,
+					username: resolvedAccount.username,
+					userId: String(accountUser.id),
+					paginationToken: nextToken,
+					...(sinceId ? { sinceId } : {}),
+					...(startTime ? { startTime } : {}),
+				}),
+			);
+			pages.push(payload);
+			const metaNextToken =
+				typeof payload.meta?.next_token === "string"
+					? payload.meta.next_token
+					: undefined;
+			nextToken = metaNextToken;
+			pageCount += 1;
+		} while (
+			all &&
+			nextToken &&
+			(parsedMaxPages === null || pageCount < parsedMaxPages)
+		);
 
-	return mergeMentionPayloads(pages);
+		return mergeMentionPayloads(pages);
+	});
 }
 
-async function fetchMentionsViaBird({ limit }: { limit: number }) {
-	return listMentionsViaBird({ maxResults: limit });
+function fetchMentionsViaBirdEffect({ limit }: { limit: number }) {
+	return listMentionsViaBirdEffect({ maxResults: limit });
 }
 
 function isMaxPagesPartial({
@@ -725,7 +767,7 @@ function isMaxPagesPartial({
 	);
 }
 
-export async function syncMentions({
+export function syncMentionsEffect({
 	account,
 	mode,
 	limit = 20,
@@ -734,222 +776,239 @@ export async function syncMentions({
 	cacheTtlMs,
 	sinceId,
 	startTime,
-}: {
-	account?: string;
-	mode?: string;
-	limit?: number;
-	maxPages?: number;
-	refresh?: boolean;
-	cacheTtlMs?: number;
-	sinceId?: string;
-	startTime?: string;
-}) {
-	const parsedMode = parseSyncMode(mode);
-	const explicitSinceId = sinceId?.trim() || undefined;
-	const explicitStartTime = startTime?.trim() || undefined;
-	if (parsedMode === "bird" && (explicitSinceId || explicitStartTime)) {
-		throw new Error("bird mode does not support --since-id or --start-time");
-	}
-	if (parsedMode === "xurl") {
-		assertXurlLimit(limit);
-	} else {
-		assertBirdLimit(limit);
-	}
-	const parsedMaxPages = parseMaxPages(maxPages);
-	const fetchAll = parsedMode === "xurl" && parsedMaxPages !== null;
-	const db = getNativeDb();
-	const resolvedAccount = resolveAccount(db, account);
-	const cursorShape: MentionScanShape = {
-		endpoint: "mentions",
-		mode: parsedMode,
-		accountId: resolvedAccount.accountId,
-		pageSize: limit,
-		boundary: getMentionCursorBoundary({
-			explicitSinceId,
-			explicitStartTime,
-		}),
-	};
-	const cursorKey = getMentionCursorKey(cursorShape);
-	const legacyCursorKeys = getLegacyMentionCursorKeys(cursorShape);
-	const cursor =
-		parsedMode === "xurl"
-			? readMentionCursor({
-					db,
-					shape: cursorShape,
-					cursorKey,
-					legacyCursorKeys,
-				})
-			: undefined;
-	const startPaginationToken = cursor?.token;
-	const cursorSinceId =
-		cursor?.boundary?.kind === "since" ? cursor.boundary.sinceId : undefined;
-	const cursorStartTime =
-		cursor?.boundary?.kind === "start" ? cursor.boundary.startTime : undefined;
-	const committedSinceId =
-		parsedMode === "xurl" &&
-		cursorShape.boundary.kind === "auto" &&
-		!startPaginationToken
-			? readMentionHighWaterId(db, parsedMode, resolvedAccount.accountId)
-			: undefined;
-	const seededSinceId =
-		parsedMode === "xurl" &&
-		!explicitSinceId &&
-		!explicitStartTime &&
-		!startPaginationToken
-			? (committedSinceId ??
-				findNewestArchiveMentionId(db, resolvedAccount.accountId))
-			: undefined;
-	const resolvedSinceId = startPaginationToken
-		? cursorSinceId
-		: (explicitSinceId ?? seededSinceId);
-	const resolvedStartTime = startPaginationToken
-		? cursorStartTime
-		: !resolvedSinceId
-			? explicitStartTime
-			: undefined;
-	const resultShape: MentionScanShape = {
-		endpoint: "mentions",
-		mode: parsedMode,
-		accountId: resolvedAccount.accountId,
-		pageSize: limit,
-		boundary: getMentionRequestBoundary({
-			sinceId: resolvedSinceId,
-			startTime: resolvedStartTime,
-		}),
-	};
-	const resultCacheKey = getMentionResultCacheKey({
-		shape: resultShape,
-		all: fetchAll,
-		maxPages: parsedMaxPages,
-	});
-	const ttlMs = parseCacheTtlMs(cacheTtlMs);
-	const cached = startPaginationToken
-		? null
-		: readSyncCache<XurlMentionsResponse>(resultCacheKey, db);
-	const cachedPaginationToken = getCachedPaginationToken(cached);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
-
-	if (
-		!startPaginationToken &&
-		!cachedPaginationToken &&
-		!refresh &&
-		cached &&
-		cacheAgeMs <= ttlMs
-	) {
-		mergeMentionsIntoLocalStore(
-			db,
-			resolvedAccount.accountId,
-			cached.value,
-			parsedMode,
-		);
-		return {
-			ok: true,
-			source: "cache",
-			kind: "mentions",
-			accountId: resolvedAccount.accountId,
-			count: cached.value.data.length,
-			partial: isMaxPagesPartial({
-				payload: cached.value,
-				maxPages: parsedMaxPages,
-			}),
-			payload: cached.value,
-		};
-	}
-
-	if (
-		parsedMode === "xurl" &&
-		!explicitSinceId &&
-		!explicitStartTime &&
-		!startPaginationToken &&
-		!seededSinceId
-	) {
-		console.error(
-			"No local mention baseline found; syncing mentions from the newest page backwards.",
-		);
-	}
-
-	const payload =
-		parsedMode === "bird"
-			? await fetchMentionsViaBird({ limit })
-			: await fetchMentionsViaXurl({
-					resolvedAccount,
-					limit,
-					all: fetchAll,
-					parsedMaxPages,
-					sinceId: resolvedSinceId,
-					startPaginationToken,
-					startTime: resolvedStartTime,
-				});
-	mergeMentionsIntoLocalStore(
-		db,
-		resolvedAccount.accountId,
-		payload,
-		parsedMode,
-	);
-	const payloadPaginationToken = getCachedPaginationToken({ value: payload });
-	if (parsedMode === "xurl") {
-		if (payloadPaginationToken) {
-			writeSyncCache(
-				cursorKey,
-				addMentionCursorState(
-					payload,
-					getMentionRequestBoundary({
-						sinceId: resolvedSinceId,
-						startTime: resolvedStartTime,
-					}),
-					maxNumericTweetId(resolvedSinceId, getNewestMentionId(payload)),
-				),
-				db,
+}: SyncMentionsOptions) {
+	return Effect.gen(function* () {
+		const parsedMode = yield* trySync(() => parseSyncMode(mode));
+		const explicitSinceId = sinceId?.trim() || undefined;
+		const explicitStartTime = startTime?.trim() || undefined;
+		if (parsedMode === "bird" && (explicitSinceId || explicitStartTime)) {
+			return yield* Effect.fail(
+				new Error("bird mode does not support --since-id or --start-time"),
 			);
-			deleteSyncCache(resultCacheKey, db);
-			deleteSyncCache(
-				getMentionResultCacheKey({
-					shape: cursorShape,
-					all: fetchAll,
+		}
+		if (parsedMode === "xurl") {
+			yield* trySync(() => assertXurlLimit(limit));
+		} else {
+			yield* trySync(() => assertBirdLimit(limit));
+		}
+		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const fetchAll = parsedMode === "xurl" && parsedMaxPages !== null;
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccount = yield* trySync(() => resolveAccount(db, account));
+		const cursorShape: MentionScanShape = {
+			endpoint: "mentions",
+			mode: parsedMode,
+			accountId: resolvedAccount.accountId,
+			pageSize: limit,
+			boundary: getMentionCursorBoundary({
+				explicitSinceId,
+				explicitStartTime,
+			}),
+		};
+		const cursorKey = getMentionCursorKey(cursorShape);
+		const legacyCursorKeys = getLegacyMentionCursorKeys(cursorShape);
+		const cursor =
+			parsedMode === "xurl"
+				? yield* trySync(() =>
+						readMentionCursor({
+							db,
+							shape: cursorShape,
+							cursorKey,
+							legacyCursorKeys,
+						}),
+					)
+				: undefined;
+		const startPaginationToken = cursor?.token;
+		const cursorSinceId =
+			cursor?.boundary?.kind === "since" ? cursor.boundary.sinceId : undefined;
+		const cursorStartTime =
+			cursor?.boundary?.kind === "start"
+				? cursor.boundary.startTime
+				: undefined;
+		const committedSinceId =
+			parsedMode === "xurl" &&
+			cursorShape.boundary.kind === "auto" &&
+			!startPaginationToken
+				? yield* trySync(() =>
+						readMentionHighWaterId(db, parsedMode, resolvedAccount.accountId),
+					)
+				: undefined;
+		const seededSinceId =
+			parsedMode === "xurl" &&
+			!explicitSinceId &&
+			!explicitStartTime &&
+			!startPaginationToken
+				? (committedSinceId ??
+					(yield* trySync(() =>
+						findNewestArchiveMentionId(db, resolvedAccount.accountId),
+					)))
+				: undefined;
+		const resolvedSinceId = startPaginationToken
+			? cursorSinceId
+			: (explicitSinceId ?? seededSinceId);
+		const resolvedStartTime = startPaginationToken
+			? cursorStartTime
+			: !resolvedSinceId
+				? explicitStartTime
+				: undefined;
+		const resultShape: MentionScanShape = {
+			endpoint: "mentions",
+			mode: parsedMode,
+			accountId: resolvedAccount.accountId,
+			pageSize: limit,
+			boundary: getMentionRequestBoundary({
+				sinceId: resolvedSinceId,
+				startTime: resolvedStartTime,
+			}),
+		};
+		const resultCacheKey = getMentionResultCacheKey({
+			shape: resultShape,
+			all: fetchAll,
+			maxPages: parsedMaxPages,
+		});
+		const ttlMs = parseCacheTtlMs(cacheTtlMs);
+		const cached = startPaginationToken
+			? null
+			: yield* trySync(() =>
+					readSyncCache<XurlMentionsResponse>(resultCacheKey, db),
+				);
+		const cachedPaginationToken = getCachedPaginationToken(cached);
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
+
+		if (
+			!startPaginationToken &&
+			!cachedPaginationToken &&
+			!refresh &&
+			cached &&
+			cacheAgeMs <= ttlMs
+		) {
+			yield* trySync(() =>
+				mergeMentionsIntoLocalStore(
+					db,
+					resolvedAccount.accountId,
+					cached.value,
+					parsedMode,
+				),
+			);
+			return {
+				ok: true,
+				source: "cache",
+				kind: "mentions",
+				accountId: resolvedAccount.accountId,
+				count: cached.value.data.length,
+				partial: isMaxPagesPartial({
+					payload: cached.value,
 					maxPages: parsedMaxPages,
 				}),
-				db,
+				payload: cached.value,
+			};
+		}
+
+		if (
+			parsedMode === "xurl" &&
+			!explicitSinceId &&
+			!explicitStartTime &&
+			!startPaginationToken &&
+			!seededSinceId
+		) {
+			console.error(
+				"No local mention baseline found; syncing mentions from the newest page backwards.",
 			);
-			for (const legacyKey of cursor?.legacyKeys ?? []) {
-				deleteSyncCache(legacyKey, db);
-			}
-		} else {
-			deleteSyncCache(cursorKey, db);
-			for (const legacyKey of legacyCursorKeys) {
-				deleteSyncCache(legacyKey, db);
-			}
-			if (cursorShape.boundary.kind === "auto") {
-				writeMentionHighWaterId(
-					db,
-					parsedMode,
-					resolvedAccount.accountId,
-					maxNumericTweetId(
-						resolvedSinceId,
-						cursor?.pendingNewestId,
-						getNewestMentionId(payload),
-					),
-				);
+		}
+
+		const payload =
+			parsedMode === "bird"
+				? yield* fetchMentionsViaBirdEffect({ limit })
+				: yield* fetchMentionsViaXurlEffect({
+						resolvedAccount,
+						limit,
+						all: fetchAll,
+						parsedMaxPages,
+						sinceId: resolvedSinceId,
+						startPaginationToken,
+						startTime: resolvedStartTime,
+					});
+		yield* trySync(() =>
+			mergeMentionsIntoLocalStore(
+				db,
+				resolvedAccount.accountId,
+				payload,
+				parsedMode,
+			),
+		);
+		const payloadPaginationToken = getCachedPaginationToken({ value: payload });
+		if (parsedMode === "xurl") {
+			if (payloadPaginationToken) {
+				yield* trySync(() => {
+					writeSyncCache(
+						cursorKey,
+						addMentionCursorState(
+							payload,
+							getMentionRequestBoundary({
+								sinceId: resolvedSinceId,
+								startTime: resolvedStartTime,
+							}),
+							maxNumericTweetId(resolvedSinceId, getNewestMentionId(payload)),
+						),
+						db,
+					);
+					deleteSyncCache(resultCacheKey, db);
+					deleteSyncCache(
+						getMentionResultCacheKey({
+							shape: cursorShape,
+							all: fetchAll,
+							maxPages: parsedMaxPages,
+						}),
+						db,
+					);
+					for (const legacyKey of cursor?.legacyKeys ?? []) {
+						deleteSyncCache(legacyKey, db);
+					}
+				});
+			} else {
+				yield* trySync(() => {
+					deleteSyncCache(cursorKey, db);
+					for (const legacyKey of legacyCursorKeys) {
+						deleteSyncCache(legacyKey, db);
+					}
+					if (cursorShape.boundary.kind === "auto") {
+						writeMentionHighWaterId(
+							db,
+							parsedMode,
+							resolvedAccount.accountId,
+							maxNumericTweetId(
+								resolvedSinceId,
+								cursor?.pendingNewestId,
+								getNewestMentionId(payload),
+							),
+						);
+					}
+				});
 			}
 		}
-	}
-	if (!payloadPaginationToken && !startPaginationToken) {
-		writeSyncCache(resultCacheKey, payload, db);
-	}
+		if (!payloadPaginationToken && !startPaginationToken) {
+			yield* trySync(() => writeSyncCache(resultCacheKey, payload, db));
+		}
 
-	return {
-		ok: true,
-		source: parsedMode,
-		kind: "mentions",
-		accountId: resolvedAccount.accountId,
-		count: payload.data.length,
-		partial: isMaxPagesPartial({ payload, maxPages: parsedMaxPages }),
-		payload,
-	};
+		return {
+			ok: true,
+			source: parsedMode,
+			kind: "mentions",
+			accountId: resolvedAccount.accountId,
+			count: payload.data.length,
+			partial: isMaxPagesPartial({ payload, maxPages: parsedMaxPages }),
+			payload,
+		};
+	});
 }
 
-async function exportMentionsViaCachedLiveSource({
+export function syncMentions(options: SyncMentionsOptions) {
+	return runEffectPromise(syncMentionsEffect(options));
+}
+
+function exportMentionsViaCachedLiveSourceEffect({
 	mode,
 	account,
 	search,
@@ -959,90 +1018,36 @@ async function exportMentionsViaCachedLiveSource({
 	maxPages,
 	refresh = false,
 	cacheTtlMs,
-}: {
-	mode: MentionsDataSource;
-	account?: string;
-	search?: string;
-	replyFilter?: ReplyFilter;
-	limit?: number;
-	all?: boolean;
-	maxPages?: number;
-	refresh?: boolean;
-	cacheTtlMs?: number;
-}) {
-	if (mode === "xurl") {
-		assertXurlLimit(limit);
-	} else {
-		assertBirdLimit(limit);
-	}
-	const parsedMaxPages = parseMaxPages(maxPages);
-	const fetchAll = mode === "xurl" && (all || parsedMaxPages !== null);
-
-	const db = getNativeDb();
-	const resolvedAccount = resolveAccount(db, account);
-	const cacheKey = getMentionsFetchModeKey({
-		scope: "export",
-		mode,
-		accountId: resolvedAccount.accountId,
-		pageSize: limit,
-		all: fetchAll,
-		maxPages: parsedMaxPages,
-		sinceId: null,
-		startTime: null,
-	});
-	const ttlMs = parseCacheTtlMs(cacheTtlMs);
-	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
-
-	if (!refresh && cached && cacheAgeMs <= ttlMs) {
-		if (
-			shouldReturnFilteredLocalPayload({
-				search,
-				replyFilter,
-			})
-		) {
-			return readLocalXurlCompatiblePayload({
-				accountId: resolvedAccount.accountId,
-				search,
-				replyFilter,
-				limit: fetchAll ? cached.value.data.length : limit,
-			});
+}: ExportMentionsViaCachedLiveSourceOptions) {
+	return Effect.gen(function* () {
+		if (mode === "xurl") {
+			yield* trySync(() => assertXurlLimit(limit));
+		} else {
+			yield* trySync(() => assertBirdLimit(limit));
 		}
-		return cached.value;
-	}
+		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const fetchAll = mode === "xurl" && (all || parsedMaxPages !== null);
 
-	try {
-		const payload =
-			mode === "bird"
-				? await listMentionsViaBird({ maxResults: limit })
-				: await fetchMentionsViaXurl({
-						resolvedAccount,
-						limit,
-						all: fetchAll,
-						parsedMaxPages,
-					});
-		mergeMentionsIntoLocalStore(db, resolvedAccount.accountId, payload, mode);
-		writeSyncCache(cacheKey, payload, db);
-
-		if (
-			shouldReturnFilteredLocalPayload({
-				search,
-				replyFilter,
-			})
-		) {
-			return readLocalXurlCompatiblePayload({
-				accountId: resolvedAccount.accountId,
-				search,
-				replyFilter,
-				limit: fetchAll ? payload.data.length : limit,
-			});
-		}
-
-		return payload;
-	} catch (error) {
-		if (!refresh && cached) {
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccount = yield* trySync(() => resolveAccount(db, account));
+		const cacheKey = getMentionsFetchModeKey({
+			scope: "export",
+			mode,
+			accountId: resolvedAccount.accountId,
+			pageSize: limit,
+			all: fetchAll,
+			maxPages: parsedMaxPages,
+			sinceId: null,
+			startTime: null,
+		});
+		const ttlMs = parseCacheTtlMs(cacheTtlMs);
+		const cached = yield* trySync(() =>
+			readSyncCache<XurlMentionsResponse>(cacheKey, db),
+		);
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
+		const readFilteredOrRaw = (payload: XurlMentionsResponse) => {
 			if (
 				shouldReturnFilteredLocalPayload({
 					search,
@@ -1053,35 +1058,78 @@ async function exportMentionsViaCachedLiveSource({
 					accountId: resolvedAccount.accountId,
 					search,
 					replyFilter,
-					limit: fetchAll ? cached.value.data.length : limit,
+					limit: fetchAll ? payload.data.length : limit,
 				});
 			}
-			return cached.value;
+			return payload;
+		};
+
+		if (!refresh && cached && cacheAgeMs <= ttlMs) {
+			return yield* trySync(() => readFilteredOrRaw(cached.value));
 		}
-		throw error;
-	}
-}
 
-export async function exportMentionsViaCachedXurl(
-	options: Omit<
-		Parameters<typeof exportMentionsViaCachedLiveSource>[0],
-		"mode"
-	>,
-) {
-	return exportMentionsViaCachedLiveSource({
-		...options,
-		mode: "xurl",
+		const liveResult = yield* (
+			mode === "bird"
+				? fetchMentionsViaBirdEffect({ limit })
+				: fetchMentionsViaXurlEffect({
+						resolvedAccount,
+						limit,
+						all: fetchAll,
+						parsedMaxPages,
+					})
+		).pipe(
+			Effect.flatMap((payload) =>
+				trySync(() => {
+					mergeMentionsIntoLocalStore(
+						db,
+						resolvedAccount.accountId,
+						payload,
+						mode,
+					);
+					writeSyncCache(cacheKey, payload, db);
+					return readFilteredOrRaw(payload);
+				}),
+			),
+			Effect.map((payload) => ({ ok: true as const, payload })),
+			Effect.catchAll((error) => {
+				if (!refresh && cached) {
+					return Effect.succeed({ ok: false as const });
+				}
+				return Effect.fail(error);
+			}),
+		);
+
+		if (!liveResult.ok) {
+			if (!cached) {
+				return yield* Effect.fail(
+					new Error("Mention export failed without cache"),
+				);
+			}
+			return yield* trySync(() => readFilteredOrRaw(cached.value));
+		}
+
+		return liveResult.payload;
 	});
 }
 
-export async function exportMentionsViaCachedBird(
-	options: Omit<
-		Parameters<typeof exportMentionsViaCachedLiveSource>[0],
-		"mode"
-	>,
+export function exportMentionsViaCachedXurl(
+	options: Omit<ExportMentionsViaCachedLiveSourceOptions, "mode">,
 ) {
-	return exportMentionsViaCachedLiveSource({
-		...options,
-		mode: "bird",
-	});
+	return runEffectPromise(
+		exportMentionsViaCachedLiveSourceEffect({
+			...options,
+			mode: "xurl",
+		}),
+	);
+}
+
+export function exportMentionsViaCachedBird(
+	options: Omit<ExportMentionsViaCachedLiveSourceOptions, "mode">,
+) {
+	return runEffectPromise(
+		exportMentionsViaCachedLiveSourceEffect({
+			...options,
+			mode: "bird",
+		}),
+	);
 }

--- a/src/lib/moderation-target.test.ts
+++ b/src/lib/moderation-target.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -189,6 +190,38 @@ describe("moderation target helpers", () => {
 		expect(mocks.lookupUsersByIds).toHaveBeenCalledWith(["88"]);
 	});
 
+	it("exposes moderation target resolution as lazy Effect programs", async () => {
+		makeTempHome();
+		mocks.lookupProfileViaBird.mockResolvedValueOnce(null);
+		mocks.lookupUsersByHandles.mockResolvedValueOnce([
+			{
+				id: "88",
+				username: "amelia",
+				name: "Amelia",
+			},
+		]);
+		const { resolveProfileEffect } = await import("./moderation-target");
+		const { resolveModerationTargetEffect } =
+			await import("./moderation-write");
+
+		const profileEffect = resolveProfileEffect("@amelia");
+		expect(mocks.lookupUsersByHandles).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(profileEffect)).resolves.toMatchObject({
+			profile: expect.objectContaining({ handle: "amelia" }),
+			externalUserId: "88",
+		});
+
+		const targetEffect = resolveModerationTargetEffect({
+			accountId: "acct_primary",
+			query: "@amelia",
+			selfActionError: "Cannot block the current account",
+		});
+		await expect(Effect.runPromise(targetEffect)).resolves.toMatchObject({
+			resolvedAccountId: "acct_primary",
+			actionQuery: "amelia",
+		});
+	});
+
 	it("returns authenticated ids safely", async () => {
 		makeTempHome();
 		mocks.lookupAuthenticatedUser
@@ -200,5 +233,16 @@ describe("moderation target helpers", () => {
 		await expect(getAuthenticatedUserId()).resolves.toBe("1");
 		await expect(getAuthenticatedUserId()).resolves.toBeNull();
 		await expect(getAuthenticatedUserId()).resolves.toBeNull();
+	});
+
+	it("exposes authenticated user id lookup as a safe Effect program", async () => {
+		makeTempHome();
+		mocks.lookupAuthenticatedUser.mockResolvedValueOnce({ id: "1" });
+		const { getAuthenticatedUserIdEffect } =
+			await import("./moderation-target");
+
+		const effect = getAuthenticatedUserIdEffect();
+		expect(mocks.lookupAuthenticatedUser).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toBe("1");
 	});
 });

--- a/src/lib/moderation-target.ts
+++ b/src/lib/moderation-target.ts
@@ -1,6 +1,8 @@
 import type { Database } from "./sqlite";
+import { Effect } from "effect";
 import { lookupProfileViaBird } from "./bird-actions";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { ProfileRecord, XurlMentionUser } from "./types";
 import { getExternalUserId, upsertProfileFromXUser } from "./x-profile";
 import {
@@ -12,6 +14,17 @@ import {
 export interface ResolvedModerationProfile {
 	profile: ProfileRecord;
 	externalUserId: string | null;
+}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 export function toProfile(row: Record<string, unknown>): ProfileRecord {
@@ -90,90 +103,114 @@ export function resolveLocalProfile(
 	};
 }
 
-export async function resolveProfile(
+export function resolveProfileEffect(
 	query: string,
-): Promise<ResolvedModerationProfile> {
-	const db = getNativeDb();
-	const normalizedQuery = normalizeProfileQuery(query);
-	if (!normalizedQuery) {
-		throw new Error("Missing profile handle or id");
-	}
-
-	const local = resolveLocalProfile(db, normalizedQuery);
-	if (process.env.BIRDCLAW_DISABLE_LIVE_PROFILE_LOOKUP === "1") {
-		if (local) {
-			return local;
+): Effect.Effect<ResolvedModerationProfile, unknown> {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const normalizedQuery = normalizeProfileQuery(query);
+		if (!normalizedQuery) {
+			return yield* Effect.fail(new Error("Missing profile handle or id"));
 		}
-		throw new Error(`Profile not found locally: ${query}`);
-	}
-	if (
-		local &&
-		!local.profile.id.startsWith("profile_group_") &&
-		local.externalUserId
-	) {
-		return local;
-	}
 
-	let user: XurlMentionUser | undefined;
-	let lastError: unknown;
-
-	try {
-		user =
-			(await lookupProfileViaBird(local?.profile.handle ?? normalizedQuery)) ??
-			undefined;
-	} catch (error) {
-		lastError = error;
-	}
-
-	if (!user) {
-		try {
-			if (/^\d+$/.test(normalizedQuery)) {
-				[user] = await lookupUsersByIds([normalizedQuery]);
-			} else {
-				[user] = await lookupUsersByHandles([
-					local?.profile.handle ?? normalizedQuery,
-				]);
+		const local = yield* trySync(() =>
+			resolveLocalProfile(db, normalizedQuery),
+		);
+		if (process.env.BIRDCLAW_DISABLE_LIVE_PROFILE_LOOKUP === "1") {
+			if (local) {
+				return local;
 			}
-		} catch (error) {
-			lastError = error;
+			return yield* Effect.fail(
+				new Error(`Profile not found locally: ${query}`),
+			);
 		}
-	}
-
-	if (!user && lastError) {
-		if (local) {
+		if (
+			local &&
+			!local.profile.id.startsWith("profile_group_") &&
+			local.externalUserId
+		) {
 			return local;
 		}
-		throw lastError;
-	}
 
-	if (!user) {
+		let user: XurlMentionUser | undefined;
+		let lastError: unknown;
+
+		const birdResult = yield* tryPromise(() =>
+			lookupProfileViaBird(local?.profile.handle ?? normalizedQuery),
+		).pipe(
+			Effect.map((value) => ({ ok: true as const, value })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (birdResult.ok) {
+			user = birdResult.value ?? undefined;
+		} else {
+			lastError = birdResult.error;
+		}
+
+		if (!user) {
+			const xurlResult = yield* tryPromise(() =>
+				/^\d+$/.test(normalizedQuery)
+					? lookupUsersByIds([normalizedQuery])
+					: lookupUsersByHandles([local?.profile.handle ?? normalizedQuery]),
+			).pipe(
+				Effect.map((value) => ({ ok: true as const, value })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ ok: false as const, error }),
+				),
+			);
+			if (xurlResult.ok) {
+				[user] = xurlResult.value;
+			} else {
+				lastError = xurlResult.error;
+			}
+		}
+
+		if (!user && lastError) {
+			if (local) {
+				return local;
+			}
+			return yield* Effect.fail(lastError);
+		}
+
+		if (!user) {
+			if (local) {
+				return local;
+			}
+			return yield* Effect.fail(new Error(`Profile not found: ${query}`));
+		}
+
 		if (local) {
-			return local;
+			return yield* trySync(() => upsertProfileFromXUser(db, user));
 		}
-		throw new Error(`Profile not found: ${query}`);
-	}
 
-	if (local) {
-		return upsertProfileFromXUser(db, user);
-	}
-
-	const username = String(user.username ?? "").replace(/^@/, "");
-	if (username) {
-		const localByHandle = resolveLocalProfile(db, username);
-		if (localByHandle) {
-			return upsertProfileFromXUser(db, user);
+		const username = String(user.username ?? "").replace(/^@/, "");
+		if (username) {
+			const localByHandle = yield* trySync(() =>
+				resolveLocalProfile(db, username),
+			);
+			if (localByHandle) {
+				return yield* trySync(() => upsertProfileFromXUser(db, user));
+			}
 		}
-	}
 
-	return upsertProfileFromXUser(db, user);
+		return yield* trySync(() => upsertProfileFromXUser(db, user));
+	});
 }
 
-export async function getAuthenticatedUserId() {
-	try {
-		const me = await lookupAuthenticatedUser();
+export function resolveProfile(
+	query: string,
+): Promise<ResolvedModerationProfile> {
+	return runEffectPromise(resolveProfileEffect(query));
+}
+
+export function getAuthenticatedUserIdEffect() {
+	return Effect.gen(function* () {
+		const me = yield* tryPromise(() => lookupAuthenticatedUser());
 		const id = me?.id;
 		return typeof id === "string" && id.length > 0 ? id : null;
-	} catch {
-		return null;
-	}
+	}).pipe(Effect.catchAll(() => Effect.succeed(null)));
+}
+
+export function getAuthenticatedUserId() {
+	return runEffectPromise(getAuthenticatedUserIdEffect());
 }

--- a/src/lib/moderation-write.ts
+++ b/src/lib/moderation-write.ts
@@ -1,11 +1,13 @@
 import type { Database } from "./sqlite";
+import { Effect } from "effect";
 import type { ActionsTransport } from "./config";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import {
 	getAccountHandle,
 	getDefaultAccountId,
 	normalizeProfileQuery,
-	resolveProfile,
+	resolveProfileEffect,
 } from "./moderation-target";
 
 export interface ModerationActionOptions {
@@ -18,28 +20,46 @@ interface ResolveModerationTargetParams {
 	selfActionError: string;
 }
 
-export async function resolveModerationTarget({
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+export function resolveModerationTargetEffect({
 	accountId,
 	query,
 	selfActionError,
 }: ResolveModerationTargetParams) {
-	const db = getNativeDb();
-	const resolvedAccountId = accountId || getDefaultAccountId(db);
-	const accountHandle = getAccountHandle(db, resolvedAccountId);
-	if (normalizeProfileQuery(query) === accountHandle) {
-		throw new Error(selfActionError);
-	}
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccountId = accountId || getDefaultAccountId(db);
+		const accountHandle = yield* trySync(() =>
+			getAccountHandle(db, resolvedAccountId),
+		);
+		const normalizedQuery = normalizeProfileQuery(query);
+		if (normalizedQuery === accountHandle) {
+			return yield* Effect.fail(new Error(selfActionError));
+		}
 
-	const resolved = await resolveProfile(query);
-	return {
-		db,
-		resolved,
-		resolvedAccountId,
-		actionQuery:
-			resolved.externalUserId ??
-			resolved.profile.handle ??
-			normalizeProfileQuery(query),
-	};
+		const resolved = yield* resolveProfileEffect(query);
+		return {
+			db,
+			resolved,
+			resolvedAccountId,
+			actionQuery:
+				resolved.externalUserId ?? resolved.profile.handle ?? normalizedQuery,
+		};
+	});
+}
+
+export function resolveModerationTarget(params: ResolveModerationTargetParams) {
+	return runEffectPromise(resolveModerationTargetEffect(params));
 }
 
 export function writeModerationRow(

--- a/src/lib/mutes-write.ts
+++ b/src/lib/mutes-write.ts
@@ -1,118 +1,165 @@
+import { Effect } from "effect";
 import { runModerationAction } from "./actions-transport";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import {
 	deleteModerationRow,
 	type ModerationActionOptions,
-	resolveModerationTarget,
+	resolveModerationTargetEffect,
 	writeModerationRow,
 } from "./moderation-write";
 
-export async function addMute(
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: (error) =>
+			error instanceof Error ? error : new Error(String(error)),
+	});
+}
+
+export function addMuteEffect(
 	accountId: string,
 	query: string,
 	options: ModerationActionOptions = {},
 ) {
-	const { db, resolved, resolvedAccountId, actionQuery } =
-		await resolveModerationTarget({
-			accountId,
-			query,
-			selfActionError: "Cannot mute the current account",
-		});
-	const transport = await runModerationAction({
-		action: "mute",
-		query: actionQuery,
-		targetUserId: resolved.externalUserId ?? undefined,
-		transport: options.transport,
-	});
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId, actionQuery } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot mute the current account",
+			});
+		const transport = yield* tryPromise(() =>
+			runModerationAction({
+				action: "mute",
+				query: actionQuery,
+				targetUserId: resolved.externalUserId ?? undefined,
+				transport: options.transport,
+			}),
+		);
 
-	if (!transport.ok) {
+		if (!transport.ok) {
+			return {
+				ok: false,
+				action: "mute",
+				accountId: resolvedAccountId,
+				profile: resolved.profile,
+				transport,
+			};
+		}
+
+		const mutedAt = new Date().toISOString();
+		yield* trySync(() =>
+			writeModerationRow(
+				db,
+				"mutes",
+				resolvedAccountId,
+				resolved.profile.id,
+				mutedAt,
+			),
+		);
+
 		return {
-			ok: false,
+			ok: true,
 			action: "mute",
 			accountId: resolvedAccountId,
+			mutedAt,
 			profile: resolved.profile,
 			transport,
 		};
-	}
-
-	const mutedAt = new Date().toISOString();
-	writeModerationRow(
-		db,
-		"mutes",
-		resolvedAccountId,
-		resolved.profile.id,
-		mutedAt,
-	);
-
-	return {
-		ok: true,
-		action: "mute",
-		accountId: resolvedAccountId,
-		mutedAt,
-		profile: resolved.profile,
-		transport,
-	};
-}
-
-export async function recordMute(accountId: string, query: string) {
-	const { db, resolved, resolvedAccountId } = await resolveModerationTarget({
-		accountId,
-		query,
-		selfActionError: "Cannot mute the current account",
 	});
-
-	const mutedAt = new Date().toISOString();
-	writeModerationRow(
-		db,
-		"mutes",
-		resolvedAccountId,
-		resolved.profile.id,
-		mutedAt,
-	);
-
-	return {
-		ok: true,
-		action: "record-mute",
-		accountId: resolvedAccountId,
-		mutedAt,
-		profile: resolved.profile,
-	};
 }
 
-export async function removeMute(
+export function addMute(
 	accountId: string,
 	query: string,
 	options: ModerationActionOptions = {},
 ) {
-	const { db, resolved, resolvedAccountId, actionQuery } =
-		await resolveModerationTarget({
-			accountId,
-			query,
-			selfActionError: "Cannot mute the current account",
-		});
-	const transport = await runModerationAction({
-		action: "unmute",
-		query: actionQuery,
-		targetUserId: resolved.externalUserId ?? undefined,
-		transport: options.transport,
-	});
+	return runEffectPromise(addMuteEffect(accountId, query, options));
+}
 
-	if (!transport.ok) {
+export function recordMuteEffect(accountId: string, query: string) {
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot mute the current account",
+			});
+
+		const mutedAt = new Date().toISOString();
+		yield* trySync(() =>
+			writeModerationRow(
+				db,
+				"mutes",
+				resolvedAccountId,
+				resolved.profile.id,
+				mutedAt,
+			),
+		);
+
 		return {
-			ok: false,
+			ok: true,
+			action: "record-mute",
+			accountId: resolvedAccountId,
+			mutedAt,
+			profile: resolved.profile,
+		};
+	});
+}
+
+export function recordMute(accountId: string, query: string) {
+	return runEffectPromise(recordMuteEffect(accountId, query));
+}
+
+export function removeMuteEffect(
+	accountId: string,
+	query: string,
+	options: ModerationActionOptions = {},
+) {
+	return Effect.gen(function* () {
+		const { db, resolved, resolvedAccountId, actionQuery } =
+			yield* resolveModerationTargetEffect({
+				accountId,
+				query,
+				selfActionError: "Cannot mute the current account",
+			});
+		const transport = yield* tryPromise(() =>
+			runModerationAction({
+				action: "unmute",
+				query: actionQuery,
+				targetUserId: resolved.externalUserId ?? undefined,
+				transport: options.transport,
+			}),
+		);
+
+		if (!transport.ok) {
+			return {
+				ok: false,
+				action: "unmute",
+				accountId: resolvedAccountId,
+				profile: resolved.profile,
+				transport,
+			};
+		}
+
+		yield* trySync(() =>
+			deleteModerationRow(db, "mutes", resolvedAccountId, resolved.profile.id),
+		);
+
+		return {
+			ok: true,
 			action: "unmute",
 			accountId: resolvedAccountId,
 			profile: resolved.profile,
 			transport,
 		};
-	}
+	});
+}
 
-	deleteModerationRow(db, "mutes", resolvedAccountId, resolved.profile.id);
-
-	return {
-		ok: true,
-		action: "unmute",
-		accountId: resolvedAccountId,
-		profile: resolved.profile,
-		transport,
-	};
+export function removeMute(
+	accountId: string,
+	query: string,
+	options: ModerationActionOptions = {},
+) {
+	return runEffectPromise(removeMuteEffect(accountId, query, options));
 }

--- a/src/lib/mutes.test.ts
+++ b/src/lib/mutes.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -106,6 +107,22 @@ describe("mutes", () => {
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("builds mute write effects lazily", async () => {
+		makeTempHome();
+		const { addMuteEffect } = await import("./mutes");
+
+		const effect = addMuteEffect("acct_primary", "@amelia");
+
+		expect(mocks.lookupUsersByHandles).not.toHaveBeenCalled();
+		expect(mocks.muteUserViaBird).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			action: "mute",
+			accountId: "acct_primary",
+		});
+		expect(mocks.muteUserViaBird).toHaveBeenCalledWith("7");
 	});
 
 	it("mutes, lists, and unmutes profiles", async () => {

--- a/src/lib/mutes.ts
+++ b/src/lib/mutes.ts
@@ -2,7 +2,14 @@ import { getNativeDb } from "./db";
 import { toProfile } from "./moderation-target";
 import type { BlockItem } from "./types";
 
-export { addMute, recordMute, removeMute } from "./mutes-write";
+export {
+	addMute,
+	addMuteEffect,
+	recordMute,
+	recordMuteEffect,
+	removeMute,
+	removeMuteEffect,
+} from "./mutes-write";
 
 export interface MuteItem {
 	accountId: string;

--- a/src/lib/openai.test.ts
+++ b/src/lib/openai.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { scoreInboxItemWithOpenAI } from "./openai";
+import {
+	scoreInboxItemWithOpenAI,
+	scoreInboxItemWithOpenAIEffect,
+} from "./openai";
 
 beforeEach(() => {
 	process.env.OPENAI_API_KEY = "";
@@ -72,6 +76,51 @@ describe("openai inbox scoring", () => {
 			score: 100,
 			summary: "Strong ask",
 			reasoning: "Concrete and relevant",
+		});
+	});
+
+	it("exposes inbox scoring as an Effect program", async () => {
+		process.env.OPENAI_API_KEY = "test-key";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						choices: [
+							{
+								message: {
+									content: JSON.stringify({
+										score: 44,
+										summary: "Useful",
+										reasoning: "Looks specific",
+									}),
+								},
+							},
+						],
+					}),
+				),
+			),
+		);
+
+		await expect(
+			Effect.runPromise(
+				scoreInboxItemWithOpenAIEffect({
+					entityKind: "mention",
+					title: "Mention",
+					text: "question?",
+					influenceScore: 80,
+					participant: {
+						handle: "amelia",
+						displayName: "Amelia",
+						bio: "bio",
+						followersCount: 4200,
+					},
+				}),
+			),
+		).resolves.toMatchObject({
+			score: 44,
+			summary: "Useful",
+			reasoning: "Looks specific",
 		});
 	});
 

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,3 +1,6 @@
+import { Effect } from "effect";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
+
 export interface OpenAIInboxScore {
 	score: number;
 	summary: string;
@@ -22,65 +25,93 @@ function clampScore(value: number) {
 	return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-export async function scoreInboxItemWithOpenAI(
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+export function scoreInboxItemWithOpenAIEffect(
+	input: OpenAIInboxInput,
+): Effect.Effect<OpenAIInboxScore, Error> {
+	return Effect.gen(function* () {
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (!apiKey) {
+			return yield* Effect.fail(new Error("OPENAI_API_KEY is not set"));
+		}
+
+		const model = process.env.BIRDCLAW_OPENAI_MODEL || "gpt-5.2";
+		const response = yield* tryPromise(() =>
+			fetch("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${apiKey}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					model,
+					response_format: { type: "json_object" },
+					messages: [
+						{
+							role: "system",
+							content:
+								"You rank inbound Twitter mentions and DMs for Peter Steinberger. Return JSON only with keys score, summary, reasoning. Score 0-100. High score means worth replying soon. Prefer specific, actionable, novel, high-signal items. Penalize generic praise, low-context asks, and low-signal chatter. summary max 18 words. reasoning max 28 words.",
+						},
+						{
+							role: "user",
+							content: JSON.stringify(input),
+						},
+					],
+				}),
+			}),
+		).pipe(Effect.mapError(toError));
+
+		if (!response.ok) {
+			return yield* Effect.fail(
+				new Error(`OpenAI request failed: ${response.status}`),
+			);
+		}
+
+		const payload = (yield* tryPromise(() => response.json()).pipe(
+			Effect.mapError(toError),
+		)) as {
+			choices?: Array<{
+				message?: {
+					content?: string;
+				};
+			}>;
+		};
+
+		const content = payload.choices?.[0]?.message?.content;
+		if (!content) {
+			return yield* Effect.fail(new Error("OpenAI returned no content"));
+		}
+
+		const parsed = yield* trySync(
+			() =>
+				JSON.parse(content) as {
+					score?: number;
+					summary?: string;
+					reasoning?: string;
+				},
+		);
+
+		return {
+			model,
+			score: clampScore(parsed.score ?? 0),
+			summary: String(parsed.summary ?? "No summary"),
+			reasoning: String(parsed.reasoning ?? "No reasoning"),
+		};
+	});
+}
+
+export function scoreInboxItemWithOpenAI(
 	input: OpenAIInboxInput,
 ): Promise<OpenAIInboxScore> {
-	const apiKey = process.env.OPENAI_API_KEY;
-	if (!apiKey) {
-		throw new Error("OPENAI_API_KEY is not set");
-	}
-
-	const model = process.env.BIRDCLAW_OPENAI_MODEL || "gpt-5.2";
-	const response = await fetch("https://api.openai.com/v1/chat/completions", {
-		method: "POST",
-		headers: {
-			authorization: `Bearer ${apiKey}`,
-			"content-type": "application/json",
-		},
-		body: JSON.stringify({
-			model,
-			response_format: { type: "json_object" },
-			messages: [
-				{
-					role: "system",
-					content:
-						"You rank inbound Twitter mentions and DMs for Peter Steinberger. Return JSON only with keys score, summary, reasoning. Score 0-100. High score means worth replying soon. Prefer specific, actionable, novel, high-signal items. Penalize generic praise, low-context asks, and low-signal chatter. summary max 18 words. reasoning max 28 words.",
-				},
-				{
-					role: "user",
-					content: JSON.stringify(input),
-				},
-			],
-		}),
-	});
-
-	if (!response.ok) {
-		throw new Error(`OpenAI request failed: ${response.status}`);
-	}
-
-	const payload = (await response.json()) as {
-		choices?: Array<{
-			message?: {
-				content?: string;
-			};
-		}>;
-	};
-
-	const content = payload.choices?.[0]?.message?.content;
-	if (!content) {
-		throw new Error("OpenAI returned no content");
-	}
-
-	const parsed = JSON.parse(content) as {
-		score?: number;
-		summary?: string;
-		reasoning?: string;
-	};
-
-	return {
-		model,
-		score: clampScore(parsed.score ?? 0),
-		summary: String(parsed.summary ?? "No summary"),
-		reasoning: String(parsed.reasoning ?? "No reasoning"),
-	};
+	return runEffectPromise(scoreInboxItemWithOpenAIEffect(input));
 }

--- a/src/lib/profile-affiliation-hydration.test.ts
+++ b/src/lib/profile-affiliation-hydration.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -12,6 +13,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	lookupProfileViaBird: mocks.lookupProfileViaBird,
+	lookupProfileViaBirdEffect: (handle: string) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupProfileViaBird(handle),
+			catch: (error) => error,
+		}),
 }));
 
 let homeDir = "";
@@ -121,6 +127,28 @@ describe("profile affiliation hydration", () => {
 				is_active: 1,
 			},
 		]);
+	});
+
+	it("exposes affiliation hydration as a lazy Effect program", async () => {
+		seedProfile("profile_user_42", "aditya");
+		seedProfile("profile_user_999", "useblacksmith");
+		seedSyntheticAffiliation(
+			"profile_user_42",
+			"profile_affiliation_blacksmith",
+			"@useblacksmith",
+		);
+		const { hydrateProfileAffiliationOrganizationsEffect } =
+			await import("./profile-affiliation-hydration");
+
+		const effect = hydrateProfileAffiliationOrganizationsEffect(
+			getNativeDb(),
+			"profile_user_42",
+		);
+		expect(mocks.lookupProfileViaBird).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			checked: 1,
+			hydrated: 1,
+		});
 	});
 
 	it("skips empty handles, bird misses, and records lookup errors", async () => {

--- a/src/lib/profile-affiliation-hydration.ts
+++ b/src/lib/profile-affiliation-hydration.ts
@@ -1,5 +1,7 @@
 import type { Database } from "./sqlite";
-import { lookupProfileViaBird } from "./bird";
+import { Effect } from "effect";
+import { lookupProfileViaBirdEffect } from "./bird";
+import { runEffectPromise } from "./effect-runtime";
 import { syncIdentitySearchIndexForProfileIds } from "./identity-search-index";
 import { syncProfileBioEntitiesForProfileId } from "./profile-bio-entities";
 import { recordProfileSnapshot } from "./profile-history";
@@ -22,6 +24,17 @@ interface SyntheticAffiliationRow {
 	label: string | null;
 	source: string;
 	raw_json: string;
+}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 function normalizeHandle(value: string | null) {
@@ -112,13 +125,16 @@ function findLocalOrganizationProfileId(db: Database, handle: string) {
 	return row?.id ?? null;
 }
 
-export async function hydrateProfileAffiliationOrganizations(
+export function hydrateProfileAffiliationOrganizationsEffect(
 	db: Database,
 	subjectProfileId: string,
-): Promise<ProfileAffiliationHydrationResult> {
-	const rows = db
-		.prepare(
-			`
+): Effect.Effect<ProfileAffiliationHydrationResult, unknown> {
+	return Effect.gen(function* () {
+		const rows = yield* trySync(
+			() =>
+				db
+					.prepare(
+						`
       select subject_profile_id, organization_profile_id, organization_name,
         organization_handle, badge_url, url, label, source, raw_json
       from profile_affiliations
@@ -128,62 +144,85 @@ export async function hydrateProfileAffiliationOrganizations(
         and organization_handle is not null
       order by last_seen_at desc
       `,
-		)
-		.all(subjectProfileId) as SyntheticAffiliationRow[];
+					)
+					.all(subjectProfileId) as SyntheticAffiliationRow[],
+		);
 
-	const result: ProfileAffiliationHydrationResult = {
-		checked: rows.length,
-		hydrated: 0,
-		skipped: 0,
-		errors: [],
-	};
+		const result: ProfileAffiliationHydrationResult = {
+			checked: rows.length,
+			hydrated: 0,
+			skipped: 0,
+			errors: [],
+		};
 
-	for (const row of rows) {
-		const handle = normalizeHandle(row.organization_handle);
-		if (!handle) {
-			result.skipped += 1;
-			continue;
-		}
-		try {
-			const localOrganizationProfileId = findLocalOrganizationProfileId(
-				db,
-				handle,
-			);
-			if (localOrganizationProfileId) {
-				db.transaction(() => {
-					replaceSyntheticAffiliation(db, row, localOrganizationProfileId);
-				})();
+		for (const row of rows) {
+			const handle = normalizeHandle(row.organization_handle);
+			if (!handle) {
+				result.skipped += 1;
+				continue;
+			}
+			const hydrated = yield* Effect.gen(function* () {
+				const localOrganizationProfileId = yield* trySync(() =>
+					findLocalOrganizationProfileId(db, handle),
+				);
+				if (localOrganizationProfileId) {
+					yield* trySync(() =>
+						db.transaction(() => {
+							replaceSyntheticAffiliation(db, row, localOrganizationProfileId);
+						})(),
+					);
+					result.hydrated += 1;
+					return true;
+				}
+
+				const user = yield* lookupProfileViaBirdEffect(handle);
+				if (!user) {
+					result.skipped += 1;
+					return true;
+				}
+				const resolved = yield* trySync(() => upsertProfileFromXUser(db, user));
+				if (resolved.profile.id === row.organization_profile_id) {
+					result.skipped += 1;
+					return true;
+				}
+				yield* trySync(() =>
+					db.transaction(() => {
+						replaceSyntheticAffiliation(db, row, resolved.profile.id);
+					})(),
+				);
 				result.hydrated += 1;
+				return true;
+			}).pipe(
+				Effect.catchAll((error) => {
+					result.errors.push({
+						handle,
+						error: error instanceof Error ? error.message : String(error),
+					});
+					return Effect.succeed(false);
+				}),
+			);
+			if (!hydrated) {
 				continue;
 			}
+		}
 
-			const user = await lookupProfileViaBird(handle);
-			if (!user) {
-				result.skipped += 1;
-				continue;
-			}
-			const resolved = upsertProfileFromXUser(db, user);
-			if (resolved.profile.id === row.organization_profile_id) {
-				result.skipped += 1;
-				continue;
-			}
-			db.transaction(() => {
-				replaceSyntheticAffiliation(db, row, resolved.profile.id);
-			})();
-			result.hydrated += 1;
-		} catch (error) {
-			result.errors.push({
-				handle,
-				error: error instanceof Error ? error.message : String(error),
+		if (result.hydrated > 0) {
+			yield* trySync(() => {
+				recordProfileSnapshot(db, subjectProfileId, "affiliation_hydration");
+				syncProfileBioEntitiesForProfileId(db, subjectProfileId);
+				syncIdentitySearchIndexForProfileIds(db, [subjectProfileId]);
 			});
 		}
-	}
 
-	if (result.hydrated > 0) {
-		recordProfileSnapshot(db, subjectProfileId, "affiliation_hydration");
-		syncProfileBioEntitiesForProfileId(db, subjectProfileId);
-		syncIdentitySearchIndexForProfileIds(db, [subjectProfileId]);
-	}
+		return result;
+	});
+}
 
-	return result;
+export function hydrateProfileAffiliationOrganizations(
+	db: Database,
+	subjectProfileId: string,
+): Promise<ProfileAffiliationHydrationResult> {
+	return runEffectPromise(
+		hydrateProfileAffiliationOrganizationsEffect(db, subjectProfileId),
+	);
 }

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -36,6 +37,25 @@ describe("profile hydration", () => {
 		resetBirdclawPathsForTests();
 		delete process.env.BIRDCLAW_HOME;
 		rmSync(homeDir, { recursive: true, force: true });
+	});
+
+	it("builds profile hydration effects lazily", async () => {
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "local",
+			installed: false,
+			statusText: "xurl missing",
+		});
+		const { hydrateProfilesFromXEffect } = await import("./profile-hydration");
+
+		const effect = hydrateProfilesFromXEffect();
+
+		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "xurl missing",
+		});
+		expect(mocks.lookupUsersByIds).not.toHaveBeenCalled();
 	});
 
 	it("hydrates imported placeholder profiles from xurl", async () => {

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -1,11 +1,21 @@
+import { Effect } from "effect";
+
 import { normalizeAvatarUrl } from "./avatar-cache";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import {
 	getTransportStatus,
 	lookupAuthenticatedUser,
 	lookupUsersByIds,
 } from "./xurl";
 import { upsertProfileFromXUser } from "./x-profile";
+
+export type HydrateProfilesResult = {
+	ok: true;
+	hydratedProfiles: number;
+	hydratedAccount: boolean;
+	reason?: string;
+};
 
 function asRecord(value: unknown): Record<string, unknown> | null {
 	return value && typeof value === "object" && !Array.isArray(value)
@@ -18,40 +28,62 @@ function toInt(value: unknown) {
 	return Number.isFinite(parsed) ? Math.trunc(parsed) : 0;
 }
 
-export async function hydrateProfilesFromX() {
-	const transport = await getTransportStatus();
-	if (transport.availableTransport !== "xurl") {
-		return {
-			ok: true,
-			hydratedProfiles: 0,
-			hydratedAccount: false,
-			reason: transport.statusText,
-		};
-	}
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
 
-	const db = getNativeDb();
-	const candidateRows = db
-		.prepare(
-			`
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+export function hydrateProfilesFromXEffect(): Effect.Effect<
+	HydrateProfilesResult,
+	unknown
+> {
+	return Effect.gen(function* () {
+		const transport = yield* tryPromise(() => getTransportStatus());
+		if (transport.availableTransport !== "xurl") {
+			return {
+				ok: true,
+				hydratedProfiles: 0,
+				hydratedAccount: false,
+				reason: transport.statusText,
+			};
+		}
+
+		const {
+			candidateIds,
+			db,
+			updateAccount,
+			updateConversationTitle,
+			updateLocalProfile,
+		} = yield* trySync(() => {
+			const db = getNativeDb();
+			const candidateRows = db
+				.prepare(
+					`
       select id
       from profiles
       where id like 'profile_user_%'
         and (followers_count = 0 or bio like 'Imported from archive user %' or handle like 'id%')
       order by id asc
       `,
-		)
-		.all() as Array<{ id: string }>;
+				)
+				.all() as Array<{ id: string }>;
 
-	const candidateIds = candidateRows
-		.map((row) => row.id.replace(/^profile_user_/, ""))
-		.filter((id) => /^\d+$/.test(id));
+			const candidateIds = candidateRows
+				.map((row) => row.id.replace(/^profile_user_/, ""))
+				.filter((id) => /^\d+$/.test(id));
 
-	const updateConversationTitle = db.prepare(`
+			const updateConversationTitle = db.prepare(`
     update dm_conversations
     set title = ?
     where participant_profile_id = ?
   `);
-	const updateLocalProfile = db.prepare(`
+			const updateLocalProfile = db.prepare(`
     update profiles
     set handle = ?,
         display_name = ?,
@@ -62,7 +94,7 @@ export async function hydrateProfilesFromX() {
         created_at = coalesce(?, created_at)
     where id = 'profile_me'
   `);
-	const updateAccount = db.prepare(`
+			const updateAccount = db.prepare(`
     update accounts
     set name = ?,
         handle = ?,
@@ -70,56 +102,76 @@ export async function hydrateProfilesFromX() {
     where id = 'acct_primary'
   `);
 
-	let hydratedProfiles = 0;
+			return {
+				candidateIds,
+				db,
+				updateAccount,
+				updateConversationTitle,
+				updateLocalProfile,
+			};
+		});
 
-	for (let index = 0; index < candidateIds.length; index += 100) {
-		const batch = candidateIds.slice(index, index + 100);
-		const users = await lookupUsersByIds(batch);
+		let hydratedProfiles = 0;
 
-		db.transaction(() => {
-			for (const user of users) {
-				const profileId = `profile_user_${String(user.id ?? "")}`;
-				if (profileId === "profile_user_") continue;
+		for (let index = 0; index < candidateIds.length; index += 100) {
+			const batch = candidateIds.slice(index, index + 100);
+			const users = yield* tryPromise(() => lookupUsersByIds(batch));
 
-				const resolved = upsertProfileFromXUser(db, user);
-				updateConversationTitle.run(
-					resolved.profile.displayName || resolved.profile.handle,
-					resolved.profile.id,
-				);
-				hydratedProfiles += 1;
-			}
-		})();
-	}
+			yield* trySync(() => {
+				db.transaction(() => {
+					for (const user of users) {
+						const profileId = `profile_user_${String(user.id ?? "")}`;
+						if (profileId === "profile_user_") continue;
 
-	let hydratedAccount = false;
-	const me = await lookupAuthenticatedUser().catch(() => null);
-	if (me) {
-		const metrics = asRecord(me.public_metrics);
-		db.transaction(() => {
-			updateLocalProfile.run(
-				String(me.username ?? "steipete").replace(/^@/, ""),
-				String(me.name ?? "Peter Steinberger"),
-				String(me.description ?? ""),
-				toInt(metrics?.followers_count),
-				metrics && "following_count" in metrics
-					? toInt(metrics.following_count)
-					: null,
-				normalizeAvatarUrl(me.profile_image_url),
-				typeof me.created_at === "string" ? me.created_at : null,
-			);
-			updateAccount.run(
-				String(me.name ?? "Peter Steinberger"),
-				`@${String(me.username ?? "steipete").replace(/^@/, "")}`,
-			);
-		})();
-		hydratedAccount = true;
-	}
+						const resolved = upsertProfileFromXUser(db, user);
+						updateConversationTitle.run(
+							resolved.profile.displayName || resolved.profile.handle,
+							resolved.profile.id,
+						);
+						hydratedProfiles += 1;
+					}
+				})();
+			});
+		}
 
-	return {
-		ok: true,
-		hydratedProfiles,
-		hydratedAccount,
-	};
+		let hydratedAccount = false;
+		const me = yield* tryPromise(() => lookupAuthenticatedUser()).pipe(
+			Effect.catchAll(() => Effect.succeed(null)),
+		);
+		if (me) {
+			const metrics = asRecord(me.public_metrics);
+			yield* trySync(() => {
+				db.transaction(() => {
+					updateLocalProfile.run(
+						String(me.username ?? "steipete").replace(/^@/, ""),
+						String(me.name ?? "Peter Steinberger"),
+						String(me.description ?? ""),
+						toInt(metrics?.followers_count),
+						metrics && "following_count" in metrics
+							? toInt(metrics.following_count)
+							: null,
+						normalizeAvatarUrl(me.profile_image_url),
+						typeof me.created_at === "string" ? me.created_at : null,
+					);
+					updateAccount.run(
+						String(me.name ?? "Peter Steinberger"),
+						`@${String(me.username ?? "steipete").replace(/^@/, "")}`,
+					);
+				})();
+			});
+			hydratedAccount = true;
+		}
+
+		return {
+			ok: true,
+			hydratedProfiles,
+			hydratedAccount,
+		};
+	});
+}
+
+export function hydrateProfilesFromX(): Promise<HydrateProfilesResult> {
+	return runEffectPromise(hydrateProfilesFromXEffect());
 }
 
 export const __test__ = {

--- a/src/lib/profile-replies.test.ts
+++ b/src/lib/profile-replies.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveProfileMock = vi.fn();
@@ -17,6 +18,69 @@ describe("profile reply inspection", () => {
 		vi.resetModules();
 		resolveProfileMock.mockReset();
 		listUserTweetsMock.mockReset();
+	});
+
+	it("builds profile reply inspection effects lazily", async () => {
+		resolveProfileMock.mockResolvedValue({
+			profile: {
+				id: "profile_user_42",
+				handle: "jpctan",
+				displayName: "Jason Tan",
+				bio: "",
+				followersCount: 268,
+				avatarHue: 18,
+				createdAt: "2015-05-20T09:27:37.000Z",
+			},
+			externalUserId: "42",
+		});
+		listUserTweetsMock.mockResolvedValue({
+			items: [
+				{
+					id: "tweet_1",
+					text: "@sam one",
+					created_at: "2026-03-09T00:00:00.000Z",
+					referenced_tweets: [{ type: "replied_to", id: "root_1" }],
+				},
+			],
+		});
+		const { inspectProfileRepliesEffect } = await import("./profile-replies");
+
+		const effect = inspectProfileRepliesEffect("@jpctan", { limit: 1 });
+
+		expect(resolveProfileMock).not.toHaveBeenCalled();
+		expect(listUserTweetsMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			externalUserId: "42",
+			items: [{ id: "tweet_1" }],
+		});
+		expect(listUserTweetsMock).toHaveBeenCalledWith("42", {
+			maxResults: 20,
+			excludeRetweets: true,
+		});
+	});
+
+	it("validates profile reply inspection effects only when run", async () => {
+		resolveProfileMock.mockResolvedValue({
+			profile: {
+				id: "profile_group_1",
+				handle: "group",
+				displayName: "Group",
+				bio: "",
+				followersCount: 0,
+				avatarHue: 0,
+				createdAt: "2026-03-09T00:00:00.000Z",
+			},
+			externalUserId: null,
+		});
+		const { inspectProfileRepliesEffect } = await import("./profile-replies");
+
+		const effect = inspectProfileRepliesEffect("group");
+
+		expect(resolveProfileMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"Profile has no external Twitter user id: group",
+		);
+		expect(listUserTweetsMock).not.toHaveBeenCalled();
 	});
 
 	it("filters recent authored tweets down to replies", async () => {

--- a/src/lib/profile-replies.ts
+++ b/src/lib/profile-replies.ts
@@ -1,3 +1,6 @@
+import { Effect } from "effect";
+
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { resolveProfile } from "./moderation-target";
 import type { ProfileRepliesResponse, XurlReferencedTweet } from "./types";
 import { listUserTweets } from "./xurl";
@@ -10,51 +13,65 @@ function getScanSize(limit: number) {
 	return Math.min(Math.max(limit * 3, 20), 100);
 }
 
-export async function inspectProfileReplies(
+export function inspectProfileReplies(
 	query: string,
 	{ limit = 12 }: { limit?: number } = {},
 ): Promise<ProfileRepliesResponse> {
-	const resolved = await resolveProfile(query);
-	if (!resolved.externalUserId) {
-		throw new Error(`Profile has no external Twitter user id: ${query}`);
-	}
+	return runEffectPromise(inspectProfileRepliesEffect(query, { limit }));
+}
 
-	const timeline = await listUserTweets(resolved.externalUserId, {
-		maxResults: getScanSize(limit),
-		excludeRetweets: true,
+export function inspectProfileRepliesEffect(
+	query: string,
+	{ limit = 12 }: { limit?: number } = {},
+): Effect.Effect<ProfileRepliesResponse, unknown> {
+	return Effect.gen(function* () {
+		const resolved = yield* tryPromise(() => resolveProfile(query));
+		const externalUserId = resolved.externalUserId;
+		if (!externalUserId) {
+			return yield* Effect.fail(
+				new Error(`Profile has no external Twitter user id: ${query}`),
+			);
+		}
+
+		const timeline = yield* tryPromise(() =>
+			listUserTweets(externalUserId, {
+				maxResults: getScanSize(limit),
+				excludeRetweets: true,
+			}),
+		);
+		const items = timeline.items
+			.map((tweet) => {
+				const replyToTweetId = getReplyTargetId(tweet.referenced_tweets);
+				if (!replyToTweetId) {
+					return null;
+				}
+
+				return {
+					id: tweet.id,
+					text: tweet.text,
+					createdAt: tweet.created_at,
+					conversationId: tweet.conversation_id,
+					replyToTweetId,
+					likeCount: Number(tweet.public_metrics?.like_count ?? 0),
+					replyCount: Number(tweet.public_metrics?.reply_count ?? 0),
+					retweetCount: Number(tweet.public_metrics?.retweet_count ?? 0),
+					quoteCount: Number(tweet.public_metrics?.quote_count ?? 0),
+					bookmarkCount: Number(tweet.public_metrics?.bookmark_count ?? 0),
+					impressionCount: Number(tweet.public_metrics?.impression_count ?? 0),
+				};
+			})
+			.filter((item): item is NonNullable<typeof item> => item !== null)
+			.slice(0, limit);
+
+		return {
+			profile: resolved.profile,
+			externalUserId,
+			items,
+			meta: {
+				scannedCount: timeline.items.length,
+				returnedCount: items.length,
+				nextToken: timeline.nextToken,
+			},
+		};
 	});
-	const items = timeline.items
-		.map((tweet) => {
-			const replyToTweetId = getReplyTargetId(tweet.referenced_tweets);
-			if (!replyToTweetId) {
-				return null;
-			}
-
-			return {
-				id: tweet.id,
-				text: tweet.text,
-				createdAt: tweet.created_at,
-				conversationId: tweet.conversation_id,
-				replyToTweetId,
-				likeCount: Number(tweet.public_metrics?.like_count ?? 0),
-				replyCount: Number(tweet.public_metrics?.reply_count ?? 0),
-				retweetCount: Number(tweet.public_metrics?.retweet_count ?? 0),
-				quoteCount: Number(tweet.public_metrics?.quote_count ?? 0),
-				bookmarkCount: Number(tweet.public_metrics?.bookmark_count ?? 0),
-				impressionCount: Number(tweet.public_metrics?.impression_count ?? 0),
-			};
-		})
-		.filter((item): item is NonNullable<typeof item> => item !== null)
-		.slice(0, limit);
-
-	return {
-		profile: resolved.profile,
-		externalUserId: resolved.externalUserId,
-		items,
-		meta: {
-			scannedCount: timeline.items.length,
-			returnedCount: items.length,
-			nextToken: timeline.nextToken,
-		},
-	};
 }

--- a/src/lib/profile-resolver.test.ts
+++ b/src/lib/profile-resolver.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -15,7 +16,17 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	lookupProfileViaBird: mocks.lookupProfileViaBird,
+	lookupProfileViaBirdEffect: (target: string) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupProfileViaBird(target),
+			catch: (error) => error,
+		}),
 	lookupProfilesViaBird: mocks.lookupProfilesViaBird,
+	lookupProfilesViaBirdEffect: (targets: string[]) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupProfilesViaBird(targets),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./xurl", () => ({
@@ -79,6 +90,57 @@ describe("profile resolver", () => {
 		resetBirdclawPathsForTests();
 		delete process.env.BIRDCLAW_HOME;
 		rmSync(homeDir, { recursive: true, force: true });
+	});
+
+	it("builds profile resolver effects lazily", async () => {
+		mocks.lookupProfileViaBird.mockResolvedValueOnce({
+			id: "42",
+			username: "sam",
+			name: "Sam Altman",
+			public_metrics: { followers_count: 123, following_count: 45 },
+		});
+		const { resolveProfilesForIdsEffect } = await import("./profile-resolver");
+
+		const effect = resolveProfilesForIdsEffect(["profile_user_42"]);
+
+		expect(mocks.lookupProfileViaBird).not.toHaveBeenCalled();
+		expect(mocks.lookupUsersByIds).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual([
+			expect.objectContaining({
+				status: "hit",
+				source: "bird",
+				profile: expect.objectContaining({ handle: "sam" }),
+			}),
+		]);
+		expect(mocks.lookupProfileViaBird).toHaveBeenCalledWith("42");
+	});
+
+	it("builds handle resolver effects lazily", async () => {
+		mocks.lookupProfilesViaBird.mockResolvedValueOnce([
+			{
+				target: "sam",
+				user: {
+					id: "42",
+					username: "sam",
+					name: "Sam Altman",
+					public_metrics: { followers_count: 123, following_count: 45 },
+				},
+			},
+		]);
+		const { resolveProfilesForHandlesEffect } =
+			await import("./profile-resolver");
+
+		const effect = resolveProfilesForHandlesEffect(["@sam"]);
+
+		expect(mocks.lookupProfilesViaBird).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual([
+			expect.objectContaining({
+				handle: "sam",
+				status: "hit",
+				source: "bird",
+			}),
+		]);
+		expect(mocks.lookupProfilesViaBird).toHaveBeenCalledWith(["sam"]);
 	});
 
 	it("resolves placeholder profiles through bird and reuses persistent cache", async () => {

--- a/src/lib/profile-resolver.ts
+++ b/src/lib/profile-resolver.ts
@@ -1,8 +1,14 @@
+import { Effect } from "effect";
+
 import { getNativeDb } from "./db";
-import { lookupProfileViaBird, lookupProfilesViaBird } from "./bird";
+import {
+	lookupProfileViaBirdEffect,
+	lookupProfilesViaBirdEffect,
+} from "./bird";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import {
-	hydrateProfileAffiliationOrganizations,
+	hydrateProfileAffiliationOrganizationsEffect,
 	type ProfileAffiliationHydrationResult,
 } from "./profile-affiliation-hydration";
 import type { ProfileRecord, XurlMentionUser } from "./types";
@@ -20,6 +26,17 @@ interface CachedProfileLookup {
 	source: Exclude<ProfileLookupSource, "local" | "cache">;
 	user?: XurlMentionUser;
 	error?: string;
+}
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
 }
 
 export interface ResolveProfilesOptions {
@@ -130,384 +147,467 @@ function writeProfileLookupCache(
 	writeSyncCache(cacheKeyForUserId(externalUserId), value);
 }
 
-function updateConversationTitles(profile: ProfileRecord) {
-	getNativeDb()
-		.prepare(
-			`
+function updateConversationTitles(profile: ProfileRecord, db = getNativeDb()) {
+	db.prepare(
+		`
       update dm_conversations
       set title = ?
       where participant_profile_id = ?
       `,
-		)
-		.run(profile.displayName || profile.handle, profile.id);
+	).run(profile.displayName || profile.handle, profile.id);
 }
 
-async function lookupViaXurl(externalUserId: string) {
-	const [user] = await lookupUsersByIds([externalUserId]);
-	return user ?? null;
+function lookupViaXurlEffect(externalUserId: string) {
+	return Effect.gen(function* () {
+		const [user] = yield* tryPromise(() => lookupUsersByIds([externalUserId]));
+		return user ?? null;
+	});
 }
 
 function normalizeHandle(value: string) {
 	return value.trim().replace(/^@/, "").toLowerCase();
 }
 
-async function fetchProfileUser(
+function fetchProfileUserEffect(
 	externalUserId: string,
 	xurlFallback: boolean,
-): Promise<CachedProfileLookup> {
-	try {
-		const birdUser = await lookupProfileViaBird(externalUserId);
-		if (birdUser) {
-			return { status: "hit", source: "bird", user: birdUser };
-		}
-	} catch (error) {
-		if (!xurlFallback) {
+): Effect.Effect<CachedProfileLookup, never> {
+	return Effect.gen(function* () {
+		const birdResult = yield* lookupProfileViaBirdEffect(externalUserId).pipe(
+			Effect.map((user) => ({ ok: true as const, user })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (birdResult.ok) {
+			const birdUser = birdResult.user;
+			if (birdUser) {
+				return { status: "hit", source: "bird", user: birdUser };
+			}
+		} else if (!xurlFallback) {
 			return {
 				status: "error",
 				source: "bird",
-				error: error instanceof Error ? error.message : String(error),
+				error:
+					birdResult.error instanceof Error
+						? birdResult.error.message
+						: String(birdResult.error),
 			};
 		}
-	}
 
-	if (!xurlFallback) {
-		return { status: "miss", source: "bird" };
-	}
+		if (!xurlFallback) {
+			return { status: "miss", source: "bird" };
+		}
 
-	try {
-		const xurlUser = await lookupViaXurl(externalUserId);
-		return xurlUser
-			? { status: "hit", source: "xurl", user: xurlUser }
-			: { status: "miss", source: "xurl" };
-	} catch (error) {
+		const xurlResult = yield* lookupViaXurlEffect(externalUserId).pipe(
+			Effect.map((user) => ({ ok: true as const, user })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (xurlResult.ok) {
+			const xurlUser = xurlResult.user;
+			return xurlUser
+				? { status: "hit", source: "xurl", user: xurlUser }
+				: { status: "miss", source: "xurl" };
+		}
 		return {
 			status: "error",
 			source: "xurl",
-			error: error instanceof Error ? error.message : String(error),
+			error:
+				xurlResult.error instanceof Error
+					? xurlResult.error.message
+					: String(xurlResult.error),
 		};
-	}
+	});
 }
 
-async function fetchProfileUsers(
+function fetchProfileUsersEffect(
 	externalUserIds: string[],
 	xurlFallback: boolean,
 ) {
-	const uniqueIds = Array.from(new Set(externalUserIds));
-	const results = new Map<string, CachedProfileLookup>();
-	let unresolved = uniqueIds;
+	return Effect.gen(function* () {
+		const uniqueIds = Array.from(new Set(externalUserIds));
+		const results = new Map<string, CachedProfileLookup>();
+		let unresolved = uniqueIds;
 
-	try {
-		const birdResults = await lookupProfilesViaBird(uniqueIds);
-		for (const result of birdResults) {
-			const externalUserId = result.target;
-			if (result.user) {
-				results.set(externalUserId, {
-					status: "hit",
-					source: "bird",
-					user: result.user,
-				});
-			} else if (result.error && !xurlFallback) {
-				results.set(externalUserId, {
-					status: "error",
-					source: "bird",
-					error: result.error,
-				});
+		const birdResult = yield* lookupProfilesViaBirdEffect(uniqueIds).pipe(
+			Effect.map((items) => ({ ok: true as const, items })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (birdResult.ok) {
+			const birdResults = birdResult.items;
+			for (const result of birdResults) {
+				const externalUserId = result.target;
+				if (result.user) {
+					results.set(externalUserId, {
+						status: "hit",
+						source: "bird",
+						user: result.user,
+					});
+				} else if (result.error && !xurlFallback) {
+					results.set(externalUserId, {
+						status: "error",
+						source: "bird",
+						error: result.error,
+					});
+				}
 			}
-		}
-		unresolved = uniqueIds.filter((id) => !results.has(id));
-	} catch (error) {
-		if (!xurlFallback) {
+			unresolved = uniqueIds.filter((id) => !results.has(id));
+		} else if (!xurlFallback) {
 			for (const externalUserId of uniqueIds) {
 				results.set(externalUserId, {
 					status: "error",
 					source: "bird",
-					error: error instanceof Error ? error.message : String(error),
+					error:
+						birdResult.error instanceof Error
+							? birdResult.error.message
+							: String(birdResult.error),
 				});
 			}
 			return results;
 		}
-	}
 
-	if (unresolved.length === 0) {
-		return results;
-	}
-	if (!xurlFallback) {
-		for (const externalUserId of unresolved) {
-			results.set(externalUserId, { status: "miss", source: "bird" });
+		if (unresolved.length === 0) {
+			return results;
 		}
-		return results;
-	}
+		if (!xurlFallback) {
+			for (const externalUserId of unresolved) {
+				results.set(externalUserId, { status: "miss", source: "bird" });
+			}
+			return results;
+		}
 
-	try {
-		const xurlUsers = await lookupUsersByIds(unresolved);
-		const usersById = new Map(xurlUsers.map((user) => [String(user.id), user]));
-		for (const externalUserId of unresolved) {
-			const user = usersById.get(externalUserId);
-			results.set(
-				externalUserId,
-				user
-					? { status: "hit", source: "xurl", user }
-					: { status: "miss", source: "xurl" },
+		const xurlResult = yield* tryPromise(() =>
+			lookupUsersByIds(unresolved),
+		).pipe(
+			Effect.map((users) => ({ ok: true as const, users })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (xurlResult.ok) {
+			const xurlUsers = xurlResult.users;
+			const usersById = new Map(
+				xurlUsers.map((user) => [String(user.id), user]),
 			);
+			for (const externalUserId of unresolved) {
+				const user = usersById.get(externalUserId);
+				results.set(
+					externalUserId,
+					user
+						? { status: "hit", source: "xurl", user }
+						: { status: "miss", source: "xurl" },
+				);
+			}
+		} else {
+			for (const externalUserId of unresolved) {
+				results.set(externalUserId, {
+					status: "error",
+					source: "xurl",
+					error:
+						xurlResult.error instanceof Error
+							? xurlResult.error.message
+							: String(xurlResult.error),
+				});
+			}
 		}
-	} catch (error) {
-		for (const externalUserId of unresolved) {
-			results.set(externalUserId, {
-				status: "error",
-				source: "xurl",
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	}
 
-	return results;
+		return results;
+	});
 }
 
-export async function resolveProfilesForIds(
+export function resolveProfilesForIdsEffect(
 	profileIds: string[],
 	options: ResolveProfilesOptions = {},
-): Promise<ProfileResolveResult[]> {
-	const maxAgeMs = options.maxAgeMs ?? PROFILE_CACHE_TTL_MS;
-	const negativeMaxAgeMs =
-		options.negativeMaxAgeMs ?? PROFILE_NEGATIVE_CACHE_TTL_MS;
-	const xurlFallback = options.xurlFallback ?? true;
-	const ordered: Array<
-		| { kind: "ready"; result: ProfileResolveResult }
-		| { kind: "pending"; profileId: string; externalUserId: string }
-	> = [];
+): Effect.Effect<ProfileResolveResult[], unknown> {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const maxAgeMs = options.maxAgeMs ?? PROFILE_CACHE_TTL_MS;
+		const negativeMaxAgeMs =
+			options.negativeMaxAgeMs ?? PROFILE_NEGATIVE_CACHE_TTL_MS;
+		const xurlFallback = options.xurlFallback ?? true;
+		const ordered: Array<
+			| { kind: "ready"; result: ProfileResolveResult }
+			| { kind: "pending"; profileId: string; externalUserId: string }
+		> = [];
 
-	for (const profileId of Array.from(new Set(profileIds))) {
-		const externalUserId = getExternalUserId(profileId);
-		if (!externalUserId) {
-			ordered.push({
-				kind: "ready",
-				result: {
-					profileId,
-					externalUserId: null,
-					status: "miss",
-					source: "local",
-				},
-			});
-			continue;
-		}
+		for (const profileId of Array.from(new Set(profileIds))) {
+			const externalUserId = getExternalUserId(profileId);
+			if (!externalUserId) {
+				ordered.push({
+					kind: "ready",
+					result: {
+						profileId,
+						externalUserId: null,
+						status: "miss",
+						source: "local",
+					},
+				});
+				continue;
+			}
 
-		const localProfile = getProfile(profileId);
-		if (
-			localProfile &&
-			!options.refresh &&
-			!isPlaceholderProfile(localProfile)
-		) {
-			ordered.push({
-				kind: "ready",
-				result: {
-					profileId,
-					externalUserId,
-					status: "hit",
-					source: "local",
-					profile: localProfile,
-				},
-			});
-			continue;
-		}
-
-		const cached = readSyncCache<CachedProfileLookup>(
-			cacheKeyForUserId(externalUserId),
-		);
-		if (cached && !options.refresh) {
-			const maxAge =
-				cached.value.status === "hit" ? maxAgeMs : negativeMaxAgeMs;
-			if (isFresh(cached.updatedAt, maxAge)) {
-				if (cached.value.status === "hit" && cached.value.user) {
-					const resolved = upsertProfileFromXUser(
-						getNativeDb(),
-						cached.value.user,
-					);
-					updateConversationTitles(resolved.profile);
-					ordered.push({
-						kind: "ready",
-						result: {
-							profileId: resolved.profile.id,
-							externalUserId,
-							status: "hit",
-							source: "cache",
-							profile: resolved.profile,
-						},
-					});
-					continue;
-				}
+			const localProfile = yield* trySync(() => getProfile(profileId));
+			if (
+				localProfile &&
+				!options.refresh &&
+				!isPlaceholderProfile(localProfile)
+			) {
 				ordered.push({
 					kind: "ready",
 					result: {
 						profileId,
 						externalUserId,
-						status: cached.value.status,
-						source: "negative-cache",
-						error: cached.value.error,
+						status: "hit",
+						source: "local",
+						profile: localProfile,
 					},
 				});
 				continue;
 			}
-		}
 
-		ordered.push({ kind: "pending", profileId, externalUserId });
-	}
-
-	const pendingExternalIds = ordered.flatMap((item) =>
-		item.kind === "pending" ? [item.externalUserId] : [],
-	);
-	const fetchedByExternalId =
-		pendingExternalIds.length > 1
-			? await fetchProfileUsers(pendingExternalIds, xurlFallback)
-			: new Map<string, CachedProfileLookup>();
-
-	const results: ProfileResolveResult[] = [];
-	for (const item of ordered) {
-		if (item.kind === "ready") {
-			results.push(item.result);
-			continue;
-		}
-		const fetched =
-			fetchedByExternalId.get(item.externalUserId) ??
-			(await fetchProfileUser(item.externalUserId, xurlFallback));
-		writeProfileLookupCache(item.externalUserId, fetched);
-		if (fetched.status === "hit" && fetched.user) {
-			const resolved = upsertProfileFromXUser(getNativeDb(), fetched.user);
-			const affiliationHydration = await hydrateProfileAffiliationOrganizations(
-				getNativeDb(),
-				resolved.profile.id,
+			const cached = yield* trySync(() =>
+				readSyncCache<CachedProfileLookup>(cacheKeyForUserId(externalUserId)),
 			);
-			updateConversationTitles(resolved.profile);
-			results.push({
-				profileId: resolved.profile.id,
-				externalUserId: item.externalUserId,
-				status: "hit",
-				source: fetched.source,
-				profile: resolved.profile,
-				...(affiliationHydration.checked > 0 ? { affiliationHydration } : {}),
-			});
-			continue;
-		}
-		results.push({
-			profileId: item.profileId,
-			externalUserId: item.externalUserId,
-			status: fetched.status,
-			source: fetched.source,
-			error: fetched.error,
-		});
-	}
+			if (cached && !options.refresh) {
+				const maxAge =
+					cached.value.status === "hit" ? maxAgeMs : negativeMaxAgeMs;
+				if (isFresh(cached.updatedAt, maxAge)) {
+					if (cached.value.status === "hit" && cached.value.user) {
+						const resolved = yield* trySync(() => {
+							const resolved = upsertProfileFromXUser(db, cached.value.user!);
+							updateConversationTitles(resolved.profile, db);
+							return resolved;
+						});
+						ordered.push({
+							kind: "ready",
+							result: {
+								profileId: resolved.profile.id,
+								externalUserId,
+								status: "hit",
+								source: "cache",
+								profile: resolved.profile,
+							},
+						});
+						continue;
+					}
+					ordered.push({
+						kind: "ready",
+						result: {
+							profileId,
+							externalUserId,
+							status: cached.value.status,
+							source: "negative-cache",
+							error: cached.value.error,
+						},
+					});
+					continue;
+				}
+			}
 
-	return results;
+			ordered.push({ kind: "pending", profileId, externalUserId });
+		}
+
+		const pendingExternalIds = ordered.flatMap((item) =>
+			item.kind === "pending" ? [item.externalUserId] : [],
+		);
+		const fetchedByExternalId =
+			pendingExternalIds.length > 1
+				? yield* fetchProfileUsersEffect(pendingExternalIds, xurlFallback)
+				: new Map<string, CachedProfileLookup>();
+
+		const results: ProfileResolveResult[] = [];
+		for (const item of ordered) {
+			if (item.kind === "ready") {
+				results.push(item.result);
+				continue;
+			}
+			const fetched =
+				fetchedByExternalId.get(item.externalUserId) ??
+				(yield* fetchProfileUserEffect(item.externalUserId, xurlFallback));
+			yield* trySync(() =>
+				writeProfileLookupCache(item.externalUserId, fetched),
+			);
+			if (fetched.status === "hit" && fetched.user) {
+				const resolved = yield* trySync(() =>
+					upsertProfileFromXUser(db, fetched.user!),
+				);
+				const affiliationHydration =
+					yield* hydrateProfileAffiliationOrganizationsEffect(
+						db,
+						resolved.profile.id,
+					);
+				yield* trySync(() => updateConversationTitles(resolved.profile, db));
+				results.push({
+					profileId: resolved.profile.id,
+					externalUserId: item.externalUserId,
+					status: "hit",
+					source: fetched.source,
+					profile: resolved.profile,
+					...(affiliationHydration.checked > 0 ? { affiliationHydration } : {}),
+				});
+				continue;
+			}
+			results.push({
+				profileId: item.profileId,
+				externalUserId: item.externalUserId,
+				status: fetched.status,
+				source: fetched.source,
+				error: fetched.error,
+			});
+		}
+
+		return results;
+	});
 }
 
-export async function resolveProfilesForHandles(
+export function resolveProfilesForIds(
+	profileIds: string[],
+	options: ResolveProfilesOptions = {},
+): Promise<ProfileResolveResult[]> {
+	return runEffectPromise(resolveProfilesForIdsEffect(profileIds, options));
+}
+
+export function resolveProfilesForHandlesEffect(
 	handles: string[],
 	options: Pick<ResolveProfilesOptions, "xurlFallback"> = {},
-): Promise<HandleProfileResolveResult[]> {
-	const xurlFallback = options.xurlFallback ?? true;
-	const targets = Array.from(
-		new Set(handles.map(normalizeHandle).filter((handle) => handle.length > 0)),
-	);
-	if (targets.length === 0) {
-		return [];
-	}
-
-	const results = new Map<string, HandleProfileResolveResult>();
-	let unresolved = targets;
-
-	try {
-		const birdResults = await lookupProfilesViaBird(targets);
-		for (const item of birdResults) {
-			const handle = normalizeHandle(item.target);
-			if (item.user) {
-				const resolved = upsertProfileFromXUser(getNativeDb(), item.user);
-				updateConversationTitles(resolved.profile);
-				results.set(handle, {
-					handle,
-					status: "hit",
-					source: "bird",
-					profile: resolved.profile,
-				});
-			} else if (item.error && !xurlFallback) {
-				results.set(handle, {
-					handle,
-					status: "error",
-					source: "bird",
-					error: item.error,
-				});
-			}
+): Effect.Effect<HandleProfileResolveResult[], unknown> {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const xurlFallback = options.xurlFallback ?? true;
+		const targets = Array.from(
+			new Set(
+				handles.map(normalizeHandle).filter((handle) => handle.length > 0),
+			),
+		);
+		if (targets.length === 0) {
+			return [];
 		}
-		unresolved = targets.filter((handle) => !results.has(handle));
-	} catch (error) {
-		if (!xurlFallback) {
+
+		const results = new Map<string, HandleProfileResolveResult>();
+		let unresolved = targets;
+
+		const birdResult = yield* lookupProfilesViaBirdEffect(targets).pipe(
+			Effect.map((items) => ({ ok: true as const, items })),
+			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
+		);
+		if (birdResult.ok) {
+			const birdResults = birdResult.items;
+			for (const item of birdResults) {
+				const handle = normalizeHandle(item.target);
+				if (item.user) {
+					const resolved = yield* trySync(() => {
+						const resolved = upsertProfileFromXUser(db, item.user!);
+						updateConversationTitles(resolved.profile, db);
+						return resolved;
+					});
+					results.set(handle, {
+						handle,
+						status: "hit",
+						source: "bird",
+						profile: resolved.profile,
+					});
+				} else if (item.error && !xurlFallback) {
+					results.set(handle, {
+						handle,
+						status: "error",
+						source: "bird",
+						error: item.error,
+					});
+				}
+			}
+			unresolved = targets.filter((handle) => !results.has(handle));
+		} else if (!xurlFallback) {
 			for (const handle of targets) {
 				results.set(handle, {
 					handle,
 					status: "error",
 					source: "bird",
-					error: error instanceof Error ? error.message : String(error),
+					error:
+						birdResult.error instanceof Error
+							? birdResult.error.message
+							: String(birdResult.error),
 				});
 			}
 			unresolved = [];
 		}
-	}
 
-	if (unresolved.length > 0 && xurlFallback) {
-		try {
-			const users = await lookupUsersByHandles(unresolved);
-			const usersByHandle = new Map(
-				users.map((user) => [
-					normalizeHandle(String(user.username ?? "")),
-					user,
-				]),
+		if (unresolved.length > 0 && xurlFallback) {
+			const xurlResult = yield* tryPromise(() =>
+				lookupUsersByHandles(unresolved),
+			).pipe(
+				Effect.map((users) => ({ ok: true as const, users })),
+				Effect.catchAll((error) =>
+					Effect.succeed({ ok: false as const, error }),
+				),
 			);
-			for (const handle of unresolved) {
-				const user = usersByHandle.get(handle);
-				if (user) {
-					const resolved = upsertProfileFromXUser(getNativeDb(), user);
-					updateConversationTitles(resolved.profile);
+			if (xurlResult.ok) {
+				const users = xurlResult.users;
+				const usersByHandle = new Map(
+					users.map((user) => [
+						normalizeHandle(String(user.username ?? "")),
+						user,
+					]),
+				);
+				for (const handle of unresolved) {
+					const user = usersByHandle.get(handle);
+					if (user) {
+						const resolved = yield* trySync(() => {
+							const resolved = upsertProfileFromXUser(db, user);
+							updateConversationTitles(resolved.profile, db);
+							return resolved;
+						});
+						results.set(handle, {
+							handle,
+							status: "hit",
+							source: "xurl",
+							profile: resolved.profile,
+						});
+					} else {
+						results.set(handle, {
+							handle,
+							status: "miss",
+							source: "xurl",
+						});
+					}
+				}
+			} else {
+				for (const handle of unresolved) {
 					results.set(handle, {
 						handle,
-						status: "hit",
+						status: "error",
 						source: "xurl",
-						profile: resolved.profile,
-					});
-				} else {
-					results.set(handle, {
-						handle,
-						status: "miss",
-						source: "xurl",
+						error:
+							xurlResult.error instanceof Error
+								? xurlResult.error.message
+								: String(xurlResult.error),
 					});
 				}
 			}
-		} catch (error) {
-			for (const handle of unresolved) {
-				results.set(handle, {
-					handle,
-					status: "error",
-					source: "xurl",
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
 		}
-	}
 
-	return targets.map(
-		(handle) =>
-			results.get(handle) ?? {
-				handle,
-				status: "miss",
-				source: "bird",
-			},
-	);
+		return targets.map(
+			(handle) =>
+				results.get(handle) ?? {
+					handle,
+					status: "miss",
+					source: "bird",
+				},
+		);
+	});
 }
 
-export async function resolvePlaceholderProfiles(
+export function resolveProfilesForHandles(
+	handles: string[],
+	options: Pick<ResolveProfilesOptions, "xurlFallback"> = {},
+): Promise<HandleProfileResolveResult[]> {
+	return runEffectPromise(resolveProfilesForHandlesEffect(handles, options));
+}
+
+export function resolvePlaceholderProfilesEffect(
 	options: ResolveProfilesOptions & { limit?: number } = {},
 ) {
-	const db = getNativeDb();
-	const rows = db
-		.prepare(
-			`
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getNativeDb());
+		const rows = yield* trySync(
+			() =>
+				db
+					.prepare(
+						`
       select id
       from profiles
       where id like 'profile_user_%'
@@ -520,20 +620,28 @@ export async function resolvePlaceholderProfiles(
       order by id asc
       limit ?
       `,
-		)
-		.all(options.limit ?? 500) as Array<{ id: string }>;
+					)
+					.all(options.limit ?? 500) as Array<{ id: string }>,
+		);
 
-	const results = await resolveProfilesForIds(
-		rows.map((row) => row.id),
-		options,
-	);
-	return {
-		ok: true,
-		requestedProfiles: rows.length,
-		hydratedProfiles: results.filter((result) => result.status === "hit")
-			.length,
-		results,
-	};
+		const results = yield* resolveProfilesForIdsEffect(
+			rows.map((row) => row.id),
+			options,
+		);
+		return {
+			ok: true,
+			requestedProfiles: rows.length,
+			hydratedProfiles: results.filter((result) => result.status === "hit")
+				.length,
+			results,
+		};
+	});
+}
+
+export function resolvePlaceholderProfiles(
+	options: ResolveProfilesOptions & { limit?: number } = {},
+) {
+	return runEffectPromise(resolvePlaceholderProfilesEffect(options));
 }
 
 export const __test__ = {

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -2,16 +2,21 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listInboxItems } from "./inbox";
 import {
 	createDmReply,
+	createDmReplyEffect,
 	createPost,
+	createPostEffect,
 	createTweetReply,
+	createTweetReplyEffect,
 	getConversationThread,
 	getQueryEnvelope,
+	getQueryEnvelopeEffect,
 	getTweetConversation,
 	listDmConversations,
 	listTimelineItems,
@@ -26,16 +31,51 @@ const mocks = vi.hoisted(() => ({
 	dmViaXurl: vi.fn(),
 }));
 
-vi.mock("./archive-finder", () => ({
-	findArchives: mocks.findArchives,
-}));
+vi.mock("./archive-finder", async () => {
+	const { Effect } = await import("effect");
+	const toError = (error: unknown) =>
+		error instanceof Error ? error : new Error(String(error));
+	return {
+		findArchives: mocks.findArchives,
+		findArchivesEffect: () =>
+			Effect.tryPromise({
+				try: () => mocks.findArchives(),
+				catch: toError,
+			}),
+	};
+});
 
-vi.mock("./xurl", () => ({
-	getTransportStatus: mocks.getTransportStatus,
-	postViaXurl: mocks.postViaXurl,
-	replyViaXurl: mocks.replyViaXurl,
-	dmViaXurl: mocks.dmViaXurl,
-}));
+vi.mock("./xurl", async () => {
+	const { Effect } = await import("effect");
+	const toError = (error: unknown) =>
+		error instanceof Error ? error : new Error(String(error));
+	return {
+		getTransportStatus: mocks.getTransportStatus,
+		getTransportStatusEffect: () =>
+			Effect.tryPromise({
+				try: () => mocks.getTransportStatus(),
+				catch: toError,
+			}),
+		postViaXurl: mocks.postViaXurl,
+		postViaXurlEffect: (text: string) =>
+			Effect.tryPromise({
+				try: () => mocks.postViaXurl(text),
+				catch: toError,
+			}),
+		replyViaXurl: mocks.replyViaXurl,
+		replyViaXurlEffect: (tweetId: string, text: string) =>
+			Effect.tryPromise({
+				try: () => mocks.replyViaXurl(tweetId, text),
+				catch: toError,
+			}),
+		dmViaXurl: mocks.dmViaXurl,
+		dmViaXurlEffect: (handle: string, text: string) =>
+			Effect.tryPromise({
+				try: () => mocks.dmViaXurl(handle, text),
+				catch: toError,
+			}),
+	};
+});
 
 const tempRoots: string[] = [];
 
@@ -132,6 +172,25 @@ describe("birdclaw queries", () => {
 		expect(filtered[0]?.searchSnippet).toContain(
 			"<mark>context</mark> <mark>rail</mark>",
 		);
+	});
+
+	it("filters DM conversations by time before applying the limit", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		db.prepare(
+			"update dm_conversations set last_message_at = ? where id in ('dm_001', 'dm_002', 'dm_003')",
+		).run("2026-05-03T00:00:00.000Z");
+		db.prepare(
+			"update dm_conversations set last_message_at = ? where id = 'dm_004'",
+		).run("2026-05-01T12:00:00.000Z");
+
+		const filtered = listDmConversations({
+			since: "2026-05-01T00:00:00.000Z",
+			until: "2026-05-02T00:00:00.000Z",
+			limit: 1,
+		});
+
+		expect(filtered.map((item) => item.id)).toEqual(["dm_004"]);
 	});
 
 	it("uses the latest matching DM message as the search snippet", () => {
@@ -783,6 +842,21 @@ describe("birdclaw queries", () => {
 		expect(envelope.transport.availableTransport).toBe("xurl");
 	});
 
+	it("exposes the status envelope as a lazy Effect program", async () => {
+		setupTempHome();
+
+		const effect = getQueryEnvelopeEffect();
+
+		expect(mocks.findArchives).not.toHaveBeenCalled();
+		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			stats: { home: 4, mentions: 2 },
+			transport: { availableTransport: "xurl" },
+		});
+		expect(mocks.findArchives).toHaveBeenCalledTimes(1);
+		expect(mocks.getTransportStatus).toHaveBeenCalledTimes(1);
+	});
+
 	it("counts envelope timeline stats from account edges", async () => {
 		setupTempHome();
 		const db = getNativeDb();
@@ -892,6 +966,46 @@ describe("birdclaw queries", () => {
 			body: "Fresh local-first post",
 		});
 		expect(mocks.postViaXurl).toHaveBeenCalledWith("Fresh local-first post");
+	});
+
+	it("exposes local compose writes as lazy Effect programs", async () => {
+		setupTempHome();
+		const db = getNativeDb();
+
+		const postEffect = createPostEffect("acct_primary", "Effect post");
+		const replyEffect = createTweetReplyEffect(
+			"acct_primary",
+			"tweet_004",
+			"Effect reply",
+		);
+		const dmEffect = createDmReplyEffect("dm_003", "Effect DM");
+
+		expect(mocks.postViaXurl).not.toHaveBeenCalled();
+		expect(mocks.replyViaXurl).not.toHaveBeenCalled();
+		expect(mocks.dmViaXurl).not.toHaveBeenCalled();
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweet_actions where body like ?",
+				)
+				.get("Effect%") as { count: number },
+		).toEqual({ count: 0 });
+
+		await expect(Effect.runPromise(postEffect)).resolves.toMatchObject({
+			ok: true,
+		});
+		await expect(Effect.runPromise(replyEffect)).resolves.toMatchObject({
+			ok: true,
+		});
+		await expect(Effect.runPromise(dmEffect)).resolves.toMatchObject({
+			ok: true,
+		});
+		expect(mocks.postViaXurl).toHaveBeenCalledWith("Effect post");
+		expect(mocks.replyViaXurl).toHaveBeenCalledWith(
+			"tweet_004",
+			"Effect reply",
+		);
+		expect(mocks.dmViaXurl).toHaveBeenCalledWith("amelia", "Effect DM");
 	});
 
 	it("rejects tweet writes when the local author profile is unavailable", async () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { Effect } from "effect";
 import type { Database } from "./sqlite";
-import { findArchives } from "./archive-finder";
+import { findArchivesEffect } from "./archive-finder";
 import { getDb, getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { fetchProfileAffiliations } from "./profile-affiliations";
 import { displayUrlForLink, enrichFallbackUrlEntities } from "./tweet-render";
 import type {
@@ -23,11 +25,22 @@ import type {
 	TweetUrlEntity,
 } from "./types";
 import {
-	dmViaXurl,
-	getTransportStatus,
-	postViaXurl,
-	replyViaXurl,
+	dmViaXurlEffect,
+	getTransportStatusEffect,
+	postViaXurlEffect,
+	replyViaXurlEffect,
 } from "./xurl";
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
 
 function getInfluenceScore(followersCount: number) {
 	return Math.round(Math.log10(followersCount + 10) * 24);
@@ -354,51 +367,70 @@ function countTimelineEdges(db: Database, kind: "home" | "mention") {
 
 const RECENT_TIMELINE_EDGE_CANDIDATES = 5000;
 
-export async function getQueryEnvelope(): Promise<QueryEnvelope> {
-	const db = getDb();
-	const nativeDb = getNativeDb();
-	const homeCount = countTimelineEdges(nativeDb, "home");
-	const mentionCount = countTimelineEdges(nativeDb, "mention");
-	const counts = await Promise.all([
-		db
-			.selectFrom("dm_conversations")
-			.select((eb) => eb.fn.countAll().as("count"))
-			.executeTakeFirstOrThrow(),
-		db
-			.selectFrom("dm_conversations")
-			.select((eb) => eb.fn.countAll().as("count"))
-			.where("needs_reply", "=", 1)
-			.executeTakeFirstOrThrow(),
-		db
-			.selectFrom("accounts")
-			.selectAll()
-			.orderBy("is_default", "desc")
-			.orderBy("name", "asc")
-			.execute(),
-		findArchives(),
-		getTransportStatus(),
-	]);
+export function getQueryEnvelopeEffect(): Effect.Effect<
+	QueryEnvelope,
+	unknown
+> {
+	return Effect.gen(function* () {
+		const db = yield* trySync(() => getDb());
+		const nativeDb = yield* trySync(() => getNativeDb());
+		const homeCount = yield* trySync(() =>
+			countTimelineEdges(nativeDb, "home"),
+		);
+		const mentionCount = yield* trySync(() =>
+			countTimelineEdges(nativeDb, "mention"),
+		);
+		const counts = yield* Effect.all({
+			dms: tryPromise(() =>
+				db
+					.selectFrom("dm_conversations")
+					.select((eb) => eb.fn.countAll().as("count"))
+					.executeTakeFirstOrThrow(),
+			),
+			needsReply: tryPromise(() =>
+				db
+					.selectFrom("dm_conversations")
+					.select((eb) => eb.fn.countAll().as("count"))
+					.where("needs_reply", "=", 1)
+					.executeTakeFirstOrThrow(),
+			),
+			accounts: tryPromise(() =>
+				db
+					.selectFrom("accounts")
+					.selectAll()
+					.orderBy("is_default", "desc")
+					.orderBy("name", "asc")
+					.execute(),
+			),
+			archives: findArchivesEffect(),
+			transport: getTransportStatusEffect(),
+		});
 
-	return {
-		stats: {
-			home: homeCount,
-			mentions: mentionCount,
-			dms: Number(counts[0].count),
-			needsReply: Number(counts[1].count),
-			inbox: mentionCount + Number(counts[1].count),
-		},
-		accounts: counts[2].map((row) => ({
-			id: row.id,
-			name: row.name,
-			handle: row.handle,
-			externalUserId: row.external_user_id,
-			transport: row.transport,
-			isDefault: row.is_default,
-			createdAt: row.created_at,
-		})) satisfies AccountRecord[],
-		archives: counts[3],
-		transport: counts[4],
-	};
+		return {
+			stats: {
+				home: homeCount,
+				mentions: mentionCount,
+				dms: Number(counts.dms.count),
+				needsReply: Number(counts.needsReply.count),
+				inbox: mentionCount + Number(counts.needsReply.count),
+			},
+			accounts: counts.accounts.map((row) => ({
+				id: row.id,
+				name: row.name,
+				handle: row.handle,
+				externalUserId: row.external_user_id,
+				transport: row.transport,
+				isDefault: row.is_default,
+				createdAt: row.created_at,
+			})) satisfies AccountRecord[],
+			archives: counts.archives,
+			transport: counts.transport,
+		};
+	});
+}
+
+export function getQueryEnvelope(): Promise<QueryEnvelope> {
+	return runEffectPromise(getQueryEnvelopeEffect());
 }
 
 export function listTimelineItems({
@@ -924,6 +956,8 @@ export function listDmConversations({
 	participant,
 	search,
 	replyFilter = "all",
+	since,
+	until,
 	minFollowers,
 	maxFollowers,
 	minInfluenceScore,
@@ -960,6 +994,15 @@ export function listDmConversations({
 		where += " and c.needs_reply = 0";
 	} else if (replyFilter === "unreplied") {
 		where += " and c.needs_reply = 1";
+	}
+
+	if (since?.trim()) {
+		where += " and c.last_message_at >= ?";
+		params.push(since);
+	}
+	if (until?.trim()) {
+		where += " and c.last_message_at < ?";
+		params.push(until);
 	}
 
 	if (typeof minFollowers === "number") {
@@ -1435,105 +1478,136 @@ function getLocalAuthorProfileId(accountId: string) {
 	return row?.id;
 }
 
-export async function createPost(accountId: string, text: string) {
-	const db = getNativeDb();
-	const authorProfileId = getLocalAuthorProfileId(accountId);
-	if (!authorProfileId) {
-		throw new Error("No local author profile for account");
-	}
+export function createPostEffect(accountId: string, text: string) {
+	return Effect.gen(function* () {
+		const { tweetId } = yield* trySync(() => {
+			const db = getNativeDb();
+			const authorProfileId = getLocalAuthorProfileId(accountId);
+			if (!authorProfileId) {
+				throw new Error("No local author profile for account");
+			}
 
-	const now = new Date().toISOString();
-	const tweetId = `tweet_${randomUUID()}`;
+			const now = new Date().toISOString();
+			const tweetId = `tweet_${randomUUID()}`;
 
-	db.prepare(
-		`
+			db.prepare(
+				`
     insert into tweets (
       id, account_id, author_profile_id, kind, text, created_at,
       is_replied, reply_to_id, like_count, media_count, bookmarked, liked
     ) values (?, ?, ?, 'home', ?, ?, 0, null, 0, 0, 0, 0)
     `,
-	).run(tweetId, accountId, authorProfileId, text, now);
+			).run(tweetId, accountId, authorProfileId, text, now);
 
-	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
-		tweetId,
-		text,
-	);
-	db.prepare(
-		"insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at) values (?, ?, ?, ?, ?, ?)",
-	).run(randomUUID(), accountId, tweetId, "post", text, now);
+			db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
+				tweetId,
+				text,
+			);
+			db.prepare(
+				"insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at) values (?, ?, ?, ?, ?, ?)",
+			).run(randomUUID(), accountId, tweetId, "post", text, now);
+			return { tweetId };
+		});
 
-	const transport = await postViaXurl(text);
-	return { ok: true, transport, tweetId };
+		const transport = yield* postViaXurlEffect(text);
+		return { ok: true, transport, tweetId };
+	});
 }
 
-export async function createTweetReply(
+export function createPost(accountId: string, text: string) {
+	return runEffectPromise(createPostEffect(accountId, text));
+}
+
+export function createTweetReplyEffect(
 	accountId: string,
 	tweetId: string,
 	text: string,
 ) {
-	const db = getNativeDb();
-	const authorProfileId = getLocalAuthorProfileId(accountId);
-	if (!authorProfileId) {
-		throw new Error("No local author profile for account");
-	}
+	return Effect.gen(function* () {
+		const { replyId } = yield* trySync(() => {
+			const db = getNativeDb();
+			const authorProfileId = getLocalAuthorProfileId(accountId);
+			if (!authorProfileId) {
+				throw new Error("No local author profile for account");
+			}
 
-	const now = new Date().toISOString();
-	db.prepare("update tweets set is_replied = 1 where id = ?").run(tweetId);
+			const now = new Date().toISOString();
+			db.prepare("update tweets set is_replied = 1 where id = ?").run(tweetId);
 
-	const replyId = `tweet_${randomUUID()}`;
-	db.prepare(
-		`
+			const replyId = `tweet_${randomUUID()}`;
+			db.prepare(
+				`
     insert into tweets (
       id, account_id, author_profile_id, kind, text, created_at,
       is_replied, reply_to_id, like_count, media_count, bookmarked, liked
     ) values (?, ?, ?, 'home', ?, ?, 1, ?, 0, 0, 0, 0)
     `,
-	).run(replyId, accountId, authorProfileId, text, now, tweetId);
-	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
-		replyId,
-		text,
-	);
+			).run(replyId, accountId, authorProfileId, text, now, tweetId);
+			db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
+				replyId,
+				text,
+			);
 
-	db.prepare(
-		"insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at) values (?, ?, ?, ?, ?, ?)",
-	).run(randomUUID(), accountId, tweetId, "reply", text, now);
+			db.prepare(
+				"insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at) values (?, ?, ?, ?, ?, ?)",
+			).run(randomUUID(), accountId, tweetId, "reply", text, now);
+			return { replyId };
+		});
 
-	const transport = await replyViaXurl(tweetId, text);
-	return { ok: true, transport, replyId };
+		const transport = yield* replyViaXurlEffect(tweetId, text);
+		return { ok: true, transport, replyId };
+	});
 }
 
-export async function createDmReply(conversationId: string, text: string) {
-	const db = getNativeDb();
-	const conversation = getConversationThread(conversationId);
-	if (!conversation) {
-		throw new Error("Conversation not found");
-	}
-	const authorProfileId = getLocalAuthorProfileId(
-		conversation.conversation.accountId,
-	);
-	if (!authorProfileId) {
-		throw new Error("No local author profile for account");
-	}
+export function createTweetReply(
+	accountId: string,
+	tweetId: string,
+	text: string,
+) {
+	return runEffectPromise(createTweetReplyEffect(accountId, tweetId, text));
+}
 
-	const now = new Date().toISOString();
-	const outboundId = `msg_${randomUUID()}`;
+export function createDmReplyEffect(conversationId: string, text: string) {
+	return Effect.gen(function* () {
+		const { handle, outboundId } = yield* trySync(() => {
+			const db = getNativeDb();
+			const conversation = getConversationThread(conversationId);
+			if (!conversation) {
+				throw new Error("Conversation not found");
+			}
+			const authorProfileId = getLocalAuthorProfileId(
+				conversation.conversation.accountId,
+			);
+			if (!authorProfileId) {
+				throw new Error("No local author profile for account");
+			}
 
-	db.prepare(
-		`
+			const now = new Date().toISOString();
+			const outboundId = `msg_${randomUUID()}`;
+
+			db.prepare(
+				`
     insert into dm_messages (
       id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
     ) values (?, ?, ?, ?, ?, 'outbound', 1, 0)
     `,
-	).run(outboundId, conversationId, authorProfileId, text, now);
-	db.prepare("insert into dm_fts (message_id, text) values (?, ?)").run(
-		outboundId,
-		text,
-	);
+			).run(outboundId, conversationId, authorProfileId, text, now);
+			db.prepare("insert into dm_fts (message_id, text) values (?, ?)").run(
+				outboundId,
+				text,
+			);
 
-	refreshDmConversationState(db, conversationId, now);
-	const transport = await dmViaXurl(
-		conversation.conversation.participant.handle,
-		text,
-	);
-	return { ok: true, transport, messageId: outboundId };
+			refreshDmConversationState(db, conversationId, now);
+			return {
+				handle: conversation.conversation.participant.handle,
+				outboundId,
+			};
+		});
+		const transport = yield* dmViaXurlEffect(handle, text);
+		return { ok: true, transport, messageId: outboundId };
+	});
+}
+
+export function createDmReply(conversationId: string, text: string) {
+	return runEffectPromise(createDmReplyEffect(conversationId, text));
 }

--- a/src/lib/research.test.ts
+++ b/src/lib/research.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -269,6 +269,27 @@ describe("research mode", () => {
 
 		expect(report.seedCount).toBe(1);
 		expect(report.markdown).toContain("Birdclaw Research");
+		expect(readFileSync(outputPath, "utf8")).toContain("Birdclaw Research");
+	});
+
+	it("builds research reports lazily as Effect programs", async () => {
+		const { runEffectPromise } = await import("./effect-runtime");
+		const { runResearchModeEffect } = await import("./research");
+		const outputPath = path.join(
+			process.env.BIRDCLAW_HOME ?? "",
+			"lazy-brief.md",
+		);
+
+		const effect = runResearchModeEffect({
+			account: "acct_research",
+			limit: 1,
+			maxThreadDepth: 4,
+			outPath: outputPath,
+		});
+
+		expect(existsSync(outputPath)).toBe(false);
+		const report = await runEffectPromise(effect);
+		expect(report.seedCount).toBe(1);
 		expect(readFileSync(outputPath, "utf8")).toContain("Birdclaw Research");
 	});
 

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -1,8 +1,10 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import { listTimelineItems } from "./queries";
-import { lookupTweetsByIds } from "./tweet-lookup";
+import { lookupTweetsByIdsEffect } from "./tweet-lookup";
 import { renderTweetMarkdown, renderTweetPlainText } from "./tweet-render";
 import type { TweetEntities, XurlMentionUser } from "./types";
 
@@ -76,6 +78,13 @@ interface ResearchRow {
 	author_avatar_url: string | null;
 	author_created_at: string;
 	thread_depth?: number;
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: (cause) => cause,
+	});
 }
 
 function parseJsonField<T>(value: unknown, fallback: T): T {
@@ -291,80 +300,89 @@ function getTweetDescendants(
 	return rows.map((row) => toResearchNode(row, "local"));
 }
 
-async function lookupTweetNode(tweetId: string): Promise<ResearchNode | null> {
-	const payload = await lookupTweetsByIds([tweetId]);
-	const tweet = payload.data[0];
-	if (!tweet) {
-		return null;
-	}
-	const entities = normalizeTweetEntities(tweet.entities);
+function lookupTweetNodeEffect(
+	tweetId: string,
+): Effect.Effect<ResearchNode | null, unknown> {
+	return Effect.gen(function* () {
+		const payload = yield* lookupTweetsByIdsEffect([tweetId]);
+		const tweet = payload.data[0];
+		if (!tweet) {
+			return null;
+		}
+		const entities = normalizeTweetEntities(tweet.entities);
 
-	const usersById = new Map(
-		(payload.includes?.users ?? []).map((user: XurlMentionUser) => [
-			user.id,
-			user,
-		]),
-	);
-	const author = usersById.get(tweet.author_id) ?? {
-		id: tweet.author_id,
-		username: `user_${tweet.author_id}`,
-		name: `user_${tweet.author_id}`,
-	};
+		const usersById = new Map(
+			(payload.includes?.users ?? []).map((user: XurlMentionUser) => [
+				user.id,
+				user,
+			]),
+		);
+		const author = usersById.get(tweet.author_id) ?? {
+			id: tweet.author_id,
+			username: `user_${tweet.author_id}`,
+			name: `user_${tweet.author_id}`,
+		};
 
-	return {
-		id: tweet.id,
-		url: `https://x.com/${author.username}/status/${tweet.id}`,
-		authorHandle: author.username,
-		authorName: author.name,
-		createdAt: tweet.created_at,
-		text: tweet.text,
-		plainText: renderTweetPlainText(tweet.text, entities),
-		markdown: renderTweetMarkdown(tweet.text, entities),
-		likeCount: Number(tweet.public_metrics?.like_count ?? 0),
-		bookmarked: false,
-		liked: false,
-		replyToTweetId:
-			tweet.referenced_tweets?.find((item) => item.type === "replied_to")?.id ??
-			null,
-		quotedTweetId:
-			tweet.referenced_tweets?.find((item) => item.type === "quoted")?.id ??
-			null,
-		threadDepth: 0,
-		source: "live",
-	};
+		return {
+			id: tweet.id,
+			url: `https://x.com/${author.username}/status/${tweet.id}`,
+			authorHandle: author.username,
+			authorName: author.name,
+			createdAt: tweet.created_at,
+			text: tweet.text,
+			plainText: renderTweetPlainText(tweet.text, entities),
+			markdown: renderTweetMarkdown(tweet.text, entities),
+			likeCount: Number(tweet.public_metrics?.like_count ?? 0),
+			bookmarked: false,
+			liked: false,
+			replyToTweetId:
+				tweet.referenced_tweets?.find((item) => item.type === "replied_to")
+					?.id ?? null,
+			quotedTweetId:
+				tweet.referenced_tweets?.find((item) => item.type === "quoted")?.id ??
+				null,
+			threadDepth: 0,
+			source: "live",
+		};
+	});
 }
 
-async function collectAncestorChain(
+function collectAncestorChainEffect(
 	tweetId: string,
 	maxThreadDepth: number,
-): Promise<ResearchNode[]> {
-	const chain: ResearchNode[] = [];
-	let currentId: string | undefined = tweetId;
-	const visited = new Set<string>();
-	let depth = 0;
+): Effect.Effect<ResearchNode[], unknown> {
+	return Effect.gen(function* () {
+		const chain: ResearchNode[] = [];
+		let currentId: string | undefined = tweetId;
+		const visited = new Set<string>();
+		let depth = 0;
 
-	while (currentId && !visited.has(currentId) && depth < maxThreadDepth) {
-		visited.add(currentId);
-		const localRow = getTweetRowById(currentId);
-		if (localRow) {
-			chain.push(toResearchNode(localRow, "local"));
-			currentId = localRow.reply_to_id ?? undefined;
+		while (currentId && !visited.has(currentId) && depth < maxThreadDepth) {
+			const lookupId: string = currentId;
+			visited.add(lookupId);
+			const localRow: ResearchRow | null = yield* trySync(() =>
+				getTweetRowById(lookupId),
+			);
+			if (localRow) {
+				chain.push(yield* trySync(() => toResearchNode(localRow, "local")));
+				currentId = localRow.reply_to_id ?? undefined;
+				depth += 1;
+				continue;
+			}
+
+			const remoteNode = yield* lookupTweetNodeEffect(lookupId);
+			if (!remoteNode) {
+				break;
+			}
+			chain.push(remoteNode);
+			currentId = remoteNode.replyToTweetId ?? undefined;
 			depth += 1;
-			continue;
 		}
 
-		const remoteNode = await lookupTweetNode(currentId);
-		if (!remoteNode) {
-			break;
-		}
-		chain.push(remoteNode);
-		currentId = remoteNode.replyToTweetId ?? undefined;
-		depth += 1;
-	}
-
-	return chain
-		.reverse()
-		.map((node, index) => ({ ...node, threadDepth: index }));
+		return chain
+			.reverse()
+			.map((node, index) => ({ ...node, threadDepth: index }));
+	});
 }
 
 function dedupeNodes(nodes: ResearchNode[]) {
@@ -533,64 +551,89 @@ function resolveSeedTimelineItems({
 	});
 }
 
-export async function runResearchMode(
+export function runResearchModeEffect(
+	options: ResearchOptions = {},
+): Effect.Effect<ResearchReport, unknown> {
+	return Effect.gen(function* () {
+		const limit = yield* trySync(() =>
+			Number.isFinite(options.limit ?? 20)
+				? Math.max(1, Math.floor(options.limit ?? 20))
+				: 20,
+		);
+		const maxThreadDepth = yield* trySync(() =>
+			Number.isFinite(options.maxThreadDepth ?? 10)
+				? Math.max(1, Math.floor(options.maxThreadDepth ?? 10))
+				: 10,
+		);
+		const seeds = yield* trySync(() =>
+			resolveSeedTimelineItems({
+				account: options.account,
+				query: options.query,
+				limit,
+			}),
+		);
+
+		const items: ResearchThread[] = [];
+		for (const seed of seeds) {
+			const ancestorChain = yield* collectAncestorChainEffect(
+				seed.id,
+				maxThreadDepth,
+			);
+			const rootId = ancestorChain[0]?.id ?? seed.id;
+			const localThread = yield* trySync(() =>
+				getTweetDescendants(rootId, maxThreadDepth),
+			);
+			const thread = yield* trySync(() =>
+				orderThreadNodes(
+					rootId,
+					dedupeNodes([...ancestorChain, ...localThread]),
+				),
+			);
+			const links = yield* trySync(() => collectExternalLinks(thread));
+			const handles = yield* trySync(() => collectHandles(thread));
+			items.push({
+				seedTweetId: seed.id,
+				seedUrl: `https://x.com/${seed.author.handle}/status/${seed.id}`,
+				seedText: yield* trySync(() =>
+					renderTweetPlainText(seed.text, seed.entities),
+				),
+				threadRootId: rootId,
+				thread,
+				links,
+				handles,
+			});
+		}
+
+		const reportBase = {
+			query: options.query,
+			account: options.account,
+			generatedAt: new Date().toISOString(),
+			seedCount: seeds.length,
+			threadCount: items.length,
+			items,
+		};
+		const markdown = yield* trySync(() => renderReportMarkdown(reportBase));
+		const report: ResearchReport = {
+			...reportBase,
+			markdown,
+		};
+
+		if (options.outPath) {
+			yield* trySync(() => {
+				const resolved = path.resolve(options.outPath ?? "");
+				mkdirSync(path.dirname(resolved), { recursive: true });
+				writeFileSync(resolved, markdown, "utf8");
+			});
+		}
+
+		return report;
+	});
+}
+
+export function runResearchMode(
 	options: ResearchOptions = {},
 ): Promise<ResearchReport> {
-	const limit = Number.isFinite(options.limit ?? 20)
-		? Math.max(1, Math.floor(options.limit ?? 20))
-		: 20;
-	const maxThreadDepth = Number.isFinite(options.maxThreadDepth ?? 10)
-		? Math.max(1, Math.floor(options.maxThreadDepth ?? 10))
-		: 10;
-	const seeds = resolveSeedTimelineItems({
-		account: options.account,
-		query: options.query,
-		limit,
-	});
-
-	const items: ResearchThread[] = [];
-	for (const seed of seeds) {
-		const ancestorChain = await collectAncestorChain(seed.id, maxThreadDepth);
-		const rootId = ancestorChain[0]?.id ?? seed.id;
-		const localThread = getTweetDescendants(rootId, maxThreadDepth);
-		const thread = orderThreadNodes(
-			rootId,
-			dedupeNodes([...ancestorChain, ...localThread]),
-		);
-		const links = collectExternalLinks(thread);
-		const handles = collectHandles(thread);
-		items.push({
-			seedTweetId: seed.id,
-			seedUrl: `https://x.com/${seed.author.handle}/status/${seed.id}`,
-			seedText: renderTweetPlainText(seed.text, seed.entities),
-			threadRootId: rootId,
-			thread,
-			links,
-			handles,
-		});
-	}
-
-	const reportBase = {
-		query: options.query,
-		account: options.account,
-		generatedAt: new Date().toISOString(),
-		seedCount: seeds.length,
-		threadCount: items.length,
-		items,
-	};
-	const markdown = renderReportMarkdown(reportBase);
-	const report: ResearchReport = {
-		...reportBase,
-		markdown,
-	};
-
-	if (options.outPath) {
-		const resolved = path.resolve(options.outPath);
-		mkdirSync(path.dirname(resolved), { recursive: true });
-		writeFileSync(resolved, markdown, "utf8");
-	}
-
-	return report;
+	return runEffectPromise(runResearchModeEffect(options));
 }
 
 export const __test__ = {
@@ -602,6 +645,8 @@ export const __test__ = {
 	collectExternalLinks,
 	collectHandles,
 	renderReportMarkdown,
+	lookupTweetNodeEffect,
+	collectAncestorChainEffect,
 };
 
 export type { ResearchRow };

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -18,8 +19,23 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	listBookmarkedTweetsViaBird: mocks.listBookmarkedTweetsViaBird,
+	listBookmarkedTweetsViaBirdEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listBookmarkedTweetsViaBird(options),
+			catch: (error) => error,
+		}),
 	listHomeTimelineViaBird: mocks.listHomeTimelineViaBird,
+	listHomeTimelineViaBirdEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listHomeTimelineViaBird(options),
+			catch: (error) => error,
+		}),
 	listLikedTweetsViaBird: mocks.listLikedTweetsViaBird,
+	listLikedTweetsViaBirdEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listLikedTweetsViaBird(options),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./xurl", () => ({
@@ -93,6 +109,46 @@ afterEach(() => {
 });
 
 describe("live timeline collection sync", () => {
+	it("builds collection sync effects lazily", async () => {
+		setupTempHome();
+		const { syncTimelineCollectionEffect } =
+			await import("./timeline-collections-live");
+
+		const effect = syncTimelineCollectionEffect({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+			refresh: true,
+		});
+
+		expect(mocks.listLikedTweetsViaXurl).not.toHaveBeenCalled();
+		mocks.listLikedTweetsViaXurl.mockResolvedValue({
+			data: [makeTweet("liked_lazy_1")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1 },
+		});
+
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 1,
+		});
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(1);
+	});
+
+	it("validates collection sync effects only when run", async () => {
+		setupTempHome();
+		const { syncTimelineCollectionEffect } =
+			await import("./timeline-collections-live");
+
+		const effect = syncTimelineCollectionEffect({ kind: "likes", limit: 0 });
+
+		await expect(Effect.runPromise(effect)).rejects.toThrow(
+			"--limit must be at least 1",
+		);
+		expect(mocks.listLikedTweetsViaXurl).not.toHaveBeenCalled();
+	});
+
 	it("syncs liked tweets from xurl into local search filters", async () => {
 		setupTempHome();
 		mocks.listLikedTweetsViaXurl.mockResolvedValue({

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -1,6 +1,11 @@
 import type { Database } from "./sqlite";
-import { listBookmarkedTweetsViaBird, listLikedTweetsViaBird } from "./bird";
+import { Effect } from "effect";
+import {
+	listBookmarkedTweetsViaBirdEffect,
+	listLikedTweetsViaBirdEffect,
+} from "./bird";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type {
@@ -18,11 +23,33 @@ import {
 
 export type TimelineCollectionKind = "likes" | "bookmarks";
 export type TimelineCollectionMode = "auto" | "xurl" | "bird";
+export interface SyncTimelineCollectionOptions {
+	kind: TimelineCollectionKind;
+	account?: string;
+	mode?: TimelineCollectionMode;
+	limit?: number;
+	all?: boolean;
+	maxPages?: number;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+	earlyStop?: boolean;
+}
 
 const DEFAULT_COLLECTION_CACHE_TTL_MS = 2 * 60_000;
 const DEFAULT_EARLY_STOP_MAX_PAGES = 10;
 const MIN_XURL_LIMIT = 5;
 const MAX_XURL_LIMIT = 100;
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
 
 function parseCacheTtlMs(value?: number) {
 	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
@@ -300,7 +327,7 @@ function mergeTimelineCollectionIntoLocalStore(
 	})();
 }
 
-async function fetchXurlCollection({
+function fetchXurlCollectionEffect({
 	db,
 	kind,
 	accountId,
@@ -321,80 +348,84 @@ async function fetchXurlCollection({
 	maxPages: number | null;
 	earlyStop: boolean;
 }) {
-	let resolvedUserId = userId;
-	if (!resolvedUserId) {
-		const [accountUser] = await lookupUsersByHandles([username]);
-		if (!accountUser?.id) {
-			throw new Error(`Could not resolve Twitter user id for @${username}`);
-		}
-		resolvedUserId = String(accountUser.id);
-	}
-
-	const pages: XurlMentionsResponse[] = [];
-	let nextToken: string | undefined;
-	let pageCount = 0;
-	let saturatedAtPage: number | undefined;
-	do {
-		const payload =
-			kind === "likes"
-				? await listLikedTweetsViaXurl({
-						maxResults: limit,
-						username,
-						userId: resolvedUserId,
-						paginationToken: nextToken,
-					})
-				: await listBookmarkedTweetsViaXurl({
-						maxResults: limit,
-						username,
-						userId: resolvedUserId,
-						isPaginatedWalk: all,
-						paginationToken: nextToken,
-					});
-		pageCount += 1;
-		if (earlyStop) {
-			const tweetIds = payload.data.map((tweet) => tweet.id);
-			const { existingTweetIds, uniqueTweetCount } = getCollectionPageDedupe(
-				db,
-				accountId,
-				kind,
-				tweetIds,
+	return Effect.gen(function* () {
+		let resolvedUserId = userId;
+		if (!resolvedUserId) {
+			const [accountUser] = yield* tryPromise(() =>
+				lookupUsersByHandles([username]),
 			);
-			if (tweetIds.length > 0 && existingTweetIds.size === uniqueTweetCount) {
-				saturatedAtPage = pageCount;
-				console.error(
-					`${kind} saturated at page ${pageCount} (100% existing rows)`,
+			if (!accountUser?.id) {
+				return yield* Effect.fail(
+					new Error(`Could not resolve Twitter user id for @${username}`),
 				);
-				break;
 			}
-			pages.push(filterExistingCollectionTweets(payload, existingTweetIds));
-		} else {
-			pages.push(payload);
+			resolvedUserId = String(accountUser.id);
 		}
-		nextToken =
-			typeof payload.meta?.next_token === "string"
-				? payload.meta.next_token
-				: undefined;
-	} while (
-		(all || earlyStop) &&
-		nextToken &&
-		(maxPages === null || pageCount < maxPages)
-	);
 
-	const merged = mergePayloads(pages);
-	// A saturated page may expose another token, but our walk is complete.
-	const saturationMeta =
-		saturatedAtPage === undefined
-			? {}
-			: { saturated_at_page: saturatedAtPage, next_token: null };
-	merged.meta = {
-		...merged.meta,
-		page_count: pageCount,
-		...saturationMeta,
-	};
-	return merged;
+		const pages: XurlMentionsResponse[] = [];
+		let nextToken: string | undefined;
+		let pageCount = 0;
+		let saturatedAtPage: number | undefined;
+		do {
+			const payload = yield* tryPromise(() =>
+				kind === "likes"
+					? listLikedTweetsViaXurl({
+							maxResults: limit,
+							username,
+							userId: resolvedUserId,
+							paginationToken: nextToken,
+						})
+					: listBookmarkedTweetsViaXurl({
+							maxResults: limit,
+							username,
+							userId: resolvedUserId,
+							isPaginatedWalk: all,
+							paginationToken: nextToken,
+						}),
+			);
+			pageCount += 1;
+			if (earlyStop) {
+				const tweetIds = payload.data.map((tweet) => tweet.id);
+				const { existingTweetIds, uniqueTweetCount } = yield* trySync(() =>
+					getCollectionPageDedupe(db, accountId, kind, tweetIds),
+				);
+				if (tweetIds.length > 0 && existingTweetIds.size === uniqueTweetCount) {
+					saturatedAtPage = pageCount;
+					console.error(
+						`${kind} saturated at page ${pageCount} (100% existing rows)`,
+					);
+					break;
+				}
+				pages.push(filterExistingCollectionTweets(payload, existingTweetIds));
+			} else {
+				pages.push(payload);
+			}
+			nextToken =
+				typeof payload.meta?.next_token === "string"
+					? payload.meta.next_token
+					: undefined;
+		} while (
+			(all || earlyStop) &&
+			nextToken &&
+			(maxPages === null || pageCount < maxPages)
+		);
+
+		const merged = mergePayloads(pages);
+		// A saturated page may expose another token, but our walk is complete.
+		const saturationMeta =
+			saturatedAtPage === undefined
+				? {}
+				: { saturated_at_page: saturatedAtPage, next_token: null };
+		merged.meta = {
+			...merged.meta,
+			page_count: pageCount,
+			...saturationMeta,
+		};
+		return merged;
+	});
 }
 
-async function fetchBirdCollection({
+function fetchBirdCollectionEffect({
 	kind,
 	limit,
 	all,
@@ -406,19 +437,19 @@ async function fetchBirdCollection({
 	maxPages: number | null;
 }) {
 	return kind === "likes"
-		? listLikedTweetsViaBird({
+		? listLikedTweetsViaBirdEffect({
 				maxResults: limit,
 				all,
 				maxPages: maxPages ?? undefined,
 			})
-		: listBookmarkedTweetsViaBird({
+		: listBookmarkedTweetsViaBirdEffect({
 				maxResults: limit,
 				all,
 				maxPages: maxPages ?? undefined,
 			});
 }
 
-export async function syncTimelineCollection({
+export function syncTimelineCollectionEffect({
 	kind,
 	account,
 	mode = "auto",
@@ -428,72 +459,64 @@ export async function syncTimelineCollection({
 	refresh = false,
 	cacheTtlMs,
 	earlyStop = false,
-}: {
-	kind: TimelineCollectionKind;
-	account?: string;
-	mode?: TimelineCollectionMode;
-	limit?: number;
-	all?: boolean;
-	maxPages?: number;
-	refresh?: boolean;
-	cacheTtlMs?: number;
-	earlyStop?: boolean;
-}) {
-	assertLimit(limit);
-	const parsedMaxPages = parseMaxPages(maxPages);
-	const shouldApplyEarlyStopCap =
-		earlyStop && !all && parsedMaxPages === null && mode !== "bird";
-	const xurlMaxPages = shouldApplyEarlyStopCap
-		? DEFAULT_EARLY_STOP_MAX_PAGES
-		: parsedMaxPages;
-	if (mode === "xurl" || mode === "auto") {
-		assertXurlLimit(limit);
-	}
+}: SyncTimelineCollectionOptions) {
+	return Effect.gen(function* () {
+		yield* trySync(() => assertLimit(limit));
+		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const shouldApplyEarlyStopCap =
+			earlyStop && !all && parsedMaxPages === null && mode !== "bird";
+		const xurlMaxPages = shouldApplyEarlyStopCap
+			? DEFAULT_EARLY_STOP_MAX_PAGES
+			: parsedMaxPages;
+		if (mode === "xurl" || mode === "auto") {
+			yield* trySync(() => assertXurlLimit(limit));
+		}
 
-	const db = getNativeDb();
-	const resolvedAccount = resolveAccount(db, account);
-	const cacheMaxPages = mode === "bird" ? parsedMaxPages : xurlMaxPages;
-	const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${cacheMaxPages === null ? "all-pages" : String(cacheMaxPages)}${earlyStop ? ":early-stop" : ""}`;
-	const ttlMs = parseCacheTtlMs(cacheTtlMs);
-	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
-
-	if (!refresh && cached && cacheAgeMs <= ttlMs) {
-		const saturatedAtPage = readSaturatedAtPage(cached.value);
-		return {
-			ok: true,
-			source: "cache",
-			kind,
-			accountId: resolvedAccount.accountId,
-			count: cached.value.data.length,
-			payload: cached.value,
-			...(saturatedAtPage === undefined
-				? {}
-				: { saturated_at_page: saturatedAtPage }),
-		};
-	}
-
-	if (shouldApplyEarlyStopCap) {
-		console.error(
-			`${kind} early-stop capped at ${DEFAULT_EARLY_STOP_MAX_PAGES} pages by default; pass --max-pages or --all to override`,
+		const db = yield* trySync(() => getNativeDb());
+		const resolvedAccount = yield* trySync(() => resolveAccount(db, account));
+		const cacheMaxPages = mode === "bird" ? parsedMaxPages : xurlMaxPages;
+		const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${cacheMaxPages === null ? "all-pages" : String(cacheMaxPages)}${earlyStop ? ":early-stop" : ""}`;
+		const ttlMs = parseCacheTtlMs(cacheTtlMs);
+		const cached = yield* trySync(() =>
+			readSyncCache<XurlMentionsResponse>(cacheKey, db),
 		);
-	}
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
 
-	let source: "xurl" | "bird";
-	let payload: XurlMentionsResponse;
-	if (mode === "bird") {
-		payload = await fetchBirdCollection({
-			kind,
-			limit,
-			all,
-			maxPages: parsedMaxPages,
-		});
-		source = "bird";
-	} else {
-		try {
-			payload = await fetchXurlCollection({
+		if (!refresh && cached && cacheAgeMs <= ttlMs) {
+			const saturatedAtPage = readSaturatedAtPage(cached.value);
+			return {
+				ok: true,
+				source: "cache",
+				kind,
+				accountId: resolvedAccount.accountId,
+				count: cached.value.data.length,
+				payload: cached.value,
+				...(saturatedAtPage === undefined
+					? {}
+					: { saturated_at_page: saturatedAtPage }),
+			};
+		}
+
+		if (shouldApplyEarlyStopCap) {
+			console.error(
+				`${kind} early-stop capped at ${DEFAULT_EARLY_STOP_MAX_PAGES} pages by default; pass --max-pages or --all to override`,
+			);
+		}
+
+		let source: "xurl" | "bird";
+		let payload: XurlMentionsResponse;
+		if (mode === "bird") {
+			payload = yield* fetchBirdCollectionEffect({
+				kind,
+				limit,
+				all,
+				maxPages: parsedMaxPages,
+			});
+			source = "bird";
+		} else {
+			const xurlPayload = yield* fetchXurlCollectionEffect({
 				db,
 				kind,
 				accountId: resolvedAccount.accountId,
@@ -503,41 +526,55 @@ export async function syncTimelineCollection({
 				all,
 				maxPages: xurlMaxPages,
 				earlyStop,
-			});
-			source = "xurl";
-		} catch (error) {
-			if (mode === "xurl") {
-				throw error;
+			}).pipe(
+				Effect.map((value) => ({ ok: true as const, value })),
+				Effect.catchAll((error) => {
+					if (mode === "xurl") {
+						return Effect.fail(error);
+					}
+					return Effect.succeed({ ok: false as const });
+				}),
+			);
+			if (xurlPayload.ok) {
+				payload = xurlPayload.value;
+				source = "xurl";
+			} else {
+				payload = yield* fetchBirdCollectionEffect({
+					kind,
+					limit,
+					all,
+					maxPages: parsedMaxPages,
+				});
+				source = "bird";
 			}
-			payload = await fetchBirdCollection({
-				kind,
-				limit,
-				all,
-				maxPages: parsedMaxPages,
-			});
-			source = "bird";
 		}
-	}
 
-	mergeTimelineCollectionIntoLocalStore(
-		db,
-		resolvedAccount.accountId,
-		kind,
-		payload,
-		source,
-	);
-	writeSyncCache(cacheKey, payload, db);
-	const saturatedAtPage = readSaturatedAtPage(payload);
+		yield* trySync(() =>
+			mergeTimelineCollectionIntoLocalStore(
+				db,
+				resolvedAccount.accountId,
+				kind,
+				payload,
+				source,
+			),
+		);
+		yield* trySync(() => writeSyncCache(cacheKey, payload, db));
+		const saturatedAtPage = readSaturatedAtPage(payload);
 
-	return {
-		ok: true,
-		source,
-		kind,
-		accountId: resolvedAccount.accountId,
-		count: payload.data.length,
-		payload,
-		...(saturatedAtPage === undefined
-			? {}
-			: { saturated_at_page: saturatedAtPage }),
-	};
+		return {
+			ok: true,
+			source,
+			kind,
+			accountId: resolvedAccount.accountId,
+			count: payload.data.length,
+			payload,
+			...(saturatedAtPage === undefined
+				? {}
+				: { saturated_at_page: saturatedAtPage }),
+		};
+	});
+}
+
+export function syncTimelineCollection(options: SyncTimelineCollectionOptions) {
+	return runEffectPromise(syncTimelineCollectionEffect(options));
 }

--- a/src/lib/timeline-live.test.ts
+++ b/src/lib/timeline-live.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
@@ -9,10 +10,18 @@ import { listTimelineItems } from "./queries";
 
 const listHomeTimelineViaBirdMock = vi.fn();
 
-vi.mock("./bird", () => ({
-	listHomeTimelineViaBird: (...args: unknown[]) =>
-		listHomeTimelineViaBirdMock(...args),
-}));
+vi.mock("./bird", async () => {
+	const { Effect } = await import("effect");
+	return {
+		listHomeTimelineViaBird: (...args: unknown[]) =>
+			listHomeTimelineViaBirdMock(...args),
+		listHomeTimelineViaBirdEffect: (...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => listHomeTimelineViaBirdMock(...args),
+				catch: (error) => error,
+			}),
+	};
+});
 
 const tempDirs: string[] = [];
 
@@ -37,6 +46,28 @@ afterEach(() => {
 });
 
 describe("live home timeline sync", () => {
+	it("keeps home timeline sync effects lazy", async () => {
+		makeTempHome();
+		listHomeTimelineViaBirdMock.mockResolvedValueOnce({
+			data: [],
+			meta: { result_count: 0 },
+		});
+		const { syncHomeTimelineEffect } = await import("./timeline-live");
+
+		const effect = syncHomeTimelineEffect({
+			account: "acct_primary",
+			limit: 5,
+			refresh: true,
+		});
+
+		expect(listHomeTimelineViaBirdMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			source: "bird",
+			count: 0,
+		});
+		expect(listHomeTimelineViaBirdMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("stores account-scoped home timeline edges without moving canonical tweets", async () => {
 		makeTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-live.ts
+++ b/src/lib/timeline-live.ts
@@ -1,6 +1,8 @@
+import { Effect } from "effect";
 import type { Database } from "./sqlite";
-import { listHomeTimelineViaBird } from "./bird";
+import { listHomeTimelineViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type { XurlMentionsResponse } from "./types";
@@ -8,6 +10,14 @@ import { upsertTweetAccountEdge } from "./tweet-account-edges";
 import { ensureStubProfileForXUser, upsertProfileFromXUser } from "./x-profile";
 
 const DEFAULT_TIMELINE_CACHE_TTL_MS = 2 * 60_000;
+
+export interface SyncHomeTimelineOptions {
+	account?: string;
+	limit?: number;
+	following?: boolean;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+}
 
 function parseCacheTtlMs(value?: number) {
 	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
@@ -123,55 +133,66 @@ function mergeHomeTimelineIntoLocalStore(
 	})();
 }
 
-export async function syncHomeTimeline({
+export function syncHomeTimelineEffect({
 	account,
 	limit = 100,
 	following = true,
 	refresh = false,
 	cacheTtlMs,
-}: {
-	account?: string;
-	limit?: number;
-	following?: boolean;
-	refresh?: boolean;
-	cacheTtlMs?: number;
-}) {
-	assertLimit(limit);
-	const db = getNativeDb();
-	const accountId = resolveAccount(db, account);
-	const cacheKey = `timeline:bird:${accountId}:${following ? "following" : "for-you"}:${String(limit)}`;
-	const ttlMs = parseCacheTtlMs(cacheTtlMs);
-	const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
+}: SyncHomeTimelineOptions = {}): Effect.Effect<
+	{
+		ok: true;
+		source: "bird" | "cache";
+		kind: "timeline";
+		accountId: string;
+		feed: "following" | "for-you";
+		count: number;
+		payload: XurlMentionsResponse;
+	},
+	unknown
+> {
+	return Effect.gen(function* () {
+		assertLimit(limit);
+		const db = getNativeDb();
+		const accountId = resolveAccount(db, account);
+		const cacheKey = `timeline:bird:${accountId}:${following ? "following" : "for-you"}:${String(limit)}`;
+		const ttlMs = parseCacheTtlMs(cacheTtlMs);
+		const cached = readSyncCache<XurlMentionsResponse>(cacheKey, db);
+		const cacheAgeMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
 
-	if (!refresh && cached && cacheAgeMs <= ttlMs) {
+		if (!refresh && cached && cacheAgeMs <= ttlMs) {
+			return {
+				ok: true,
+				source: "cache",
+				kind: "timeline",
+				accountId,
+				feed: following ? "following" : "for-you",
+				count: cached.value.data.length,
+				payload: cached.value,
+			} as const;
+		}
+
+		const payload = yield* listHomeTimelineViaBirdEffect({
+			maxResults: limit,
+			following,
+		});
+		mergeHomeTimelineIntoLocalStore(db, accountId, payload);
+		writeSyncCache(cacheKey, payload, db);
+
 		return {
 			ok: true,
-			source: "cache",
+			source: "bird",
 			kind: "timeline",
 			accountId,
 			feed: following ? "following" : "for-you",
-			count: cached.value.data.length,
-			payload: cached.value,
-		};
-	}
-
-	const payload = await listHomeTimelineViaBird({
-		maxResults: limit,
-		following,
+			count: payload.data.length,
+			payload,
+		} as const;
 	});
-	mergeHomeTimelineIntoLocalStore(db, accountId, payload);
-	writeSyncCache(cacheKey, payload, db);
+}
 
-	return {
-		ok: true,
-		source: "bird",
-		kind: "timeline",
-		accountId,
-		feed: following ? "following" : "for-you",
-		count: payload.data.length,
-		payload,
-	};
+export function syncHomeTimeline(options: SyncHomeTimelineOptions = {}) {
+	return runEffectPromise(syncHomeTimelineEffect(options));
 }

--- a/src/lib/tweet-lookup.test.ts
+++ b/src/lib/tweet-lookup.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -8,11 +9,25 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./bird", () => ({
 	lookupTweetsByIdsViaBird: mocks.lookupTweetsByIdsViaBird,
+	lookupTweetsByIdsViaBirdEffect: (ids: string[]) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupTweetsByIdsViaBird(ids),
+			catch: (error) => error,
+		}),
 }));
 
-vi.mock("./xurl", () => ({
-	lookupTweetsByIds: mocks.lookupTweetsByIdsViaXurl,
-}));
+vi.mock("./xurl", async () => {
+	const { Effect } = await import("effect");
+	return {
+		lookupTweetsByIds: mocks.lookupTweetsByIdsViaXurl,
+		lookupTweetsByIdsEffect: (ids: string[]) =>
+			Effect.tryPromise({
+				try: () => mocks.lookupTweetsByIdsViaXurl(ids),
+				catch: (error) =>
+					error instanceof Error ? error : new Error(String(error)),
+			}),
+	};
+});
 
 describe("shared tweet lookup", () => {
 	afterEach(() => {
@@ -35,6 +50,21 @@ describe("shared tweet lookup", () => {
 		});
 		expect(mocks.lookupTweetsByIdsViaXurl).toHaveBeenCalledWith(["tweet_1"]);
 		expect(mocks.lookupTweetsByIdsViaBird).not.toHaveBeenCalled();
+	});
+
+	it("exposes tweet lookup as a lazy Effect program", async () => {
+		mocks.lookupTweetsByIdsViaXurl.mockResolvedValue({
+			data: [
+				{ id: "tweet_1", author_id: "42", text: "xurl", created_at: "now" },
+			],
+		});
+		const { lookupTweetsByIdsEffect } = await import("./tweet-lookup");
+
+		const effect = lookupTweetsByIdsEffect(["tweet_1"]);
+		expect(mocks.lookupTweetsByIdsViaXurl).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			data: [{ id: "tweet_1", text: "xurl" }],
+		});
 	});
 
 	it("falls back to bird when xurl lookup fails in auto mode", async () => {

--- a/src/lib/tweet-lookup.ts
+++ b/src/lib/tweet-lookup.ts
@@ -1,6 +1,8 @@
-import { lookupTweetsByIdsViaBird } from "./bird";
+import { Effect } from "effect";
+import { lookupTweetsByIdsViaBirdEffect } from "./bird";
+import { runEffectPromise } from "./effect-runtime";
 import type { XurlTweetsResponse } from "./types";
-import { lookupTweetsByIds as lookupTweetsByIdsViaXurl } from "./xurl";
+import { lookupTweetsByIdsEffect as lookupTweetsByIdsViaXurlEffect } from "./xurl";
 
 export type TweetLookupMode = "auto" | "xurl" | "bird";
 
@@ -8,28 +10,37 @@ function errorMessage(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
 }
 
-export async function lookupTweetsByIds(
+export function lookupTweetsByIdsEffect(
+	ids: string[],
+	mode: TweetLookupMode = "auto",
+): Effect.Effect<XurlTweetsResponse, unknown> {
+	if (mode === "bird") {
+		return lookupTweetsByIdsViaBirdEffect(ids);
+	}
+	if (mode === "xurl") {
+		return lookupTweetsByIdsViaXurlEffect(ids);
+	}
+
+	return lookupTweetsByIdsViaXurlEffect(ids).pipe(
+		Effect.catchAll((xurlError) =>
+			lookupTweetsByIdsViaBirdEffect(ids).pipe(
+				Effect.catchAll((birdError) =>
+					Effect.fail(
+						new Error(
+							`Tweet lookup failed via xurl and bird: xurl: ${errorMessage(
+								xurlError,
+							)}; bird: ${errorMessage(birdError)}`,
+						),
+					),
+				),
+			),
+		),
+	);
+}
+
+export function lookupTweetsByIds(
 	ids: string[],
 	mode: TweetLookupMode = "auto",
 ): Promise<XurlTweetsResponse> {
-	if (mode === "bird") {
-		return lookupTweetsByIdsViaBird(ids);
-	}
-	if (mode === "xurl") {
-		return lookupTweetsByIdsViaXurl(ids);
-	}
-
-	try {
-		return await lookupTweetsByIdsViaXurl(ids);
-	} catch (xurlError) {
-		try {
-			return await lookupTweetsByIdsViaBird(ids);
-		} catch (birdError) {
-			throw new Error(
-				`Tweet lookup failed via xurl and bird: xurl: ${errorMessage(
-					xurlError,
-				)}; bird: ${errorMessage(birdError)}`,
-			);
-		}
-	}
+	return runEffectPromise(lookupTweetsByIdsEffect(ids, mode));
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -359,6 +359,8 @@ export interface DmQuery {
 	participant?: string;
 	search?: string;
 	replyFilter?: ReplyFilter;
+	since?: string;
+	until?: string;
 	minFollowers?: number;
 	maxFollowers?: number;
 	minInfluenceScore?: number;

--- a/src/lib/url-expansion.test.ts
+++ b/src/lib/url-expansion.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { resetDatabaseForTests } from "./db";
@@ -178,5 +179,39 @@ describe("URL expansion cache", () => {
 			}),
 		]);
 		expect(fetchImpl).toHaveBeenCalledTimes(2);
+	});
+
+	it("exposes URL expansion as Effect programs", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			url: "https://example.com/final",
+		});
+		const { expandUrlsEffect, expandUrlsFromTextsEffect } =
+			await import("./url-expansion");
+
+		await expect(
+			Effect.runPromise(
+				expandUrlsEffect(["https://t.co/effect"], { fetchImpl }),
+			),
+		).resolves.toEqual([
+			expect.objectContaining({
+				finalUrl: "https://example.com/final",
+				source: "network",
+			}),
+		]);
+		await expect(
+			Effect.runPromise(
+				expandUrlsFromTextsEffect(["Again https://t.co/effect"], {
+					fetchImpl,
+				}),
+			),
+		).resolves.toEqual([
+			expect.objectContaining({
+				finalUrl: "https://example.com/final",
+				source: "cache",
+			}),
+		]);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/url-expansion.ts
+++ b/src/lib/url-expansion.ts
@@ -1,4 +1,6 @@
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import type { UrlExpansionItem } from "./types";
 import {
@@ -40,6 +42,17 @@ function trimTrailingPunctuation(url: string) {
 	return url.replace(/[.,;:!?]+$/g, "");
 }
 
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
 export function extractUrls(text: string) {
 	return Array.from(
 		new Set(
@@ -76,28 +89,32 @@ function persistExpansion(item: UrlExpansionItem) {
 	upsertUrlExpansion(db, normalizeUrlExpansionForIndex(item));
 }
 
-async function fetchExpansion(
+function fetchExpansionEffect(
 	url: string,
 	fetchImpl: typeof fetch,
 	timeoutMs: number,
-): Promise<CachedUrlExpansion> {
+): Effect.Effect<CachedUrlExpansion, never> {
 	const requestInit = {
 		redirect: "follow",
 		headers: { "user-agent": "birdclaw/0.3 url-expander" },
 		signal: AbortSignal.timeout(timeoutMs),
 	} satisfies RequestInit;
 
-	try {
-		let response = await fetchImpl(url, {
-			...requestInit,
-			method: "HEAD",
-		});
+	return Effect.gen(function* () {
+		let response = yield* tryPromise(() =>
+			fetchImpl(url, {
+				...requestInit,
+				method: "HEAD",
+			}),
+		);
 
 		if (!response.url || response.url === url || response.status >= 400) {
-			response = await fetchImpl(url, {
-				...requestInit,
-				method: "GET",
-			});
+			response = yield* tryPromise(() =>
+				fetchImpl(url, {
+					...requestInit,
+					method: "GET",
+				}),
+			);
 		}
 
 		const finalUrl = response.url || url;
@@ -106,64 +123,86 @@ async function fetchExpansion(
 			finalUrl,
 			status: response.ok || finalUrl !== url ? "hit" : "miss",
 			...(response.ok ? {} : { error: `HTTP ${response.status}` }),
-		};
-	} catch (error) {
-		return {
-			expandedUrl: url,
-			finalUrl: url,
-			status: "error",
-			error: error instanceof Error ? error.message : String(error),
-		};
-	}
+		} satisfies CachedUrlExpansion;
+	}).pipe(
+		Effect.catchAll((error) =>
+			Effect.succeed({
+				expandedUrl: url,
+				finalUrl: url,
+				status: "error" as const,
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		),
+	);
 }
 
-export async function expandUrls(
+export function expandUrlsEffect(
+	urls: string[],
+	options: ExpandUrlsOptions = {},
+): Effect.Effect<UrlExpansionItem[], unknown> {
+	return Effect.gen(function* () {
+		const uniqueUrls = Array.from(new Set(urls));
+		const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+		const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+		const results: UrlExpansionItem[] = [];
+
+		for (const url of uniqueUrls) {
+			const cached = yield* trySync(() =>
+				readSyncCache<CachedUrlExpansion>(cacheKeyForUrl(url)),
+			);
+			if (cached && !options.refresh) {
+				const maxAge =
+					cached.value.status === "hit"
+						? (options.successMaxAgeMs ?? SUCCESS_CACHE_TTL_MS)
+						: (options.failureMaxAgeMs ?? FAILURE_CACHE_TTL_MS);
+				if (isFresh(cached.updatedAt, maxAge)) {
+					const item = toExpansionItem(
+						url,
+						cached.value,
+						"cache",
+						cached.updatedAt,
+					);
+					yield* trySync(() => persistExpansion(item));
+					results.push(item);
+					continue;
+				}
+			}
+
+			const value = yield* fetchExpansionEffect(url, fetchImpl, timeoutMs);
+			const updatedAt = yield* trySync(() =>
+				writeSyncCache(cacheKeyForUrl(url), value),
+			);
+			const item = toExpansionItem(url, value, "network", updatedAt);
+			yield* trySync(() => persistExpansion(item));
+			results.push(item);
+		}
+
+		return results;
+	});
+}
+
+export function expandUrls(
 	urls: string[],
 	options: ExpandUrlsOptions = {},
 ): Promise<UrlExpansionItem[]> {
-	const uniqueUrls = Array.from(new Set(urls));
-	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-	const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
-	const results: UrlExpansionItem[] = [];
-
-	for (const url of uniqueUrls) {
-		const cached = readSyncCache<CachedUrlExpansion>(cacheKeyForUrl(url));
-		if (cached && !options.refresh) {
-			const maxAge =
-				cached.value.status === "hit"
-					? (options.successMaxAgeMs ?? SUCCESS_CACHE_TTL_MS)
-					: (options.failureMaxAgeMs ?? FAILURE_CACHE_TTL_MS);
-			if (isFresh(cached.updatedAt, maxAge)) {
-				const item = toExpansionItem(
-					url,
-					cached.value,
-					"cache",
-					cached.updatedAt,
-				);
-				persistExpansion(item);
-				results.push(item);
-				continue;
-			}
-		}
-
-		const value = await fetchExpansion(url, fetchImpl, timeoutMs);
-		const updatedAt = writeSyncCache(cacheKeyForUrl(url), value);
-		const item = toExpansionItem(url, value, "network", updatedAt);
-		persistExpansion(item);
-		results.push(item);
-	}
-
-	return results;
+	return runEffectPromise(expandUrlsEffect(urls, options));
 }
 
-export async function expandUrlsFromTexts(
+export function expandUrlsFromTextsEffect(
 	texts: string[],
 	options: ExpandUrlsOptions = {},
 ) {
-	return expandUrls(
+	return expandUrlsEffect(
 		texts.flatMap((text) => extractUrls(text)),
 		options,
 	);
+}
+
+export function expandUrlsFromTexts(
+	texts: string[],
+	options: ExpandUrlsOptions = {},
+) {
+	return runEffectPromise(expandUrlsFromTextsEffect(texts, options));
 }
 
 export const __test__ = {

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const maybeAutoSyncBackupMock = vi.fn();
@@ -13,28 +14,58 @@ const syncHomeTimelineMock = vi.fn();
 
 vi.mock("./backup", () => ({
 	maybeAutoSyncBackup: (...args: unknown[]) => maybeAutoSyncBackupMock(...args),
+	maybeAutoSyncBackupEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => maybeAutoSyncBackupMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./dms-live", () => ({
 	syncDirectMessagesViaCachedBird: (...args: unknown[]) =>
 		syncDirectMessagesViaCachedBirdMock(...args),
+	syncDirectMessagesViaCachedBirdEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncDirectMessagesViaCachedBirdMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./mention-threads-live", () => ({
 	syncMentionThreads: (...args: unknown[]) => syncMentionThreadsMock(...args),
+	syncMentionThreadsEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncMentionThreadsMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./mentions-live", () => ({
 	syncMentions: (...args: unknown[]) => syncMentionsMock(...args),
+	syncMentionsEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncMentionsMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./timeline-collections-live", () => ({
 	syncTimelineCollection: (...args: unknown[]) =>
 		syncTimelineCollectionMock(...args),
+	syncTimelineCollectionEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncTimelineCollectionMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 vi.mock("./timeline-live", () => ({
 	syncHomeTimeline: (...args: unknown[]) => syncHomeTimelineMock(...args),
+	syncHomeTimelineEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => syncHomeTimelineMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 import { resetBirdclawPathsForTests } from "./config";
@@ -44,6 +75,7 @@ import {
 	getWebSyncJob,
 	parseWebSyncKind,
 	runWebSync,
+	runWebSyncEffect,
 	startWebSync,
 } from "./web-sync";
 
@@ -240,6 +272,24 @@ describe("web sync dispatcher", () => {
 			summary: "Sync already running",
 		});
 		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not start a sync while constructing the Effect", async () => {
+		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		syncHomeTimelineMock.mockReturnValue(pending.promise);
+
+		const effect = runWebSyncEffect("timeline");
+
+		expect(syncHomeTimelineMock).not.toHaveBeenCalled();
+
+		const result = Effect.runPromise(effect);
+		expect(syncHomeTimelineMock).toHaveBeenCalledTimes(1);
+		pending.resolve({ ok: true, source: "bird", count: 1 });
+
+		await expect(result).resolves.toMatchObject({
+			ok: true,
+			kind: "timeline",
+		});
 	});
 
 	it("keeps account-aware running locks scoped by account", async () => {

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -1,12 +1,14 @@
 import { existsSync } from "node:fs";
-import { maybeAutoSyncBackup } from "./backup";
+import { Effect } from "effect";
+import { maybeAutoSyncBackupEffect } from "./backup";
 import { getBirdclawPaths } from "./config";
-import { syncDirectMessagesViaCachedBird } from "./dms-live";
-import { syncMentionThreads } from "./mention-threads-live";
-import { syncMentions } from "./mentions-live";
+import { syncDirectMessagesViaCachedBirdEffect } from "./dms-live";
+import { runEffectPromise } from "./effect-runtime";
+import { syncMentionThreadsEffect } from "./mention-threads-live";
+import { syncMentionsEffect } from "./mentions-live";
 import NativeSqliteDatabase from "./sqlite";
-import { syncTimelineCollection } from "./timeline-collections-live";
-import { syncHomeTimeline } from "./timeline-live";
+import { syncTimelineCollectionEffect } from "./timeline-collections-live";
+import { syncHomeTimelineEffect } from "./timeline-live";
 
 export type WebSyncKind =
 	| "timeline"
@@ -33,7 +35,7 @@ export interface WebSyncResponse {
 	summary: string;
 	steps: WebSyncStep[];
 	inProgress?: boolean;
-	backup?: Awaited<ReturnType<typeof maybeAutoSyncBackup>>;
+	backup?: Effect.Effect.Success<ReturnType<typeof maybeAutoSyncBackupEffect>>;
 	error?: string;
 }
 
@@ -55,7 +57,7 @@ export interface WebSyncJobSnapshot {
 interface WebSyncPlan {
 	label: string;
 	accountAware: boolean;
-	run: (accountId: string | undefined) => Promise<WebSyncStep[]>;
+	run: (accountId: string | undefined) => Effect.Effect<WebSyncStep[], unknown>;
 }
 
 const runningSyncs = new Map<string, WebSyncJobSnapshot>();
@@ -114,64 +116,66 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	timeline: {
 		label: "Home timeline",
 		accountAware: false,
-		run: async (account) => {
-			const result = await syncHomeTimeline({
-				account,
-				limit: 100,
-				following: true,
-				refresh: true,
-			});
-			return [
-				{
-					kind: "timeline",
-					label: "Home timeline",
-					count: readNumber(result, "count"),
-					source: readString(result, "source"),
-				},
-			];
-		},
+		run: (account) =>
+			Effect.gen(function* () {
+				const result = yield* syncHomeTimelineEffect({
+					account,
+					limit: 100,
+					following: true,
+					refresh: true,
+				});
+				return [
+					{
+						kind: "timeline",
+						label: "Home timeline",
+						count: readNumber(result, "count"),
+						source: readString(result, "source"),
+					},
+				];
+			}),
 	},
 	mentions: {
 		label: "Mentions",
 		accountAware: true,
-		run: async (account) => {
-			const mentions = await syncMentions({
-				account,
-				mode: "xurl",
-				limit: 100,
-				maxPages: 3,
-				refresh: true,
-			});
-			const steps: WebSyncStep[] = [
-				{
-					kind: "mentions",
-					label: "Mentions",
-					count: readNumber(mentions, "count"),
-					source: readString(mentions, "source"),
-					partial: readBoolean(mentions, "partial"),
-				},
-			];
+		run: (account) =>
+			Effect.gen(function* () {
+				const mentions = yield* syncMentionsEffect({
+					account,
+					mode: "xurl",
+					limit: 100,
+					maxPages: 3,
+					refresh: true,
+				});
+				const steps: WebSyncStep[] = [
+					{
+						kind: "mentions",
+						label: "Mentions",
+						count: readNumber(mentions, "count"),
+						source: readString(mentions, "source"),
+						partial: readBoolean(mentions, "partial"),
+					},
+				];
 
-			const threads = await syncMentionThreads({
-				account,
-				mode: "xurl",
-				limit: 30,
-				delayMs: 1500,
-				timeoutMs: 15000,
-			});
-			steps.push({
-				kind: "mention-threads",
-				label: "Mention threads",
-				count: readNumber(threads, "mergedTweets"),
-				source: readString(threads, "source"),
-				partial: readBoolean(threads, "partial"),
-				warnings:
-					Array.isArray(threads.warnings) && threads.warnings.length > 0
-						? threads.warnings.map(String)
-						: undefined,
-			});
-			return steps;
-		},
+				const threads = yield* syncMentionThreadsEffect({
+					account,
+					mode: "xurl",
+					limit: 30,
+					delayMs: 1500,
+					timeoutMs: 15000,
+				});
+				steps.push({
+					kind: "mention-threads",
+					label: "Mention threads",
+					count: readNumber(threads, "mergedTweets"),
+					source: readString(threads, "source"),
+					partial: readBoolean(threads, "partial"),
+					warnings:
+						Array.isArray(threads.warnings) && threads.warnings.length > 0
+							? threads.warnings.map(String)
+							: undefined,
+				});
+				return steps;
+			}),
 	},
 	likes: {
 		label: "Likes",
@@ -186,68 +190,77 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	dms: {
 		label: "Direct messages",
 		accountAware: false,
-		run: async (account) => {
-			const result = await syncDirectMessagesViaCachedBird({
-				account,
-				limit: 50,
-				refresh: true,
-			});
-			return [
-				{
-					kind: "dms",
-					label: "Direct messages",
-					count: readNumber(result, "messages"),
-					source: readString(result, "source"),
-				},
-			];
-		},
+		run: (account) =>
+			Effect.gen(function* () {
+				const result = yield* syncDirectMessagesViaCachedBirdEffect({
+					account,
+					limit: 50,
+					refresh: true,
+				});
+				return [
+					{
+						kind: "dms",
+						label: "Direct messages",
+						count: readNumber(result, "messages"),
+						source: readString(result, "source"),
+					},
+				];
+			}),
 	},
 };
 
-async function syncSavedCollection(
+function syncSavedCollection(
 	kind: "likes" | "bookmarks",
 	account: string | undefined,
-) {
-	const isNonDefaultAccount =
-		account !== undefined && account !== resolveDefaultSyncAccountId();
-	const result = await syncTimelineCollection({
-		kind,
-		account,
-		mode: isNonDefaultAccount ? "xurl" : "auto",
-		limit: 100,
-		maxPages: 5,
-		refresh: true,
-		earlyStop: true,
-	});
-	return [
-		{
+): Effect.Effect<WebSyncStep[], unknown> {
+	return Effect.gen(function* () {
+		const isNonDefaultAccount =
+			account !== undefined && account !== resolveDefaultSyncAccountId();
+		const result = yield* syncTimelineCollectionEffect({
 			kind,
-			label: kind === "likes" ? "Likes" : "Bookmarks",
-			count: readNumber(result, "count"),
-			source: readString(result, "source"),
-		},
-	];
+			account,
+			mode: isNonDefaultAccount ? "xurl" : "auto",
+			limit: 100,
+			maxPages: 5,
+			refresh: true,
+			earlyStop: true,
+		});
+		return [
+			{
+				kind,
+				label: kind === "likes" ? "Likes" : "Bookmarks",
+				count: readNumber(result, "count"),
+				source: readString(result, "source"),
+			},
+		];
+	});
 }
 
-async function performWebSync(
+export function performWebSyncEffect(kind: WebSyncKind, accountId?: string) {
+	return Effect.gen(function* () {
+		const startedAt = new Date().toISOString();
+		const steps = yield* WEB_SYNC_PLANS[kind].run(accountId);
+
+		const backup = yield* maybeAutoSyncBackupEffect();
+		const finishedAt = new Date().toISOString();
+		return {
+			ok: true,
+			kind,
+			...(accountId ? { accountId } : {}),
+			startedAt,
+			finishedAt,
+			summary: summarizeSteps(steps),
+			steps,
+			backup,
+		} satisfies WebSyncResponse;
+	});
+}
+
+function performWebSync(
 	kind: WebSyncKind,
 	accountId?: string,
 ): Promise<WebSyncResponse> {
-	const startedAt = new Date().toISOString();
-	const steps = await WEB_SYNC_PLANS[kind].run(accountId);
-
-	const backup = await maybeAutoSyncBackup();
-	const finishedAt = new Date().toISOString();
-	return {
-		ok: true,
-		kind,
-		...(accountId ? { accountId } : {}),
-		startedAt,
-		finishedAt,
-		summary: summarizeSteps(steps),
-		steps,
-		backup,
-	};
+	return runEffectPromise(performWebSyncEffect(kind, accountId));
 }
 
 function createWebSyncJobId(kind: WebSyncKind) {
@@ -399,37 +412,50 @@ export function getWebSyncJob(id: string): WebSyncJobSnapshot | null {
 	return webSyncJobs.get(id) ?? null;
 }
 
-export async function runWebSync(
+export function runWebSyncEffect(
+	kind: WebSyncKind,
+	accountId?: string,
+): Effect.Effect<WebSyncResponse, Error> {
+	return Effect.gen(function* () {
+		const effectiveAccountId = getEffectiveAccountId(kind, accountId);
+		const current = runningSyncs.get(
+			getRunningSyncKey(kind, effectiveAccountId),
+		);
+		const startedAt = new Date().toISOString();
+		if (current) {
+			return {
+				ok: false,
+				kind,
+				...(effectiveAccountId ? { accountId: effectiveAccountId } : {}),
+				startedAt,
+				summary: "Sync already running",
+				steps: [],
+				inProgress: true,
+			} satisfies WebSyncResponse;
+		}
+
+		const job = startWebSync(kind, effectiveAccountId);
+		while (job.inProgress) {
+			yield* Effect.sleep(25);
+			const latest = getWebSyncJob(job.id);
+			if (!latest?.inProgress) {
+				if (!latest?.result)
+					return yield* Effect.fail(new Error("Sync job disappeared"));
+				return latest.result;
+			}
+		}
+
+		if (!job.result)
+			return yield* Effect.fail(new Error("Sync job did not finish"));
+		return job.result;
+	});
+}
+
+export function runWebSync(
 	kind: WebSyncKind,
 	accountId?: string,
 ): Promise<WebSyncResponse> {
-	const effectiveAccountId = getEffectiveAccountId(kind, accountId);
-	const current = runningSyncs.get(getRunningSyncKey(kind, effectiveAccountId));
-	const startedAt = new Date().toISOString();
-	if (current) {
-		return {
-			ok: false,
-			kind,
-			...(effectiveAccountId ? { accountId: effectiveAccountId } : {}),
-			startedAt,
-			summary: "Sync already running",
-			steps: [],
-			inProgress: true,
-		};
-	}
-
-	const job = startWebSync(kind, effectiveAccountId);
-	while (job.inProgress) {
-		await new Promise((resolve) => setTimeout(resolve, 25));
-		const latest = getWebSyncJob(job.id);
-		if (!latest?.inProgress) {
-			if (!latest?.result) throw new Error("Sync job disappeared");
-			return latest.result;
-		}
-	}
-
-	if (!job.result) throw new Error("Sync job did not finish");
-	return job.result;
+	return runEffectPromise(runWebSyncEffect(kind, accountId));
 }
 
 export function clearWebSyncLocksForTests() {

--- a/src/lib/whois.test.ts
+++ b/src/lib/whois.test.ts
@@ -660,6 +660,39 @@ describe("whois", () => {
 		);
 	});
 
+	it("builds whois lookups lazily as Effect programs", async () => {
+		const { runEffectPromise } = await import("./effect-runtime");
+		const { runWhoisEffect } = await import("./whois");
+		const db = getNativeDb();
+
+		const effect = runWhoisEffect("lazyprobe", {
+			dms: false,
+			tweets: true,
+			resolveProfiles: false,
+			expandUrls: false,
+			limit: 2,
+		});
+		db.prepare(
+			`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values ('tweet_lazyprobe', 'acct_primary', 'profile_user_42', 'home', 'lazyprobe public tweet', '2026-05-01T00:03:00.000Z', 0, null, 0, 0, 0, 0, '{}', '[]', null)
+      `,
+		).run();
+		db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
+			"tweet_lazyprobe",
+			"lazyprobe public tweet",
+		);
+
+		const result = await runEffectPromise(effect);
+
+		expect(result.relatedTweets).toEqual([
+			expect.objectContaining({ id: "tweet_lazyprobe" }),
+		]);
+	});
+
 	it("can search only related tweets and formats empty DM candidates", async () => {
 		const { formatWhois, runWhois } = await import("./whois");
 

--- a/src/lib/whois.ts
+++ b/src/lib/whois.ts
@@ -1,13 +1,16 @@
+import { Effect } from "effect";
 import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
 import {
 	ensureIdentitySearchIndexForDmProfiles,
 	syncIdentitySearchIndexForProfileIds,
 } from "./identity-search-index";
 import { fetchProfileBioEntities } from "./profile-bio-entities";
 import { fetchProfileSnapshots } from "./profile-history";
-import { expandUrlsFromTexts } from "./url-expansion";
-import { resolveProfilesForIds } from "./profile-resolver";
+import { resolveProfilesForIdsEffect } from "./profile-resolver";
+import type { ProfileResolveResult } from "./profile-resolver";
 import { listDmConversations, listTimelineItems } from "./queries";
+import { expandUrlsFromTextsEffect } from "./url-expansion";
 import type {
 	DmConversationItem,
 	ProfileAffiliation,
@@ -61,7 +64,7 @@ export interface WhoisResult {
 	candidates: WhoisCandidate[];
 	relatedTweets: TimelineItem[];
 	urlExpansions: UrlExpansionItem[];
-	profileResolution?: Awaited<ReturnType<typeof resolveProfilesForIds>>;
+	profileResolution?: ProfileResolveResult[];
 }
 
 export interface WhoisEvidenceSignal {
@@ -82,6 +85,13 @@ export interface WhoisEvidenceSignal {
 		| "expanded_url";
 	value: string;
 	source: "profile" | "affiliation" | "bio_entity" | "history" | "dm" | "url";
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: (cause) => cause,
+	});
 }
 
 interface WhoisQueryIntent {
@@ -771,160 +781,169 @@ function loadWhoisConversations(
 	return [...merged.values()];
 }
 
-export async function runWhois(
+export function runWhoisEffect(
+	query: string,
+	options: WhoisOptions = {},
+): Effect.Effect<WhoisResult, unknown> {
+	return Effect.gen(function* () {
+		const includeDms = options.dms ?? true;
+		const includeTweets = options.tweets ?? false;
+		const limit = options.limit ?? 10;
+		const context = options.context ?? 4;
+		let conversations = yield* trySync(() =>
+			loadWhoisConversations(query, options, includeDms, context, limit),
+		);
+		let profileResolution: WhoisResult["profileResolution"];
+
+		if (options.resolveProfiles ?? true) {
+			profileResolution = yield* resolveProfilesForIdsEffect(
+				conversations.map((item) => item.participant.id),
+				{
+					refresh: options.refreshProfileCache,
+					xurlFallback: options.xurlFallback ?? true,
+				},
+			);
+			conversations = yield* trySync(() =>
+				loadWhoisConversations(query, options, includeDms, context, limit),
+			);
+		}
+		yield* trySync(() =>
+			syncIdentitySearchIndexForProfileIds(
+				getNativeDb(),
+				conversations.map((item) => item.participant.id),
+			),
+		);
+
+		const relatedTweets = includeTweets
+			? yield* trySync(() => [
+					...listTimelineItems({
+						resource: "home",
+						account: options.account,
+						search: query,
+						limit,
+					}),
+					...listTimelineItems({
+						resource: "mentions",
+						account: options.account,
+						search: query,
+						limit,
+					}),
+				])
+			: [];
+
+		const texts = yield* trySync(() => [
+			...conversations.flatMap(getMessageTexts),
+			...conversations.flatMap((conversation) =>
+				[
+					conversation.participant.bio,
+					conversation.participant.url ?? "",
+					...getProfileBioUrls(conversation.participant),
+				].filter((text) => text.includes("https://t.co/")),
+			),
+			...relatedTweets.map((tweet) => tweet.text),
+		]);
+		const urlExpansions =
+			(options.expandUrls ?? true)
+				? yield* expandUrlsFromTextsEffect(texts, {
+						refresh: options.refreshUrlCache,
+					})
+				: [];
+		yield* trySync(() => {
+			for (const conversation of conversations) {
+				attachExpansionsToMatches(conversation, urlExpansions);
+			}
+		});
+
+		const candidates = yield* trySync(() => {
+			const profileIds = conversations.map(
+				(conversation) => conversation.participant.id,
+			);
+			const db = getNativeDb();
+			const bioEntitiesByProfile = fetchProfileBioEntities(db, profileIds);
+			const snapshotsByProfile = fetchProfileSnapshots(db, profileIds);
+			return conversations
+				.map((conversation): WhoisCandidate | null => {
+					const conversationExpansions = urlExpansions.filter((item) =>
+						getMessageTexts(conversation).some((text) =>
+							text.includes(item.url),
+						),
+					);
+					const profileId = conversation.participant.id;
+					const score = scoreCandidate(
+						query,
+						conversation,
+						conversationExpansions,
+						bioEntitiesByProfile.get(profileId) ?? [],
+						snapshotsByProfile.get(profileId) ?? [],
+					);
+					if (
+						!hasCurrentAffiliationMatch(
+							conversation.participant,
+							options.currentAffiliation,
+						)
+					) {
+						return null;
+					}
+					if (
+						!hasAffiliationEvidenceMatch(
+							conversation.participant,
+							score.profileEvidence,
+							options.affiliation,
+						)
+					) {
+						return null;
+					}
+					if (
+						options.excludeDomainOnly &&
+						!hasNonDomainEvidence(score.profileEvidence)
+					) {
+						return null;
+					}
+					return {
+						conversation,
+						confidence: score.confidence,
+						category: score.category,
+						reasons: score.reasons,
+						profileEvidence: score.profileEvidence,
+						evidence: (conversation.matches ?? []).map((match) => ({
+							messageId: match.message.id,
+							createdAt: match.message.createdAt,
+							direction: match.message.direction,
+							text: match.message.text,
+							...(match.urlExpansions
+								? { urlExpansions: match.urlExpansions }
+								: {}),
+						})),
+					};
+				})
+				.filter((candidate): candidate is WhoisCandidate => candidate !== null)
+				.sort((left, right) => {
+					if (right.confidence !== left.confidence) {
+						return right.confidence - left.confidence;
+					}
+					return (
+						new Date(right.conversation.lastMessageAt).getTime() -
+						new Date(left.conversation.lastMessageAt).getTime()
+					);
+				})
+				.slice(0, limit);
+		});
+
+		return {
+			query,
+			candidates,
+			relatedTweets,
+			urlExpansions,
+			...(profileResolution ? { profileResolution } : {}),
+		};
+	});
+}
+
+export function runWhois(
 	query: string,
 	options: WhoisOptions = {},
 ): Promise<WhoisResult> {
-	const includeDms = options.dms ?? true;
-	const includeTweets = options.tweets ?? false;
-	const limit = options.limit ?? 10;
-	const context = options.context ?? 4;
-	let conversations = loadWhoisConversations(
-		query,
-		options,
-		includeDms,
-		context,
-		limit,
-	);
-	let profileResolution: WhoisResult["profileResolution"];
-
-	if (options.resolveProfiles ?? true) {
-		profileResolution = await resolveProfilesForIds(
-			conversations.map((item) => item.participant.id),
-			{
-				refresh: options.refreshProfileCache,
-				xurlFallback: options.xurlFallback ?? true,
-			},
-		);
-		conversations = loadWhoisConversations(
-			query,
-			options,
-			includeDms,
-			context,
-			limit,
-		);
-	}
-	syncIdentitySearchIndexForProfileIds(
-		getNativeDb(),
-		conversations.map((item) => item.participant.id),
-	);
-
-	const relatedTweets = includeTweets
-		? [
-				...listTimelineItems({
-					resource: "home",
-					account: options.account,
-					search: query,
-					limit,
-				}),
-				...listTimelineItems({
-					resource: "mentions",
-					account: options.account,
-					search: query,
-					limit,
-				}),
-			]
-		: [];
-
-	const texts = [
-		...conversations.flatMap(getMessageTexts),
-		...conversations.flatMap((conversation) =>
-			[
-				conversation.participant.bio,
-				conversation.participant.url ?? "",
-				...getProfileBioUrls(conversation.participant),
-			].filter((text) => text.includes("https://t.co/")),
-		),
-		...relatedTweets.map((tweet) => tweet.text),
-	];
-	const urlExpansions =
-		(options.expandUrls ?? true)
-			? await expandUrlsFromTexts(texts, { refresh: options.refreshUrlCache })
-			: [];
-	for (const conversation of conversations) {
-		attachExpansionsToMatches(conversation, urlExpansions);
-	}
-
-	const profileIds = conversations.map(
-		(conversation) => conversation.participant.id,
-	);
-	const bioEntitiesByProfile = fetchProfileBioEntities(
-		getNativeDb(),
-		profileIds,
-	);
-	const snapshotsByProfile = fetchProfileSnapshots(getNativeDb(), profileIds);
-	const candidates = conversations
-		.map((conversation): WhoisCandidate | null => {
-			const conversationExpansions = urlExpansions.filter((item) =>
-				getMessageTexts(conversation).some((text) => text.includes(item.url)),
-			);
-			const profileId = conversation.participant.id;
-			const score = scoreCandidate(
-				query,
-				conversation,
-				conversationExpansions,
-				bioEntitiesByProfile.get(profileId) ?? [],
-				snapshotsByProfile.get(profileId) ?? [],
-			);
-			if (
-				!hasCurrentAffiliationMatch(
-					conversation.participant,
-					options.currentAffiliation,
-				)
-			) {
-				return null;
-			}
-			if (
-				!hasAffiliationEvidenceMatch(
-					conversation.participant,
-					score.profileEvidence,
-					options.affiliation,
-				)
-			) {
-				return null;
-			}
-			if (
-				options.excludeDomainOnly &&
-				!hasNonDomainEvidence(score.profileEvidence)
-			) {
-				return null;
-			}
-			return {
-				conversation,
-				confidence: score.confidence,
-				category: score.category,
-				reasons: score.reasons,
-				profileEvidence: score.profileEvidence,
-				evidence: (conversation.matches ?? []).map((match) => ({
-					messageId: match.message.id,
-					createdAt: match.message.createdAt,
-					direction: match.message.direction,
-					text: match.message.text,
-					...(match.urlExpansions
-						? { urlExpansions: match.urlExpansions }
-						: {}),
-				})),
-			};
-		})
-		.filter((candidate): candidate is WhoisCandidate => candidate !== null)
-		.sort((left, right) => {
-			if (right.confidence !== left.confidence) {
-				return right.confidence - left.confidence;
-			}
-			return (
-				new Date(right.conversation.lastMessageAt).getTime() -
-				new Date(left.conversation.lastMessageAt).getTime()
-			);
-		})
-		.slice(0, limit);
-
-	return {
-		query,
-		candidates,
-		relatedTweets,
-		urlExpansions,
-		...(profileResolution ? { profileResolution } : {}),
-	};
+	return runEffectPromise(runWhoisEffect(query, options));
 }
 
 const CATEGORY_LABELS: Record<WhoisCandidateCategory, string> = {

--- a/src/lib/x-web.test.ts
+++ b/src/lib/x-web.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getCookiesMock = vi.fn();
@@ -16,6 +17,23 @@ describe("x-web transport", () => {
 		delete process.env.TWITTER_AUTH_TOKEN;
 		delete process.env.CT0;
 		delete process.env.TWITTER_CT0;
+	});
+
+	it("builds x-web mutation effects lazily", async () => {
+		process.env.AUTH_TOKEN = "auth";
+		process.env.CT0 = "csrf";
+		const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+		const { blockUserViaXWebEffect } = await import("./x-web");
+
+		const effect = blockUserViaXWebEffect("42");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toEqual({
+			ok: true,
+			output: "x-web block ok via env",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("blocks users with env cookies", async () => {

--- a/src/lib/x-web.ts
+++ b/src/lib/x-web.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { getCookies } from "@steipete/sweet-cookie";
+import { Effect } from "effect";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
 
 const X_WEB_BEARER_TOKEN =
 	"AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
@@ -48,53 +50,57 @@ function pickCookieValue(
 	return matches[0]?.value ?? null;
 }
 
-async function resolveXWebCookies() {
-	const envAuthToken = normalizeCookieValue(
-		process.env.AUTH_TOKEN ?? process.env.TWITTER_AUTH_TOKEN,
-	);
-	const envCt0 = normalizeCookieValue(
-		process.env.CT0 ?? process.env.TWITTER_CT0,
-	);
+function resolveXWebCookiesEffect() {
+	return Effect.gen(function* () {
+		const envAuthToken = normalizeCookieValue(
+			process.env.AUTH_TOKEN ?? process.env.TWITTER_AUTH_TOKEN,
+		);
+		const envCt0 = normalizeCookieValue(
+			process.env.CT0 ?? process.env.TWITTER_CT0,
+		);
 
-	if (envAuthToken && envCt0) {
+		if (envAuthToken && envCt0) {
+			return {
+				authToken: envAuthToken,
+				ct0: envCt0,
+				cookieHeader: buildCookieHeader(envAuthToken, envCt0),
+				source: "env",
+			};
+		}
+
+		const cookieResult = yield* tryPromise(() =>
+			getCookies({
+				url: "https://x.com/",
+				origins: [...X_WEB_ORIGINS],
+				names: [...X_WEB_COOKIE_NAMES],
+				browsers: ["safari", "chrome", "firefox"] satisfies CookieSource[],
+				mode: "merge",
+				timeoutMs: process.platform === "darwin" ? 30_000 : undefined,
+			}),
+		);
+
+		const authToken = pickCookieValue(cookieResult.cookies, "auth_token");
+		const ct0 = pickCookieValue(cookieResult.cookies, "ct0");
+		if (!authToken || !ct0) {
+			return null;
+		}
+
 		return {
-			authToken: envAuthToken,
-			ct0: envCt0,
-			cookieHeader: buildCookieHeader(envAuthToken, envCt0),
-			source: "env",
+			authToken,
+			ct0,
+			cookieHeader: buildCookieHeader(authToken, ct0),
+			source: "browser",
 		};
-	}
-
-	const cookieResult = await getCookies({
-		url: "https://x.com/",
-		origins: [...X_WEB_ORIGINS],
-		names: [...X_WEB_COOKIE_NAMES],
-		browsers: ["safari", "chrome", "firefox"] satisfies CookieSource[],
-		mode: "merge",
-		timeoutMs: process.platform === "darwin" ? 30_000 : undefined,
 	});
-
-	const authToken = pickCookieValue(cookieResult.cookies, "auth_token");
-	const ct0 = pickCookieValue(cookieResult.cookies, "ct0");
-	if (!authToken || !ct0) {
-		return null;
-	}
-
-	return {
-		authToken,
-		ct0,
-		cookieHeader: buildCookieHeader(authToken, ct0),
-		source: "browser",
-	};
 }
 
-async function runXWebBlockMutation(
+function runXWebBlockMutationEffect(
 	path: string,
 	params: URLSearchParams,
 	action: string,
 ) {
-	try {
-		const cookies = await resolveXWebCookies();
+	return Effect.gen(function* () {
+		const cookies = yield* resolveXWebCookiesEffect();
 		if (!cookies) {
 			return {
 				ok: false,
@@ -102,27 +108,29 @@ async function runXWebBlockMutation(
 			};
 		}
 
-		const response = await fetch(`https://x.com/i/api/1.1/${path}`, {
-			method: "POST",
-			headers: {
-				accept: "*/*",
-				"accept-language": "en-US,en;q=0.9",
-				authorization: `Bearer ${X_WEB_BEARER_TOKEN}`,
-				"content-type": "application/x-www-form-urlencoded",
-				cookie: cookies.cookieHeader,
-				origin: "https://x.com",
-				referer: "https://x.com/",
-				"user-agent": X_WEB_USER_AGENT,
-				"x-client-transaction-id": randomUUID().replaceAll("-", ""),
-				"x-csrf-token": cookies.ct0,
-				"x-twitter-active-user": "yes",
-				"x-twitter-auth-type": "OAuth2Session",
-				"x-twitter-client-language": "en",
-			},
-			body: params,
-		});
+		const response = yield* tryPromise(() =>
+			fetch(`https://x.com/i/api/1.1/${path}`, {
+				method: "POST",
+				headers: {
+					accept: "*/*",
+					"accept-language": "en-US,en;q=0.9",
+					authorization: `Bearer ${X_WEB_BEARER_TOKEN}`,
+					"content-type": "application/x-www-form-urlencoded",
+					cookie: cookies.cookieHeader,
+					origin: "https://x.com",
+					referer: "https://x.com/",
+					"user-agent": X_WEB_USER_AGENT,
+					"x-client-transaction-id": randomUUID().replaceAll("-", ""),
+					"x-csrf-token": cookies.ct0,
+					"x-twitter-active-user": "yes",
+					"x-twitter-auth-type": "OAuth2Session",
+					"x-twitter-client-language": "en",
+				},
+				body: params,
+			}),
+		);
 
-		const text = await response.text();
+		const text = yield* tryPromise(() => response.text());
 		if (!response.ok) {
 			return {
 				ok: false,
@@ -134,19 +142,21 @@ async function runXWebBlockMutation(
 			ok: true,
 			output: `x-web ${action} ok via ${cookies.source}`,
 		};
-	} catch (error) {
-		return {
-			ok: false,
-			output:
-				error instanceof Error
-					? `x-web ${action} failed: ${error.message}`
-					: `x-web ${action} failed`,
-		};
-	}
+	}).pipe(
+		Effect.catchAll((error) =>
+			Effect.succeed({
+				ok: false,
+				output:
+					error instanceof Error
+						? `x-web ${action} failed: ${error.message}`
+						: `x-web ${action} failed`,
+			}),
+		),
+	);
 }
 
-export async function blockUserViaXWeb(targetUserId: string) {
-	return runXWebBlockMutation(
+export function blockUserViaXWebEffect(targetUserId: string) {
+	return runXWebBlockMutationEffect(
 		"blocks/create.json",
 		new URLSearchParams({
 			user_id: targetUserId,
@@ -156,8 +166,8 @@ export async function blockUserViaXWeb(targetUserId: string) {
 	);
 }
 
-export async function unblockUserViaXWeb(targetUserId: string) {
-	return runXWebBlockMutation(
+export function unblockUserViaXWebEffect(targetUserId: string) {
+	return runXWebBlockMutationEffect(
 		"blocks/destroy.json",
 		new URLSearchParams({
 			user_id: targetUserId,
@@ -165,4 +175,12 @@ export async function unblockUserViaXWeb(targetUserId: string) {
 		}),
 		"unblock",
 	);
+}
+
+export function blockUserViaXWeb(targetUserId: string) {
+	return runEffectPromise(blockUserViaXWebEffect(targetUserId));
+}
+
+export function unblockUserViaXWeb(targetUserId: string) {
+	return runEffectPromise(unblockUserViaXWebEffect(targetUserId));
 }

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsyncMock = vi.fn();
@@ -72,6 +73,21 @@ describe("xurl transport wrapper", () => {
 			rawStatus: "ok",
 		});
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, "xurl", ["version"]);
+	});
+
+	it("exposes transport status as a lazy Effect program", async () => {
+		execFileAsyncMock
+			.mockResolvedValueOnce({ stdout: "xurl 1.0", stderr: "" })
+			.mockResolvedValueOnce({ stdout: "ok", stderr: "" });
+		const { getTransportStatusEffect } = await import("./xurl");
+
+		const effect = getTransportStatusEffect();
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(effect)).resolves.toMatchObject({
+			installed: true,
+			availableTransport: "xurl",
+			rawStatus: "ok",
+		});
 	});
 
 	it("falls back to local mode when xurl has no registered apps", async () => {
@@ -164,6 +180,32 @@ describe("xurl transport wrapper", () => {
 			{ id: "42", username: "sam" },
 		]);
 		await expect(lookupAuthenticatedUser()).resolves.toEqual({
+			id: "1",
+			username: "steipete",
+		});
+	});
+
+	it("exposes xurl lookup helpers as lazy Effect programs", async () => {
+		execFileAsyncMock
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ data: [{ id: "42", username: "sam" }] }),
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({ data: { id: "1", username: "steipete" } }),
+				stderr: "",
+			});
+		const { lookupAuthenticatedUserEffect, lookupUsersByIdsEffect } =
+			await import("./xurl");
+
+		const usersEffect = lookupUsersByIdsEffect(["42"]);
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+		await expect(Effect.runPromise(usersEffect)).resolves.toEqual([
+			{ id: "42", username: "sam" },
+		]);
+		await expect(
+			Effect.runPromise(lookupAuthenticatedUserEffect()),
+		).resolves.toEqual({
 			id: "1",
 			username: "steipete",
 		});
@@ -511,6 +553,56 @@ describe("xurl transport wrapper", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("starts timeout budgets when xurl effects run", async () => {
+		vi.useFakeTimers();
+		try {
+			process.env.BIRDCLAW_XURL_RETRY_BASE_MS = "500";
+			execFileAsyncMock
+				.mockRejectedValueOnce(
+					Object.assign(new Error("rate limited"), {
+						stdout: JSON.stringify({ status: 429 }),
+					}),
+				)
+				.mockResolvedValueOnce({
+					stdout: JSON.stringify({
+						data: { id: "tweet_1", author_id: "42", text: "hello" },
+					}),
+					stderr: "",
+				});
+			const { getTweetByIdEffect } = await import("./xurl");
+
+			const effect = getTweetByIdEffect("tweet_1", { timeoutMs: 1000 });
+			await vi.advanceTimersByTimeAsync(5000);
+			const result = Effect.runPromise(effect);
+			await vi.advanceTimersByTimeAsync(500);
+
+			await expect(result).resolves.toEqual({
+				data: [{ id: "tweet_1", author_id: "42", text: "hello" }],
+			});
+			expect(execFileAsyncMock).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("checks live-write disable when xurl effects run", async () => {
+		const { dmViaXurlEffect, muteUserViaXurlEffect } = await import("./xurl");
+
+		const dmEffect = dmViaXurlEffect("sam", "hello");
+		const muteEffect = muteUserViaXurlEffect("1", "2");
+		process.env.BIRDCLAW_DISABLE_LIVE_WRITES = "1";
+
+		await expect(Effect.runPromise(dmEffect)).resolves.toEqual({
+			ok: true,
+			output: "live writes disabled",
+		});
+		await expect(Effect.runPromise(muteEffect)).resolves.toEqual({
+			ok: true,
+			output: "live writes disabled",
+		});
+		expect(execFileAsyncMock).not.toHaveBeenCalled();
+	});
+
 	it("lists liked and bookmarked tweets through raw Twitter endpoints", async () => {
 		execFileAsyncMock
 			.mockResolvedValueOnce({
@@ -844,6 +936,28 @@ describe("xurl transport wrapper", () => {
 		await expect(lookupAuthenticatedUser()).rejects.toThrow(
 			'Command failed: xurl whoami\n{"title":"Unauthorized","detail":"OAuth token expired"}\nrun xurl auth oauth2',
 		);
+	});
+
+	it("preserves formatted xurl errors without FiberFailure wrappers", async () => {
+		execFileAsyncMock.mockRejectedValueOnce(
+			Object.assign(new Error("Command failed: xurl whoami"), {
+				stdout: '{"detail":"OAuth token expired"}',
+				stderr: "run xurl auth oauth2",
+			}),
+		);
+		const { lookupAuthenticatedUser } = await import("./xurl");
+
+		let rejected: unknown;
+		try {
+			await lookupAuthenticatedUser();
+		} catch (error) {
+			rejected = error;
+		}
+
+		expect(rejected).toBeInstanceOf(Error);
+		expect((rejected as Error).message).toContain("OAuth token expired");
+		expect((rejected as Error).name).not.toContain("FiberFailure");
+		expect(String(rejected)).not.toContain("(FiberFailure)");
 	});
 
 	it("does not retry malformed or exhausted rate limit failures", async () => {

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -1,5 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { Effect } from "effect";
+import { runEffectPromise } from "./effect-runtime";
 import type {
 	FollowDirection,
 	TransportStatus,
@@ -90,6 +92,10 @@ function formatXurlCommandError(error: unknown, args: string[]) {
 	return new Error(formatExecError(error, `xurl ${args.join(" ")} failed`));
 }
 
+function normalizeError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
 function parseErrorPayload(error: unknown) {
 	const stdout =
 		typeof error === "object" &&
@@ -133,13 +139,6 @@ function capTimelineCollectionMaxResults(
 		: maxResults;
 }
 
-async function sleep(ms: number) {
-	if (ms <= 0) {
-		return;
-	}
-	await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function resetTransportStatusCache() {
 	transportStatusCache = undefined;
 }
@@ -148,13 +147,14 @@ export function resetAuthenticatedUserCache() {
 	authenticatedUserCache = undefined;
 }
 
-async function hasXurl(): Promise<boolean> {
-	try {
-		await execFileAsync("xurl", ["version"]);
-		return true;
-	} catch {
-		return false;
-	}
+function hasXurlEffect() {
+	return Effect.tryPromise({
+		try: () => execFileAsync("xurl", ["version"]),
+		catch: normalizeError,
+	}).pipe(
+		Effect.as(true),
+		Effect.catchAll(() => Effect.succeed(false)),
+	);
 }
 
 function isUnauthenticatedXurlStatus(status: string) {
@@ -163,164 +163,227 @@ function isUnauthenticatedXurlStatus(status: string) {
 	);
 }
 
-export async function getTransportStatus(): Promise<TransportStatus> {
-	const now = Date.now();
-	if (transportStatusCache?.value && transportStatusCache.expiresAt > now) {
-		return transportStatusCache.value;
-	}
-
-	if (transportStatusCache?.pending) {
-		return transportStatusCache.pending;
-	}
-
-	const pending: Promise<TransportStatus> = (async () => {
-		const installed = await hasXurl();
+function readTransportStatusEffect(): Effect.Effect<TransportStatus, never> {
+	return Effect.gen(function* () {
+		const installed = yield* hasXurlEffect();
 		if (!installed) {
 			return {
 				installed: false,
-				availableTransport: "local",
+				availableTransport: "local" as const,
 				statusText: "xurl not installed. local mode active.",
 			};
 		}
 
-		try {
-			const { stdout } = await execFileAsync("xurl", ["auth", "status"]);
-			const rawStatus = stdout.trim();
+		return yield* Effect.tryPromise({
+			try: () => execFileAsync("xurl", ["auth", "status"]),
+			catch: (cause) => cause,
+		}).pipe(
+			Effect.map(({ stdout }) => {
+				const rawStatus = stdout.trim();
 
-			if (isUnauthenticatedXurlStatus(rawStatus)) {
+				if (isUnauthenticatedXurlStatus(rawStatus)) {
+					return {
+						installed: true,
+						availableTransport: "local" as const,
+						statusText:
+							"xurl installed but not authenticated. local (bird) mode active.",
+						rawStatus,
+					};
+				}
+
 				return {
 					installed: true,
-					availableTransport: "local",
-					statusText:
-						"xurl installed but not authenticated. local (bird) mode active.",
+					availableTransport: "xurl" as const,
+					statusText: "xurl available",
 					rawStatus,
 				};
-			}
+			}),
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					installed: true,
+					availableTransport: "local" as const,
+					statusText: `xurl detected but auth unavailable: ${
+						error instanceof Error ? error.message : "unknown error"
+					}`,
+				}),
+			),
+		);
+	});
+}
 
-			return {
-				installed: true,
-				availableTransport: "xurl",
-				statusText: "xurl available",
-				rawStatus,
-			};
-		} catch (error) {
-			return {
-				installed: true,
-				availableTransport: "local",
-				statusText: `xurl detected but auth unavailable: ${
-					error instanceof Error ? error.message : "unknown error"
-				}`,
-			};
+export function getTransportStatusEffect() {
+	return Effect.gen(function* () {
+		const now = Date.now();
+		if (transportStatusCache?.value && transportStatusCache.expiresAt > now) {
+			return transportStatusCache.value;
 		}
-	})();
 
-	transportStatusCache = {
-		expiresAt: 0,
-		pending,
-	};
+		if (transportStatusCache?.pending) {
+			const status = yield* Effect.tryPromise({
+				try: () => transportStatusCache?.pending ?? Promise.resolve(undefined),
+				catch: normalizeError,
+			});
+			if (status) return status;
+		}
 
-	try {
-		const status = await pending;
+		const pending = runEffectPromise(readTransportStatusEffect());
+
+		transportStatusCache = {
+			expiresAt: 0,
+			pending,
+		};
+
+		const status = yield* Effect.tryPromise({
+			try: () => pending,
+			catch: normalizeError,
+		}).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					transportStatusCache = undefined;
+				}).pipe(Effect.flatMap(() => Effect.fail(error))),
+			),
+		);
 		transportStatusCache = {
 			expiresAt: Date.now() + TRANSPORT_STATUS_TTL_MS,
 			value: status,
 		};
 		return status;
-	} catch (error) {
-		transportStatusCache = undefined;
-		throw error;
-	}
+	});
 }
 
-async function runShortcut(
+export function getTransportStatus(): Promise<TransportStatus> {
+	return runEffectPromise(getTransportStatusEffect());
+}
+
+function runShortcutEffect(args: string[]) {
+	return Effect.gen(function* () {
+		if (liveWritesDisabled()) {
+			return { ok: true, output: "live writes disabled" };
+		}
+
+		return yield* Effect.tryPromise({
+			try: () => execFileAsync("xurl", args),
+			catch: normalizeError,
+		}).pipe(
+			Effect.map(({ stdout, stderr }) => ({
+				ok: true,
+				output: stdout || stderr,
+			})),
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false,
+					output: formatExecError(error, "xurl execution failed"),
+				}),
+			),
+		);
+	});
+}
+
+function execXurlJsonEffect(
 	args: string[],
-): Promise<{ ok: boolean; output: string }> {
-	if (liveWritesDisabled()) {
-		return { ok: true, output: "live writes disabled" };
-	}
-
-	try {
-		const { stdout, stderr } = await execFileAsync("xurl", args);
-		return { ok: true, output: stdout || stderr };
-	} catch (error) {
-		return {
-			ok: false,
-			output: formatExecError(error, "xurl execution failed"),
-		};
-	}
+	timeoutMs?: number,
+): Effect.Effect<{ stdout: string; stderr: string }, Error> {
+	return Effect.tryPromise({
+		try: () => {
+			const controller =
+				typeof timeoutMs === "number" &&
+				Number.isFinite(timeoutMs) &&
+				timeoutMs > 0
+					? new AbortController()
+					: undefined;
+			const timeout = controller
+				? setTimeout(() => controller.abort(), timeoutMs)
+				: undefined;
+			const result = controller
+				? execFileAsync("xurl", args, { signal: controller.signal })
+				: execFileAsync("xurl", args);
+			return result.finally(() => {
+				if (timeout) {
+					clearTimeout(timeout);
+				}
+			});
+		},
+		catch: normalizeError,
+	});
 }
 
-async function runJsonCommand(
+function parseJsonPayloadEffect(
+	stdout: string,
+	args: string[],
+): Effect.Effect<Record<string, unknown>, Error> {
+	return Effect.try({
+		try: () => JSON.parse(stdout) as Record<string, unknown>,
+		catch: (error) => formatXurlCommandError(error, args),
+	});
+}
+
+function runJsonCommandEffect(
 	args: string[],
 	options: JsonCommandOptions = {},
 	attempt = 0,
-) {
-	const deadlineMs =
-		options.deadlineMs ??
-		(typeof options.timeoutMs === "number" &&
-		Number.isFinite(options.timeoutMs) &&
-		options.timeoutMs > 0
-			? Date.now() + options.timeoutMs
-			: undefined);
-	const timeoutMs = deadlineMs
-		? Math.max(0, deadlineMs - Date.now())
-		: undefined;
-	const controller =
-		typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
-			? new AbortController()
-			: undefined;
-	const timeout = controller
-		? setTimeout(() => controller.abort(), timeoutMs)
-		: undefined;
-
-	try {
-		const { stdout } = controller
-			? await execFileAsync("xurl", args, { signal: controller.signal })
-			: await execFileAsync("xurl", args);
-		return JSON.parse(stdout) as Record<string, unknown>;
-	} catch (error) {
-		const retryDelayMs = getRetryDelayMs(error, attempt);
-		if (retryDelayMs === null || attempt >= JSON_RETRY_LIMIT - 1) {
-			throw formatXurlCommandError(error, args);
-		}
-		const remainingMs = deadlineMs
+): Effect.Effect<Record<string, unknown>, Error> {
+	return Effect.gen(function* () {
+		const deadlineMs =
+			options.deadlineMs ??
+			(typeof options.timeoutMs === "number" &&
+			Number.isFinite(options.timeoutMs) &&
+			options.timeoutMs > 0
+				? Date.now() + options.timeoutMs
+				: undefined);
+		const timeoutMs = deadlineMs
 			? Math.max(0, deadlineMs - Date.now())
 			: undefined;
-		if (remainingMs !== undefined && retryDelayMs >= remainingMs) {
-			throw formatXurlCommandError(error, args);
-		}
+		return yield* execXurlJsonEffect(args, timeoutMs).pipe(
+			Effect.flatMap(({ stdout }) => parseJsonPayloadEffect(stdout, args)),
+			Effect.catchAll((error) => {
+				const retryDelayMs = getRetryDelayMs(error, attempt);
+				if (retryDelayMs === null || attempt >= JSON_RETRY_LIMIT - 1) {
+					return Effect.fail(formatXurlCommandError(error, args));
+				}
+				const remainingMs = deadlineMs
+					? Math.max(0, deadlineMs - Date.now())
+					: undefined;
+				if (remainingMs !== undefined && retryDelayMs >= remainingMs) {
+					return Effect.fail(formatXurlCommandError(error, args));
+				}
 
-		await sleep(retryDelayMs);
-		return runJsonCommand(args, { ...options, deadlineMs }, attempt + 1);
-	} finally {
-		if (timeout) {
-			clearTimeout(timeout);
-		}
-	}
+				return Effect.sleep(retryDelayMs).pipe(
+					Effect.flatMap(() =>
+						runJsonCommandEffect(args, { ...options, deadlineMs }, attempt + 1),
+					),
+				);
+			}),
+		);
+	});
 }
 
-async function runMutationCommand(args: string[]) {
-	if (liveWritesDisabled()) {
-		return { ok: true, output: "live writes disabled" };
-	}
+function runMutationCommandEffect(args: string[]) {
+	return Effect.gen(function* () {
+		if (liveWritesDisabled()) {
+			return { ok: true, output: "live writes disabled" };
+		}
 
-	try {
-		const { stdout, stderr } = await execFileAsync("xurl", args);
-		return {
-			ok: true,
-			output: stdout || stderr || "ok",
-		};
-	} catch (error) {
-		return {
-			ok: false,
-			output: formatExecError(error, "xurl execution failed"),
-		};
-	}
+		return yield* Effect.tryPromise({
+			try: () => execFileAsync("xurl", args),
+			catch: normalizeError,
+		}).pipe(
+			Effect.map(({ stdout, stderr }) => ({
+				ok: true,
+				output: stdout || stderr || "ok",
+			})),
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false,
+					output: formatExecError(error, "xurl execution failed"),
+				}),
+			),
+		);
+	});
 }
 
-export async function lookupUsersByIds(ids: string[]) {
+export function lookupUsersByIdsEffect(ids: string[]) {
 	if (ids.length === 0) {
-		return [];
+		return Effect.succeed([]);
 	}
 
 	const query = new URLSearchParams({
@@ -328,14 +391,20 @@ export async function lookupUsersByIds(ids: string[]) {
 		"user.fields":
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
 	});
-	const payload = await runJsonCommand([`/2/users?${query.toString()}`]);
-	const data = payload.data;
-	return Array.isArray(data) ? (data as XurlMentionUser[]) : [];
+	return runJsonCommandEffect([`/2/users?${query.toString()}`]).pipe(
+		Effect.map((payload) =>
+			Array.isArray(payload.data) ? (payload.data as XurlMentionUser[]) : [],
+		),
+	);
 }
 
-export async function lookupUsersByHandles(handles: string[]) {
+export function lookupUsersByIds(ids: string[]) {
+	return runEffectPromise(lookupUsersByIdsEffect(ids));
+}
+
+export function lookupUsersByHandlesEffect(handles: string[]) {
 	if (handles.length === 0) {
-		return [];
+		return Effect.succeed([]);
 	}
 
 	const query = new URLSearchParams({
@@ -343,52 +412,104 @@ export async function lookupUsersByHandles(handles: string[]) {
 		"user.fields":
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
 	});
-	const payload = await runJsonCommand([`/2/users/by?${query.toString()}`]);
-	const data = payload.data;
-	return Array.isArray(data) ? (data as XurlMentionUser[]) : [];
+	return runJsonCommandEffect([`/2/users/by?${query.toString()}`]).pipe(
+		Effect.map((payload) =>
+			Array.isArray(payload.data) ? (payload.data as XurlMentionUser[]) : [],
+		),
+	);
 }
 
-export async function lookupAuthenticatedUser() {
-	const now = Date.now();
-	if (
-		authenticatedUserCache &&
-		"value" in authenticatedUserCache &&
-		authenticatedUserCache.expiresAt > now
-	) {
-		return authenticatedUserCache.value ?? null;
-	}
+export function lookupUsersByHandles(handles: string[]) {
+	return runEffectPromise(lookupUsersByHandlesEffect(handles));
+}
 
-	if (authenticatedUserCache?.pending) {
-		return authenticatedUserCache.pending;
-	}
+function authenticatedUserFromPayload(payload: Record<string, unknown>) {
+	const data = payload.data;
+	return data && typeof data === "object"
+		? (data as Record<string, unknown>)
+		: null;
+}
 
-	const pending = (async () => {
-		const payload = await runJsonCommand(["whoami"]);
-		const data = payload.data;
-		return data && typeof data === "object"
-			? (data as Record<string, unknown>)
-			: null;
-	})();
+export function lookupAuthenticatedUserEffect() {
+	return Effect.gen(function* () {
+		const now = Date.now();
+		if (
+			authenticatedUserCache &&
+			"value" in authenticatedUserCache &&
+			authenticatedUserCache.expiresAt > now
+		) {
+			return authenticatedUserCache.value ?? null;
+		}
 
-	authenticatedUserCache = {
-		expiresAt: 0,
-		pending,
-	};
+		if (authenticatedUserCache?.pending) {
+			return yield* Effect.tryPromise({
+				try: () => authenticatedUserCache?.pending ?? Promise.resolve(null),
+				catch: normalizeError,
+			});
+		}
 
-	try {
-		const value = await pending;
+		const pending = runEffectPromise(
+			runJsonCommandEffect(["whoami"]).pipe(
+				Effect.map(authenticatedUserFromPayload),
+			),
+		);
+
+		authenticatedUserCache = {
+			expiresAt: 0,
+			pending,
+		};
+
+		const value = yield* Effect.tryPromise({
+			try: () => pending,
+			catch: normalizeError,
+		}).pipe(
+			Effect.catchAll((error) =>
+				Effect.sync(() => {
+					authenticatedUserCache = undefined;
+				}).pipe(Effect.flatMap(() => Effect.fail(error))),
+			),
+		);
 		authenticatedUserCache = {
 			expiresAt: Date.now() + AUTHENTICATED_USER_TTL_MS,
 			value,
 		};
 		return value;
-	} catch (error) {
-		authenticatedUserCache = undefined;
-		throw error;
-	}
+	});
 }
 
-export async function listMentionsViaXurl({
+export function lookupAuthenticatedUser() {
+	return runEffectPromise(lookupAuthenticatedUserEffect());
+}
+
+function resolveUserIdEffect({
+	username,
+	userId,
+}: {
+	username?: string;
+	userId?: string;
+}) {
+	return Effect.gen(function* () {
+		if (userId) return userId;
+		if (username) {
+			const [user] = yield* lookupUsersByHandlesEffect([username]);
+			if (!user?.id) {
+				return yield* Effect.fail(
+					new Error(`Could not resolve Twitter user id for @${username}`),
+				);
+			}
+			return String(user.id);
+		}
+		const user = yield* lookupAuthenticatedUserEffect();
+		if (!user?.id) {
+			return yield* Effect.fail(
+				new Error("Could not resolve authenticated Twitter user id"),
+			);
+		}
+		return String(user.id);
+	});
+}
+
+export function listMentionsViaXurlEffect({
 	maxResults,
 	username,
 	userId,
@@ -402,45 +523,48 @@ export async function listMentionsViaXurl({
 	paginationToken?: string;
 	sinceId?: string;
 	startTime?: string;
-}): Promise<XurlMentionsResponse> {
-	let resolvedUserId = userId;
-	if (!resolvedUserId) {
-		if (username) {
-			const [user] = await lookupUsersByHandles([username]);
-			if (!user?.id) {
-				throw new Error(`Could not resolve Twitter user id for @${username}`);
-			}
-			resolvedUserId = String(user.id);
-		} else {
-			const user = await lookupAuthenticatedUser();
-			if (!user?.id) {
-				throw new Error("Could not resolve authenticated Twitter user id");
-			}
-			resolvedUserId = String(user.id);
+}): Effect.Effect<XurlMentionsResponse, Error> {
+	return Effect.gen(function* () {
+		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
+		const query = new URLSearchParams({
+			max_results: String(maxResults),
+			expansions: AUTHOR_MEDIA_EXPANSIONS,
+			"tweet.fields": "created_at,conversation_id,entities,public_metrics",
+			"media.fields": MEDIA_FIELDS,
+			"user.fields":
+				"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
+		});
+		if (paginationToken) {
+			query.set("pagination_token", paginationToken);
 		}
-	}
+		if (sinceId) {
+			query.set("since_id", sinceId);
+		}
+		if (startTime) {
+			query.set("start_time", startTime);
+		}
 
-	const query = new URLSearchParams({
-		max_results: String(maxResults),
-		expansions: AUTHOR_MEDIA_EXPANSIONS,
-		"tweet.fields": "created_at,conversation_id,entities,public_metrics",
-		"media.fields": MEDIA_FIELDS,
-		"user.fields":
-			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
+		const payload = yield* runJsonCommandEffect([
+			`/2/users/${resolvedUserId}/mentions?${query.toString()}`,
+		]);
+		return toXurlMentionsResponse(payload);
 	});
-	if (paginationToken) {
-		query.set("pagination_token", paginationToken);
-	}
-	if (sinceId) {
-		query.set("since_id", sinceId);
-	}
-	if (startTime) {
-		query.set("start_time", startTime);
-	}
+}
 
-	const payload = await runJsonCommand([
-		`/2/users/${resolvedUserId}/mentions?${query.toString()}`,
-	]);
+export function listMentionsViaXurl(options: {
+	maxResults: number;
+	username?: string;
+	userId?: string;
+	paginationToken?: string;
+	sinceId?: string;
+	startTime?: string;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listMentionsViaXurlEffect(options));
+}
+
+function toXurlMentionsResponse(
+	payload: Record<string, unknown>,
+): XurlMentionsResponse {
 	return {
 		data: Array.isArray(payload.data)
 			? (payload.data as XurlMentionsResponse["data"])
@@ -456,7 +580,7 @@ export async function listMentionsViaXurl({
 	};
 }
 
-async function listTimelineCollectionViaXurl({
+function listTimelineCollectionViaXurlEffect({
 	collection,
 	maxResults,
 	username,
@@ -470,88 +594,81 @@ async function listTimelineCollectionViaXurl({
 	userId?: string;
 	isPaginatedWalk?: boolean;
 	paginationToken?: string;
-}): Promise<XurlMentionsResponse> {
-	let resolvedUserId = userId;
-	if (!resolvedUserId) {
-		if (username) {
-			const [user] = await lookupUsersByHandles([username]);
-			if (!user?.id) {
-				throw new Error(`Could not resolve Twitter user id for @${username}`);
-			}
-			resolvedUserId = String(user.id);
-		} else {
-			const user = await lookupAuthenticatedUser();
-			if (!user?.id) {
-				throw new Error("Could not resolve authenticated Twitter user id");
-			}
-			resolvedUserId = String(user.id);
+}): Effect.Effect<XurlMentionsResponse, Error> {
+	return Effect.gen(function* () {
+		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
+		const requestMaxResults = capTimelineCollectionMaxResults(
+			collection,
+			maxResults,
+			isPaginatedWalk,
+		);
+		const query = new URLSearchParams({
+			max_results: String(requestMaxResults),
+			expansions: AUTHOR_MEDIA_EXPANSIONS,
+			"tweet.fields":
+				"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+			"media.fields": MEDIA_FIELDS,
+			"user.fields":
+				"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
+		});
+		if (paginationToken) {
+			query.set("pagination_token", paginationToken);
 		}
-	}
 
-	const requestMaxResults = capTimelineCollectionMaxResults(
-		collection,
-		maxResults,
-		isPaginatedWalk,
-	);
-	const query = new URLSearchParams({
-		max_results: String(requestMaxResults),
-		expansions: AUTHOR_MEDIA_EXPANSIONS,
-		"tweet.fields":
-			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
-		"media.fields": MEDIA_FIELDS,
-		"user.fields":
-			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
+		const payload = yield* runJsonCommandEffect([
+			"--auth",
+			"oauth2",
+			`/2/users/${resolvedUserId}/${collection}?${query.toString()}`,
+		]);
+		return toXurlMentionsResponse(payload);
 	});
-	if (paginationToken) {
-		query.set("pagination_token", paginationToken);
-	}
-
-	const payload = await runJsonCommand([
-		"--auth",
-		"oauth2",
-		`/2/users/${resolvedUserId}/${collection}?${query.toString()}`,
-	]);
-	return {
-		data: Array.isArray(payload.data)
-			? (payload.data as XurlMentionsResponse["data"])
-			: [],
-		includes:
-			payload.includes && typeof payload.includes === "object"
-				? (payload.includes as XurlMentionsResponse["includes"])
-				: undefined,
-		meta:
-			payload.meta && typeof payload.meta === "object"
-				? (payload.meta as XurlMentionsResponse["meta"])
-				: undefined,
-	};
 }
 
-export async function listLikedTweetsViaXurl(options: {
+export function listLikedTweetsViaXurlEffect(options: {
 	maxResults: number;
 	username?: string;
 	userId?: string;
 	paginationToken?: string;
-}): Promise<XurlMentionsResponse> {
-	return listTimelineCollectionViaXurl({
+}) {
+	return listTimelineCollectionViaXurlEffect({
 		...options,
 		collection: "liked_tweets",
 	});
 }
 
-export async function listBookmarkedTweetsViaXurl(options: {
+export function listLikedTweetsViaXurl(options: {
+	maxResults: number;
+	username?: string;
+	userId?: string;
+	paginationToken?: string;
+}): Promise<XurlMentionsResponse> {
+	return runEffectPromise(listLikedTweetsViaXurlEffect(options));
+}
+
+export function listBookmarkedTweetsViaXurlEffect(options: {
+	maxResults: number;
+	username?: string;
+	userId?: string;
+	isPaginatedWalk?: boolean;
+	paginationToken?: string;
+}) {
+	return listTimelineCollectionViaXurlEffect({
+		...options,
+		collection: "bookmarks",
+	});
+}
+
+export function listBookmarkedTweetsViaXurl(options: {
 	maxResults: number;
 	username?: string;
 	userId?: string;
 	isPaginatedWalk?: boolean;
 	paginationToken?: string;
 }): Promise<XurlMentionsResponse> {
-	return listTimelineCollectionViaXurl({
-		...options,
-		collection: "bookmarks",
-	});
+	return runEffectPromise(listBookmarkedTweetsViaXurlEffect(options));
 }
 
-export async function listFollowUsersViaXurl({
+export function listFollowUsersViaXurlEffect({
 	direction,
 	maxResults,
 	username,
@@ -563,50 +680,46 @@ export async function listFollowUsersViaXurl({
 	username?: string;
 	userId?: string;
 	paginationToken?: string;
-}): Promise<XurlFollowUsersResponse> {
-	let resolvedUserId = userId;
-	if (!resolvedUserId) {
-		if (username) {
-			const [user] = await lookupUsersByHandles([username]);
-			if (!user?.id) {
-				throw new Error(`Could not resolve Twitter user id for @${username}`);
-			}
-			resolvedUserId = String(user.id);
-		} else {
-			const user = await lookupAuthenticatedUser();
-			if (!user?.id) {
-				throw new Error("Could not resolve authenticated Twitter user id");
-			}
-			resolvedUserId = String(user.id);
+}): Effect.Effect<XurlFollowUsersResponse, Error> {
+	return Effect.gen(function* () {
+		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
+		const query = new URLSearchParams({
+			max_results: String(maxResults),
+			"user.fields":
+				"id,username,name,description,verified,protected,public_metrics,profile_image_url,created_at",
+		});
+		if (paginationToken) {
+			query.set("pagination_token", paginationToken);
 		}
-	}
 
-	const query = new URLSearchParams({
-		max_results: String(maxResults),
-		"user.fields":
-			"id,username,name,description,verified,protected,public_metrics,profile_image_url,created_at",
+		const payload = yield* runJsonCommandEffect([
+			"--auth",
+			"oauth2",
+			`/2/users/${resolvedUserId}/${direction}?${query.toString()}`,
+		]);
+		return {
+			data: Array.isArray(payload.data)
+				? (payload.data as XurlMentionUser[])
+				: [],
+			meta:
+				payload.meta && typeof payload.meta === "object"
+					? (payload.meta as Record<string, unknown>)
+					: undefined,
+		};
 	});
-	if (paginationToken) {
-		query.set("pagination_token", paginationToken);
-	}
-
-	const payload = await runJsonCommand([
-		"--auth",
-		"oauth2",
-		`/2/users/${resolvedUserId}/${direction}?${query.toString()}`,
-	]);
-	return {
-		data: Array.isArray(payload.data)
-			? (payload.data as XurlMentionUser[])
-			: [],
-		meta:
-			payload.meta && typeof payload.meta === "object"
-				? (payload.meta as Record<string, unknown>)
-				: undefined,
-	};
 }
 
-export async function listBlockedUsers(
+export function listFollowUsersViaXurl(options: {
+	direction: FollowDirection;
+	maxResults: number;
+	username?: string;
+	userId?: string;
+	paginationToken?: string;
+}): Promise<XurlFollowUsersResponse> {
+	return runEffectPromise(listFollowUsersViaXurlEffect(options));
+}
+
+export function listBlockedUsersEffect(
 	userId: string,
 	paginationToken?: string,
 ) {
@@ -619,25 +732,30 @@ export async function listBlockedUsers(
 		query.set("pagination_token", paginationToken);
 	}
 
-	const payload = await runJsonCommand([
-		`/2/users/${userId}/blocking?${query}`,
-	]);
-	const data = Array.isArray(payload.data)
-		? (payload.data as XurlMentionUser[])
-		: [];
-	const meta =
-		payload.meta && typeof payload.meta === "object"
-			? (payload.meta as Record<string, unknown>)
-			: null;
+	return runJsonCommandEffect([`/2/users/${userId}/blocking?${query}`]).pipe(
+		Effect.map((payload) => {
+			const data = Array.isArray(payload.data)
+				? (payload.data as XurlMentionUser[])
+				: [];
+			const meta =
+				payload.meta && typeof payload.meta === "object"
+					? (payload.meta as Record<string, unknown>)
+					: null;
 
-	return {
-		items: data,
-		nextToken:
-			typeof meta?.next_token === "string" ? String(meta.next_token) : null,
-	};
+			return {
+				items: data,
+				nextToken:
+					typeof meta?.next_token === "string" ? String(meta.next_token) : null,
+			};
+		}),
+	);
 }
 
-export async function listUserTweets(
+export function listBlockedUsers(userId: string, paginationToken?: string) {
+	return runEffectPromise(listBlockedUsersEffect(userId, paginationToken));
+}
+
+export function listUserTweetsEffect(
 	userId: string,
 	{
 		maxResults,
@@ -662,7 +780,7 @@ export async function listUserTweets(
 		mediaFields?: string[];
 		auth?: "oauth2";
 	},
-): Promise<XurlUserTweetsResponse> {
+): Effect.Effect<XurlUserTweetsResponse, Error> {
 	const query = new URLSearchParams({
 		max_results: String(maxResults),
 		expansions: MEDIA_EXPANSION,
@@ -694,34 +812,73 @@ export async function listUserTweets(
 	}
 
 	const endpoint = `/2/users/${userId}/tweets?${query}`;
-	const payload = await runJsonCommand(
+	return runJsonCommandEffect(
 		auth === "oauth2" ? ["--auth", "oauth2", endpoint] : [endpoint],
-	);
-	const data = Array.isArray(payload.data)
-		? (payload.data as XurlUserTweet[])
-		: [];
-	const meta =
-		payload.meta && typeof payload.meta === "object"
-			? (payload.meta as Record<string, unknown>)
-			: null;
-	const includes =
-		payload.includes && typeof payload.includes === "object"
-			? (payload.includes as XurlUserTweetsResponse["includes"])
-			: undefined;
+	).pipe(
+		Effect.map((payload) => {
+			const data = Array.isArray(payload.data)
+				? (payload.data as XurlUserTweet[])
+				: [];
+			const meta =
+				payload.meta && typeof payload.meta === "object"
+					? (payload.meta as Record<string, unknown>)
+					: null;
+			const includes =
+				payload.includes && typeof payload.includes === "object"
+					? (payload.includes as XurlUserTweetsResponse["includes"])
+					: undefined;
 
+			return {
+				items: data,
+				nextToken:
+					typeof meta?.next_token === "string" ? String(meta.next_token) : null,
+				...(includes ? { includes } : {}),
+			};
+		}),
+	);
+}
+
+export function listUserTweets(
+	userId: string,
+	options: {
+		maxResults: number;
+		paginationToken?: string;
+		excludeRetweets?: boolean;
+		sinceId?: string;
+		untilId?: string;
+		tweetFields?: string[];
+		expansions?: string[];
+		userFields?: string[];
+		mediaFields?: string[];
+		auth?: "oauth2";
+	},
+): Promise<XurlUserTweetsResponse> {
+	return runEffectPromise(listUserTweetsEffect(userId, options));
+}
+
+function toXurlTweetsResponse(
+	payload: Record<string, unknown>,
+): XurlTweetsResponse {
 	return {
-		items: data,
-		nextToken:
-			typeof meta?.next_token === "string" ? String(meta.next_token) : null,
-		...(includes ? { includes } : {}),
+		data: Array.isArray(payload.data)
+			? (payload.data as XurlTweetsResponse["data"])
+			: [],
+		includes:
+			payload.includes && typeof payload.includes === "object"
+				? (payload.includes as XurlTweetsResponse["includes"])
+				: undefined,
+		meta:
+			payload.meta && typeof payload.meta === "object"
+				? (payload.meta as XurlTweetsResponse["meta"])
+				: undefined,
 	};
 }
 
-export async function lookupTweetsByIds(
+export function lookupTweetsByIdsEffect(
 	ids: string[],
-): Promise<XurlTweetsResponse> {
+): Effect.Effect<XurlTweetsResponse, Error> {
 	if (ids.length === 0) {
-		return { data: [] };
+		return Effect.succeed({ data: [] });
 	}
 
 	const query = new URLSearchParams({
@@ -734,23 +891,16 @@ export async function lookupTweetsByIds(
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
 	});
 
-	const payload = await runJsonCommand([`/2/tweets?${query.toString()}`]);
-	return {
-		data: Array.isArray(payload.data)
-			? (payload.data as XurlTweetsResponse["data"])
-			: [],
-		includes:
-			payload.includes && typeof payload.includes === "object"
-				? (payload.includes as XurlTweetsResponse["includes"])
-				: undefined,
-		meta:
-			payload.meta && typeof payload.meta === "object"
-				? (payload.meta as XurlTweetsResponse["meta"])
-				: undefined,
-	};
+	return runJsonCommandEffect([`/2/tweets?${query.toString()}`]).pipe(
+		Effect.map(toXurlTweetsResponse),
+	);
 }
 
-export async function searchRecentByConversationId(
+export function lookupTweetsByIds(ids: string[]): Promise<XurlTweetsResponse> {
+	return runEffectPromise(lookupTweetsByIdsEffect(ids));
+}
+
+export function searchRecentByConversationIdEffect(
 	conversationId: string,
 	{
 		maxResults,
@@ -761,7 +911,7 @@ export async function searchRecentByConversationId(
 		paginationToken?: string;
 		timeoutMs?: number;
 	},
-): Promise<XurlTweetsResponse> {
+): Effect.Effect<XurlTweetsResponse, Error> {
 	const query = new URLSearchParams({
 		query: `conversation_id:${conversationId}`,
 		max_results: String(maxResults),
@@ -774,29 +924,28 @@ export async function searchRecentByConversationId(
 		query.set("pagination_token", paginationToken);
 	}
 
-	const payload = await runJsonCommand(
-		[`/2/tweets/search/recent?${query.toString()}`],
-		{ timeoutMs },
-	);
-	return {
-		data: Array.isArray(payload.data)
-			? (payload.data as XurlTweetsResponse["data"])
-			: [],
-		includes:
-			payload.includes && typeof payload.includes === "object"
-				? (payload.includes as XurlTweetsResponse["includes"])
-				: undefined,
-		meta:
-			payload.meta && typeof payload.meta === "object"
-				? (payload.meta as XurlTweetsResponse["meta"])
-				: undefined,
-	};
+	return runJsonCommandEffect([`/2/tweets/search/recent?${query.toString()}`], {
+		timeoutMs,
+	}).pipe(Effect.map(toXurlTweetsResponse));
 }
 
-export async function getTweetById(
+export function searchRecentByConversationId(
+	conversationId: string,
+	options: {
+		maxResults: number;
+		paginationToken?: string;
+		timeoutMs?: number;
+	},
+): Promise<XurlTweetsResponse> {
+	return runEffectPromise(
+		searchRecentByConversationIdEffect(conversationId, options),
+	);
+}
+
+export function getTweetByIdEffect(
 	id: string,
 	{ timeoutMs }: { timeoutMs?: number } = {},
-): Promise<XurlTweetsResponse> {
+): Effect.Effect<XurlTweetsResponse, Error> {
 	const query = new URLSearchParams({
 		expansions: AUTHOR_MEDIA_EXPANSIONS,
 		"tweet.fields": THREAD_TWEET_FIELDS,
@@ -804,55 +953,74 @@ export async function getTweetById(
 		"user.fields": RICH_USER_FIELDS,
 	});
 
-	const payload = await runJsonCommand(
-		[`/2/tweets/${id}?${query.toString()}`],
-		{
-			timeoutMs,
-		},
+	return runJsonCommandEffect([`/2/tweets/${id}?${query.toString()}`], {
+		timeoutMs,
+	}).pipe(
+		Effect.map((payload) => {
+			const data =
+				payload.data &&
+				typeof payload.data === "object" &&
+				!Array.isArray(payload.data)
+					? [payload.data as XurlTweetsResponse["data"][number]]
+					: Array.isArray(payload.data)
+						? (payload.data as XurlTweetsResponse["data"])
+						: [];
+
+			return {
+				data,
+				includes:
+					payload.includes && typeof payload.includes === "object"
+						? (payload.includes as XurlTweetsResponse["includes"])
+						: undefined,
+				meta:
+					payload.meta && typeof payload.meta === "object"
+						? (payload.meta as XurlTweetsResponse["meta"])
+						: undefined,
+			};
+		}),
 	);
-	const data =
-		payload.data &&
-		typeof payload.data === "object" &&
-		!Array.isArray(payload.data)
-			? [payload.data as XurlTweetsResponse["data"][number]]
-			: Array.isArray(payload.data)
-				? (payload.data as XurlTweetsResponse["data"])
-				: [];
-
-	return {
-		data,
-		includes:
-			payload.includes && typeof payload.includes === "object"
-				? (payload.includes as XurlTweetsResponse["includes"])
-				: undefined,
-		meta:
-			payload.meta && typeof payload.meta === "object"
-				? (payload.meta as XurlTweetsResponse["meta"])
-				: undefined,
-	};
 }
 
-export async function postViaXurl(text: string) {
-	return runShortcut(["post", text]);
+export function getTweetById(
+	id: string,
+	options: { timeoutMs?: number } = {},
+): Promise<XurlTweetsResponse> {
+	return runEffectPromise(getTweetByIdEffect(id, options));
 }
 
-export async function replyViaXurl(tweetId: string, text: string) {
-	return runShortcut(["reply", tweetId, text]);
+export function postViaXurlEffect(text: string) {
+	return runShortcutEffect(["post", text]);
 }
 
-export async function dmViaXurl(handle: string, text: string) {
-	return runShortcut([
+export function postViaXurl(text: string) {
+	return runEffectPromise(postViaXurlEffect(text));
+}
+
+export function replyViaXurlEffect(tweetId: string, text: string) {
+	return runShortcutEffect(["reply", tweetId, text]);
+}
+
+export function replyViaXurl(tweetId: string, text: string) {
+	return runEffectPromise(replyViaXurlEffect(tweetId, text));
+}
+
+export function dmViaXurlEffect(handle: string, text: string) {
+	return runShortcutEffect([
 		"dm",
 		handle.startsWith("@") ? handle : `@${handle}`,
 		text,
 	]);
 }
 
-export async function blockUserViaXurl(
+export function dmViaXurl(handle: string, text: string) {
+	return runEffectPromise(dmViaXurlEffect(handle, text));
+}
+
+export function blockUserViaXurlEffect(
 	sourceUserId: string,
 	targetUserId: string,
 ) {
-	return runMutationCommand([
+	return runMutationCommandEffect([
 		"-X",
 		"POST",
 		`/2/users/${sourceUserId}/blocking`,
@@ -861,22 +1029,30 @@ export async function blockUserViaXurl(
 	]);
 }
 
-export async function unblockUserViaXurl(
+export function blockUserViaXurl(sourceUserId: string, targetUserId: string) {
+	return runEffectPromise(blockUserViaXurlEffect(sourceUserId, targetUserId));
+}
+
+export function unblockUserViaXurlEffect(
 	sourceUserId: string,
 	targetUserId: string,
 ) {
-	return runMutationCommand([
+	return runMutationCommandEffect([
 		"-X",
 		"DELETE",
 		`/2/users/${sourceUserId}/blocking/${targetUserId}`,
 	]);
 }
 
-export async function muteUserViaXurl(
+export function unblockUserViaXurl(sourceUserId: string, targetUserId: string) {
+	return runEffectPromise(unblockUserViaXurlEffect(sourceUserId, targetUserId));
+}
+
+export function muteUserViaXurlEffect(
 	sourceUserId: string,
 	targetUserId: string,
 ) {
-	return runMutationCommand([
+	return runMutationCommandEffect([
 		"-X",
 		"POST",
 		`/2/users/${sourceUserId}/muting`,
@@ -885,13 +1061,21 @@ export async function muteUserViaXurl(
 	]);
 }
 
-export async function unmuteUserViaXurl(
+export function muteUserViaXurl(sourceUserId: string, targetUserId: string) {
+	return runEffectPromise(muteUserViaXurlEffect(sourceUserId, targetUserId));
+}
+
+export function unmuteUserViaXurlEffect(
 	sourceUserId: string,
 	targetUserId: string,
 ) {
-	return runMutationCommand([
+	return runMutationCommandEffect([
 		"-X",
 		"DELETE",
 		`/2/users/${sourceUserId}/muting/${targetUserId}`,
 	]);
+}
+
+export function unmuteUserViaXurl(sourceUserId: string, targetUserId: string) {
+	return runEffectPromise(unmuteUserViaXurlEffect(sourceUserId, targetUserId));
 }

--- a/src/package-config.test.ts
+++ b/src/package-config.test.ts
@@ -33,7 +33,7 @@ describe("package configuration", () => {
 		);
 
 		expect(stdout.trim()).toBe(packageJson.version);
-	});
+	}, 15_000);
 
 	it("keeps published bin files in lint and format script coverage", () => {
 		const binTargets = Object.values(packageJson.bin);


### PR DESCRIPTION
## Summary
- add Effect as a runtime dependency and introduce the shared Effect-to-Promise boundary
- migrate core IO-heavy lib internals to Effect programs while preserving Promise-compatible public wrappers
- document the Effect runtime boundary and migrated surfaces

## Review
- codex-review clean: no accepted/actionable findings

## Proof
- ./node_modules/.bin/tsgo --noEmit --pretty false
- node ./scripts/run-vitest.mjs run --reporter=dot
- ./node_modules/.bin/vite build
- ./node_modules/.bin/oxlint --import-plugin --node-plugin --vitest-plugin --deny-warnings -A require-mock-type-parameters -A no-control-regex
