### PR TITLE
feat: add streaming period digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add a streaming `What happened` AI digest in the web UI and CLI (`birdclaw today`, `birdclaw digest`) backed by OpenAI Responses API, GPT-5.5 by default, medium reasoning, priority service tier, local context hashing, and cached final structured results.
+
 ### Changed
 
 - Start the Effect rewrite by making `effect` a first-class runtime dependency and moving web API fetches, web sync orchestration, live command helpers, action transport, `bird`/`xurl` JSON/action transports and public adapters, backup export/import/validation and Git orchestration, moderation target resolution, blocks/mutes write helpers, remote block sync, batch blocklist imports, x-web mutations, authored/mentions/mention-thread sync including xurl recent-search and parent-walk fallback internals, conversation loading, home timeline, saved collection, DM live sync, profile hydration/resolution/affiliation/reply inspection, shared tweet lookup, research and whois report generation, follow graph live sync, link preview/index fetches, archive discovery/import subprocesses, avatar/URL caches, OpenAI/inbox scoring, scheduled bookmark sync locking/audit/launchd install, and media-fetch archive reuse/download concurrency onto Effect programs with Promise-compatible public wrappers.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you need polished product-grade sync parity today, this is not there yet.
 ## Screens
 
 - `Home`: read and reply without fighting the main Twitter timeline
+- `What happened`: stream an AI digest for today, 24h, yesterday, or week
 - `Mentions`: work the reply queue with clean filters
 - `Likes` / `Bookmarks`: revisit saved posts from archive or live sync
 - `DMs`: triage by sender context, follower count, and influence
@@ -379,6 +380,20 @@ Notes:
 birdclaw research "codex" --limit 20 --thread-depth 10 --json
 birdclaw research --account acct_primary --out ~/research/codex.md
 ```
+
+### What happened today
+
+`birdclaw today` streams a local "what happened" digest from the SQLite store. It uses the OpenAI Responses API with `gpt-5.5`, medium reasoning, and priority service tier by default. Set `OPENAI_API_KEY`; override with `BIRDCLAW_AI_MODEL`, `BIRDCLAW_OPENAI_REASONING_EFFORT`, or `BIRDCLAW_OPENAI_SERVICE_TIER` when needed.
+
+```bash
+birdclaw today
+birdclaw digest 24h --refresh
+birdclaw digest week --json
+birdclaw digest --since 2026-05-16T00:00:00Z --until 2026-05-17T00:00:00Z
+birdclaw digest today --include-dms
+```
+
+The web UI exposes the same stream under `What happened`. DMs are excluded unless explicitly enabled. Final structured results are cached by the exact local context hash, model, reasoning effort, and service tier.
 
 ### Search and triage DMs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,8 @@ birdclaw sync followers
 birdclaw sync following
 birdclaw search tweets <query>
 birdclaw search dms <query>
+birdclaw today
+birdclaw digest [today|24h|yesterday|week]
 birdclaw mentions export [query]
 birdclaw media fetch
 birdclaw dms list
@@ -110,6 +112,22 @@ birdclaw debug transport
 ```
 
 ## Subcommand semantics
+
+### `today`
+
+- alias for `digest today`
+- streams Markdown as model tokens arrive
+- uses `gpt-5.5`, medium reasoning, and priority service tier by default
+- requires `OPENAI_API_KEY`
+- excludes DMs unless `--include-dms` is passed
+- supports `--refresh`, `--model`, `--max-tweets`, and `--max-links`
+
+### `digest [period]`
+
+- period: `today`, `24h`, `yesterday`, or `week`
+- accepts explicit `--since <iso>` and `--until <iso>` windows
+- caches the final structured result by local context hash, model, reasoning effort, and service tier
+- `--json` suppresses token streaming and emits the final envelope
 
 ### `init`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,10 @@ birdclaw search tweets --bookmarked --hide-low-quality --limit 100 --json
 # Triage with AI ranking and reply from the CLI.
 birdclaw inbox --score --hide-low-signal --limit 8 --json
 birdclaw compose reply 1891234567890 "On it."
+
+# Stream a local "what happened" digest.
+birdclaw today
+birdclaw digest week --json
 ```
 
 Stable `--json` envelopes go to stdout, progress and warnings to stderr — pipes stay parseable.
@@ -34,8 +38,9 @@ Stable `--json` envelopes go to stdout, progress and warnings to stderr — pipe
 - **One local SQLite database** for tweets, DMs, likes, bookmarks, mentions, follows, blocks, and mutes — multi-account, FTS5-indexed.
 - **Archive-first, live-aware.** Import a Twitter archive when you have one, selectively re-import stale slices with `--select`, or stay live-only. All paths converge on the same canonical tables.
 - **Cached live reads** through [`xurl`](https://github.com/xdevplatform/xurl) and [`bird`](https://github.com/steipete/bird), so repeated reads do not keep spending the API budget.
-- **Local web app** for `Home`, `Mentions`, `Likes`, `Bookmarks`, `DMs`, `Inbox`, and `Blocks` — light/dark/system theme, focused timeline lane, no dashboard chrome.
+- **Local web app** for `What happened`, `Home`, `Mentions`, `Likes`, `Bookmarks`, `DMs`, `Inbox`, and `Blocks` — light/dark/system theme, focused timeline lane, no dashboard chrome.
 - **AI-ranked inbox** (OpenAI) for low-signal filtering on mentions and DMs.
+- **Streaming AI digest** (OpenAI Responses API) for today, 24h, yesterday, or week, with DMs excluded unless explicitly enabled.
 - **Account-scoped moderation** with bulk blocklist import and a cookie-backed fallback when OAuth2 block writes get rejected.
 - **Git-friendly text backups** with yearly tweet shards and per-conversation DM shards — push the local SQLite truth into a private Git repo.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -40,6 +40,7 @@ const listDmConversationsMock = vi.fn();
 const hydrateProfilesFromXMock = vi.fn();
 const inspectProfileRepliesMock = vi.fn();
 const runResearchModeMock = vi.fn();
+const streamPeriodDigestMock = vi.fn();
 const syncAuthoredTweetsMock = vi.fn();
 const syncTimelineCollectionMock = vi.fn();
 const createPostMock = vi.fn();
@@ -177,6 +178,10 @@ vi.mock("#/lib/research", () => ({
 	runResearchMode: (...args: unknown[]) => runResearchModeMock(...args),
 }));
 
+vi.mock("#/lib/period-digest", () => ({
+	streamPeriodDigest: (...args: unknown[]) => streamPeriodDigestMock(...args),
+}));
+
 vi.mock("#/lib/authored-live", () => ({
 	AuthoredSyncError: class AuthoredSyncError extends Error {
 		constructor(
@@ -264,6 +269,7 @@ describe("cli", () => {
 		hydrateProfilesFromXMock.mockReset();
 		inspectProfileRepliesMock.mockReset();
 		runResearchModeMock.mockReset();
+		streamPeriodDigestMock.mockReset();
 		syncAuthoredTweetsMock.mockReset();
 		syncTimelineCollectionMock.mockReset();
 		createPostMock.mockReset();
@@ -398,6 +404,16 @@ describe("cli", () => {
 			threadCount: 1,
 			items: [],
 			markdown: "# Birdclaw Research\n",
+		});
+		streamPeriodDigestMock.mockResolvedValue({
+			context: { counts: {}, includeDms: false },
+			digest: { actionItems: [] },
+			markdown: "# Today\n",
+			model: "gpt-5.5",
+			reasoningEffort: "medium",
+			serviceTier: "priority",
+			cached: false,
+			updatedAt: "2026-05-16T12:00:00.000Z",
 		});
 		syncTimelineCollectionMock.mockResolvedValue({
 			ok: true,
@@ -1897,6 +1913,106 @@ describe("cli", () => {
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining("# Birdclaw Research"),
 		);
+	});
+
+	it("streams digest commands as markdown and json", async () => {
+		const stdoutWriteMock = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		streamPeriodDigestMock.mockImplementation(
+			async (
+				_options: unknown,
+				handlers?: { onDelta?: (delta: string) => void },
+			) => {
+				handlers?.onDelta?.("# Today\n");
+				return {
+					context: { counts: {}, includeDms: false },
+					digest: { actionItems: [] },
+					markdown: "# Today\n",
+					model: "gpt-5.5",
+					reasoningEffort: "medium",
+					serviceTier: "priority",
+					cached: false,
+					updatedAt: "2026-05-16T12:00:00.000Z",
+				};
+			},
+		);
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"today",
+			"--include-dms",
+			"--refresh",
+			"--max-tweets",
+			"10",
+			"--max-links",
+			"2",
+			"--model",
+			"gpt-5.5",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"digest",
+			"7d",
+			"--since",
+			"2026-05-01",
+			"--until",
+			"2026-05-16",
+			"--account",
+			"acct_primary",
+		]);
+
+		expect(streamPeriodDigestMock).toHaveBeenNthCalledWith(
+			1,
+			{
+				period: "today",
+				since: undefined,
+				until: undefined,
+				account: undefined,
+				includeDms: true,
+				refresh: true,
+				model: "gpt-5.5",
+				maxTweets: 10,
+				maxLinks: 2,
+			},
+			expect.objectContaining({ onDelta: expect.any(Function) }),
+		);
+		expect(streamPeriodDigestMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				period: "week",
+				since: "2026-05-01",
+				until: "2026-05-16",
+				account: "acct_primary",
+				includeDms: false,
+			}),
+			expect.objectContaining({ onDelta: undefined }),
+		);
+		expect(stdoutWriteMock).toHaveBeenCalledWith("# Today\n");
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"model": "gpt-5.5"'),
+		);
+		stdoutWriteMock.mockRestore();
+	});
+
+	it("rejects invalid digest numeric options", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "digest", "week", "--max-tweets", "nah"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(streamPeriodDigestMock).not.toHaveBeenCalled();
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining("--max-tweets must be a non-negative integer"),
+		);
+		consoleErrorMock.mockRestore();
 	});
 
 	it("inspects recent profile replies", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,11 @@ import {
 	syncMentions,
 } from "#/lib/mentions-live";
 import {
+	streamPeriodDigest,
+	type PeriodDigestOptions,
+	type PeriodDigestPreset,
+} from "#/lib/period-digest";
+import {
 	getFollowGraphSummary,
 	listFollowEvents,
 	listMutuals,
@@ -207,6 +212,73 @@ function resolveActionOptions(options: { transport?: string }) {
 	return {
 		transport: options.transport as ActionsTransport | undefined,
 	};
+}
+
+function parseDigestPeriod(value: string | undefined): PeriodDigestPreset {
+	const normalized = value?.trim().toLowerCase();
+	if (normalized === "yesterday") return "yesterday";
+	if (normalized === "24h" || normalized === "day") return "24h";
+	if (normalized === "week" || normalized === "7d") return "week";
+	return "today";
+}
+
+function buildDigestOptions(
+	period: string | undefined,
+	options: {
+		account?: string;
+		includeDms?: boolean;
+		model?: string;
+		refresh?: boolean;
+		since?: string;
+		until?: string;
+		maxTweets?: string;
+		maxLinks?: string;
+	},
+): PeriodDigestOptions | null {
+	const maxTweets = parseNonNegativeIntegerOption(
+		options.maxTweets,
+		"--max-tweets",
+	);
+	if (options.maxTweets !== undefined && maxTweets === undefined) {
+		return null;
+	}
+	const maxLinks = parseNonNegativeIntegerOption(
+		options.maxLinks,
+		"--max-links",
+	);
+	if (options.maxLinks !== undefined && maxLinks === undefined) {
+		return null;
+	}
+	return {
+		period: parseDigestPeriod(period),
+		since: options.since,
+		until: options.until,
+		account: options.account,
+		includeDms: Boolean(options.includeDms),
+		refresh: Boolean(options.refresh),
+		model: options.model,
+		maxTweets,
+		maxLinks,
+	};
+}
+
+function runDigestCli(options: PeriodDigestOptions) {
+	const asJson = Boolean(program.opts().json);
+	return streamPeriodDigest(options, {
+		onDelta: asJson
+			? undefined
+			: (delta) => {
+					process.stdout.write(delta);
+				},
+	}).then((result) => {
+		if (asJson) {
+			print(result, true);
+			return;
+		}
+		if (!result.markdown.endsWith("\n")) {
+			process.stdout.write("\n");
+		}
+	});
 }
 
 async function enrichDmItems(
@@ -718,6 +790,40 @@ program
 			program.opts().json ? report : report.markdown,
 			program.opts().json ?? false,
 		);
+	});
+
+program
+	.command("today")
+	.description("Stream an AI digest of what happened today")
+	.option("--account <accountId>", "Account id")
+	.option("--include-dms", "Include private DM context")
+	.option("--model <model>", "OpenAI model id")
+	.option("--refresh", "Bypass the local digest cache")
+	.option("--max-tweets <n>", "Maximum tweet context", "120")
+	.option("--max-links <n>", "Maximum linked articles", "12")
+	.action(async (options) => {
+		await autoUpdateBeforeRead();
+		const digestOptions = buildDigestOptions("today", options);
+		if (!digestOptions) return;
+		await runDigestCli(digestOptions);
+	});
+
+program
+	.command("digest [period]")
+	.description("Stream an AI digest for today, 24h, yesterday, or week")
+	.option("--account <accountId>", "Account id")
+	.option("--include-dms", "Include private DM context")
+	.option("--since <isoDate>", "Start of explicit window")
+	.option("--until <isoDate>", "End of explicit window")
+	.option("--model <model>", "OpenAI model id")
+	.option("--refresh", "Bypass the local digest cache")
+	.option("--max-tweets <n>", "Maximum tweet context", "120")
+	.option("--max-links <n>", "Maximum linked articles", "12")
+	.action(async (period, options) => {
+		await autoUpdateBeforeRead();
+		const digestOptions = buildDigestOptions(period, options);
+		if (!digestOptions) return;
+		await runDigestCli(digestOptions);
 	});
 
 const mentionsCommand = program

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -2,6 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import {
 	Bell,
 	Bookmark,
+	CalendarDays,
 	Heart,
 	Home,
 	Inbox,
@@ -29,6 +30,7 @@ import { ThemeSlider } from "./ThemeSlider";
 
 const links = [
 	{ to: "/inbox", label: "Inbox", icon: Inbox },
+	{ to: "/today", label: "Today", icon: CalendarDays },
 	{ to: "/", label: "Home", icon: Home },
 	{ to: "/mentions", label: "Mentions", icon: Bell },
 	{ to: "/likes", label: "Likes", icon: Heart },

--- a/src/lib/link-insights.test.ts
+++ b/src/lib/link-insights.test.ts
@@ -12,17 +12,27 @@ type TestDb = ReturnType<typeof getNativeDb>;
 
 function insertAccountFixture() {
 	const db = getNativeDb({ seedDemoData: false });
-	db.prepare(`
-    insert into accounts (
-      id, name, handle, external_user_id, transport, is_default, created_at
-    ) values (?, ?, ?, ?, ?, ?, ?)
-  `).run(
+	const insertAccount = db.prepare(`
+	    insert into accounts (
+	      id, name, handle, external_user_id, transport, is_default, created_at
+	    ) values (?, ?, ?, ?, ?, ?, ?)
+	  `);
+	insertAccount.run(
 		"acct_primary",
 		"Peter",
 		"steipete",
 		"25401953",
 		"bird",
 		1,
+		"2026-05-01T00:00:00.000Z",
+	);
+	insertAccount.run(
+		"acct_secondary",
+		"Alt",
+		"alt",
+		"999",
+		"bird",
+		0,
 		"2026-05-01T00:00:00.000Z",
 	);
 	for (const profile of [
@@ -53,6 +63,7 @@ function insertTweet(
 	db: TestDb,
 	options: {
 		id: string;
+		accountId?: string;
 		authorProfileId: string;
 		text: string;
 		createdAt: string;
@@ -66,7 +77,7 @@ function insertTweet(
     ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
 		options.id,
-		"acct_primary",
+		options.accountId ?? "acct_primary",
 		options.authorProfileId,
 		"home",
 		options.text,
@@ -150,6 +161,7 @@ function insertOccurrence(
 		sourceKind: "dm" | "tweet";
 		sourceId: string;
 		shortUrl: string;
+		accountId?: string;
 		createdAt: string;
 	},
 ) {
@@ -163,10 +175,29 @@ function insertOccurrence(
 		options.sourceId,
 		0,
 		options.shortUrl,
-		"acct_primary",
+		options.accountId ?? "acct_primary",
 		options.sourceKind === "dm" ? "dm_bob" : null,
 		options.sourceKind === "dm" ? "inbound" : null,
 		options.createdAt,
+	);
+}
+
+function insertTweetAccountEdge(
+	db: TestDb,
+	options: { accountId: string; tweetId: string; kind?: string },
+) {
+	db.prepare(`
+    insert into tweet_account_edges (
+      account_id, tweet_id, kind, first_seen_at, last_seen_at, source, updated_at
+    ) values (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+		options.accountId,
+		options.tweetId,
+		options.kind ?? "home",
+		"2026-05-11T00:00:00.000Z",
+		"2026-05-11T00:00:00.000Z",
+		"test",
+		"2026-05-11T00:00:00.000Z",
 	);
 }
 
@@ -384,6 +415,89 @@ describe("link insights", () => {
 			direction: "inbound",
 			participant: expect.objectContaining({ handle: "bob" }),
 		});
+	});
+
+	it("scopes results to the selected account", () => {
+		const db = insertAccountFixture();
+		insertTweet(db, {
+			id: "tweet_primary",
+			authorProfileId: "profile_a",
+			text: "Primary link https://t.co/primary",
+			createdAt: "2026-05-11T09:00:00.000Z",
+		});
+		insertTweet(db, {
+			id: "tweet_secondary",
+			accountId: "acct_secondary",
+			authorProfileId: "profile_b",
+			text: "Secondary link https://t.co/secondary",
+			createdAt: "2026-05-11T10:00:00.000Z",
+		});
+		insertTweet(db, {
+			id: "tweet_shared",
+			authorProfileId: "profile_a",
+			text: "Shared edge link https://t.co/shared",
+			createdAt: "2026-05-11T11:00:00.000Z",
+		});
+		insertExpansion(db, {
+			shortUrl: "https://t.co/primary",
+			finalUrl: "https://primary.example/post",
+		});
+		insertExpansion(db, {
+			shortUrl: "https://t.co/secondary",
+			finalUrl: "https://secondary.example/post",
+		});
+		insertExpansion(db, {
+			shortUrl: "https://t.co/shared",
+			finalUrl: "https://shared.example/post",
+		});
+		insertOccurrence(db, {
+			sourceKind: "tweet",
+			sourceId: "tweet_primary",
+			shortUrl: "https://t.co/primary",
+			createdAt: "2026-05-11T09:00:00.000Z",
+		});
+		insertOccurrence(db, {
+			sourceKind: "tweet",
+			sourceId: "tweet_secondary",
+			shortUrl: "https://t.co/secondary",
+			accountId: "acct_secondary",
+			createdAt: "2026-05-11T10:00:00.000Z",
+		});
+		insertOccurrence(db, {
+			sourceKind: "tweet",
+			sourceId: "tweet_shared",
+			shortUrl: "https://t.co/shared",
+			createdAt: "2026-05-11T11:00:00.000Z",
+		});
+		insertTweetAccountEdge(db, {
+			accountId: "acct_secondary",
+			tweetId: "tweet_shared",
+		});
+
+		const now = new Date("2026-05-11T12:00:00.000Z");
+		expect(
+			getLinkInsights({
+				account: "acct_primary",
+				range: "today",
+				now,
+			}).items.map((item) => item.host),
+		).toEqual(["shared.example", "primary.example"]);
+		expect(
+			getLinkInsights({
+				account: "acct_secondary",
+				range: "today",
+				now,
+			}).items.map((item) => item.host),
+		).toEqual(["shared.example", "secondary.example"]);
+		expect(
+			new Set(
+				getLinkInsights({ account: "all", range: "today", now }).items.map(
+					(item) => item.host,
+				),
+			),
+		).toEqual(
+			new Set(["primary.example", "secondary.example", "shared.example"]),
+		);
 	});
 
 	it("preserves http schemes on exposed link urls", () => {

--- a/src/lib/link-insights.ts
+++ b/src/lib/link-insights.ts
@@ -635,6 +635,30 @@ export function getLinkInsights(
 		conditions.push("o.source_kind = ?");
 		params.push(source);
 	}
+	if (query.account && query.account !== "all") {
+		conditions.push(`(
+	    (o.source_kind = 'dm' and o.account_id = ?)
+	    or (
+	      o.source_kind = 'tweet'
+	      and (
+	        o.account_id = ?
+	        or exists (
+	          select 1
+	          from tweet_account_edges edge
+	          where edge.account_id = ?
+	            and edge.tweet_id = o.source_id
+	        )
+	        or exists (
+	          select 1
+	          from tweet_collections collection
+	          where collection.account_id = ?
+	            and collection.tweet_id = o.source_id
+	        )
+	      )
+	    )
+	  )`);
+		params.push(query.account, query.account, query.account, query.account);
+	}
 	if (kind === "videos") {
 		addVideoUrlPrefilter(conditions);
 	}

--- a/src/lib/period-digest.test.ts
+++ b/src/lib/period-digest.test.ts
@@ -263,6 +263,36 @@ describe("period digest", () => {
 		).rejects.toThrow("model overloaded");
 	});
 
+	it("rejects missing OpenAI credentials before starting the request", async () => {
+		delete process.env.OPENAI_API_KEY;
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			streamPeriodDigest({
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+				refresh: true,
+			}),
+		).rejects.toThrow("OPENAI_API_KEY is not set");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects non-ok OpenAI responses with the response body", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response("rate limited", { status: 429 })),
+		);
+
+		await expect(
+			streamPeriodDigest({
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+				refresh: true,
+			}),
+		).rejects.toThrow("OpenAI request failed: 429 rate limited");
+	});
+
 	it("passes abort signals to the OpenAI stream request", async () => {
 		const controller = new AbortController();
 		const fetchMock = vi.fn(

--- a/src/lib/period-digest.test.ts
+++ b/src/lib/period-digest.test.ts
@@ -1,0 +1,302 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+import {
+	__test__,
+	collectPeriodDigestContext,
+	resolvePeriodDigestWindow,
+	streamPeriodDigest,
+	streamPeriodDigestEffect,
+} from "./period-digest";
+
+const tempRoots: string[] = [];
+
+function setupTempHome() {
+	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-digest-"));
+	tempRoots.push(tempRoot);
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+}
+
+function sseFrame(value: unknown) {
+	return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+function streamResponse(text: string) {
+	return new Response(
+		new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(text));
+				controller.close();
+			},
+		}),
+	);
+}
+
+beforeEach(() => {
+	setupTempHome();
+	process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	resetDatabaseForTests();
+	resetBirdclawPathsForTests();
+	delete process.env.BIRDCLAW_HOME;
+	delete process.env.OPENAI_API_KEY;
+	delete process.env.BIRDCLAW_AI_MODEL;
+	delete process.env.BIRDCLAW_OPENAI_REASONING_EFFORT;
+	delete process.env.BIRDCLAW_OPENAI_SERVICE_TIER;
+	vi.unstubAllGlobals();
+	for (const tempRoot of tempRoots.splice(0)) {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("period digest", () => {
+	it("resolves named local windows", () => {
+		const now = new Date("2026-05-16T10:30:00.000Z");
+		const today = resolvePeriodDigestWindow({ period: "today", now });
+		const yesterday = resolvePeriodDigestWindow({ period: "yesterday", now });
+
+		expect(today.label).toBe("Today");
+		expect(today.until).toBe("2026-05-16T10:30:00.000Z");
+		expect(new Date(today.since).getTime()).toBeLessThan(
+			new Date(today.until).getTime(),
+		);
+		expect(yesterday.label).toBe("Yesterday");
+		expect(new Date(yesterday.until).getTime()).toBe(
+			new Date(today.since).getTime(),
+		);
+	});
+
+	it("collects a deterministic local context hash", () => {
+		const first = collectPeriodDigestContext({
+			since: "2026-01-01T00:00:00.000Z",
+			until: "2027-01-01T00:00:00.000Z",
+			maxTweets: 20,
+		});
+		const second = collectPeriodDigestContext({
+			since: "2026-01-01T00:00:00.000Z",
+			until: "2027-01-01T00:00:00.000Z",
+			maxTweets: 20,
+		});
+
+		expect(first.hash).toBe(second.hash);
+		expect(first.tweets.length).toBeGreaterThan(0);
+		expect(first.counts.home).toBeGreaterThan(0);
+	});
+
+	it("keeps same-day default windows on a stable cache key", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2028-05-16T10:30:00.000Z"));
+		const first = collectPeriodDigestContext({ period: "today" });
+		vi.setSystemTime(new Date("2028-05-16T12:30:00.000Z"));
+		const second = collectPeriodDigestContext({ period: "today" });
+
+		expect(first.window.until).not.toBe(second.window.until);
+		expect(first.hash).toBe(second.hash);
+	});
+
+	it("streams markdown, parses final JSON, and sends GPT-5.5 medium priority", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta: "# Today\n\nA useful thing happened.\n",
+			}),
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'\n---\n{"title":"Today","summary":"Useful things happened","keyTopics":[{"title":"Launch","summary":"People discussed the launch","tweetIds":["tweet_1"],"handles":["alice"]}],"notableLinks":[],"people":[],"actionItems":[{"kind":"read","label":"Read the linked launch notes","tweetId":"tweet_1"}],"sourceTweetIds":["tweet_1"]}',
+			}),
+			sseFrame({
+				type: "response.completed",
+				response: { id: "resp_1", usage: { input_tokens: 10 } },
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+
+		let markdown = "";
+		const result = await streamPeriodDigest(
+			{
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+				refresh: true,
+			},
+			{ onDelta: (delta) => (markdown += delta) },
+		);
+
+		expect(markdown).toBe("# Today\n\nA useful thing happened.\n");
+		expect(result.digest.title).toBe("Today");
+		expect(result.digest.actionItems).toHaveLength(1);
+		expect(result.markdown).toBe(markdown.trimEnd());
+		expect(result.cached).toBe(false);
+
+		const body = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		) as Record<string, unknown>;
+		expect(body.model).toBe("gpt-5.5");
+		expect(body.reasoning).toEqual({ effort: "medium" });
+		expect(body.service_tier).toBe("priority");
+		expect(body.stream).toBe(true);
+	});
+
+	it("exposes the streaming digest as an Effect program", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Effect\n\nThe stream is effectful.\n\n---\n{"title":"Effect","summary":"Effect stream","keyTopics":[],"notableLinks":[],"people":[],"actionItems":[],"sourceTweetIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse(streamed)));
+
+		const result = await Effect.runPromise(
+			streamPeriodDigestEffect({
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+				refresh: true,
+			}),
+		);
+
+		expect(result.digest.title).toBe("Effect");
+		expect(result.markdown).toBe("# Effect\n\nThe stream is effectful.");
+	});
+
+	it("serves cached digests without calling OpenAI again", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Cached\n\nFirst pass.\n\n---\n{"title":"Cached","summary":"First pass","keyTopics":[],"notableLinks":[],"people":[],"actionItems":[],"sourceTweetIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+		const options = {
+			since: "2026-01-01T00:00:00.000Z",
+			until: "2027-01-01T00:00:00.000Z",
+		};
+
+		await streamPeriodDigest({ ...options, refresh: true });
+		const cached = await streamPeriodDigest(options);
+
+		expect(cached.cached).toBe(true);
+		expect(cached.digest.title).toBe("Cached");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects invalid cached digests through the Promise boundary", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Cached\n\nFirst pass.\n\n---\n{"title":"Cached","summary":"First pass","keyTopics":[],"notableLinks":[],"people":[],"actionItems":[],"sourceTweetIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+		const options = {
+			since: "2026-01-01T00:00:00.000Z",
+			until: "2027-01-01T00:00:00.000Z",
+		};
+
+		await streamPeriodDigest({ ...options, refresh: true });
+		getNativeDb()
+			.prepare(
+				`
+				update sync_cache
+				set value_json = ?
+				where cache_key like 'period-digest:%'
+				`,
+			)
+			.run(
+				JSON.stringify({
+					digest: { title: "Invalid" },
+					markdown: "# Invalid",
+					model: "gpt-5.5",
+					reasoningEffort: "medium",
+					serviceTier: "priority",
+				}),
+			);
+
+		let promise: Promise<unknown> | undefined;
+		expect(() => {
+			promise = streamPeriodDigest(options);
+		}).not.toThrow();
+		await expect(promise).rejects.toBeInstanceOf(Error);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects failed Responses streams instead of caching partial output", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta: "# Partial\n\nThis should not be cached.\n",
+			}),
+			sseFrame({
+				type: "response.failed",
+				response: { error: { message: "model overloaded" } },
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			streamPeriodDigest({
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+				refresh: true,
+			}),
+		).rejects.toThrow("model overloaded");
+	});
+
+	it("passes abort signals to the OpenAI stream request", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn(
+			(_input: RequestInfo | URL, init?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () =>
+						reject(new DOMException("aborted", "AbortError")),
+					);
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const promise = streamPeriodDigest({
+			since: "2026-01-01T00:00:00.000Z",
+			until: "2027-01-01T00:00:00.000Z",
+			refresh: true,
+			signal: controller.signal,
+		});
+		controller.abort();
+
+		await expect(promise).rejects.toThrow("aborted");
+		expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+	});
+
+	it("falls back when the streamed JSON is malformed", () => {
+		const parsed = __test__.parseDigestFromHybridText(
+			collectPeriodDigestContext({
+				since: "2026-01-01T00:00:00.000Z",
+				until: "2027-01-01T00:00:00.000Z",
+			}),
+			"# Report\n\nOnly Markdown\n\n---\n{bad",
+		);
+
+		expect(parsed.markdown).toContain("Only Markdown");
+		expect(parsed.digest.title).toContain("digest");
+	});
+});

--- a/src/lib/period-digest.ts
+++ b/src/lib/period-digest.ts
@@ -1,0 +1,911 @@
+import { createHash } from "node:crypto";
+import { Effect } from "effect";
+import { z } from "zod";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { getLinkInsights } from "./link-insights";
+import { listDmConversations, listTimelineItems } from "./queries";
+import { readSyncCache, writeSyncCache } from "./sync-cache";
+
+export type PeriodDigestPreset = "today" | "yesterday" | "24h" | "week";
+export type PeriodDigestSourceKind =
+	| "home"
+	| "mentions"
+	| "authored"
+	| "likes"
+	| "bookmarks"
+	| "dms";
+
+export interface PeriodDigestOptions {
+	period?: string;
+	since?: string;
+	until?: string;
+	account?: string;
+	includeDms?: boolean;
+	refresh?: boolean;
+	model?: string;
+	reasoningEffort?: "minimal" | "low" | "medium" | "high";
+	serviceTier?: "default" | "flex" | "priority";
+	signal?: AbortSignal;
+	maxTweets?: number;
+	maxLinks?: number;
+}
+
+export interface PeriodDigestWindow {
+	label: string;
+	since: string;
+	until: string;
+}
+
+export interface PeriodDigestRunResult {
+	context: PeriodDigestContext;
+	digest: PeriodDigest;
+	markdown: string;
+	model: string;
+	reasoningEffort: string;
+	serviceTier: string;
+	cached: boolean;
+	updatedAt: string;
+}
+
+export interface PeriodDigestStreamHandlers {
+	onDelta?: (delta: string) => void;
+	onEvent?: (event: PeriodDigestStreamEvent) => void;
+}
+
+export type PeriodDigestStreamEvent =
+	| { type: "start"; context: PeriodDigestContext; cached: boolean }
+	| { type: "delta"; delta: string }
+	| { type: "done"; result: PeriodDigestRunResult }
+	| { type: "error"; error: string };
+
+const PeriodDigestSchema = z.object({
+	title: z.string().min(1),
+	summary: z.string().min(1),
+	keyTopics: z.array(
+		z.object({
+			title: z.string().min(1),
+			summary: z.string().min(1),
+			tweetIds: z.array(z.string()).default([]),
+			handles: z.array(z.string()).default([]),
+		}),
+	),
+	notableLinks: z.array(
+		z.object({
+			title: z.string().min(1),
+			url: z.string().min(1),
+			why: z.string().min(1),
+			sourceTweetIds: z.array(z.string()).default([]),
+		}),
+	),
+	people: z.array(
+		z.object({
+			handle: z.string().min(1),
+			name: z.string().optional(),
+			why: z.string().min(1),
+		}),
+	),
+	actionItems: z.array(
+		z.object({
+			kind: z.enum(["reply", "follow_up", "read", "sync"]),
+			label: z.string().min(1),
+			tweetId: z.string().optional(),
+			dmConversationId: z.string().optional(),
+		}),
+	),
+	sourceTweetIds: z.array(z.string()).default([]),
+});
+
+export type PeriodDigest = z.infer<typeof PeriodDigestSchema>;
+
+interface CompactTweet {
+	id: string;
+	url: string;
+	source: PeriodDigestSourceKind;
+	author: string;
+	name: string;
+	createdAt: string;
+	text: string;
+	likeCount: number;
+	liked: boolean;
+	bookmarked: boolean;
+	needsReply: boolean;
+}
+
+interface CompactDm {
+	id: string;
+	participant: string;
+	name: string;
+	lastMessageAt: string;
+	text: string;
+	needsReply: boolean;
+	influenceScore: number;
+}
+
+interface CompactLink {
+	title: string;
+	url: string;
+	displayUrl: string;
+	description?: string | null;
+	shareCount: number;
+	commentCount: number;
+	lastSeenAt: string;
+	mentions: Array<{
+		id: string;
+		sourceKind: string;
+		sourceId: string;
+		createdAt: string;
+		author?: string;
+		text: string;
+		tweetId?: string | null;
+	}>;
+}
+
+export interface PeriodDigestContext {
+	window: PeriodDigestWindow;
+	account?: string;
+	includeDms: boolean;
+	counts: Record<PeriodDigestSourceKind | "links", number>;
+	tweets: CompactTweet[];
+	dms: CompactDm[];
+	links: CompactLink[];
+	hash: string;
+}
+
+interface OpenAIStreamState {
+	eventBuffer: string;
+	rawText: string;
+	pendingVisible: string;
+	jsonMode: boolean;
+	responseId?: string;
+	usage?: unknown;
+	error?: string;
+}
+
+const DEFAULT_MODEL = "gpt-5.5";
+const DEFAULT_REASONING_EFFORT = "medium";
+const DEFAULT_SERVICE_TIER = "priority";
+const DEFAULT_MAX_TWEETS = 120;
+const DEFAULT_MAX_LINKS = 12;
+const DELIMITER_PATTERN = /\n---\s*\n/;
+const VISIBLE_DELIMITER_HOLD = 8;
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function tryDigestSync<T>(try_: () => T): Effect.Effect<T, Error> {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+function tryDigestPromise<T>(
+	try_: () => PromiseLike<T>,
+): Effect.Effect<T, Error> {
+	return tryPromise(try_).pipe(Effect.mapError(toError));
+}
+
+function localDateStart(date: Date) {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number) {
+	const next = new Date(date);
+	next.setDate(next.getDate() + days);
+	return next;
+}
+
+function parseDate(value: string | undefined) {
+	if (!value?.trim()) return null;
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizePeriod(value: string | undefined): PeriodDigestPreset {
+	const normalized = value?.trim().toLowerCase();
+	if (normalized === "yesterday") return "yesterday";
+	if (normalized === "24h" || normalized === "day") return "24h";
+	if (normalized === "week" || normalized === "7d") return "week";
+	return "today";
+}
+
+export function resolvePeriodDigestWindow(
+	options: Pick<PeriodDigestOptions, "period" | "since" | "until"> & {
+		now?: Date;
+	} = {},
+): PeriodDigestWindow {
+	const now = options.now ?? new Date();
+	const explicitSince = parseDate(options.since);
+	const explicitUntil = parseDate(options.until);
+	if (explicitSince || explicitUntil) {
+		const since = explicitSince ?? addDays(explicitUntil ?? now, -1);
+		const until = explicitUntil ?? now;
+		return {
+			label: `${since.toLocaleString()} - ${until.toLocaleString()}`,
+			since: since.toISOString(),
+			until: until.toISOString(),
+		};
+	}
+
+	const period = normalizePeriod(options.period);
+	if (period === "24h") {
+		const since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+		return {
+			label: "Last 24 hours",
+			since: since.toISOString(),
+			until: now.toISOString(),
+		};
+	}
+	if (period === "week") {
+		const since = addDays(now, -7);
+		return {
+			label: "Last 7 days",
+			since: since.toISOString(),
+			until: now.toISOString(),
+		};
+	}
+	if (period === "yesterday") {
+		const today = localDateStart(now);
+		const yesterday = addDays(today, -1);
+		return {
+			label: "Yesterday",
+			since: yesterday.toISOString(),
+			until: today.toISOString(),
+		};
+	}
+
+	const start = localDateStart(now);
+	return {
+		label: "Today",
+		since: start.toISOString(),
+		until: now.toISOString(),
+	};
+}
+
+function tweetUrl(handle: string, id: string) {
+	return `https://x.com/${handle}/status/${id}`;
+}
+
+function compactTweet(
+	source: PeriodDigestSourceKind,
+	item: ReturnType<typeof listTimelineItems>[number],
+): CompactTweet {
+	return {
+		id: item.id,
+		url: tweetUrl(item.author.handle, item.id),
+		source,
+		author: item.author.handle,
+		name: item.author.displayName,
+		createdAt: item.createdAt,
+		text: item.text,
+		likeCount: item.likeCount,
+		liked: item.liked,
+		bookmarked: item.bookmarked,
+		needsReply: !item.isReplied,
+	};
+}
+
+function dedupeTweets(tweets: CompactTweet[]) {
+	const seen = new Set<string>();
+	const items: CompactTweet[] = [];
+	for (const tweet of tweets) {
+		if (seen.has(tweet.id)) continue;
+		seen.add(tweet.id);
+		items.push(tweet);
+	}
+	return items.sort((left, right) =>
+		right.createdAt.localeCompare(left.createdAt),
+	);
+}
+
+function collectTweetsForSource(
+	source: Exclude<PeriodDigestSourceKind, "dms">,
+	options: {
+		account?: string;
+		window: PeriodDigestWindow;
+		limit: number;
+	},
+) {
+	if (source === "likes" || source === "bookmarks") {
+		return listTimelineItems({
+			resource: "home",
+			account: options.account,
+			since: options.window.since,
+			until: options.window.until,
+			likedOnly: source === "likes",
+			bookmarkedOnly: source === "bookmarks",
+			limit: Math.ceil(options.limit / 3),
+		}).map((item) => compactTweet(source, item));
+	}
+	return listTimelineItems({
+		resource: source,
+		account: options.account,
+		since: options.window.since,
+		until: options.window.until,
+		limit: source === "home" ? options.limit : Math.ceil(options.limit / 2),
+	}).map((item) => compactTweet(source, item));
+}
+
+function collectDms(options: {
+	account?: string;
+	includeDms: boolean;
+	window: PeriodDigestWindow;
+	limit: number;
+}) {
+	if (!options.includeDms) return [];
+	return listDmConversations({
+		account: options.account,
+		since: options.window.since,
+		until: options.window.until,
+		sort: "recent",
+		limit: options.limit,
+	}).map(
+		(item): CompactDm => ({
+			id: item.id,
+			participant: item.participant.handle,
+			name: item.participant.displayName,
+			lastMessageAt: item.lastMessageAt,
+			text: item.lastMessagePreview,
+			needsReply: item.needsReply,
+			influenceScore: item.influenceScore,
+		}),
+	);
+}
+
+function compactLinks(options: { window: PeriodDigestWindow; limit: number }) {
+	return getLinkInsights({
+		range: "today",
+		sort: "rank",
+		source: "tweet",
+		since: options.window.since,
+		until: options.window.until,
+		limit: options.limit,
+		commentsLimit: 5,
+	}).items.map(
+		(item): CompactLink => ({
+			title: item.title ?? item.displayUrl,
+			url: item.url,
+			displayUrl: item.displayUrl,
+			description: item.description,
+			shareCount: item.shareCount,
+			commentCount: item.commentCount,
+			lastSeenAt: item.lastSeenAt,
+			mentions: item.mentions.slice(0, 5).map((mention) => ({
+				id: mention.id,
+				sourceKind: mention.sourceKind,
+				sourceId: mention.sourceId,
+				createdAt: mention.createdAt,
+				author: mention.sharedBy?.handle,
+				text:
+					mention.commentText || mention.sharedContentText || mention.rawText,
+				tweetId: mention.timelineTweetId ?? mention.contentTweetId,
+			})),
+		}),
+	);
+}
+
+function contextHash(context: Omit<PeriodDigestContext, "hash">) {
+	return createHash("sha1")
+		.update(
+			JSON.stringify({
+				window: {
+					label: context.window.label,
+					bucket: context.window.until.slice(0, 10),
+				},
+				account: context.account,
+				includeDms: context.includeDms,
+				tweets: context.tweets.map((tweet) => [
+					tweet.id,
+					tweet.source,
+					tweet.createdAt,
+					tweet.text,
+					tweet.liked,
+					tweet.bookmarked,
+					tweet.needsReply,
+				]),
+				dms: context.dms.map((dm) => [
+					dm.id,
+					dm.lastMessageAt,
+					dm.text,
+					dm.needsReply,
+				]),
+				links: context.links.map((link) => [
+					link.url,
+					link.shareCount,
+					link.commentCount,
+					link.lastSeenAt,
+				]),
+			}),
+		)
+		.digest("hex");
+}
+
+export function collectPeriodDigestContext(
+	options: PeriodDigestOptions = {},
+): PeriodDigestContext {
+	const window = resolvePeriodDigestWindow(options);
+	const maxTweets = Math.max(
+		20,
+		Math.trunc(options.maxTweets ?? DEFAULT_MAX_TWEETS),
+	);
+	const maxLinks = Math.max(
+		3,
+		Math.trunc(options.maxLinks ?? DEFAULT_MAX_LINKS),
+	);
+	const home = collectTweetsForSource("home", {
+		account: options.account,
+		window,
+		limit: maxTweets,
+	});
+	const mentions = collectTweetsForSource("mentions", {
+		account: options.account,
+		window,
+		limit: maxTweets,
+	});
+	const authored = collectTweetsForSource("authored", {
+		account: options.account,
+		window,
+		limit: maxTweets,
+	});
+	const likes = collectTweetsForSource("likes", {
+		account: options.account,
+		window,
+		limit: maxTweets,
+	});
+	const bookmarks = collectTweetsForSource("bookmarks", {
+		account: options.account,
+		window,
+		limit: maxTweets,
+	});
+	const dms = collectDms({
+		account: options.account,
+		includeDms: Boolean(options.includeDms),
+		window,
+		limit: Math.ceil(maxTweets / 3),
+	});
+	const links = compactLinks({ window, limit: maxLinks });
+	const tweets = dedupeTweets([
+		...home,
+		...mentions,
+		...authored,
+		...likes,
+		...bookmarks,
+	]).slice(0, maxTweets);
+	const withoutHash = {
+		window,
+		...(options.account ? { account: options.account } : {}),
+		includeDms: Boolean(options.includeDms),
+		counts: {
+			home: home.length,
+			mentions: mentions.length,
+			authored: authored.length,
+			likes: likes.length,
+			bookmarks: bookmarks.length,
+			dms: dms.length,
+			links: links.length,
+		},
+		tweets,
+		dms,
+		links,
+	} satisfies Omit<PeriodDigestContext, "hash">;
+	return {
+		...withoutHash,
+		hash: contextHash(withoutHash),
+	};
+}
+
+function modelFromOptions(options: PeriodDigestOptions) {
+	return options.model ?? process.env.BIRDCLAW_AI_MODEL ?? DEFAULT_MODEL;
+}
+
+function reasoningEffortFromOptions(options: PeriodDigestOptions) {
+	return (
+		options.reasoningEffort ??
+		(process.env.BIRDCLAW_OPENAI_REASONING_EFFORT as
+			| PeriodDigestOptions["reasoningEffort"]
+			| undefined) ??
+		DEFAULT_REASONING_EFFORT
+	);
+}
+
+function serviceTierFromOptions(options: PeriodDigestOptions) {
+	return (
+		options.serviceTier ??
+		(process.env.BIRDCLAW_OPENAI_SERVICE_TIER as
+			| PeriodDigestOptions["serviceTier"]
+			| undefined) ??
+		DEFAULT_SERVICE_TIER
+	);
+}
+
+function digestCacheKey(
+	context: PeriodDigestContext,
+	options: PeriodDigestOptions,
+) {
+	return [
+		"period-digest:v1",
+		modelFromOptions(options),
+		reasoningEffortFromOptions(options),
+		serviceTierFromOptions(options),
+		context.hash,
+	].join(":");
+}
+
+function buildPrompt(context: PeriodDigestContext) {
+	return `Window: ${context.window.label}
+Since: ${context.window.since}
+Until: ${context.window.until}
+Sources: ${JSON.stringify(context.counts)}
+
+Write a concise, high-signal "what happened" report from this local Twitter/X dataset.
+
+Requirements:
+- Stream readable Markdown first.
+- Be specific about what happened, not generic about "engagement".
+- Cite tweets inline with their id in parentheses, e.g. (tweet_123), and use authors/links when useful.
+- Separate signal from noise.
+- Include action items only when there is something Peter should reply to, read, or follow up.
+- DMs are private context and only present when explicitly included.
+- After the Markdown, output a blank line, then a line containing only three hyphens, then one compact JSON object.
+- JSON shape: { "title": string, "summary": string, "keyTopics": [{ "title": string, "summary": string, "tweetIds": string[], "handles": string[] }], "notableLinks": [{ "title": string, "url": string, "why": string, "sourceTweetIds": string[] }], "people": [{ "handle": string, "name"?: string, "why": string }], "actionItems": [{ "kind": "reply"|"follow_up"|"read"|"sync", "label": string, "tweetId"?: string, "dmConversationId"?: string }], "sourceTweetIds": string[] }
+
+Dataset:
+${JSON.stringify(
+	{
+		tweets: context.tweets,
+		dms: context.dms,
+		links: context.links,
+	},
+	null,
+	2,
+)}`;
+}
+
+function fallbackDigest(
+	context: PeriodDigestContext,
+	markdown: string,
+): PeriodDigest {
+	const title = `${context.window.label} digest`;
+	return {
+		title,
+		summary:
+			markdown.replaceAll(/\s+/g, " ").trim().slice(0, 280) ||
+			"No model summary was returned.",
+		keyTopics: [],
+		notableLinks: [],
+		people: [],
+		actionItems: [],
+		sourceTweetIds: context.tweets.slice(0, 20).map((tweet) => tweet.id),
+	};
+}
+
+function parseDigestFromHybridText(
+	context: PeriodDigestContext,
+	rawText: string,
+): { digest: PeriodDigest; markdown: string } {
+	const [markdownPart, jsonPart] = rawText.split(DELIMITER_PATTERN);
+	const markdown = (markdownPart ?? rawText).trim();
+	const candidate = jsonPart?.slice(
+		jsonPart.indexOf("{"),
+		jsonPart.lastIndexOf("}") + 1,
+	);
+	if (candidate?.startsWith("{")) {
+		try {
+			return {
+				markdown,
+				digest: PeriodDigestSchema.parse(JSON.parse(candidate)),
+			};
+		} catch {
+			return { markdown, digest: fallbackDigest(context, markdown) };
+		}
+	}
+	return { markdown, digest: fallbackDigest(context, markdown) };
+}
+
+function emitVisibleDelta(
+	state: OpenAIStreamState,
+	delta: string,
+	handlers: PeriodDigestStreamHandlers,
+) {
+	state.rawText += delta;
+	if (state.jsonMode) return;
+
+	const combined = state.pendingVisible + delta;
+	const delimiterIndex = combined.search(DELIMITER_PATTERN);
+	if (delimiterIndex >= 0) {
+		const visible = combined.slice(0, delimiterIndex);
+		if (visible) {
+			handlers.onDelta?.(visible);
+			handlers.onEvent?.({ type: "delta", delta: visible });
+		}
+		state.pendingVisible = "";
+		state.jsonMode = true;
+		return;
+	}
+
+	if (combined.length <= VISIBLE_DELIMITER_HOLD) {
+		state.pendingVisible = combined;
+		return;
+	}
+
+	const visible = combined.slice(0, -VISIBLE_DELIMITER_HOLD);
+	state.pendingVisible = combined.slice(-VISIBLE_DELIMITER_HOLD);
+	if (visible) {
+		handlers.onDelta?.(visible);
+		handlers.onEvent?.({ type: "delta", delta: visible });
+	}
+}
+
+function flushPendingVisible(
+	state: OpenAIStreamState,
+	handlers: PeriodDigestStreamHandlers,
+) {
+	if (state.jsonMode || !state.pendingVisible) return;
+	const delta = state.pendingVisible;
+	state.pendingVisible = "";
+	handlers.onDelta?.(delta);
+	handlers.onEvent?.({ type: "delta", delta });
+}
+
+function handleOpenAIEvent(
+	state: OpenAIStreamState,
+	event: Record<string, unknown>,
+	handlers: PeriodDigestStreamHandlers,
+) {
+	const type = typeof event.type === "string" ? event.type : "";
+	if (
+		type === "response.output_text.delta" &&
+		typeof event.delta === "string"
+	) {
+		emitVisibleDelta(state, event.delta, handlers);
+		return;
+	}
+	if (type === "response.completed") {
+		const response = event.response;
+		if (response && typeof response === "object") {
+			const record = response as Record<string, unknown>;
+			state.responseId = typeof record.id === "string" ? record.id : undefined;
+			state.usage = record.usage;
+		}
+		return;
+	}
+	if (type === "response.error" || type === "error") {
+		const error = event.error;
+		state.error =
+			error && typeof error === "object" && "message" in error
+				? String((error as { message?: unknown }).message)
+				: "OpenAI stream failed";
+		return;
+	}
+	if (type === "response.failed" || type === "response.incomplete") {
+		const response = event.response;
+		const record =
+			response && typeof response === "object"
+				? (response as Record<string, unknown>)
+				: {};
+		const error = record.error;
+		const incomplete = record.incomplete_details;
+		state.error =
+			error && typeof error === "object" && "message" in error
+				? String((error as { message?: unknown }).message)
+				: incomplete && typeof incomplete === "object" && "reason" in incomplete
+					? `OpenAI response incomplete: ${String((incomplete as { reason?: unknown }).reason)}`
+					: "OpenAI stream failed";
+	}
+}
+
+function processSseChunk(
+	state: OpenAIStreamState,
+	chunk: string,
+	handlers: PeriodDigestStreamHandlers,
+) {
+	state.eventBuffer += chunk;
+	let boundary = state.eventBuffer.indexOf("\n\n");
+	while (boundary >= 0) {
+		const block = state.eventBuffer.slice(0, boundary);
+		state.eventBuffer = state.eventBuffer.slice(boundary + 2);
+		const data = block
+			.split("\n")
+			.filter((line) => line.startsWith("data:"))
+			.map((line) => line.slice(5).trimStart())
+			.join("\n");
+		if (data && data !== "[DONE]") {
+			try {
+				handleOpenAIEvent(
+					state,
+					JSON.parse(data) as Record<string, unknown>,
+					handlers,
+				);
+			} catch {
+				// Ignore malformed event frames; the final JSON parse will decide result quality.
+			}
+		}
+		boundary = state.eventBuffer.indexOf("\n\n");
+	}
+}
+
+function createOpenAIRequestBody(
+	context: PeriodDigestContext,
+	options: PeriodDigestOptions,
+) {
+	return {
+		model: modelFromOptions(options),
+		reasoning: { effort: reasoningEffortFromOptions(options) },
+		service_tier: serviceTierFromOptions(options),
+		store: false,
+		stream: true,
+		max_output_tokens: 7000,
+		input: [
+			{
+				role: "system",
+				content:
+					"You are a precise local Twitter archive analyst. Stream Markdown first, then emit the requested JSON object after the delimiter. Do not invent events not present in the dataset.",
+			},
+			{
+				role: "user",
+				content: buildPrompt(context),
+			},
+		],
+	};
+}
+
+function readOpenAIStreamEffect(
+	response: Response,
+	context: PeriodDigestContext,
+	options: PeriodDigestOptions,
+	handlers: PeriodDigestStreamHandlers,
+): Effect.Effect<PeriodDigestRunResult, Error> {
+	const reader = response.body?.getReader();
+	if (!reader) {
+		return Effect.fail(new Error("OpenAI response did not include a stream"));
+	}
+
+	const decoder = new TextDecoder();
+	const state: OpenAIStreamState = {
+		eventBuffer: "",
+		rawText: "",
+		pendingVisible: "",
+		jsonMode: false,
+	};
+
+	return Effect.gen(function* () {
+		for (;;) {
+			const { done, value } = yield* tryDigestPromise(() => reader.read());
+			if (!done) {
+				processSseChunk(
+					state,
+					decoder.decode(value, { stream: true }),
+					handlers,
+				);
+				continue;
+			}
+
+			flushPendingVisible(state, handlers);
+			if (state.error) {
+				return yield* Effect.fail(new Error(state.error));
+			}
+
+			const parsed = yield* tryDigestSync(() =>
+				parseDigestFromHybridText(context, state.rawText),
+			);
+			const cacheKey = digestCacheKey(context, options);
+			const updatedAt = yield* tryDigestSync(() =>
+				writeSyncCache(cacheKey, {
+					digest: parsed.digest,
+					markdown: parsed.markdown,
+					model: modelFromOptions(options),
+					reasoningEffort: reasoningEffortFromOptions(options),
+					serviceTier: serviceTierFromOptions(options),
+					usage: state.usage,
+					responseId: state.responseId,
+				}),
+			);
+			const result: PeriodDigestRunResult = {
+				context,
+				digest: parsed.digest,
+				markdown: parsed.markdown,
+				model: modelFromOptions(options),
+				reasoningEffort: reasoningEffortFromOptions(options),
+				serviceTier: serviceTierFromOptions(options),
+				cached: false,
+				updatedAt,
+			};
+			handlers.onEvent?.({ type: "done", result });
+			return result;
+		}
+	}).pipe(
+		Effect.ensuring(
+			Effect.sync(() => {
+				reader.releaseLock();
+			}),
+		),
+	);
+}
+
+export function streamPeriodDigestEffect(
+	options: PeriodDigestOptions = {},
+	handlers: PeriodDigestStreamHandlers = {},
+): Effect.Effect<PeriodDigestRunResult, Error> {
+	return Effect.gen(function* () {
+		const context = yield* tryDigestSync(() =>
+			collectPeriodDigestContext(options),
+		);
+		const cacheKey = digestCacheKey(context, options);
+		const cached = options.refresh
+			? null
+			: yield* tryDigestSync(() =>
+					readSyncCache<{
+						digest: PeriodDigest;
+						markdown: string;
+						model: string;
+						reasoningEffort: string;
+						serviceTier: string;
+					}>(cacheKey),
+				);
+
+		if (cached) {
+			const result: PeriodDigestRunResult = yield* tryDigestSync(() => ({
+				context,
+				digest: PeriodDigestSchema.parse(cached.value.digest),
+				markdown: cached.value.markdown,
+				model: cached.value.model,
+				reasoningEffort: cached.value.reasoningEffort,
+				serviceTier: cached.value.serviceTier,
+				cached: true,
+				updatedAt: cached.updatedAt,
+			}));
+			handlers.onEvent?.({ type: "start", context, cached: true });
+			handlers.onDelta?.(result.markdown);
+			handlers.onEvent?.({ type: "delta", delta: result.markdown });
+			handlers.onEvent?.({ type: "done", result });
+			return result;
+		}
+
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (!apiKey) {
+			return yield* Effect.fail(new Error("OPENAI_API_KEY is not set"));
+		}
+
+		handlers.onEvent?.({ type: "start", context, cached: false });
+		const response = yield* tryDigestPromise(() =>
+			fetch("https://api.openai.com/v1/responses", {
+				method: "POST",
+				signal: options.signal,
+				headers: {
+					authorization: `Bearer ${apiKey}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify(createOpenAIRequestBody(context, options)),
+			}),
+		);
+		if (!response.ok) {
+			const text = yield* tryDigestPromise(() => response.text());
+			return yield* Effect.fail(
+				new Error(
+					`OpenAI request failed: ${String(response.status)} ${text.slice(
+						0,
+						400,
+					)}`,
+				),
+			);
+		}
+		return yield* readOpenAIStreamEffect(response, context, options, handlers);
+	});
+}
+
+export function streamPeriodDigest(
+	options: PeriodDigestOptions = {},
+	handlers: PeriodDigestStreamHandlers = {},
+): Promise<PeriodDigestRunResult> {
+	return runEffectPromise(streamPeriodDigestEffect(options, handlers));
+}
+
+export const __test__ = {
+	PeriodDigestSchema,
+	buildPrompt,
+	readOpenAIStreamEffect,
+	parseDigestFromHybridText,
+	processSseChunk,
+	resolvePeriodDigestWindow,
+};

--- a/src/lib/period-digest.ts
+++ b/src/lib/period-digest.ts
@@ -353,8 +353,13 @@ function collectDms(options: {
 	);
 }
 
-function compactLinks(options: { window: PeriodDigestWindow; limit: number }) {
+function compactLinks(options: {
+	account?: string;
+	window: PeriodDigestWindow;
+	limit: number;
+}) {
 	return getLinkInsights({
+		account: options.account,
 		range: "today",
 		sort: "rank",
 		source: "tweet",
@@ -464,7 +469,11 @@ export function collectPeriodDigestContext(
 		window,
 		limit: Math.ceil(maxTweets / 3),
 	});
-	const links = compactLinks({ window, limit: maxLinks });
+	const links = compactLinks({
+		account: options.account,
+		window,
+		limit: maxLinks,
+	});
 	const tweets = dedupeTweets([
 		...home,
 		...mentions,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -289,6 +289,7 @@ export interface LinkInsightItem {
 }
 
 export interface LinkInsightQuery {
+	account?: string;
 	kind?: LinkInsightKind;
 	range?: LinkInsightRange;
 	sort?: LinkInsightSort;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TodayRouteImport } from './routes/today'
 import { Route as MentionsRouteImport } from './routes/mentions'
 import { Route as LinksRouteImport } from './routes/links'
 import { Route as LikesRouteImport } from './routes/likes'
@@ -21,6 +22,7 @@ import { Route as ApiSyncRouteImport } from './routes/api/sync'
 import { Route as ApiStatusRouteImport } from './routes/api/status'
 import { Route as ApiQueryRouteImport } from './routes/api/query'
 import { Route as ApiProfileHydrateRouteImport } from './routes/api/profile-hydrate'
+import { Route as ApiPeriodDigestRouteImport } from './routes/api/period-digest'
 import { Route as ApiLinkPreviewRouteImport } from './routes/api/link-preview'
 import { Route as ApiLinkInsightsRouteImport } from './routes/api/link-insights'
 import { Route as ApiInboxRouteImport } from './routes/api/inbox'
@@ -29,6 +31,11 @@ import { Route as ApiBlocksRouteImport } from './routes/api/blocks'
 import { Route as ApiAvatarRouteImport } from './routes/api/avatar'
 import { Route as ApiActionRouteImport } from './routes/api/action'
 
+const TodayRoute = TodayRouteImport.update({
+  id: '/today',
+  path: '/today',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MentionsRoute = MentionsRouteImport.update({
   id: '/mentions',
   path: '/mentions',
@@ -89,6 +96,11 @@ const ApiProfileHydrateRoute = ApiProfileHydrateRouteImport.update({
   path: '/api/profile-hydrate',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiPeriodDigestRoute = ApiPeriodDigestRouteImport.update({
+  id: '/api/period-digest',
+  path: '/api/period-digest',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiLinkPreviewRoute = ApiLinkPreviewRouteImport.update({
   id: '/api/link-preview',
   path: '/api/link-preview',
@@ -134,6 +146,7 @@ export interface FileRoutesByFullPath {
   '/likes': typeof LikesRoute
   '/links': typeof LinksRoute
   '/mentions': typeof MentionsRoute
+  '/today': typeof TodayRoute
   '/api/action': typeof ApiActionRoute
   '/api/avatar': typeof ApiAvatarRoute
   '/api/blocks': typeof ApiBlocksRoute
@@ -141,6 +154,7 @@ export interface FileRoutesByFullPath {
   '/api/inbox': typeof ApiInboxRoute
   '/api/link-insights': typeof ApiLinkInsightsRoute
   '/api/link-preview': typeof ApiLinkPreviewRoute
+  '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
@@ -155,6 +169,7 @@ export interface FileRoutesByTo {
   '/likes': typeof LikesRoute
   '/links': typeof LinksRoute
   '/mentions': typeof MentionsRoute
+  '/today': typeof TodayRoute
   '/api/action': typeof ApiActionRoute
   '/api/avatar': typeof ApiAvatarRoute
   '/api/blocks': typeof ApiBlocksRoute
@@ -162,6 +177,7 @@ export interface FileRoutesByTo {
   '/api/inbox': typeof ApiInboxRoute
   '/api/link-insights': typeof ApiLinkInsightsRoute
   '/api/link-preview': typeof ApiLinkPreviewRoute
+  '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
@@ -177,6 +193,7 @@ export interface FileRoutesById {
   '/likes': typeof LikesRoute
   '/links': typeof LinksRoute
   '/mentions': typeof MentionsRoute
+  '/today': typeof TodayRoute
   '/api/action': typeof ApiActionRoute
   '/api/avatar': typeof ApiAvatarRoute
   '/api/blocks': typeof ApiBlocksRoute
@@ -184,6 +201,7 @@ export interface FileRoutesById {
   '/api/inbox': typeof ApiInboxRoute
   '/api/link-insights': typeof ApiLinkInsightsRoute
   '/api/link-preview': typeof ApiLinkPreviewRoute
+  '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
   '/api/status': typeof ApiStatusRoute
@@ -200,6 +218,7 @@ export interface FileRouteTypes {
     | '/likes'
     | '/links'
     | '/mentions'
+    | '/today'
     | '/api/action'
     | '/api/avatar'
     | '/api/blocks'
@@ -207,6 +226,7 @@ export interface FileRouteTypes {
     | '/api/inbox'
     | '/api/link-insights'
     | '/api/link-preview'
+    | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
@@ -221,6 +241,7 @@ export interface FileRouteTypes {
     | '/likes'
     | '/links'
     | '/mentions'
+    | '/today'
     | '/api/action'
     | '/api/avatar'
     | '/api/blocks'
@@ -228,6 +249,7 @@ export interface FileRouteTypes {
     | '/api/inbox'
     | '/api/link-insights'
     | '/api/link-preview'
+    | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
@@ -242,6 +264,7 @@ export interface FileRouteTypes {
     | '/likes'
     | '/links'
     | '/mentions'
+    | '/today'
     | '/api/action'
     | '/api/avatar'
     | '/api/blocks'
@@ -249,6 +272,7 @@ export interface FileRouteTypes {
     | '/api/inbox'
     | '/api/link-insights'
     | '/api/link-preview'
+    | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
     | '/api/status'
@@ -264,6 +288,7 @@ export interface RootRouteChildren {
   LikesRoute: typeof LikesRoute
   LinksRoute: typeof LinksRoute
   MentionsRoute: typeof MentionsRoute
+  TodayRoute: typeof TodayRoute
   ApiActionRoute: typeof ApiActionRoute
   ApiAvatarRoute: typeof ApiAvatarRoute
   ApiBlocksRoute: typeof ApiBlocksRoute
@@ -271,6 +296,7 @@ export interface RootRouteChildren {
   ApiInboxRoute: typeof ApiInboxRoute
   ApiLinkInsightsRoute: typeof ApiLinkInsightsRoute
   ApiLinkPreviewRoute: typeof ApiLinkPreviewRoute
+  ApiPeriodDigestRoute: typeof ApiPeriodDigestRoute
   ApiProfileHydrateRoute: typeof ApiProfileHydrateRoute
   ApiQueryRoute: typeof ApiQueryRoute
   ApiStatusRoute: typeof ApiStatusRoute
@@ -279,6 +305,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/today': {
+      id: '/today'
+      path: '/today'
+      fullPath: '/today'
+      preLoaderRoute: typeof TodayRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/mentions': {
       id: '/mentions'
       path: '/mentions'
@@ -363,6 +396,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiProfileHydrateRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/period-digest': {
+      id: '/api/period-digest'
+      path: '/api/period-digest'
+      fullPath: '/api/period-digest'
+      preLoaderRoute: typeof ApiPeriodDigestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/link-preview': {
       id: '/api/link-preview'
       path: '/api/link-preview'
@@ -424,6 +464,7 @@ const rootRouteChildren: RootRouteChildren = {
   LikesRoute: LikesRoute,
   LinksRoute: LinksRoute,
   MentionsRoute: MentionsRoute,
+  TodayRoute: TodayRoute,
   ApiActionRoute: ApiActionRoute,
   ApiAvatarRoute: ApiAvatarRoute,
   ApiBlocksRoute: ApiBlocksRoute,
@@ -431,6 +472,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiInboxRoute: ApiInboxRoute,
   ApiLinkInsightsRoute: ApiLinkInsightsRoute,
   ApiLinkPreviewRoute: ApiLinkPreviewRoute,
+  ApiPeriodDigestRoute: ApiPeriodDigestRoute,
   ApiProfileHydrateRoute: ApiProfileHydrateRoute,
   ApiQueryRoute: ApiQueryRoute,
   ApiStatusRoute: ApiStatusRoute,

--- a/src/routes/api/period-digest.test.ts
+++ b/src/routes/api/period-digest.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRouteHandler } from "#/test/route-handlers";
+
+const maybeAutoUpdateBackupMock = vi.fn();
+const streamPeriodDigestMock = vi.fn();
+
+vi.mock("#/lib/backup", () => ({
+	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
+}));
+vi.mock("#/lib/period-digest", () => ({
+	streamPeriodDigest: (...args: unknown[]) => streamPeriodDigestMock(...args),
+}));
+
+import { Route } from "./period-digest";
+
+const GET = getRouteHandler(Route, "GET");
+
+describe("api period digest route", () => {
+	beforeEach(() => {
+		maybeAutoUpdateBackupMock.mockReset();
+		streamPeriodDigestMock.mockReset();
+		maybeAutoUpdateBackupMock.mockResolvedValue({ skipped: true });
+		streamPeriodDigestMock.mockImplementation(
+			async (
+				_options: unknown,
+				handlers?: {
+					onEvent?: (event: unknown) => void;
+				},
+			) => {
+				handlers?.onEvent?.({ type: "delta", delta: "# Week\n" });
+				handlers?.onEvent?.({
+					type: "done",
+					result: {
+						markdown: "# Week",
+						model: "gpt-5.5",
+						cached: false,
+						serviceTier: "priority",
+						context: {
+							window: { label: "Week" },
+							counts: { home: 1, mentions: 0, links: 0, dms: 0 },
+							includeDms: true,
+						},
+						digest: { actionItems: [] },
+					},
+				});
+			},
+		);
+	});
+
+	it("streams NDJSON and passes query options to the digest runner", async () => {
+		const response = await GET({
+			request: new Request(
+				"http://localhost/api/period-digest?period=week&since=2026-05-01&until=2026-05-16&account=acct_primary&includeDms=yes&refresh=1&model=gpt-5.5&maxTweets=42&maxLinks=7",
+			),
+		});
+
+		expect(response.headers.get("content-type")).toContain(
+			"application/x-ndjson",
+		);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(await response.text()).toContain('"type":"done"');
+		expect(maybeAutoUpdateBackupMock).toHaveBeenCalledWith();
+		expect(streamPeriodDigestMock).toHaveBeenCalledWith(
+			{
+				period: "week",
+				since: "2026-05-01",
+				until: "2026-05-16",
+				account: "acct_primary",
+				includeDms: true,
+				refresh: true,
+				model: "gpt-5.5",
+				maxTweets: 42,
+				maxLinks: 7,
+				signal: expect.any(AbortSignal),
+			},
+			expect.objectContaining({ onEvent: expect.any(Function) }),
+		);
+	});
+
+	it("emits an error event when the digest runner rejects", async () => {
+		streamPeriodDigestMock.mockRejectedValueOnce(new Error("no api key"));
+
+		const response = await GET({
+			request: new Request("http://localhost/api/period-digest?maxTweets=nope"),
+		});
+
+		expect(await response.text()).toContain('"error":"no api key"');
+		expect(streamPeriodDigestMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				includeDms: false,
+				refresh: false,
+				maxTweets: undefined,
+			}),
+			expect.any(Object),
+		);
+	});
+});

--- a/src/routes/api/period-digest.tsx
+++ b/src/routes/api/period-digest.tsx
@@ -1,0 +1,102 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { maybeAutoUpdateBackup } from "#/lib/backup";
+import {
+	streamPeriodDigest,
+	type PeriodDigestOptions,
+	type PeriodDigestStreamEvent,
+} from "#/lib/period-digest";
+
+const encoder = new TextEncoder();
+
+function parseBoolean(value: string | null) {
+	return value === "true" || value === "1" || value === "yes";
+}
+
+function parseNumber(value: string | null) {
+	if (!value) return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptions(url: URL): PeriodDigestOptions {
+	return {
+		period: url.searchParams.get("period") ?? undefined,
+		since: url.searchParams.get("since") ?? undefined,
+		until: url.searchParams.get("until") ?? undefined,
+		account: url.searchParams.get("account") ?? undefined,
+		includeDms: parseBoolean(url.searchParams.get("includeDms")),
+		refresh: parseBoolean(url.searchParams.get("refresh")),
+		model: url.searchParams.get("model") ?? undefined,
+		maxTweets: parseNumber(url.searchParams.get("maxTweets")),
+		maxLinks: parseNumber(url.searchParams.get("maxLinks")),
+	};
+}
+
+function encodeEvent(event: PeriodDigestStreamEvent) {
+	return encoder.encode(`${JSON.stringify(event)}\n`);
+}
+
+export const Route = createFileRoute("/api/period-digest")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				await maybeAutoUpdateBackup();
+				const url = new URL(request.url);
+				const options = parseOptions(url);
+				let abortDigest: (() => void) | undefined;
+
+				return new Response(
+					new ReadableStream({
+						cancel() {
+							abortDigest?.();
+						},
+						start(controller) {
+							const abortController = new AbortController();
+							let closed = false;
+							const close = () => {
+								closed = true;
+								abortController.abort();
+							};
+							const onAbort = () => close();
+							request.signal.addEventListener("abort", onAbort, { once: true });
+							abortDigest = close;
+							const enqueue = (event: PeriodDigestStreamEvent) => {
+								if (closed) return;
+								try {
+									controller.enqueue(encodeEvent(event));
+								} catch {
+									close();
+								}
+							};
+
+							streamPeriodDigest(
+								{ ...options, signal: abortController.signal },
+								{ onEvent: enqueue },
+							)
+								.catch((error: unknown) => {
+									enqueue({
+										type: "error",
+										error:
+											error instanceof Error ? error.message : "Digest failed",
+									});
+								})
+								.finally(() => {
+									request.signal.removeEventListener("abort", onAbort);
+									if (!closed) {
+										closed = true;
+										controller.close();
+									}
+								});
+						},
+					}),
+					{
+						headers: {
+							"cache-control": "no-store",
+							"content-type": "application/x-ndjson; charset=utf-8",
+						},
+					},
+				);
+			},
+		},
+	},
+});

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -1,0 +1,151 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route } from "./today";
+
+const TodayRoute = Route.options.component as ComponentType;
+
+function digestResult(label: string, markdown: string, includeDms = false) {
+	return {
+		context: {
+			window: {
+				label,
+				since: "2026-05-16T00:00:00.000Z",
+				until: "2026-05-16T12:00:00.000Z",
+			},
+			includeDms,
+			counts: {
+				home: 3,
+				mentions: 2,
+				authored: 1,
+				likes: 1,
+				bookmarks: 1,
+				dms: includeDms ? 1 : 0,
+				links: 4,
+			},
+			tweets: [],
+			dms: [],
+			links: [],
+			hash: label,
+		},
+		digest: {
+			title: label,
+			summary: markdown,
+			keyTopics: [],
+			notableLinks: [],
+			people: [],
+			actionItems: [
+				{ kind: "reply", label: "Reply to Alice", tweetId: "tweet_1" },
+			],
+			sourceTweetIds: ["tweet_1"],
+		},
+		markdown,
+		model: "gpt-5.5",
+		reasoningEffort: "medium",
+		serviceTier: "priority",
+		cached: false,
+		updatedAt: "2026-05-16T12:00:00.000Z",
+	};
+}
+
+function ndjsonResponse(events: unknown[]) {
+	const body = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+	return new Response(body, {
+		headers: { "content-type": "application/x-ndjson" },
+	});
+}
+
+describe("today route", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
+	});
+
+	it("streams a digest and reloads when controls change", async () => {
+		const urls: URL[] = [];
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = new URL(String(input));
+			urls.push(url);
+			const period = url.searchParams.get("period") ?? "today";
+			const includeDms = url.searchParams.get("includeDms") === "true";
+			const label = period === "week" ? "Last 7 days" : "Today";
+			const markdown = includeDms ? "# With DMs" : `# ${label}`;
+			return ndjsonResponse([
+				{ type: "delta", delta: `${markdown}\n` },
+				{ type: "done", result: digestResult(label, markdown, includeDms) },
+			]);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<TodayRoute />);
+
+		expect(await screen.findByText("# Today")).toBeInTheDocument();
+		expect(
+			screen.getAllByText(
+				(_, element) => element?.textContent === "reply: Reply to Alice",
+			).length,
+		).toBeGreaterThan(0);
+		expect(
+			screen.getByText("3 home · 2 mentions · 4 links"),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Week" }));
+		expect(await screen.findByText("# Last 7 days")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByLabelText("DMs"));
+		expect(await screen.findByText("# With DMs")).toBeInTheDocument();
+		expect(
+			screen.getByText("3 home · 2 mentions · 4 links · 1 DMs"),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+		await waitFor(() =>
+			expect(
+				urls.some((url) => url.searchParams.get("refresh") === "true"),
+			).toBe(true),
+		);
+		expect(
+			urls.some(
+				(url) =>
+					url.searchParams.get("period") === "week" &&
+					url.searchParams.get("includeDms") === "true",
+			),
+		).toBe(true);
+	});
+
+	it("shows request errors", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("", { status: 500 })),
+		);
+
+		render(<TodayRoute />);
+
+		expect(
+			await screen.findByText("Digest request failed: 500"),
+		).toBeInTheDocument();
+	});
+
+	it("shows streamed error events", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				ndjsonResponse([{ type: "error", error: "model failed" }]),
+			),
+		);
+
+		render(<TodayRoute />);
+
+		expect(await screen.findByText("model failed")).toBeInTheDocument();
+	});
+});

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -1,0 +1,271 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+	CalendarDays,
+	CheckCircle2,
+	Loader2,
+	MessageSquare,
+	RefreshCw,
+	Sparkles,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+	PeriodDigestRunResult,
+	PeriodDigestStreamEvent,
+} from "#/lib/period-digest";
+import {
+	cx,
+	errorCopyClass,
+	pageHeaderActionsClass,
+	pageHeaderClass,
+	pageHeaderRowClass,
+	pageSubtitleClass,
+	pageTitleClass,
+	secondaryButtonClass,
+	segmentActiveClass,
+	segmentClass,
+	segmentedClass,
+	statusCopyClass,
+} from "#/lib/ui";
+
+export const Route = createFileRoute("/today")({
+	component: TodayRoute,
+});
+
+type PeriodOption = "today" | "24h" | "yesterday" | "week";
+
+const periods: Array<{ value: PeriodOption; label: string }> = [
+	{ value: "today", label: "Today" },
+	{ value: "24h", label: "24h" },
+	{ value: "yesterday", label: "Yesterday" },
+	{ value: "week", label: "Week" },
+];
+
+function digestUrl(
+	period: PeriodOption,
+	includeDms: boolean,
+	refresh: boolean,
+) {
+	const url = new URL("/api/period-digest", window.location.origin);
+	url.searchParams.set("period", period);
+	url.searchParams.set("includeDms", String(includeDms));
+	if (refresh) {
+		url.searchParams.set("refresh", "true");
+	}
+	return url;
+}
+
+function formatCounts(result: PeriodDigestRunResult | null) {
+	if (!result) return "Local Twitter memory, summarized as it streams.";
+	const counts = result.context.counts;
+	return [
+		`${String(counts.home)} home`,
+		`${String(counts.mentions)} mentions`,
+		`${String(counts.links)} links`,
+		result.context.includeDms ? `${String(counts.dms)} DMs` : null,
+	]
+		.filter(Boolean)
+		.join(" · ");
+}
+
+function useDigestStream(period: PeriodOption, includeDms: boolean) {
+	const [markdown, setMarkdown] = useState("");
+	const [result, setResult] = useState<PeriodDigestRunResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const abortRef = useRef<AbortController | null>(null);
+	const requestIdRef = useRef(0);
+
+	const run = useCallback(
+		(refresh = false) => {
+			abortRef.current?.abort();
+			const controller = new AbortController();
+			const requestId = requestIdRef.current + 1;
+			requestIdRef.current = requestId;
+			abortRef.current = controller;
+			const isActiveRequest = () =>
+				abortRef.current === controller &&
+				requestIdRef.current === requestId &&
+				!controller.signal.aborted;
+			setMarkdown("");
+			setResult(null);
+			setError(null);
+			setLoading(true);
+
+			fetch(digestUrl(period, includeDms, refresh), {
+				signal: controller.signal,
+			})
+				.then((response) => {
+					if (!response.ok || !response.body) {
+						throw new Error(
+							`Digest request failed: ${String(response.status)}`,
+						);
+					}
+					const reader = response.body.getReader();
+					const decoder = new TextDecoder();
+					let buffer = "";
+					const pump = (): Promise<void> =>
+						reader.read().then(({ done, value }) => {
+							if (!isActiveRequest()) return;
+							if (done) return;
+							buffer += decoder.decode(value, { stream: true });
+							let newline = buffer.indexOf("\n");
+							while (newline >= 0) {
+								const line = buffer.slice(0, newline).trim();
+								buffer = buffer.slice(newline + 1);
+								if (line) {
+									const event = JSON.parse(line) as PeriodDigestStreamEvent;
+									if (!isActiveRequest()) return;
+									if (event.type === "delta") {
+										setMarkdown((current) => current + event.delta);
+									} else if (event.type === "done") {
+										setResult(event.result);
+										setMarkdown(event.result.markdown);
+									} else if (event.type === "error") {
+										setError(event.error);
+									}
+								}
+								newline = buffer.indexOf("\n");
+							}
+							return pump();
+						});
+					return pump();
+				})
+				.catch((cause: unknown) => {
+					if (!isActiveRequest()) return;
+					setError(cause instanceof Error ? cause.message : "Digest failed");
+				})
+				.finally(() => {
+					if (isActiveRequest()) {
+						setLoading(false);
+					}
+				});
+		},
+		[includeDms, period],
+	);
+
+	useEffect(() => {
+		run(false);
+		return () => abortRef.current?.abort();
+	}, [run]);
+
+	return { error, loading, markdown, result, run };
+}
+
+function TodayRoute() {
+	const [period, setPeriod] = useState<PeriodOption>("today");
+	const [includeDms, setIncludeDms] = useState(false);
+	const { error, loading, markdown, result, run } = useDigestStream(
+		period,
+		includeDms,
+	);
+	const actionCount = result?.digest.actionItems.length ?? 0;
+	const sourceLabel = useMemo(() => formatCounts(result), [result]);
+
+	return (
+		<div className="flex min-h-screen flex-col">
+			<header className={pageHeaderClass}>
+				<div className={pageHeaderRowClass}>
+					<div className="min-w-0">
+						<h1 className={pageTitleClass}>What happened</h1>
+						<p className={pageSubtitleClass}>{sourceLabel}</p>
+					</div>
+					<div className={pageHeaderActionsClass}>
+						<button
+							type="button"
+							className={secondaryButtonClass}
+							onClick={() => run(true)}
+							disabled={loading}
+						>
+							<RefreshCw
+								className={cx("size-4", loading && "animate-spin")}
+								aria-hidden="true"
+							/>
+							Refresh
+						</button>
+					</div>
+				</div>
+				<div className="flex flex-wrap items-center gap-2 px-4 pb-3">
+					<div className={segmentedClass} aria-label="Digest period">
+						{periods.map((item) => (
+							<button
+								key={item.value}
+								type="button"
+								className={cx(
+									segmentClass,
+									period === item.value && segmentActiveClass,
+								)}
+								onClick={() => setPeriod(item.value)}
+							>
+								{item.label}
+							</button>
+						))}
+					</div>
+					<label className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] px-3 py-1 text-[13px] font-medium text-[var(--ink-soft)]">
+						<input
+							type="checkbox"
+							checked={includeDms}
+							onChange={(event) => setIncludeDms(event.currentTarget.checked)}
+						/>
+						DMs
+					</label>
+				</div>
+			</header>
+
+			{error ? <div className={errorCopyClass}>{error}</div> : null}
+
+			<section className="flex flex-col gap-4 border-b border-[var(--line)] px-4 py-4">
+				<div className="flex flex-wrap items-center gap-2 text-[13px] text-[var(--ink-soft)]">
+					<span className="inline-flex items-center gap-1">
+						{loading ? (
+							<Loader2 className="size-4 animate-spin" aria-hidden="true" />
+						) : (
+							<CheckCircle2 className="size-4" aria-hidden="true" />
+						)}
+						{loading ? "Streaming GPT-5.5 medium" : "Ready"}
+					</span>
+					{result ? (
+						<>
+							<span>· {result.model}</span>
+							<span>· {result.cached ? "cached" : result.serviceTier}</span>
+							<span>· {result.context.window.label}</span>
+						</>
+					) : null}
+				</div>
+
+				{result && actionCount > 0 ? (
+					<div className="rounded-lg border border-[var(--line)] bg-[var(--bg-elevated)] px-3 py-2">
+						<div className="mb-2 flex items-center gap-2 text-[13px] font-bold">
+							<MessageSquare className="size-4" aria-hidden="true" />
+							Action items
+						</div>
+						<ul className="flex flex-col gap-1 text-[14px] text-[var(--ink)]">
+							{result.digest.actionItems.map((item, index) => (
+								<li key={`${item.kind}:${item.label}:${String(index)}`}>
+									<span className="font-semibold capitalize">{item.kind}</span>:{" "}
+									{item.label}
+								</li>
+							))}
+						</ul>
+					</div>
+				) : null}
+			</section>
+
+			{markdown ? (
+				<article className="prose prose-sm max-w-none whitespace-pre-wrap break-words px-4 py-4 text-[15px] leading-6 text-[var(--ink)] prose-headings:text-[var(--ink)] prose-a:text-[var(--accent)]">
+					{markdown}
+				</article>
+			) : (
+				<div className={statusCopyClass}>
+					<span className="inline-flex items-center gap-2">
+						{loading ? (
+							<Sparkles className="size-4 animate-pulse" aria-hidden="true" />
+						) : (
+							<CalendarDays className="size-4" aria-hidden="true" />
+						)}
+						{loading ? "Waiting for the first tokens..." : "No digest yet."}
+					</span>
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
Summary:
- add streaming period digest in CLI and `/today`
- implement digest core as an Effect program with Promise wrappers at CLI/route/UI boundaries
- stream OpenAI Responses API output, parse final JSON, and cache structured results by context/model/reasoning/service tier
- scope account-specific digest link context through timeline edges/collections and DM account ownership
- document CLI and web usage in README/docs/changelog

Review:
- codex-review clean on final branch; accepted findings: none
- earlier review findings on account-scoped link context were fixed and re-reviewed

Proof:
- `./node_modules/.bin/tsgo --noEmit --pretty false`
- `node ./scripts/run-vitest.mjs run --reporter=dot` (90 files, 726 tests)
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/oxlint --import-plugin --node-plugin --vitest-plugin --deny-warnings -A require-mock-type-parameters -A no-control-regex`
- focused regression: `node ./scripts/run-vitest.mjs run --reporter=dot src/lib/link-insights.test.ts src/lib/period-digest.test.ts`
- browser smoke: `/today` streamed mocked NDJSON, stale stream did not overwrite newer period/DM result
