### PR TITLE
[codex] Add DM follower sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add an explicit Messages sort toggle for newest conversations or sender follower count.
 - Render the `What happened` AI digest as a structured day overview with summary cards, signal topics, highlight tweets, links, people, and hover previews for cited tweet ids and `@handle` mentions.
 - Add a streaming `What happened` AI digest in the web UI and CLI (`birdclaw today`, `birdclaw digest`) backed by OpenAI Responses API, GPT-5.5 by default, medium reasoning, priority service tier, local context hashing, and cached final structured results.
 - Add a global web account switcher plus `jobs sync-account`/`install-account-launchd` so multi-account Birdclaw installs can refresh home, mentions, likes, bookmarks, and DMs from launchd.

--- a/README.md
+++ b/README.md
@@ -405,14 +405,14 @@ The web UI exposes the same stream under `What happened`. DMs are excluded unles
 
 ```bash
 pnpm cli search dms "prototype" --json
-pnpm cli search dms "layout" --min-followers 1000 --min-influence-score 120 --sort influence --json
+pnpm cli search dms "layout" --min-followers 1000 --min-influence-score 120 --sort followers --json
 pnpm cli search dms "blacksmith" --context 4 --resolve-profiles --expand-urls --no-xurl-fallback --json
 pnpm cli whois "blacksmith guy" --context 4 --no-xurl-fallback --json
 pnpm cli whois "github guy" --current-affiliation github --exclude-domain-only --no-xurl-fallback
 pnpm cli whois "blacksmith" --tweets --context 4 --no-xurl-fallback --json
 pnpm cli dms sync --limit 50 --refresh --json
 pnpm cli dms list --refresh --limit 10 --json
-pnpm cli dms list --unreplied --min-followers 500 --min-influence-score 90 --sort influence --json
+pnpm cli dms list --unreplied --min-followers 500 --min-influence-score 90 --sort followers --json
 ```
 
 `--resolve-profiles` fills archive-imported numeric DM profiles through the local

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -415,7 +415,7 @@ Flags:
 - `--max-followers <n>`
 - `--min-influence-score <n>`
 - `--max-influence-score <n>`
-- `--sort recent|influence`
+- `--sort recent|followers`
 - `--context <n>`
 - `--resolve-profiles`
 - `--expand-urls`
@@ -585,7 +585,7 @@ Flags:
 - `--max-followers <n>`
 - `--min-influence-score <n>`
 - `--max-influence-score <n>`
-- `--sort recent|influence`
+- `--sort recent|followers`
 - `--replied`
 - `--unreplied`
 - `--account <name>`
@@ -802,7 +802,7 @@ birdclaw sync all --transport xurl
 birdclaw search tweets "openai" --since 2024-01-01 --limit 20
 birdclaw search tweets --since 2020-01-01 --until 2021-01-01 --originals-only --hide-low-quality --limit 500
 birdclaw search dms "invoice" --participant @someone --min-followers 1000
-birdclaw dms list --unreplied --min-followers 500 --min-influence-score 90 --sort influence
+birdclaw dms list --unreplied --min-followers 500 --min-influence-score 90 --sort followers
 birdclaw inbox --json
 birdclaw serve --sync
 birdclaw graph events --json

--- a/docs/dms.md
+++ b/docs/dms.md
@@ -11,7 +11,7 @@ birdclaw treats DMs as first-class content: full-text indexed, multi-account, an
 
 ```bash
 birdclaw dms list --refresh --limit 10 --json
-birdclaw dms list --unreplied --min-followers 500 --min-influence-score 90 --sort influence --json
+birdclaw dms list --unreplied --min-followers 500 --min-influence-score 90 --sort followers --json
 ```
 
 `dms list` is the no-query view onto conversations and recent events. It is optimized for agent and operator filtering — you do not need a search query to walk the inbox.
@@ -23,7 +23,7 @@ Flags:
 - `--participant <handle-or-id>`
 - `--min-followers <n>` / `--max-followers <n>`
 - `--min-influence-score <n>` / `--max-influence-score <n>`
-- `--sort recent|influence`
+- `--sort recent|followers`
 - `--replied` / `--unreplied`
 - `--account <name>`
 - `--limit <n>`
@@ -49,7 +49,7 @@ Sync is idempotent — re-running merges new events without disturbing already-i
 
 ```bash
 birdclaw search dms "prototype" --json
-birdclaw search dms "layout" --min-followers 1000 --min-influence-score 120 --sort influence --json
+birdclaw search dms "layout" --min-followers 1000 --min-influence-score 120 --sort followers --json
 birdclaw search dms "invoice" --participant @someone --replied --json
 birdclaw search dms "blacksmith" --context 4 --resolve-profiles --expand-urls --no-xurl-fallback --json
 birdclaw whois "blacksmith guy" --context 4 --no-xurl-fallback --json
@@ -89,10 +89,10 @@ Influence is a derived ranking signal that starts with follower count and folds 
 
 It is intentionally simple. The goal is to bucket noisy inboxes ("strangers with no follow signal" vs "people you actually talk to"), not to produce a global ranking.
 
-When triaging a quiet day, sort by `influence` to surface higher-context conversations first:
+When triaging a quiet day, sort by `followers` to surface higher-context conversations first:
 
 ```bash
-birdclaw dms list --unreplied --sort influence --limit 20 --json
+birdclaw dms list --unreplied --sort followers --limit 20 --json
 ```
 
 When triaging a noisy day, hide low-influence senders entirely:

--- a/docs/search.md
+++ b/docs/search.md
@@ -67,7 +67,7 @@ birdclaw search tweets "AI" --author @borderline_handle --limit 20 --json
 
 ```bash
 birdclaw search dms "prototype" --json
-birdclaw search dms "layout" --min-followers 1000 --min-influence-score 120 --sort influence --json
+birdclaw search dms "layout" --min-followers 1000 --min-influence-score 120 --sort followers --json
 birdclaw search dms "blacksmith" --context 4 --resolve-profiles --expand-urls --no-xurl-fallback --json
 ```
 
@@ -76,7 +76,7 @@ DM-specific filters layer follower-count and influence on top of FTS5:
 - `--participant <handle-or-id>`
 - `--min-followers <n>` / `--max-followers <n>`
 - `--min-influence-score <n>` / `--max-influence-score <n>`
-- `--sort recent|influence`
+- `--sort recent|followers`
 - `--context <n>`
 - `--resolve-profiles`
 - `--expand-urls`

--- a/playwright/app.spec.ts
+++ b/playwright/app.spec.ts
@@ -69,11 +69,20 @@ test("navigates across the primary surfaces", async ({ page }) => {
 });
 
 test("manual sync controls post to the sync endpoint", async ({ page }) => {
-	const syncBodies: Array<{ kind?: string; accountId?: string }> = [];
+	const syncBodies: Array<{
+		kind?: string;
+		accountId?: string;
+		inbox?: string;
+		limit?: number;
+		maxPages?: number;
+	}> = [];
 	await page.route("**/api/sync**", async (route) => {
 		const body = route.request().postDataJSON() as {
 			kind?: string;
 			accountId?: string;
+			inbox?: string;
+			limit?: number;
+			maxPages?: number;
 		};
 		syncBodies.push(body);
 		await route.fulfill({
@@ -101,7 +110,13 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 	async function clickSync(
 		path: string,
 		buttonName: string,
-		expectedBody: { kind: string; accountId?: string },
+		expectedBody: {
+			kind: string;
+			accountId?: string;
+			inbox?: string;
+			limit?: number;
+			maxPages?: number;
+		},
 	) {
 		const statusReady = page.waitForResponse(
 			(response) =>
@@ -139,7 +154,12 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 		kind: "bookmarks",
 		accountId: "acct_primary",
 	});
-	await clickSync("/dms", "Sync DMs", { kind: "dms" });
+	await clickSync("/dms", "Sync DMs", {
+		kind: "dms",
+		inbox: "all",
+		limit: 50,
+		maxPages: 1,
+	});
 
 	await expect
 		.poll(() => syncBodies)
@@ -148,7 +168,7 @@ test("manual sync controls post to the sync endpoint", async ({ page }) => {
 			{ kind: "mentions", accountId: "acct_primary" },
 			{ kind: "likes", accountId: "acct_primary" },
 			{ kind: "bookmarks", accountId: "acct_primary" },
-			{ kind: "dms" },
+			{ kind: "dms", inbox: "all", limit: 50, maxPages: 1 },
 		]);
 });
 
@@ -288,7 +308,10 @@ test("replies to an unreplied mention and clears it from the queue", async ({
 test("filters dms and shows sender context", async ({ page }) => {
 	await page.goto("/dms");
 
-	await page.getByRole("button", { name: "all" }).click();
+	await page
+		.locator('[aria-label="DM reply filter"]')
+		.getByRole("button", { name: "all" })
+		.click();
 	await page.getByPlaceholder("Min followers").fill("1000000");
 
 	await expect(page.getByText("@sam").first()).toBeVisible();

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1038,7 +1038,7 @@ describe("cli", () => {
 			"--max-influence-score",
 			"120",
 			"--sort",
-			"influence",
+			"followers",
 			"--unreplied",
 			"--limit",
 			"9",
@@ -1130,7 +1130,7 @@ describe("cli", () => {
 			"20",
 			"--replied",
 			"--sort",
-			"influence",
+			"followers",
 		]);
 
 		expect(listTimelineItemsMock).toHaveBeenCalledWith({
@@ -1161,7 +1161,7 @@ describe("cli", () => {
 			maxFollowers: undefined,
 			minInfluenceScore: undefined,
 			maxInfluenceScore: 120,
-			sort: "influence",
+			sort: "followers",
 			replyFilter: "unreplied",
 			context: 0,
 			limit: 9,
@@ -1237,7 +1237,7 @@ describe("cli", () => {
 			maxFollowers: undefined,
 			minInfluenceScore: 20,
 			maxInfluenceScore: undefined,
-			sort: "influence",
+			sort: "followers",
 			replyFilter: "replied",
 			limit: 20,
 		});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,6 +20,10 @@ const syncMentionThreadsMock = vi.fn();
 const syncDirectMessagesViaCachedBirdMock = vi.fn();
 const resolveProfilesForIdsMock = vi.fn();
 const expandUrlsFromTextsMock = vi.fn();
+const searchLinksMock = vi.fn();
+const backfillLinkIndexMock = vi.fn();
+const fetchTweetMediaMock = vi.fn();
+const formatMediaFetchResultMock = vi.fn();
 const runWhoisMock = vi.fn();
 const formatWhoisMock = vi.fn();
 const listBlocksMock = vi.fn();
@@ -52,6 +56,10 @@ const removeBlockMock = vi.fn();
 const removeMuteMock = vi.fn();
 const maybeAutoUpdateBackupMock = vi.fn();
 const maybeAutoSyncBackupMock = vi.fn();
+const exportBackupMock = vi.fn();
+const importBackupMock = vi.fn();
+const syncBackupMock = vi.fn();
+const validateBackupMock = vi.fn();
 const packageVersion = (
 	JSON.parse(
 		readFileSync(new URL("../package.json", import.meta.url), "utf8"),
@@ -99,8 +107,12 @@ vi.mock("#/lib/backup", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("#/lib/backup")>();
 	return {
 		...actual,
+		exportBackup: (...args: unknown[]) => exportBackupMock(...args),
+		importBackup: (...args: unknown[]) => importBackupMock(...args),
 		maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
 		maybeAutoSyncBackup: () => maybeAutoSyncBackupMock(),
+		syncBackup: (...args: unknown[]) => syncBackupMock(...args),
+		validateBackup: (...args: unknown[]) => validateBackupMock(...args),
 	};
 });
 
@@ -119,6 +131,17 @@ vi.mock("#/lib/blocks", () => ({
 vi.mock("#/lib/inbox", () => ({
 	listInboxItems: (...args: unknown[]) => listInboxItemsMock(...args),
 	scoreInbox: (...args: unknown[]) => scoreInboxMock(...args),
+}));
+
+vi.mock("#/lib/link-index", () => ({
+	backfillLinkIndex: (...args: unknown[]) => backfillLinkIndexMock(...args),
+	searchLinks: (...args: unknown[]) => searchLinksMock(...args),
+}));
+
+vi.mock("#/lib/media-fetch", () => ({
+	fetchTweetMedia: (...args: unknown[]) => fetchTweetMediaMock(...args),
+	formatMediaFetchResult: (...args: unknown[]) =>
+		formatMediaFetchResultMock(...args),
 }));
 
 vi.mock("#/lib/follow-graph", () => ({
@@ -258,6 +281,10 @@ describe("cli", () => {
 		syncDirectMessagesViaCachedBirdMock.mockReset();
 		resolveProfilesForIdsMock.mockReset();
 		expandUrlsFromTextsMock.mockReset();
+		searchLinksMock.mockReset();
+		backfillLinkIndexMock.mockReset();
+		fetchTweetMediaMock.mockReset();
+		formatMediaFetchResultMock.mockReset();
 		runWhoisMock.mockReset();
 		formatWhoisMock.mockReset();
 		listBlocksMock.mockReset();
@@ -290,6 +317,10 @@ describe("cli", () => {
 		removeMuteMock.mockReset();
 		maybeAutoUpdateBackupMock.mockReset();
 		maybeAutoSyncBackupMock.mockReset();
+		exportBackupMock.mockReset();
+		importBackupMock.mockReset();
+		syncBackupMock.mockReset();
+		validateBackupMock.mockReset();
 		spawnMock.mockReset();
 		execFileAsyncMock.mockReset();
 
@@ -371,6 +402,10 @@ describe("cli", () => {
 				updatedAt: "2026-05-01T00:00:00.000Z",
 			},
 		]);
+		searchLinksMock.mockReturnValue([]);
+		backfillLinkIndexMock.mockResolvedValue({ ok: true, indexed: 2 });
+		fetchTweetMediaMock.mockResolvedValue({ ok: true, fetched: 1 });
+		formatMediaFetchResultMock.mockReturnValue("fetched 1");
 		runWhoisMock.mockResolvedValue({
 			query: "blacksmith",
 			candidates: [],
@@ -461,6 +496,10 @@ describe("cli", () => {
 			enabled: false,
 			skipped: true,
 		});
+		exportBackupMock.mockResolvedValue({ ok: true, exported: 1 });
+		importBackupMock.mockResolvedValue({ ok: true, imported: 1 });
+		syncBackupMock.mockResolvedValue({ ok: true, synced: true });
+		validateBackupMock.mockResolvedValue({ ok: true });
 		execFileAsyncMock.mockRejectedValue(new Error("missing"));
 		spawnMock.mockReturnValue({
 			on: (_event: string, handler: (code: number) => void) => handler(0),
@@ -512,6 +551,304 @@ describe("cli", () => {
 			}),
 		);
 		expect(exitMock).toHaveBeenCalledWith(0);
+	});
+
+	it("dispatches link, media, and backup utility commands", async () => {
+		const { runCli } = await loadCli();
+		searchLinksMock
+			.mockReturnValueOnce([
+				{
+					occurrence: {
+						sourceKind: "dm",
+						direction: "inbound",
+						createdAt: "2026-05-01T00:00:00.000Z",
+						shortUrl: "https://t.co/a",
+					},
+					expansion: { finalUrl: "https://example.com/a" },
+					participant: { handle: "sam" },
+				},
+				{
+					occurrence: {
+						sourceKind: "tweet",
+						createdAt: "2026-05-02T00:00:00.000Z",
+						shortUrl: "https://t.co/b",
+					},
+					linkedTweet: {
+						id: "tweet_1",
+						text: "linked",
+						author: { handle: "des" },
+					},
+				},
+			])
+			.mockReturnValueOnce([])
+			.mockReturnValueOnce([]);
+		validateBackupMock.mockResolvedValueOnce({ ok: false });
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"search",
+			"links",
+			"ai",
+			"--account",
+			"acct_primary",
+			"--since",
+			"2026-01-01",
+			"--until",
+			"2026-05-01",
+			"--source",
+			"dm",
+			"--direction",
+			"inbound",
+			"--participant",
+			"sam",
+			"--media",
+			"image",
+			"--limit",
+			"7",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"search",
+			"links",
+			"ai",
+			"--source",
+			"tweet",
+			"--direction",
+			"outbound",
+			"--media",
+			"video",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"search",
+			"links",
+			"ai",
+			"--source",
+			"other",
+			"--direction",
+			"sideways",
+			"--media",
+			"audio",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"search",
+			"links",
+			"ai",
+			"--media",
+			"gif",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"links",
+			"backfill",
+			"--all-urls",
+			"--source",
+			"tweet",
+			"--refresh-url-cache",
+			"--limit",
+			"3",
+			"--concurrency",
+			"2",
+			"--timeout-ms",
+			"1000",
+		]);
+		await runCli(["node", "birdclaw", "links", "backfill", "--source", "dm"]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"links",
+			"backfill",
+			"--source",
+			"other",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"media",
+			"fetch",
+			"--account",
+			"acct_primary",
+			"--limit",
+			"5",
+			"--kind",
+			"home",
+			"--since",
+			"2026-01-01",
+			"--parallel",
+			"2",
+			"--pacing-ms",
+			"10",
+			"--video-pacing-ms",
+			"20",
+			"--retry-max",
+			"4",
+			"--no-include-video",
+			"--max-bytes",
+			"1000",
+			"--dry-run",
+			"--json",
+		]);
+		await runCli(["node", "birdclaw", "media", "fetch"]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"backup",
+			"export",
+			"--repo",
+			"/tmp/bak",
+			"--commit",
+			"--push",
+			"--message",
+			"sync backup",
+			"--no-validate",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"backup",
+			"export",
+			"--repo",
+			"/tmp/bak",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"backup",
+			"import",
+			"/tmp/bak",
+			"--replace",
+			"--no-validate",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"backup",
+			"sync",
+			"--repo",
+			"/tmp/bak",
+			"--remote",
+			"git@example.com:backup.git",
+			"--message",
+			"sync backup",
+		]);
+		await runCli(["node", "birdclaw", "backup", "validate", "/tmp/bak"]);
+		validateBackupMock.mockResolvedValueOnce({ ok: true });
+		await runCli(["node", "birdclaw", "backup", "validate", "/tmp/bak-ok"]);
+		await runCli(["node", "birdclaw", "media", "fetch", "--parallel", "0"]);
+
+		expect(searchLinksMock).toHaveBeenNthCalledWith(1, "ai", {
+			account: "acct_primary",
+			since: "2026-01-01",
+			until: "2026-05-01",
+			source: "dm",
+			direction: "inbound",
+			participant: "sam",
+			mediaType: "image",
+			limit: 7,
+		});
+		expect(searchLinksMock).toHaveBeenNthCalledWith(
+			2,
+			"ai",
+			expect.objectContaining({
+				source: "tweet",
+				direction: "outbound",
+				mediaType: "video",
+			}),
+		);
+		expect(searchLinksMock).toHaveBeenNthCalledWith(
+			3,
+			"ai",
+			expect.objectContaining({
+				source: undefined,
+				direction: undefined,
+				mediaType: undefined,
+			}),
+		);
+		expect(searchLinksMock).toHaveBeenNthCalledWith(
+			4,
+			"ai",
+			expect.objectContaining({ mediaType: "gif" }),
+		);
+		expect(backfillLinkIndexMock).toHaveBeenCalledWith({
+			includeAllUrls: true,
+			refresh: true,
+			source: "tweet",
+			limit: 3,
+			concurrency: 2,
+			timeoutMs: 1000,
+		});
+		expect(backfillLinkIndexMock).toHaveBeenCalledWith({
+			includeAllUrls: false,
+			refresh: false,
+			source: "dm",
+			limit: undefined,
+			concurrency: 12,
+			timeoutMs: 15000,
+		});
+		expect(backfillLinkIndexMock).toHaveBeenCalledWith(
+			expect.objectContaining({ source: undefined }),
+		);
+		expect(fetchTweetMediaMock).toHaveBeenCalledWith({
+			account: "acct_primary",
+			limit: 5,
+			kind: "home",
+			since: "2026-01-01",
+			parallel: 2,
+			pacingMs: 10,
+			videoPacingMs: 20,
+			retryMax: 4,
+			includeVideo: false,
+			maxBytes: 1000,
+			dryRun: true,
+		});
+		expect(fetchTweetMediaMock).toHaveBeenCalledWith({
+			account: undefined,
+			limit: undefined,
+			kind: undefined,
+			since: undefined,
+			parallel: 1,
+			pacingMs: 250,
+			videoPacingMs: undefined,
+			retryMax: 3,
+			includeVideo: true,
+			maxBytes: 104857600,
+			dryRun: false,
+		});
+		expect(exportBackupMock).toHaveBeenCalledWith({
+			repoPath: "/tmp/bak",
+			commit: true,
+			push: true,
+			message: "sync backup",
+			validate: false,
+		});
+		expect(exportBackupMock).toHaveBeenCalledWith({
+			repoPath: "/tmp/bak",
+			commit: false,
+			push: false,
+			message: "archive: update birdclaw backup",
+			validate: true,
+		});
+		expect(importBackupMock).toHaveBeenCalledWith({
+			repoPath: "/tmp/bak",
+			validate: false,
+			mode: "replace",
+		});
+		expect(syncBackupMock).toHaveBeenCalledWith({
+			repoPath: "/tmp/bak",
+			remote: "git@example.com:backup.git",
+			message: "sync backup",
+		});
+		expect(validateBackupMock).toHaveBeenCalledWith("/tmp/bak");
+		expect(validateBackupMock).toHaveBeenCalledWith("/tmp/bak-ok");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("prints tweet search snippets in json output", async () => {
@@ -1624,6 +1961,45 @@ describe("cli", () => {
 			"tweet_2",
 			"Reply text",
 		);
+	});
+
+	it("keeps legacy influence sort as a follower-count alias for DMs", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"search",
+			"dms",
+			"sam",
+			"--sort",
+			"influence",
+		]);
+		await runCli(["node", "birdclaw", "dms", "list", "--sort", "influence"]);
+
+		expect(listDmConversationsMock).toHaveBeenNthCalledWith(1, {
+			search: "sam",
+			participant: undefined,
+			minFollowers: undefined,
+			maxFollowers: undefined,
+			minInfluenceScore: undefined,
+			maxInfluenceScore: undefined,
+			sort: "followers",
+			replyFilter: "all",
+			context: 0,
+			limit: 20,
+		});
+		expect(listDmConversationsMock).toHaveBeenNthCalledWith(2, {
+			account: undefined,
+			participant: undefined,
+			minFollowers: undefined,
+			maxFollowers: undefined,
+			minInfluenceScore: undefined,
+			maxInfluenceScore: undefined,
+			sort: "followers",
+			replyFilter: "all",
+			limit: 20,
+		});
 	});
 
 	it("dispatches cached DM enrichment and whois commands", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -512,7 +512,7 @@ searchCommand
 	.option("--max-followers <n>", "Maximum sender follower count")
 	.option("--min-influence-score <n>", "Minimum derived influence score")
 	.option("--max-influence-score <n>", "Maximum derived influence score")
-	.option("--sort <mode>", "recent or influence", "recent")
+	.option("--sort <mode>", "recent or followers", "recent")
 	.option(
 		"--context <n>",
 		"Include N messages before and after each match",
@@ -558,7 +558,10 @@ searchCommand
 			maxInfluenceScore: options.maxInfluenceScore
 				? Number(options.maxInfluenceScore)
 				: undefined,
-			sort: options.sort === "influence" ? "influence" : "recent",
+			sort:
+				options.sort === "followers" || options.sort === "influence"
+					? "followers"
+					: "recent",
 			replyFilter,
 			context,
 			limit: Number(options.limit),
@@ -1322,7 +1325,7 @@ dmsCommand
 	.option("--max-followers <n>", "Maximum sender follower count")
 	.option("--min-influence-score <n>", "Minimum derived influence score")
 	.option("--max-influence-score <n>", "Maximum derived influence score")
-	.option("--sort <mode>", "recent or influence", "recent")
+	.option("--sort <mode>", "recent or followers", "recent")
 	.option(
 		"--resolve-profiles",
 		"Resolve placeholder DM profiles through cache/bird/xurl",
@@ -1370,7 +1373,10 @@ dmsCommand
 				maxInfluenceScore: options.maxInfluenceScore
 					? Number(options.maxInfluenceScore)
 					: undefined,
-				sort: options.sort === "influence" ? "influence" : "recent",
+				sort:
+					options.sort === "followers" || options.sort === "influence"
+						? "followers"
+						: "recent",
 				replyFilter,
 				limit: Number(options.limit),
 			},

--- a/src/components/DmWorkspace.tsx
+++ b/src/components/DmWorkspace.tsx
@@ -143,8 +143,10 @@ export function DmWorkspace({
 										{conversation.needsReply ? "open" : "replied"}
 									</span>
 									<span className={cx(pillClass, pillSoftClass)}>
-										{conversation.influenceScore} ·{" "}
-										{conversation.influenceLabel}
+										{formatCompactNumber(
+											conversation.participant.followersCount,
+										)}{" "}
+										followers
 									</span>
 								</div>
 							</div>

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -108,7 +108,7 @@ export function listInboxItems({
 		for (const dm of listDmConversations({
 			account,
 			replyFilter: "unreplied",
-			sort: "influence",
+			sort: "followers",
 			limit: 50,
 		})) {
 			const scoreKey = `dm:${dm.id}`;

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -198,6 +198,17 @@ describe("birdclaw queries", () => {
 		expect(filtered.map((item) => item.id)).toEqual(["dm_003"]);
 	});
 
+	it("returns no DMs when max influence score is below the minimum follower score", () => {
+		setupTempHome();
+
+		const filtered = listDmConversations({
+			maxInfluenceScore: 10,
+			sort: "followers",
+		});
+
+		expect(filtered).toEqual([]);
+	});
+
 	it("filters DM conversations by accepted/request inbox", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -156,7 +156,7 @@ describe("birdclaw queries", () => {
 
 		const highSignal = listDmConversations({
 			minInfluenceScore: 120,
-			sort: "influence",
+			sort: "followers",
 		});
 
 		expect(highSignal.map((item) => item.id)).toEqual([
@@ -165,6 +165,36 @@ describe("birdclaw queries", () => {
 			"dm_002",
 		]);
 		expect(highSignal[0]?.influenceLabel).toBe("very high");
+	});
+
+	it("sorts DM conversations by follower count before applying the limit", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		db.prepare("update dm_conversations set last_message_at = ?").run(
+			"2026-05-01T00:00:00.000Z",
+		);
+		db.prepare(
+			"update dm_conversations set last_message_at = ? where id = 'dm_003'",
+		).run("2026-05-03T00:00:00.000Z");
+
+		const sorted = listDmConversations({
+			sort: "followers",
+			limit: 1,
+		});
+
+		expect(sorted.map((item) => item.id)).toEqual(["dm_001"]);
+	});
+
+	it("applies influence score filters before follower-sort limits", () => {
+		setupTempHome();
+
+		const filtered = listDmConversations({
+			maxInfluenceScore: 100,
+			sort: "followers",
+			limit: 1,
+		});
+
+		expect(filtered.map((item) => item.id)).toEqual(["dm_003"]);
 	});
 
 	it("filters DM conversations by participant, search, and upper bounds", () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -100,6 +100,17 @@ function getInfluenceScore(followersCount: number) {
 	return Math.round(Math.log10(followersCount + 10) * 24);
 }
 
+function getMinFollowersForInfluenceScore(score: number) {
+	if (!Number.isFinite(score)) return undefined;
+	return Math.max(0, Math.ceil(10 ** ((score - 0.5) / 24) - 10));
+}
+
+function getMaxFollowersForInfluenceScore(score: number) {
+	if (!Number.isFinite(score)) return undefined;
+	if (score < getInfluenceScore(0)) return -1;
+	return Math.max(0, Math.ceil(10 ** ((score + 0.5) / 24) - 10) - 1);
+}
+
 function getInfluenceLabel(score: number) {
 	if (score >= 150) return "very high";
 	if (score >= 120) return "high";
@@ -1402,6 +1413,31 @@ export function listDmConversations({
 	let where = "where 1 = 1";
 	let searchSnippetSelect = "";
 	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
+	const influenceMinFollowers =
+		typeof minInfluenceScore === "number"
+			? getMinFollowersForInfluenceScore(minInfluenceScore)
+			: undefined;
+	const influenceMaxFollowers =
+		typeof maxInfluenceScore === "number"
+			? getMaxFollowersForInfluenceScore(maxInfluenceScore)
+			: undefined;
+	const effectiveMinFollowers =
+		typeof minFollowers === "number" ||
+		typeof influenceMinFollowers === "number"
+			? Math.max(minFollowers ?? 0, influenceMinFollowers ?? 0)
+			: undefined;
+	const effectiveMaxFollowers =
+		typeof maxFollowers === "number" ||
+		typeof influenceMaxFollowers === "number"
+			? Math.min(
+					maxFollowers ?? Number.MAX_SAFE_INTEGER,
+					influenceMaxFollowers ?? Number.MAX_SAFE_INTEGER,
+				)
+			: undefined;
+	const orderBy =
+		sort === "followers" || sort === "influence"
+			? "p.followers_count desc, c.last_message_at desc"
+			: "c.last_message_at desc";
 
 	if (account && account !== "all") {
 		where += " and a.id = ?";
@@ -1433,14 +1469,14 @@ export function listDmConversations({
 		params.push(until);
 	}
 
-	if (typeof minFollowers === "number") {
+	if (typeof effectiveMinFollowers === "number") {
 		where += " and p.followers_count >= ?";
-		params.push(minFollowers);
+		params.push(effectiveMinFollowers);
 	}
 
-	if (typeof maxFollowers === "number") {
+	if (typeof effectiveMaxFollowers === "number") {
 		where += " and p.followers_count <= ?";
-		params.push(maxFollowers);
+		params.push(effectiveMaxFollowers);
 	}
 
 	if (ftsSearch) {
@@ -1513,7 +1549,7 @@ export function listDmConversations({
       ${join}
       ${where}
       group by c.id
-      order by c.last_message_at desc
+      order by ${orderBy}
       limit ?
       `,
 		)
@@ -1586,7 +1622,7 @@ export function listDmConversations({
 		return true;
 	});
 
-	if (sort === "influence") {
+	if (sort === "followers" || sort === "influence") {
 		filtered.sort((left, right) => {
 			if (
 				right.participant.followersCount !== left.participant.followersCount

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -375,7 +375,7 @@ export interface DmQuery {
 	maxFollowers?: number;
 	minInfluenceScore?: number;
 	maxInfluenceScore?: number;
-	sort?: "recent" | "influence";
+	sort?: "recent" | "followers" | "influence";
 	context?: number;
 	limit?: number;
 }

--- a/src/routes/api/query.test.ts
+++ b/src/routes/api/query.test.ts
@@ -30,7 +30,7 @@ describe("api query route", () => {
 		queryResourceMock.mockReturnValue({ resource: "dms", items: [] });
 		const response = await GET({
 			request: new Request(
-				"http://localhost/api/query?resource=dms&replyFilter=unreplied&minFollowers=10&minInfluenceScore=90&sort=influence",
+				"http://localhost/api/query?resource=dms&replyFilter=unreplied&minFollowers=10&minInfluenceScore=90&sort=followers",
 			),
 		});
 
@@ -40,10 +40,26 @@ describe("api query route", () => {
 				replyFilter: "unreplied",
 				minFollowers: 10,
 				minInfluenceScore: 90,
-				sort: "influence",
+				sort: "followers",
 			}),
 		);
 		expect(response.status).toBe(200);
+	});
+
+	it("accepts the legacy dm influence sort as followers", async () => {
+		queryResourceMock.mockReturnValue({ resource: "dms", items: [] });
+		await GET({
+			request: new Request(
+				"http://localhost/api/query?resource=dms&sort=influence",
+			),
+		});
+
+		expect(queryResourceMock).toHaveBeenCalledWith(
+			"dms",
+			expect.objectContaining({
+				sort: "followers",
+			}),
+		);
 	});
 
 	it("defaults invalid reply filters to all", async () => {

--- a/src/routes/api/query.tsx
+++ b/src/routes/api/query.tsx
@@ -27,6 +27,13 @@ function parseOptionalNumber(value: string | null) {
 	return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function parseDmSort(value: string | null) {
+	if (value === "followers" || value === "influence") {
+		return "followers";
+	}
+	return "recent";
+}
+
 function parseQualityFilter(value: string | null): TimelineQualityFilter {
 	return value === "summary" ? "summary" : "all";
 }
@@ -80,10 +87,7 @@ export const Route = createFileRoute("/api/query")({
 									maxInfluenceScore: parseOptionalNumber(
 										url.searchParams.get("maxInfluenceScore"),
 									),
-									sort:
-										url.searchParams.get("sort") === "influence"
-											? "influence"
-											: "recent",
+									sort: parseDmSort(url.searchParams.get("sort")),
 									conversationId:
 										url.searchParams.get("conversationId") ?? undefined,
 								}),

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -188,6 +188,12 @@ describe("dms route", () => {
 		await waitFor(() => {
 			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("followers");
 		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Newest" }));
+
+		await waitFor(() => {
+			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("recent");
+		});
 	});
 
 	it("restores dm draft and shows transport errors", async () => {

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -133,6 +133,63 @@ describe("dms route", () => {
 		});
 	});
 
+	it("lets the dm list switch from newest to follower count sorting", async () => {
+		const queryUrls: URL[] = [];
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return new Response(
+					JSON.stringify({
+						stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+						transport: { statusText: "local" },
+						accounts: [],
+						archives: [],
+					}),
+				);
+			}
+			if (url.includes("/api/query")) {
+				queryUrls.push(new URL(url));
+				return new Response(
+					JSON.stringify({
+						resource: "dms",
+						items: [
+							{
+								id: "dm_1",
+								title: "Sam Altman",
+								accountId: "acct_primary",
+								accountHandle: "@steipete",
+							},
+						],
+						selectedConversation: {
+							conversation: {
+								id: "dm_1",
+								title: "Sam Altman",
+								accountId: "acct_primary",
+								accountHandle: "@steipete",
+							},
+							messages: [],
+						},
+					}),
+				);
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DmsRoute />);
+
+		expect(await screen.findByText("Sam Altman")).toBeInTheDocument();
+		await waitFor(() => {
+			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("recent");
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Followers" }));
+
+		await waitFor(() => {
+			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("followers");
+		});
+	});
+
 	it("restores dm draft and shows transport errors", async () => {
 		const fetchMock = vi.fn(
 			async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -333,7 +333,7 @@ function DmsRoute() {
 						))}
 					</div>
 				</div>
-				<div className={tabStripClass}>
+				<div className={tabStripClass} aria-label="DM reply filter">
 					{TABS.map((tab) => {
 						const active = replyFilter === tab.value;
 						return (

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -47,6 +47,11 @@ const TABS: Array<{ value: ReplyFilter; label: string }> = [
 	{ value: "replied", label: "Replied" },
 ];
 
+const SORTS: Array<{ value: "recent" | "followers"; label: string }> = [
+	{ value: "recent", label: "Newest" },
+	{ value: "followers", label: "Followers" },
+];
+
 function DmsRoute() {
 	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
 	const [items, setItems] = useState<DmConversationItem[]>([]);
@@ -60,7 +65,7 @@ function DmsRoute() {
 	const [replyFilter, setReplyFilter] = useState<ReplyFilter>("unreplied");
 	const [minFollowers, setMinFollowers] = useState("0");
 	const [minInfluenceScore, setMinInfluenceScore] = useState("0");
-	const [sort, setSort] = useState<"recent" | "influence">("recent");
+	const [sort, setSort] = useState<"recent" | "followers">("recent");
 	const [search, setSearch] = useState("");
 	const [replyDraft, setReplyDraft] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
@@ -281,17 +286,17 @@ function DmsRoute() {
 						value={minInfluenceScore}
 					/>
 					<div className={segmentedClass}>
-						{(["recent", "influence"] as const).map((value) => (
+						{SORTS.map((option) => (
 							<button
-								key={value}
+								key={option.value}
 								className={cx(
 									segmentClass,
-									value === sort && segmentActiveClass,
+									option.value === sort && segmentActiveClass,
 								)}
-								onClick={() => setSort(value)}
+								onClick={() => setSort(option.value)}
 								type="button"
 							>
-								{value}
+								{option.label}
 							</button>
 						))}
 					</div>


### PR DESCRIPTION
Summary:
- Add a Messages sort toggle for newest conversations or sender follower count.
- Carry `sort=followers` through the web API, CLI, inbox ranking, docs, and legacy `influence` alias.
- Push follower/influence bounds into the DM SQL query before ordering and limiting.

Verification:
- codex review --uncommitted
- pnpm test src/lib/queries.test.ts src/routes/api/query.test.ts src/routes/dms.test.tsx src/components/DmWorkspace.test.tsx src/cli.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- git diff --check
