### PR TITLE
Add live search discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.1 - Unreleased
 
+### Added
+
+- Add `birdclaw discuss <query>` and a Discuss web view for live keyword search via `bird`/`xurl`, persisted search-result tweets, and streaming OpenAI summaries with optional private DM context.
+
 ## 0.6.0 - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -387,6 +387,16 @@ birdclaw research "codex" --limit 20 --thread-depth 10 --json
 birdclaw research --account acct_primary --out ~/research/codex.md
 ```
 
+### Discuss keyword searches
+
+`birdclaw discuss` fetches live keyword matches through `bird` or `xurl`, stores them as local `search` tweets, then streams an OpenAI Markdown summary and discussion. DMs are excluded unless explicitly included.
+
+```bash
+birdclaw discuss "local-first" --mode bird
+birdclaw discuss "sync engine" --question "what changed over time?"
+birdclaw discuss "prototype" --include-dms --limit 500 --max-pages 5 --json
+```
+
 ### What happened today
 
 `birdclaw today` streams a local "what happened" digest from the SQLite store. It uses the OpenAI Responses API with `gpt-5.5`, medium reasoning, and priority service tier by default. Set `OPENAI_API_KEY`; override with `BIRDCLAW_AI_MODEL`, `BIRDCLAW_OPENAI_REASONING_EFFORT`, or `BIRDCLAW_OPENAI_SERVICE_TIER` when needed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,7 @@ birdclaw sync followers
 birdclaw sync following
 birdclaw search tweets <query>
 birdclaw search dms <query>
+birdclaw discuss <query>
 birdclaw today
 birdclaw digest [today|24h|yesterday|week]
 birdclaw mentions export [query]
@@ -432,6 +433,35 @@ lookups are cached briefly so repeated searches do not keep spending live calls.
 Resolved profile rows store bio, profile URL, location, verification type,
 structured X URL entities, raw profile JSON, and affiliation badge metadata when
 the live transport exposes it.
+
+### `discuss <query>`
+
+Fetch live keyword matches through `bird` or `xurl`, store them as local
+`search` tweets, then stream an OpenAI Markdown summary and discussion. DMs stay
+out unless explicitly requested.
+
+Flags:
+
+- `--account <account-id>`
+- `--source all|search|home|mentions|authored|likes|bookmarks`
+- `--mode auto|bird|xurl|local`
+- `--include-dms`
+- `--since <date>` / `--until <date>`
+- `--question <prompt>`
+- `--originals-only`
+- `--hide-low-quality`
+- `--refresh`
+- `--model <model>`
+- `--limit <n>`
+- `--max-pages <n>`
+
+Examples:
+
+```bash
+birdclaw discuss "local-first" --mode bird
+birdclaw discuss "sync engine" --question "what changed over time?"
+birdclaw discuss "prototype" --include-dms --limit 500 --max-pages 5 --json
+```
 
 ### `whois <query>`
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -109,6 +109,22 @@ birdclaw whois "github guy" --current-affiliation github --exclude-domain-only
 birdclaw whois github --affiliation github --no-xurl-fallback --json
 ```
 
+## Discuss Search Results
+
+```bash
+birdclaw discuss "local-first" --mode bird
+birdclaw discuss "sync engine" --question "what changed over time?"
+birdclaw discuss "prototype" --include-dms --limit 500 --max-pages 5 --json
+```
+
+`birdclaw discuss` runs live keyword search through `bird` first, falls back to
+`xurl` in `auto` mode, stores matched tweets as local `search` rows/edges, then
+streams an OpenAI Markdown summary and discussion over that context. It uses the
+same Responses API defaults as `birdclaw digest`: `gpt-5.5`, medium reasoning,
+priority service tier, and a local context cache. DMs are excluded unless
+`--include-dms` is set. Use `--mode local` to discuss only previously stored
+matches.
+
 ## Snippets
 
 FTS5 snippets are returned with `<mark>` boundaries pre-rendered for the web UI. The CLI prints them as plain text in human mode and as `snippet`/`snippetHtml` fields in `--json` mode.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -47,6 +47,7 @@ const hydrateProfilesFromXMock = vi.fn();
 const inspectProfileRepliesMock = vi.fn();
 const runResearchModeMock = vi.fn();
 const streamPeriodDigestMock = vi.fn();
+const streamSearchDiscussionMock = vi.fn();
 const syncAuthoredTweetsMock = vi.fn();
 const syncTimelineCollectionMock = vi.fn();
 const createPostMock = vi.fn();
@@ -207,6 +208,11 @@ vi.mock("#/lib/period-digest", () => ({
 	streamPeriodDigest: (...args: unknown[]) => streamPeriodDigestMock(...args),
 }));
 
+vi.mock("#/lib/search-discussion", () => ({
+	streamSearchDiscussion: (...args: unknown[]) =>
+		streamSearchDiscussionMock(...args),
+}));
+
 vi.mock("#/lib/authored-live", () => ({
 	AuthoredSyncError: class AuthoredSyncError extends Error {
 		constructor(
@@ -308,6 +314,7 @@ describe("cli", () => {
 		inspectProfileRepliesMock.mockReset();
 		runResearchModeMock.mockReset();
 		streamPeriodDigestMock.mockReset();
+		streamSearchDiscussionMock.mockReset();
 		syncAuthoredTweetsMock.mockReset();
 		syncTimelineCollectionMock.mockReset();
 		createPostMock.mockReset();
@@ -459,6 +466,16 @@ describe("cli", () => {
 			context: { counts: {}, includeDms: false },
 			digest: { actionItems: [] },
 			markdown: "# Today\n",
+			model: "gpt-5.5",
+			reasoningEffort: "medium",
+			serviceTier: "priority",
+			cached: false,
+			updatedAt: "2026-05-16T12:00:00.000Z",
+		});
+		streamSearchDiscussionMock.mockResolvedValue({
+			context: { counts: {}, includeDms: false },
+			discussion: { themes: [] },
+			markdown: "# Search discussion\n",
 			model: "gpt-5.5",
 			reasoningEffort: "medium",
 			serviceTier: "priority",
@@ -2511,6 +2528,109 @@ describe("cli", () => {
 		expect(streamPeriodDigestMock).not.toHaveBeenCalled();
 		expect(consoleErrorMock).toHaveBeenCalledWith(
 			expect.stringContaining("--max-tweets must be a non-negative integer"),
+		);
+		consoleErrorMock.mockRestore();
+	});
+
+	it("streams keyword discussions as markdown and json", async () => {
+		const stdoutWriteMock = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		streamSearchDiscussionMock.mockImplementation(
+			async (
+				_options: unknown,
+				handlers?: { onDelta?: (delta: string) => void },
+			) => {
+				handlers?.onDelta?.("# Search discussion\n");
+				return {
+					context: { counts: {}, includeDms: false },
+					discussion: { themes: [] },
+					markdown: "# Search discussion\n",
+					model: "gpt-5.5",
+					reasoningEffort: "medium",
+					serviceTier: "priority",
+					cached: false,
+					updatedAt: "2026-05-16T12:00:00.000Z",
+				};
+			},
+		);
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"discuss",
+			"local-first",
+			"--include-dms",
+			"--source",
+			"bookmarks",
+			"--since",
+			"2026-01-01",
+			"--until",
+			"2026-05-01",
+			"--question",
+			"what changed?",
+			"--originals-only",
+			"--hide-low-quality",
+			"--refresh",
+			"--limit",
+			"25",
+			"--model",
+			"gpt-5.5",
+		]);
+		await runCli(["node", "birdclaw", "--json", "discuss", "sync"]);
+
+		expect(streamSearchDiscussionMock).toHaveBeenNthCalledWith(
+			1,
+			{
+				query: "local-first",
+				account: undefined,
+				source: "bookmarks",
+				includeDms: true,
+				since: "2026-01-01",
+				until: "2026-05-01",
+				question: "what changed?",
+				originalsOnly: true,
+				hideLowQuality: true,
+				mode: "auto",
+				model: "gpt-5.5",
+				refresh: true,
+				limit: 25,
+				maxPages: 5,
+			},
+			expect.objectContaining({ onDelta: expect.any(Function) }),
+		);
+		expect(streamSearchDiscussionMock).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				query: "sync",
+				source: "search",
+				mode: "auto",
+				includeDms: false,
+				limit: 500,
+				maxPages: 5,
+			}),
+			expect.objectContaining({ onDelta: undefined }),
+		);
+		expect(stdoutWriteMock).toHaveBeenCalledWith("# Search discussion\n");
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"model": "gpt-5.5"'),
+		);
+		stdoutWriteMock.mockRestore();
+	});
+
+	it("rejects invalid keyword discussion options", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "discuss", "sync", "--source", "bad"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(streamSearchDiscussionMock).not.toHaveBeenCalled();
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining("--source must be all"),
 		);
 		consoleErrorMock.mockRestore();
 	});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,6 +76,11 @@ import { resolveProfilesForIds } from "#/lib/profile-resolver";
 import { inspectProfileReplies } from "#/lib/profile-replies";
 import { runResearchMode } from "#/lib/research";
 import {
+	streamSearchDiscussion,
+	type SearchDiscussionOptions,
+	type SearchDiscussionSource,
+} from "#/lib/search-discussion";
+import {
 	applyDmRequestMutationToLocalStore,
 	createDmReply,
 	createPost,
@@ -307,6 +312,110 @@ function buildDigestOptions(
 function runDigestCli(options: PeriodDigestOptions) {
 	const asJson = Boolean(program.opts().json);
 	return streamPeriodDigest(options, {
+		onDelta: asJson
+			? undefined
+			: (delta) => {
+					process.stdout.write(delta);
+				},
+	}).then((result) => {
+		if (asJson) {
+			print(result, true);
+			return;
+		}
+		if (!result.markdown.endsWith("\n")) {
+			process.stdout.write("\n");
+		}
+	});
+}
+
+function parseSearchDiscussionSource(
+	value: string | undefined,
+): SearchDiscussionSource | undefined {
+	const normalized = (value ?? "all").trim().toLowerCase();
+	if (
+		normalized === "all" ||
+		normalized === "home" ||
+		normalized === "mentions" ||
+		normalized === "authored" ||
+		normalized === "search" ||
+		normalized === "likes" ||
+		normalized === "bookmarks"
+	) {
+		return normalized;
+	}
+	printError(
+		"--source must be all, search, home, mentions, authored, likes, or bookmarks",
+	);
+	process.exitCode = 1;
+	return undefined;
+}
+
+function parseTweetSearchMode(value: string | undefined) {
+	const normalized = (value ?? "auto").trim().toLowerCase();
+	if (
+		normalized === "auto" ||
+		normalized === "bird" ||
+		normalized === "xurl" ||
+		normalized === "local"
+	) {
+		return normalized;
+	}
+	printError("--mode must be auto, bird, xurl, or local");
+	process.exitCode = 1;
+	return undefined;
+}
+
+function buildSearchDiscussionOptions(
+	query: string,
+	options: {
+		account?: string;
+		source?: string;
+		includeDms?: boolean;
+		since?: string;
+		until?: string;
+		question?: string;
+		originalsOnly?: boolean;
+		hideLowQuality?: boolean;
+		mode?: string;
+		model?: string;
+		refresh?: boolean;
+		limit?: string;
+		maxPages?: string;
+	},
+): SearchDiscussionOptions | null {
+	const source = parseSearchDiscussionSource(options.source);
+	if (!source) return null;
+	const mode = parseTweetSearchMode(options.mode);
+	if (!mode) return null;
+	const limit = parsePositiveIntegerOption(options.limit, "--limit");
+	if (options.limit !== undefined && limit === undefined) {
+		return null;
+	}
+	const maxPages = parsePositiveIntegerOption(options.maxPages, "--max-pages");
+	if (options.maxPages !== undefined && maxPages === undefined) {
+		return null;
+	}
+	return {
+		query,
+		account: options.account,
+		source,
+		includeDms: Boolean(options.includeDms),
+		since: options.since,
+		until: options.until,
+		question: options.question,
+		originalsOnly: Boolean(options.originalsOnly),
+		hideLowQuality: Boolean(options.hideLowQuality),
+		mode,
+		model: options.model,
+		refresh: Boolean(options.refresh),
+		limit,
+		maxPages,
+	};
+}
+
+function runSearchDiscussionCli(options: SearchDiscussionOptions) {
+	const asJson = Boolean(program.opts().json);
+	return streamSearchDiscussion(options, {
 		onDelta: asJson
 			? undefined
 			: (delta) => {
@@ -855,6 +964,33 @@ program
 			program.opts().json ? report : report.markdown,
 			program.opts().json ?? false,
 		);
+	});
+
+program
+	.command("discuss <query>")
+	.description("Search live/local tweets and summarize the results with AI")
+	.option("--account <accountId>", "Account id")
+	.option(
+		"--source <source>",
+		"all, search, home, mentions, authored, likes, or bookmarks",
+		"search",
+	)
+	.option("--mode <mode>", "auto, bird, xurl, or local", "auto")
+	.option("--include-dms", "Include private DM search matches")
+	.option("--since <isoDate>", "Include matches created at or after this date")
+	.option("--until <isoDate>", "Include matches created before this date")
+	.option("--question <prompt>", "Discussion question or angle")
+	.option("--originals-only", "Exclude authored replies that start with @")
+	.option("--hide-low-quality", "Hide RTs, tiny replies, and link-only noise")
+	.option("--model <model>", "OpenAI model id")
+	.option("--refresh", "Bypass the local discussion cache")
+	.option("--limit <n>", "Maximum tweet context", "500")
+	.option("--max-pages <n>", "Maximum live search pages", "5")
+	.action(async (query, options) => {
+		await autoUpdateBeforeRead();
+		const discussionOptions = buildSearchDiscussionOptions(query, options);
+		if (!discussionOptions) return;
+		await runSearchDiscussionCli(discussionOptions);
 	});
 
 program

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -8,6 +8,7 @@ import {
 	Inbox,
 	Link as LinkIcon,
 	Mail,
+	MessagesSquare,
 	ShieldOff,
 } from "lucide-react";
 import {
@@ -36,6 +37,7 @@ import { ThemeSlider } from "./ThemeSlider";
 const links = [
 	{ to: "/inbox", label: "Inbox", icon: Inbox },
 	{ to: "/today", label: "Today", icon: CalendarDays },
+	{ to: "/discuss", label: "Discuss", icon: MessagesSquare },
 	{ to: "/", label: "Home", icon: Home },
 	{ to: "/mentions", label: "Mentions", icon: Bell },
 	{ to: "/likes", label: "Likes", icon: Heart },

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -149,7 +149,8 @@ function seedBackupFixture() {
       account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count, source,
       raw_json, updated_at
     ) values
-      ('acct_primary', 'tweet_2024', 'home', '2024-12-31T23:59:00.000Z', '2024-12-31T23:59:00.000Z', 1, 'archive', '{}', '2025-01-03T00:00:00.000Z');
+      ('acct_primary', 'tweet_2024', 'home', '2024-12-31T23:59:00.000Z', '2024-12-31T23:59:00.000Z', 1, 'archive', '{}', '2025-01-03T00:00:00.000Z'),
+      ('acct_primary', 'tweet_2025', 'search', '2025-01-02T09:00:00.000Z', '2025-01-02T09:00:00.000Z', 1, 'bird', '{"query":"useful"}', '2025-01-03T00:00:00.000Z');
 
     insert into tweets_fts (tweet_id, text) values
       ('tweet_2024', 'Shipping text backups'),
@@ -403,6 +404,7 @@ describe("text backup", () => {
 			profile_bio_entities: 2,
 			tweets: 3,
 			timeline_edges_home: 1,
+			timeline_edges_search: 1,
 			collections_bookmarks: 1,
 			collections_likes: 2,
 			dm_conversations: 1,
@@ -437,6 +439,12 @@ describe("text backup", () => {
 		expect(
 			readFileSync(path.join(repoPath, "data/tweets/2025.jsonl"), "utf8"),
 		).toContain('"bookmarked":1');
+		expect(
+			readFileSync(
+				path.join(repoPath, "data/timeline_edges/search.jsonl"),
+				"utf8",
+			),
+		).toContain('"kind":"search"');
 		expect(
 			readFileSync(
 				path.join(repoPath, "data/links/url_expansions.jsonl"),
@@ -519,6 +527,13 @@ describe("text backup", () => {
 			entities_json:
 				'{"hashtags":[{"text":"backup"}],"urls":[{"url":"https://t.co/shared","expandedUrl":"https://example.com/demo","displayUrl":"example.com/demo","start":22,"end":41}]}',
 		});
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare(
+					"select kind, source from tweet_account_edges where tweet_id = 'tweet_2025' and kind = 'search'",
+				)
+				.get(),
+		).toEqual({ kind: "search", source: "bird" });
 		expect(
 			getNativeDb({ seedDemoData: false })
 				.prepare(

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -537,7 +537,8 @@ function buildShards(db: Database) {
 					const kind =
 						row.kind === "home" ||
 						row.kind === "mention" ||
-						row.kind === "authored"
+						row.kind === "authored" ||
+						row.kind === "search"
 							? row.kind
 							: "unknown";
 					addRows(shards, `data/timeline_edges/${kind}.jsonl`, [row]);
@@ -1853,8 +1854,8 @@ export function importBackupEffect({
         account_id = coalesce(nullif(excluded.account_id, ''), tweets.account_id),
         author_profile_id = coalesce(nullif(excluded.author_profile_id, ''), tweets.author_profile_id),
         kind = case
-          when tweets.kind in ('home', 'mention', 'authored') then tweets.kind
-          when excluded.kind in ('home', 'mention', 'authored') then excluded.kind
+          when tweets.kind in ('home', 'mention', 'authored', 'search') then tweets.kind
+          when excluded.kind in ('home', 'mention', 'authored', 'search') then excluded.kind
           else coalesce(nullif(excluded.kind, ''), tweets.kind)
         end,
         text = coalesce(nullif(excluded.text, ''), tweets.text),

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -174,6 +174,44 @@ describe("bird transport wrapper", () => {
 		expectBirdCommandCall(1, ["mentions", "-n", "3", "--json"]);
 	});
 
+	it("omits max-pages for single-page bird search", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdStdoutOnce("[]");
+		mockBirdStdoutOnce("[]");
+		const { searchTweetsViaBird } = await import("./bird");
+
+		await expect(
+			searchTweetsViaBird("ChatGPT", { maxResults: 5, maxPages: 1 }),
+		).resolves.toEqual({
+			data: [],
+			includes: undefined,
+			meta: {
+				result_count: 0,
+				page_count: 1,
+				next_token: null,
+				newest_id: undefined,
+				oldest_id: undefined,
+			},
+		});
+		expectBirdCommandCall(1, ["search", "ChatGPT", "-n", "5", "--json"]);
+
+		await searchTweetsViaBird("ChatGPT", {
+			maxResults: 5,
+			all: true,
+			maxPages: 2,
+		});
+		expectBirdCommandCall(2, [
+			"search",
+			"ChatGPT",
+			"-n",
+			"5",
+			"--json",
+			"--all",
+			"--max-pages",
+			"2",
+		]);
+	});
+
 	it("maps mention fallbacks and empty mention payloads", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce(

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -566,6 +566,39 @@ export function listBookmarkedTweetsViaBird(options: {
 	return runEffectPromise(listBookmarkedTweetsViaBirdEffect(options));
 }
 
+export function searchTweetsViaBirdEffect(
+	query: string,
+	options: {
+		maxResults: number;
+		all?: boolean;
+		maxPages?: number;
+	},
+): Effect.Effect<XurlMentionsResponse, unknown> {
+	return Effect.gen(function* () {
+		const args = ["search", query, "-n", String(options.maxResults), "--json"];
+		if (options.all) {
+			args.push("--all");
+		}
+		if (options.all && options.maxPages !== undefined) {
+			args.push("--max-pages", String(options.maxPages));
+		}
+		const stdout = yield* runBirdJsonCommandEffect(args);
+		const payload = yield* parseBirdJsonEffect(stdout);
+		return yield* normalizeBirdTweetsPayloadEffect(payload, "search");
+	});
+}
+
+export function searchTweetsViaBird(
+	query: string,
+	options: {
+		maxResults: number;
+		all?: boolean;
+		maxPages?: number;
+	},
+): Promise<XurlMentionsResponse> {
+	return runEffectPromise(searchTweetsViaBirdEffect(query, options));
+}
+
 export function lookupTweetsByIdsViaBirdEffect(
 	ids: string[],
 ): Effect.Effect<XurlTweetsResponse, unknown> {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1955,7 +1955,7 @@ function getDmSearchMatches({
 }
 
 export function queryResource(
-	resource: "home" | "mentions" | "authored" | "dms",
+	resource: "home" | "mentions" | "authored" | "search" | "dms",
 	filters: (TimelineQuery | DmQuery) & { conversationId?: string },
 ): QueryResponse {
 	if (resource === "dms") {

--- a/src/lib/search-discussion.test.ts
+++ b/src/lib/search-discussion.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+import {
+	__test__,
+	collectSearchDiscussionContext,
+	streamSearchDiscussion,
+	streamSearchDiscussionEffect,
+} from "./search-discussion";
+
+const tempRoots: string[] = [];
+
+function setupTempHome() {
+	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-discuss-"));
+	tempRoots.push(tempRoot);
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+}
+
+function sseFrame(value: unknown) {
+	return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+function streamResponse(text: string) {
+	return new Response(
+		new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(text));
+				controller.close();
+			},
+		}),
+	);
+}
+
+beforeEach(() => {
+	setupTempHome();
+	process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+	resetDatabaseForTests();
+	resetBirdclawPathsForTests();
+	delete process.env.BIRDCLAW_HOME;
+	delete process.env.OPENAI_API_KEY;
+	delete process.env.BIRDCLAW_AI_MODEL;
+	delete process.env.BIRDCLAW_OPENAI_REASONING_EFFORT;
+	delete process.env.BIRDCLAW_OPENAI_SERVICE_TIER;
+	vi.unstubAllGlobals();
+	for (const tempRoot of tempRoots.splice(0)) {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("search discussion", () => {
+	it("collects keyword matches from tweets and optional DMs", () => {
+		const context = collectSearchDiscussionContext({
+			query: "local-first",
+			includeDms: true,
+			limit: 20,
+		});
+
+		expect(context.query).toBe("local-first");
+		expect(context.tweets.map((tweet) => tweet.id)).toContain("tweet_001");
+		expect(context.dms.map((dm) => dm.id)).toContain("dm_001");
+		expect(context.hash).toHaveLength(40);
+	});
+
+	it("changes the context hash when profile prompt context changes", () => {
+		const first = collectSearchDiscussionContext({
+			query: "local-first",
+			limit: 20,
+		});
+		getNativeDb()
+			.prepare("update profiles set bio = ? where id = 'profile_sam'")
+			.run("Updated search discussion profile context.");
+		const second = collectSearchDiscussionContext({
+			query: "local-first",
+			limit: 20,
+		});
+
+		expect(second.hash).not.toBe(first.hash);
+	});
+
+	it("keeps the context hash stable for cached live search provenance", () => {
+		const first = collectSearchDiscussionContext({
+			query: "local-first",
+			source: "search",
+			limit: 20,
+			liveSearch: {
+				ok: true,
+				source: "bird",
+				accountId: "acct_primary",
+				query: "local-first",
+				count: 1,
+				pageCount: 1,
+				tweetIds: ["tweet_001"],
+			},
+		});
+		const second = collectSearchDiscussionContext({
+			query: "local-first",
+			source: "search",
+			limit: 20,
+			liveSearch: {
+				ok: true,
+				source: "cache",
+				accountId: "acct_primary",
+				query: "local-first",
+				count: 1,
+				pageCount: 1,
+				tweetIds: ["tweet_001"],
+			},
+		});
+
+		expect(second.hash).toBe(first.hash);
+	});
+
+	it("streams markdown, parses final JSON, and sends Responses API options", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta: "# Local-first\n\nThe thread is about durable local state.\n",
+			}),
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'\n---\n{"title":"Local-first","summary":"People discussed local-first durability","themes":[{"title":"Durability","summary":"Local state and repairability were the center.","tweetIds":["tweet_001"],"dmConversationIds":[],"handles":["sam"]}],"tensions":["Shipping fast vs repairable systems"],"followUps":["Open the linked local-first note"],"sourceTweetIds":["tweet_001"],"sourceDmConversationIds":[]}',
+			}),
+			sseFrame({
+				type: "response.completed",
+				response: { id: "resp_1", usage: { input_tokens: 10 } },
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+
+		let markdown = "";
+		const result = await streamSearchDiscussion(
+			{
+				query: "local-first",
+				question: "What should I pay attention to?",
+				mode: "local",
+				refresh: true,
+				limit: 20,
+			},
+			{ onDelta: (delta) => (markdown += delta) },
+		);
+
+		expect(markdown).toBe(
+			"# Local-first\n\nThe thread is about durable local state.\n",
+		);
+		expect(result.discussion.title).toBe("Local-first");
+		expect(result.discussion.themes[0]?.tweetIds).toEqual(["tweet_001"]);
+		expect(result.markdown).toBe(markdown.trimEnd());
+		expect(result.cached).toBe(false);
+
+		const body = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		) as Record<string, unknown>;
+		expect(body.model).toBe("gpt-5.5");
+		expect(body.reasoning).toEqual({ effort: "medium" });
+		expect(body.service_tier).toBe("priority");
+		expect(body.stream).toBe(true);
+		expect(JSON.stringify(body)).toContain("What should I pay attention to?");
+	});
+
+	it("exposes the discussion stream as an Effect program", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Effect\n\nThe stream is effectful.\n\n---\n{"title":"Effect","summary":"Effect stream","themes":[],"tensions":[],"followUps":[],"sourceTweetIds":[],"sourceDmConversationIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(streamResponse(streamed)));
+
+		const result = await Effect.runPromise(
+			streamSearchDiscussionEffect({
+				query: "local-first",
+				mode: "local",
+				refresh: true,
+				limit: 20,
+			}),
+		);
+
+		expect(result.discussion.title).toBe("Effect");
+		expect(result.markdown).toBe("# Effect\n\nThe stream is effectful.");
+	});
+
+	it("serves cached discussions without calling OpenAI again", async () => {
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Cached\n\nFirst pass.\n\n---\n{"title":"Cached","summary":"First pass","themes":[],"tensions":[],"followUps":[],"sourceTweetIds":[],"sourceDmConversationIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+		const options = { query: "local-first", mode: "local" as const, limit: 20 };
+
+		await streamSearchDiscussion({ ...options, refresh: true });
+		const cached = await streamSearchDiscussion(options);
+
+		expect(cached.cached).toBe(true);
+		expect(cached.discussion.title).toBe("Cached");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects missing OpenAI credentials before starting the request", async () => {
+		delete process.env.OPENAI_API_KEY;
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			streamSearchDiscussion({
+				query: "local-first",
+				mode: "local",
+				refresh: true,
+				limit: 20,
+			}),
+		).rejects.toThrow("OPENAI_API_KEY is not set");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("falls back when the streamed JSON is malformed", () => {
+		const parsed = __test__.parseDiscussionFromHybridText(
+			collectSearchDiscussionContext({
+				query: "local-first",
+				limit: 20,
+			}),
+			"# Report\n\nOnly Markdown\n\n---\n{bad",
+		);
+
+		expect(parsed.markdown).toContain("Only Markdown");
+		expect(parsed.discussion.title).toContain("local-first");
+	});
+});

--- a/src/lib/search-discussion.test.ts
+++ b/src/lib/search-discussion.test.ts
@@ -170,6 +170,48 @@ describe("search discussion", () => {
 		expect(JSON.stringify(body)).toContain("What should I pay attention to?");
 	});
 
+	it("uses environment AI defaults and renders optional prompt context", async () => {
+		process.env.BIRDCLAW_AI_MODEL = "gpt-env";
+		process.env.BIRDCLAW_OPENAI_REASONING_EFFORT = "low";
+		process.env.BIRDCLAW_OPENAI_SERVICE_TIER = "flex";
+		const streamed = [
+			sseFrame({
+				type: "response.output_text.delta",
+				delta:
+					'# Env\n\nDone.\n\n---\n{"title":"Env","summary":"Env defaults","themes":[],"tensions":[],"followUps":[],"sourceTweetIds":[],"sourceDmConversationIds":[]}',
+			}),
+			"data: [DONE]\n\n",
+		].join("");
+		const fetchMock = vi.fn().mockResolvedValue(streamResponse(streamed));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await streamSearchDiscussion({
+			query: "local-first",
+			account: "acct_primary",
+			source: "all",
+			includeDms: true,
+			since: "2026-05-01",
+			until: "2026-05-24",
+			question: "What changed?",
+			mode: "local",
+			refresh: true,
+			limit: 20,
+		});
+
+		const body = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		) as Record<string, unknown>;
+		expect(body.model).toBe("gpt-env");
+		expect(body.reasoning).toEqual({ effort: "low" });
+		expect(body.service_tier).toBe("flex");
+		expect(JSON.stringify(body)).toContain("Account: acct_primary");
+		expect(JSON.stringify(body)).toContain("Since: 2026-05-01");
+		expect(JSON.stringify(body)).toContain("Until: 2026-05-24");
+		expect(JSON.stringify(body)).toContain(
+			"Discussion question: What changed?",
+		);
+	});
+
 	it("exposes the discussion stream as an Effect program", async () => {
 		const streamed = [
 			sseFrame({
@@ -229,6 +271,214 @@ describe("search discussion", () => {
 			}),
 		).rejects.toThrow("OPENAI_API_KEY is not set");
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("surfaces OpenAI response failures", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response("rate limited", {
+					status: 429,
+					statusText: "Too Many Requests",
+				}),
+			),
+		);
+
+		await expect(
+			streamSearchDiscussion({
+				query: "local-first",
+				mode: "local",
+				refresh: true,
+				limit: 20,
+			}),
+		).rejects.toThrow("OpenAI request failed: 429 rate limited");
+	});
+
+	it("processes OpenAI stream event variants", () => {
+		const handlers = {
+			onDelta: vi.fn(),
+			onEvent: vi.fn(),
+		};
+		const state: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			responseId?: string;
+			usage?: unknown;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+
+		__test__.processSseChunk(
+			state,
+			sseFrame({
+				type: "response.output_text.delta",
+				delta: "# Title\n\nVisible text",
+			}),
+			handlers,
+		);
+		__test__.processSseChunk(
+			state,
+			sseFrame({
+				type: "response.output_text.delta",
+				delta: '\n\n---\n{"title":"Hidden"}',
+			}),
+			handlers,
+		);
+		__test__.processSseChunk(
+			state,
+			sseFrame({
+				type: "response.completed",
+				response: { id: "resp_123", usage: { output_tokens: 4 } },
+			}),
+			handlers,
+		);
+		__test__.processSseChunk(state, "data: {bad json}\n\n", handlers);
+		__test__.processSseChunk(state, "data: [DONE]\n\n", handlers);
+
+		expect(state.jsonMode).toBe(true);
+		expect(state.responseId).toBe("resp_123");
+		expect(state.usage).toEqual({ output_tokens: 4 });
+		expect(handlers.onDelta.mock.calls.flat().join("")).toContain(
+			"Visible text",
+		);
+
+		const failedState: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			error?: string;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			failedState,
+			sseFrame({
+				type: "response.failed",
+				response: { incomplete_details: { reason: "max_output_tokens" } },
+			}),
+			{},
+		);
+		expect(failedState.error).toBe(
+			"OpenAI response incomplete: max_output_tokens",
+		);
+
+		const errorState: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			error?: string;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			errorState,
+			sseFrame({ type: "error", error: { message: "stream denied" } }),
+			{},
+		);
+		expect(errorState.error).toBe("stream denied");
+	});
+
+	it("handles edge cases in streamed event parsing", () => {
+		const holdState = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		const handlers = { onDelta: vi.fn(), onEvent: vi.fn() };
+		__test__.processSseChunk(
+			holdState,
+			sseFrame({ type: "response.output_text.delta", delta: "tiny" }),
+			handlers,
+		);
+		expect(holdState.pendingVisible).toBe("tiny");
+		expect(handlers.onDelta).not.toHaveBeenCalled();
+
+		const failedWithMessage: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			error?: string;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			failedWithMessage,
+			sseFrame({
+				type: "response.failed",
+				response: { error: { message: "quota exhausted" } },
+			}),
+			{},
+		);
+		expect(failedWithMessage.error).toBe("quota exhausted");
+
+		const failedDefault: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			error?: string;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			failedDefault,
+			sseFrame({ type: "response.incomplete", response: {} }),
+			{},
+		);
+		expect(failedDefault.error).toBe("OpenAI stream failed");
+
+		const errorDefault: {
+			eventBuffer: string;
+			rawText: string;
+			pendingVisible: string;
+			jsonMode: boolean;
+			error?: string;
+		} = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			errorDefault,
+			sseFrame({ type: "response.error", error: "plain" }),
+			{},
+		);
+		expect(errorDefault.error).toBe("OpenAI stream failed");
+
+		const completedDefault = {
+			eventBuffer: "",
+			rawText: "",
+			pendingVisible: "",
+			jsonMode: false,
+		};
+		__test__.processSseChunk(
+			completedDefault,
+			sseFrame({ type: "response.completed", response: null }),
+			{},
+		);
+		expect(completedDefault).not.toHaveProperty("responseId");
 	});
 
 	it("falls back when the streamed JSON is malformed", () => {

--- a/src/lib/search-discussion.ts
+++ b/src/lib/search-discussion.ts
@@ -1,0 +1,802 @@
+import { createHash } from "node:crypto";
+import { Effect } from "effect";
+import { z } from "zod";
+import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { listDmConversations, listTimelineItems } from "./queries";
+import { readSyncCache, writeSyncCache } from "./sync-cache";
+import {
+	syncTweetSearchEffect,
+	type SyncTweetSearchResult,
+	type TweetSearchMode,
+} from "./tweet-search-live";
+import type { ProfileRecord } from "./types";
+
+export type SearchDiscussionSource =
+	| "all"
+	| "home"
+	| "mentions"
+	| "authored"
+	| "search"
+	| "likes"
+	| "bookmarks";
+
+export interface SearchDiscussionOptions {
+	query: string;
+	account?: string;
+	source?: SearchDiscussionSource;
+	since?: string;
+	until?: string;
+	includeDms?: boolean;
+	originalsOnly?: boolean;
+	hideLowQuality?: boolean;
+	question?: string;
+	mode?: TweetSearchMode;
+	limit?: number;
+	maxPages?: number;
+	refresh?: boolean;
+	model?: string;
+	reasoningEffort?: "minimal" | "low" | "medium" | "high";
+	serviceTier?: "default" | "flex" | "priority";
+	signal?: AbortSignal;
+}
+
+export interface SearchDiscussionStreamHandlers {
+	onDelta?: (delta: string) => void;
+	onEvent?: (event: SearchDiscussionStreamEvent) => void;
+}
+
+interface CompactSearchTweet {
+	id: string;
+	url: string;
+	source: Exclude<SearchDiscussionSource, "all">;
+	author: string;
+	name: string;
+	authorProfile: ProfileRecord;
+	createdAt: string;
+	text: string;
+	likeCount: number;
+	liked: boolean;
+	bookmarked: boolean;
+	needsReply: boolean;
+}
+
+interface CompactSearchDm {
+	id: string;
+	participant: string;
+	name: string;
+	lastMessageAt: string;
+	text: string;
+	needsReply: boolean;
+	influenceScore: number;
+}
+
+export interface SearchDiscussionContext {
+	query: string;
+	question?: string;
+	account?: string;
+	source: SearchDiscussionSource;
+	since?: string;
+	until?: string;
+	includeDms: boolean;
+	counts: Record<Exclude<SearchDiscussionSource, "all"> | "dms", number>;
+	tweets: CompactSearchTweet[];
+	dms: CompactSearchDm[];
+	liveSearch?: SyncTweetSearchResult;
+	hash: string;
+}
+
+const SearchDiscussionSchema = z.object({
+	title: z.string().min(1),
+	summary: z.string().min(1),
+	themes: z.array(
+		z.object({
+			title: z.string().min(1),
+			summary: z.string().min(1),
+			tweetIds: z.array(z.string()).default([]),
+			dmConversationIds: z.array(z.string()).default([]),
+			handles: z.array(z.string()).default([]),
+		}),
+	),
+	tensions: z.array(z.string()).default([]),
+	followUps: z.array(z.string()).default([]),
+	sourceTweetIds: z.array(z.string()).default([]),
+	sourceDmConversationIds: z.array(z.string()).default([]),
+});
+
+export type SearchDiscussion = z.infer<typeof SearchDiscussionSchema>;
+
+export interface SearchDiscussionRunResult {
+	context: SearchDiscussionContext;
+	discussion: SearchDiscussion;
+	markdown: string;
+	model: string;
+	reasoningEffort: string;
+	serviceTier: string;
+	cached: boolean;
+	updatedAt: string;
+}
+
+export type SearchDiscussionStreamEvent =
+	| { type: "start"; context: SearchDiscussionContext; cached: boolean }
+	| { type: "delta"; delta: string }
+	| { type: "done"; result: SearchDiscussionRunResult }
+	| { type: "error"; error: string };
+
+interface OpenAIStreamState {
+	eventBuffer: string;
+	rawText: string;
+	pendingVisible: string;
+	jsonMode: boolean;
+	responseId?: string;
+	usage?: unknown;
+	error?: string;
+}
+
+const DEFAULT_MODEL = "gpt-5.5";
+const DEFAULT_REASONING_EFFORT = "medium";
+const DEFAULT_SERVICE_TIER = "priority";
+const DEFAULT_LIMIT = 500;
+const DEFAULT_MAX_PAGES = 5;
+const DELIMITER_PATTERN = /\n---\s*\n/;
+const VISIBLE_DELIMITER_HOLD = 8;
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySearchSync<T>(try_: () => T): Effect.Effect<T, Error> {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+function trySearchPromise<T>(
+	try_: () => PromiseLike<T>,
+): Effect.Effect<T, Error> {
+	return tryPromise(try_).pipe(Effect.mapError(toError));
+}
+
+function tweetUrl(handle: string, id: string) {
+	return `https://x.com/${handle}/status/${id}`;
+}
+
+function sourceList(source: SearchDiscussionSource) {
+	if (source !== "all") return [source];
+	return [
+		"search",
+		"home",
+		"mentions",
+		"authored",
+		"likes",
+		"bookmarks",
+	] as const;
+}
+
+function compactTweet(
+	source: Exclude<SearchDiscussionSource, "all">,
+	item: ReturnType<typeof listTimelineItems>[number],
+): CompactSearchTweet {
+	return {
+		id: item.id,
+		url: tweetUrl(item.author.handle, item.id),
+		source,
+		author: item.author.handle,
+		name: item.author.displayName,
+		authorProfile: item.author,
+		createdAt: item.createdAt,
+		text: item.text,
+		likeCount: item.likeCount,
+		liked: item.liked,
+		bookmarked: item.bookmarked,
+		needsReply: !item.isReplied,
+	};
+}
+
+function collectTweetsForSource(
+	source: Exclude<SearchDiscussionSource, "all">,
+	options: SearchDiscussionOptions & { limit: number },
+) {
+	const timelineResource =
+		source === "likes" || source === "bookmarks" ? "home" : source;
+	return listTimelineItems({
+		resource: timelineResource,
+		account: options.account,
+		search: options.query,
+		since: options.since,
+		until: options.until,
+		includeReplies: !options.originalsOnly,
+		qualityFilter: options.hideLowQuality ? "summary" : "all",
+		likedOnly: source === "likes",
+		bookmarkedOnly: source === "bookmarks",
+		limit: options.limit,
+	}).map((item) => compactTweet(source, item));
+}
+
+function collectDms(options: SearchDiscussionOptions & { limit: number }) {
+	if (!options.includeDms) return [];
+	return listDmConversations({
+		account: options.account,
+		search: options.query,
+		since: options.since,
+		until: options.until,
+		sort: "recent",
+		context: 2,
+		limit: Math.max(1, Math.ceil(options.limit / 2)),
+	}).map((item): CompactSearchDm => {
+		const matchText = item.matches
+			?.flatMap((match) => [
+				...match.before.map((message) => message.text),
+				match.message.text,
+				...match.after.map((message) => message.text),
+			])
+			.join("\n");
+		return {
+			id: item.id,
+			participant: item.participant.handle,
+			name: item.participant.displayName,
+			lastMessageAt: item.lastMessageAt,
+			text: matchText || item.lastMessagePreview,
+			needsReply: item.needsReply,
+			influenceScore: item.influenceScore,
+		};
+	});
+}
+
+function dedupeTweets(tweets: CompactSearchTweet[]) {
+	const seen = new Set<string>();
+	const items: CompactSearchTweet[] = [];
+	for (const tweet of tweets) {
+		if (seen.has(tweet.id)) continue;
+		seen.add(tweet.id);
+		items.push(tweet);
+	}
+	return items.sort((left, right) =>
+		right.createdAt.localeCompare(left.createdAt),
+	);
+}
+
+function contextHash(context: Omit<SearchDiscussionContext, "hash">) {
+	const liveSearch =
+		context.liveSearch?.ok === true
+			? {
+					ok: true,
+					accountId: context.liveSearch.accountId,
+					query: context.liveSearch.query,
+					count: context.liveSearch.count,
+					pageCount: context.liveSearch.pageCount,
+					tweetIds: context.liveSearch.tweetIds,
+				}
+			: context.liveSearch;
+	return createHash("sha1")
+		.update(
+			JSON.stringify({
+				query: context.query,
+				question: context.question,
+				account: context.account,
+				source: context.source,
+				since: context.since,
+				until: context.until,
+				includeDms: context.includeDms,
+				tweets: context.tweets.map((tweet) => [
+					tweet.id,
+					tweet.source,
+					tweet.author,
+					tweet.name,
+					tweet.authorProfile.bio,
+					tweet.authorProfile.followersCount,
+					tweet.createdAt,
+					tweet.text,
+					tweet.likeCount,
+					tweet.liked,
+					tweet.bookmarked,
+					tweet.needsReply,
+				]),
+				dms: context.dms.map((dm) => [
+					dm.id,
+					dm.lastMessageAt,
+					dm.text,
+					dm.needsReply,
+					dm.influenceScore,
+				]),
+				liveSearch,
+			}),
+		)
+		.digest("hex");
+}
+
+export function collectSearchDiscussionContext(
+	options: SearchDiscussionOptions & { liveSearch?: SyncTweetSearchResult },
+): SearchDiscussionContext {
+	const query = options.query.trim();
+	if (!query) {
+		throw new Error("Search query is required");
+	}
+	const limit = Math.max(1, Math.trunc(options.limit ?? DEFAULT_LIMIT));
+	const source = options.source ?? "all";
+	const counts = {
+		home: 0,
+		mentions: 0,
+		authored: 0,
+		search: 0,
+		likes: 0,
+		bookmarks: 0,
+		dms: 0,
+	};
+	const tweets = sourceList(source).flatMap((item) => {
+		const sourceTweets = collectTweetsForSource(item, {
+			...options,
+			query,
+			source,
+			limit,
+		});
+		counts[item] = sourceTweets.length;
+		return sourceTweets;
+	});
+	const dms = collectDms({ ...options, query, source, limit });
+	counts.dms = dms.length;
+	const limitedTweets = dedupeTweets(tweets).slice(0, limit);
+	const withoutHash = {
+		query,
+		...(options.question?.trim() ? { question: options.question.trim() } : {}),
+		...(options.account ? { account: options.account } : {}),
+		source,
+		...(options.since ? { since: options.since } : {}),
+		...(options.until ? { until: options.until } : {}),
+		includeDms: Boolean(options.includeDms),
+		counts,
+		tweets: limitedTweets,
+		dms,
+		...(options.liveSearch ? { liveSearch: options.liveSearch } : {}),
+	} satisfies Omit<SearchDiscussionContext, "hash">;
+	return {
+		...withoutHash,
+		hash: contextHash(withoutHash),
+	};
+}
+
+function modelFromOptions(options: SearchDiscussionOptions) {
+	return options.model ?? process.env.BIRDCLAW_AI_MODEL ?? DEFAULT_MODEL;
+}
+
+function reasoningEffortFromOptions(options: SearchDiscussionOptions) {
+	return (
+		options.reasoningEffort ??
+		(process.env.BIRDCLAW_OPENAI_REASONING_EFFORT as
+			| SearchDiscussionOptions["reasoningEffort"]
+			| undefined) ??
+		DEFAULT_REASONING_EFFORT
+	);
+}
+
+function serviceTierFromOptions(options: SearchDiscussionOptions) {
+	return (
+		options.serviceTier ??
+		(process.env.BIRDCLAW_OPENAI_SERVICE_TIER as
+			| SearchDiscussionOptions["serviceTier"]
+			| undefined) ??
+		DEFAULT_SERVICE_TIER
+	);
+}
+
+function cacheKey(
+	context: SearchDiscussionContext,
+	options: SearchDiscussionOptions,
+) {
+	return [
+		"search-discussion:v1",
+		modelFromOptions(options),
+		reasoningEffortFromOptions(options),
+		serviceTierFromOptions(options),
+		context.hash,
+	].join(":");
+}
+
+function buildPrompt(context: SearchDiscussionContext) {
+	const promptTweets = context.tweets.map((tweet) => ({
+		id: tweet.id,
+		url: tweet.url,
+		source: tweet.source,
+		author: tweet.author,
+		name: tweet.name,
+		bio: tweet.authorProfile.bio,
+		followersCount: tweet.authorProfile.followersCount,
+		createdAt: tweet.createdAt,
+		text: tweet.text,
+		likeCount: tweet.likeCount,
+		liked: tweet.liked,
+		bookmarked: tweet.bookmarked,
+		needsReply: tweet.needsReply,
+	}));
+
+	return `Search query: ${context.query}
+${context.question ? `Discussion question: ${context.question}\n` : ""}Account: ${context.account ?? "all"}
+Source: ${context.source}
+Live search: ${context.liveSearch ? JSON.stringify(context.liveSearch) : "not run"}
+Since: ${context.since ?? "(none)"}
+Until: ${context.until ?? "(none)"}
+Counts: ${JSON.stringify(context.counts)}
+
+Write a high-signal Markdown discussion from this local Twitter/X search result set.
+
+Requirements:
+- Start with a concise summary of what the matching posts are really about.
+- Then write sections named "Themes", "Discussion", and "Follow-ups".
+- Use bullets when grouping multiple points.
+- Compare agreement, disagreement, shifts over time, and recurring people or links when visible.
+- Cite claims with tweet ids or DM conversation ids at the end of the sentence, e.g. (tweet_123) or (dm_456).
+- DMs are private context and only present when explicitly included; do not quote private text at length.
+- If there is no data, say that plainly in one short paragraph.
+- After the Markdown, output a blank line, then a line containing only three hyphens, then one compact JSON object.
+- Put every cited tweet id in sourceTweetIds and every cited DM conversation id in sourceDmConversationIds.
+- JSON shape: { "title": string, "summary": string, "themes": [{ "title": string, "summary": string, "tweetIds": string[], "dmConversationIds": string[], "handles": string[] }], "tensions": string[], "followUps": string[], "sourceTweetIds": string[], "sourceDmConversationIds": string[] }
+
+Dataset:
+${JSON.stringify({ tweets: promptTweets, dms: context.dms }, null, 2)}`;
+}
+
+function fallbackDiscussion(
+	context: SearchDiscussionContext,
+	markdown: string,
+): SearchDiscussion {
+	return {
+		title: `Search discussion: ${context.query}`,
+		summary:
+			markdown.replaceAll(/\s+/g, " ").trim().slice(0, 280) ||
+			"No model summary was returned.",
+		themes: [],
+		tensions: [],
+		followUps: [],
+		sourceTweetIds: context.tweets.slice(0, 20).map((tweet) => tweet.id),
+		sourceDmConversationIds: context.dms.slice(0, 20).map((dm) => dm.id),
+	};
+}
+
+function parseDiscussionFromHybridText(
+	context: SearchDiscussionContext,
+	rawText: string,
+): { discussion: SearchDiscussion; markdown: string } {
+	const [markdownPart, jsonPart] = rawText.split(DELIMITER_PATTERN);
+	const markdown = (markdownPart ?? rawText).trim();
+	const candidate = jsonPart?.slice(
+		jsonPart.indexOf("{"),
+		jsonPart.lastIndexOf("}") + 1,
+	);
+	if (candidate?.startsWith("{")) {
+		try {
+			return {
+				markdown,
+				discussion: SearchDiscussionSchema.parse(JSON.parse(candidate)),
+			};
+		} catch {
+			return { markdown, discussion: fallbackDiscussion(context, markdown) };
+		}
+	}
+	return { markdown, discussion: fallbackDiscussion(context, markdown) };
+}
+
+function emitVisibleDelta(
+	state: OpenAIStreamState,
+	delta: string,
+	handlers: SearchDiscussionStreamHandlers,
+) {
+	state.rawText += delta;
+	if (state.jsonMode) return;
+
+	const combined = state.pendingVisible + delta;
+	const delimiterIndex = combined.search(DELIMITER_PATTERN);
+	if (delimiterIndex >= 0) {
+		const visible = combined.slice(0, delimiterIndex);
+		if (visible) {
+			handlers.onDelta?.(visible);
+			handlers.onEvent?.({ type: "delta", delta: visible });
+		}
+		state.pendingVisible = "";
+		state.jsonMode = true;
+		return;
+	}
+
+	if (combined.length <= VISIBLE_DELIMITER_HOLD) {
+		state.pendingVisible = combined;
+		return;
+	}
+
+	const visible = combined.slice(0, -VISIBLE_DELIMITER_HOLD);
+	state.pendingVisible = combined.slice(-VISIBLE_DELIMITER_HOLD);
+	if (visible) {
+		handlers.onDelta?.(visible);
+		handlers.onEvent?.({ type: "delta", delta: visible });
+	}
+}
+
+function flushPendingVisible(
+	state: OpenAIStreamState,
+	handlers: SearchDiscussionStreamHandlers,
+) {
+	if (state.jsonMode || !state.pendingVisible) return;
+	const delta = state.pendingVisible;
+	state.pendingVisible = "";
+	handlers.onDelta?.(delta);
+	handlers.onEvent?.({ type: "delta", delta });
+}
+
+function handleOpenAIEvent(
+	state: OpenAIStreamState,
+	event: Record<string, unknown>,
+	handlers: SearchDiscussionStreamHandlers,
+) {
+	const type = typeof event.type === "string" ? event.type : "";
+	if (
+		type === "response.output_text.delta" &&
+		typeof event.delta === "string"
+	) {
+		emitVisibleDelta(state, event.delta, handlers);
+		return;
+	}
+	if (type === "response.completed") {
+		const response = event.response;
+		if (response && typeof response === "object") {
+			const record = response as Record<string, unknown>;
+			state.responseId = typeof record.id === "string" ? record.id : undefined;
+			state.usage = record.usage;
+		}
+		return;
+	}
+	if (type === "response.error" || type === "error") {
+		const error = event.error;
+		state.error =
+			error && typeof error === "object" && "message" in error
+				? String((error as { message?: unknown }).message)
+				: "OpenAI stream failed";
+		return;
+	}
+	if (type === "response.failed" || type === "response.incomplete") {
+		const response = event.response;
+		const record =
+			response && typeof response === "object"
+				? (response as Record<string, unknown>)
+				: {};
+		const error = record.error;
+		const incomplete = record.incomplete_details;
+		state.error =
+			error && typeof error === "object" && "message" in error
+				? String((error as { message?: unknown }).message)
+				: incomplete && typeof incomplete === "object" && "reason" in incomplete
+					? `OpenAI response incomplete: ${String((incomplete as { reason?: unknown }).reason)}`
+					: "OpenAI stream failed";
+	}
+}
+
+function processSseChunk(
+	state: OpenAIStreamState,
+	chunk: string,
+	handlers: SearchDiscussionStreamHandlers,
+) {
+	state.eventBuffer += chunk;
+	let boundary = state.eventBuffer.indexOf("\n\n");
+	while (boundary >= 0) {
+		const block = state.eventBuffer.slice(0, boundary);
+		state.eventBuffer = state.eventBuffer.slice(boundary + 2);
+		const data = block
+			.split("\n")
+			.filter((line) => line.startsWith("data:"))
+			.map((line) => line.slice(5).trimStart())
+			.join("\n");
+		if (data && data !== "[DONE]") {
+			try {
+				handleOpenAIEvent(
+					state,
+					JSON.parse(data) as Record<string, unknown>,
+					handlers,
+				);
+			} catch {
+				// Final hybrid parse decides whether malformed output can be used.
+			}
+		}
+		boundary = state.eventBuffer.indexOf("\n\n");
+	}
+}
+
+function createOpenAIRequestBody(
+	context: SearchDiscussionContext,
+	options: SearchDiscussionOptions,
+) {
+	return {
+		model: modelFromOptions(options),
+		reasoning: { effort: reasoningEffortFromOptions(options) },
+		service_tier: serviceTierFromOptions(options),
+		store: false,
+		stream: true,
+		max_output_tokens: 7000,
+		input: [
+			{
+				role: "system",
+				content:
+					"You are a precise local Twitter archive analyst. Stream Markdown first, then emit the requested JSON object after the delimiter. Do not invent events not present in the dataset.",
+			},
+			{
+				role: "user",
+				content: buildPrompt(context),
+			},
+		],
+	};
+}
+
+function readOpenAIStreamEffect(
+	response: Response,
+	context: SearchDiscussionContext,
+	options: SearchDiscussionOptions,
+	handlers: SearchDiscussionStreamHandlers,
+): Effect.Effect<SearchDiscussionRunResult, Error> {
+	const reader = response.body?.getReader();
+	if (!reader) {
+		return Effect.fail(new Error("OpenAI response did not include a stream"));
+	}
+
+	const decoder = new TextDecoder();
+	const state: OpenAIStreamState = {
+		eventBuffer: "",
+		rawText: "",
+		pendingVisible: "",
+		jsonMode: false,
+	};
+
+	return Effect.gen(function* () {
+		for (;;) {
+			const { done, value } = yield* trySearchPromise(() => reader.read());
+			if (!done) {
+				processSseChunk(
+					state,
+					decoder.decode(value, { stream: true }),
+					handlers,
+				);
+				continue;
+			}
+
+			flushPendingVisible(state, handlers);
+			if (state.error) {
+				return yield* Effect.fail(new Error(state.error));
+			}
+
+			const parsed = yield* trySearchSync(() =>
+				parseDiscussionFromHybridText(context, state.rawText),
+			);
+			const updatedAt = yield* trySearchSync(() =>
+				writeSyncCache(cacheKey(context, options), {
+					discussion: parsed.discussion,
+					markdown: parsed.markdown,
+					model: modelFromOptions(options),
+					reasoningEffort: reasoningEffortFromOptions(options),
+					serviceTier: serviceTierFromOptions(options),
+					usage: state.usage,
+					responseId: state.responseId,
+				}),
+			);
+			const result = {
+				context,
+				discussion: parsed.discussion,
+				markdown: parsed.markdown,
+				model: modelFromOptions(options),
+				reasoningEffort: reasoningEffortFromOptions(options),
+				serviceTier: serviceTierFromOptions(options),
+				cached: false,
+				updatedAt,
+			};
+			handlers.onEvent?.({ type: "done", result });
+			return result;
+		}
+	}).pipe(
+		Effect.ensuring(
+			Effect.sync(() => {
+				reader.releaseLock();
+			}),
+		),
+	);
+}
+
+export function streamSearchDiscussionEffect(
+	options: SearchDiscussionOptions,
+	handlers: SearchDiscussionStreamHandlers = {},
+): Effect.Effect<SearchDiscussionRunResult, Error> {
+	return Effect.gen(function* () {
+		const mode = options.mode ?? "auto";
+		const liveSearch =
+			mode === "local"
+				? undefined
+				: yield* syncTweetSearchEffect({
+						query: options.query,
+						account: options.account,
+						mode,
+						limit: options.limit ?? DEFAULT_LIMIT,
+						maxPages: options.maxPages ?? DEFAULT_MAX_PAGES,
+						refresh: options.refresh,
+						timeoutMs: 30_000,
+					});
+		if (liveSearch && !liveSearch.ok) {
+			return yield* Effect.fail(
+				new Error(
+					`Live tweet search failed via ${liveSearch.source}: ${liveSearch.error}`,
+				),
+			);
+		}
+		const context = yield* trySearchSync(() =>
+			collectSearchDiscussionContext({
+				...options,
+				source: options.source ?? "search",
+				liveSearch,
+			}),
+		);
+		const cached = options.refresh
+			? null
+			: yield* trySearchSync(() =>
+					readSyncCache<{
+						discussion: SearchDiscussion;
+						markdown: string;
+						model: string;
+						reasoningEffort: string;
+						serviceTier: string;
+					}>(cacheKey(context, options)),
+				);
+		if (cached) {
+			const result: SearchDiscussionRunResult = yield* trySearchSync(() => ({
+				context,
+				discussion: SearchDiscussionSchema.parse(cached.value.discussion),
+				markdown: cached.value.markdown,
+				model: cached.value.model,
+				reasoningEffort: cached.value.reasoningEffort,
+				serviceTier: cached.value.serviceTier,
+				cached: true,
+				updatedAt: cached.updatedAt,
+			}));
+			handlers.onEvent?.({ type: "start", context, cached: true });
+			handlers.onDelta?.(result.markdown);
+			handlers.onEvent?.({ type: "delta", delta: result.markdown });
+			handlers.onEvent?.({ type: "done", result });
+			return result;
+		}
+
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (!apiKey) {
+			return yield* Effect.fail(new Error("OPENAI_API_KEY is not set"));
+		}
+
+		handlers.onEvent?.({ type: "start", context, cached: false });
+		const response = yield* trySearchPromise(() =>
+			fetch("https://api.openai.com/v1/responses", {
+				method: "POST",
+				signal: options.signal,
+				headers: {
+					authorization: `Bearer ${apiKey}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify(createOpenAIRequestBody(context, options)),
+			}),
+		);
+		if (!response.ok) {
+			const text = yield* trySearchPromise(() => response.text());
+			return yield* Effect.fail(
+				new Error(
+					`OpenAI request failed: ${String(response.status)} ${text.slice(
+						0,
+						400,
+					)}`,
+				),
+			);
+		}
+		return yield* readOpenAIStreamEffect(response, context, options, handlers);
+	});
+}
+
+export function streamSearchDiscussion(
+	options: SearchDiscussionOptions,
+	handlers: SearchDiscussionStreamHandlers = {},
+): Promise<SearchDiscussionRunResult> {
+	return runEffectPromise(streamSearchDiscussionEffect(options, handlers));
+}
+
+export const __test__ = {
+	SearchDiscussionSchema,
+	buildPrompt,
+	parseDiscussionFromHybridText,
+	processSseChunk,
+};

--- a/src/lib/tweet-account-edges.ts
+++ b/src/lib/tweet-account-edges.ts
@@ -4,6 +4,7 @@ export type TweetAccountEdgeKind =
 	| "home"
 	| "mention"
 	| "authored"
+	| "search"
 	| "thread_context";
 
 export function upsertTweetAccountEdge(

--- a/src/lib/tweet-search-live.test.ts
+++ b/src/lib/tweet-search-live.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+
+const mocks = vi.hoisted(() => ({
+	searchTweetsViaBird: vi.fn(),
+	searchRecentTweets: vi.fn(),
+}));
+
+vi.mock("./bird", async () => ({
+	searchTweetsViaBirdEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => mocks.searchTweetsViaBird(...args),
+			catch: (error) =>
+				error instanceof Error ? error : new Error(String(error)),
+		}),
+}));
+
+vi.mock("./xurl", async () => ({
+	searchRecentTweetsEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => mocks.searchRecentTweets(...args),
+			catch: (error) =>
+				error instanceof Error ? error : new Error(String(error)),
+		}),
+}));
+
+const tempRoots: string[] = [];
+
+function setupTempHome() {
+	const tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-search-"));
+	tempRoots.push(tempRoot);
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+}
+
+function payload(ids: string[], nextToken?: string) {
+	return {
+		data: ids.map((id, index) => ({
+			id,
+			author_id: `user_${id}`,
+			text: `Search result ${id} about local-first systems`,
+			created_at: `2026-05-2${String(index)}T00:00:00.000Z`,
+			conversation_id: id,
+			entities: {},
+			public_metrics: { like_count: 10 + index },
+			edit_history_tweet_ids: [id],
+		})),
+		includes: {
+			users: ids.map((id) => ({
+				id: `user_${id}`,
+				username: `handle_${id}`,
+				name: `Handle ${id}`,
+				description: "Search profile",
+				public_metrics: { followers_count: 100 },
+			})),
+		},
+		meta: {
+			result_count: ids.length,
+			page_count: 1,
+			...(nextToken ? { next_token: nextToken } : {}),
+		},
+	};
+}
+
+beforeEach(() => {
+	setupTempHome();
+	mocks.searchTweetsViaBird.mockReset();
+	mocks.searchRecentTweets.mockReset();
+});
+
+afterEach(() => {
+	resetDatabaseForTests();
+	resetBirdclawPathsForTests();
+	delete process.env.BIRDCLAW_HOME;
+	vi.clearAllMocks();
+	for (const tempRoot of tempRoots.splice(0)) {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});
+
+describe("live tweet search sync", () => {
+	it("stores bird search results as search edges and FTS rows", async () => {
+		mocks.searchTweetsViaBird.mockResolvedValue(payload(["tweet_live_1"]));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "bird",
+			refresh: true,
+			limit: 100,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			source: "bird",
+			count: 1,
+			tweetIds: ["tweet_live_1"],
+		});
+		const db = getNativeDb();
+		expect(
+			db
+				.prepare(
+					"select kind, source from tweet_account_edges where tweet_id = ?",
+				)
+				.get("tweet_live_1"),
+		).toEqual({ kind: "search", source: "bird" });
+		expect(
+			db
+				.prepare("select count(*) as count from tweets_fts where tweet_id = ?")
+				.get("tweet_live_1"),
+		).toEqual({ count: 1 });
+	});
+
+	it("paginates xurl search and falls back from auto bird failures", async () => {
+		mocks.searchTweetsViaBird.mockRejectedValue(new Error("bird unavailable"));
+		mocks.searchRecentTweets
+			.mockResolvedValueOnce(payload(["tweet_xurl_1"], "next"))
+			.mockResolvedValueOnce(payload(["tweet_xurl_2"]));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "auto",
+			refresh: true,
+			limit: 150,
+			maxPages: 2,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 2,
+			tweetIds: ["tweet_xurl_1", "tweet_xurl_2"],
+		});
+		expect(mocks.searchRecentTweets).toHaveBeenCalledTimes(2);
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from tweet_account_edges where kind = 'search' and source = 'xurl'",
+				)
+				.get(),
+		).toEqual({ count: 2 });
+	});
+
+	it("caps persisted xurl results to the requested limit", async () => {
+		mocks.searchRecentTweets.mockResolvedValue(
+			payload(["tweet_xurl_1", "tweet_xurl_2", "tweet_xurl_3"]),
+		);
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "xurl",
+			refresh: true,
+			limit: 1,
+			maxPages: 1,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 1,
+			tweetIds: ["tweet_xurl_1"],
+		});
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from tweet_account_edges where kind = 'search'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
+	});
+
+	it("uses a fresh search cache without hitting live transports", async () => {
+		mocks.searchTweetsViaBird.mockResolvedValue(payload(["tweet_cached_1"]));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+		const options = {
+			query: "local-first",
+			mode: "bird" as const,
+			limit: 100,
+		};
+
+		await syncTweetSearch({ ...options, refresh: true });
+		const cached = await syncTweetSearch(options);
+
+		expect(cached).toMatchObject({
+			ok: true,
+			source: "cache",
+			count: 1,
+			tweetIds: ["tweet_cached_1"],
+		});
+		expect(mocks.searchTweetsViaBird).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/tweet-search-live.test.ts
+++ b/src/lib/tweet-search-live.test.ts
@@ -118,6 +118,67 @@ describe("live tweet search sync", () => {
 		).toEqual({ count: 1 });
 	});
 
+	it("validates query, account, limit, and max-pages before live search", async () => {
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		await expect(syncTweetSearch({ query: "  " })).rejects.toThrow(
+			"Search query is required",
+		);
+		await expect(
+			syncTweetSearch({ query: "local-first", limit: 0 }),
+		).rejects.toThrow("--limit must be at least 1");
+		await expect(
+			syncTweetSearch({ query: "local-first", maxPages: 0 }),
+		).rejects.toThrow("--max-pages must be at least 1");
+		await expect(
+			syncTweetSearch({ query: "local-first", account: "missing" }),
+		).rejects.toThrow("Unknown account: missing");
+		expect(mocks.searchTweetsViaBird).not.toHaveBeenCalled();
+		expect(mocks.searchRecentTweets).not.toHaveBeenCalled();
+	});
+
+	it("returns a local no-op result without touching live transports", async () => {
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "local",
+			limit: 10,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			source: "cache",
+			accountId: "acct_primary",
+			query: "local-first",
+			count: 0,
+			pageCount: 0,
+			tweetIds: [],
+		});
+		expect(mocks.searchTweetsViaBird).not.toHaveBeenCalled();
+		expect(mocks.searchRecentTweets).not.toHaveBeenCalled();
+	});
+
+	it("captures explicit live transport failures", async () => {
+		mocks.searchTweetsViaBird.mockRejectedValue(new Error("bird denied"));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "bird",
+			refresh: true,
+			limit: 10,
+		});
+
+		expect(result).toMatchObject({
+			ok: false,
+			source: "bird",
+			accountId: "acct_primary",
+			query: "local-first",
+			error: "bird denied",
+		});
+	});
+
 	it("paginates xurl search and falls back from auto bird failures", async () => {
 		mocks.searchTweetsViaBird.mockRejectedValue(new Error("bird unavailable"));
 		mocks.searchRecentTweets
@@ -149,6 +210,27 @@ describe("live tweet search sync", () => {
 		).toEqual({ count: 2 });
 	});
 
+	it("reports auto failure when both live transports fail", async () => {
+		mocks.searchTweetsViaBird.mockRejectedValue(new Error("bird unavailable"));
+		mocks.searchRecentTweets.mockRejectedValue(new Error("xurl unauthorized"));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const result = await syncTweetSearch({
+			query: "local-first",
+			mode: "auto",
+			refresh: true,
+			limit: 10,
+		});
+
+		expect(result).toMatchObject({
+			ok: false,
+			source: "auto",
+			accountId: "acct_primary",
+			query: "local-first",
+			error: "bird unavailable; xurl unauthorized",
+		});
+	});
+
 	it("caps persisted xurl results to the requested limit", async () => {
 		mocks.searchRecentTweets.mockResolvedValue(
 			payload(["tweet_xurl_1", "tweet_xurl_2", "tweet_xurl_3"]),
@@ -176,6 +258,50 @@ describe("live tweet search sync", () => {
 				)
 				.get(),
 		).toEqual({ count: 1 });
+	});
+
+	it("caps bird results and reuses xurl cache entries", async () => {
+		mocks.searchTweetsViaBird.mockResolvedValue(
+			payload(["tweet_bird_1", "tweet_bird_2"]),
+		);
+		mocks.searchRecentTweets.mockResolvedValue(payload(["tweet_xurl_cached"]));
+		const { syncTweetSearch } = await import("./tweet-search-live");
+
+		const bird = await syncTweetSearch({
+			query: "local-first",
+			mode: "bird",
+			refresh: true,
+			limit: 1,
+			maxPages: 3,
+		});
+		expect(bird).toMatchObject({
+			ok: true,
+			source: "bird",
+			count: 1,
+			tweetIds: ["tweet_bird_1"],
+		});
+
+		const firstXurl = await syncTweetSearch({
+			query: "cached",
+			mode: "xurl",
+			refresh: true,
+			limit: 10,
+			cacheTtlMs: -1,
+		});
+		const cachedXurl = await syncTweetSearch({
+			query: "cached",
+			mode: "xurl",
+			limit: 10,
+			cacheTtlMs: Number.NaN,
+		});
+
+		expect(firstXurl).toMatchObject({ ok: true, source: "xurl" });
+		expect(cachedXurl).toMatchObject({
+			ok: true,
+			source: "cache",
+			tweetIds: ["tweet_xurl_cached"],
+		});
+		expect(mocks.searchRecentTweets).toHaveBeenCalledTimes(1);
 	});
 
 	it("uses a fresh search cache without hitting live transports", async () => {

--- a/src/lib/tweet-search-live.ts
+++ b/src/lib/tweet-search-live.ts
@@ -1,0 +1,465 @@
+import { Effect } from "effect";
+import { searchTweetsViaBirdEffect } from "./bird";
+import type { Database } from "./sqlite";
+import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
+import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
+import { readSyncCache, writeSyncCache } from "./sync-cache";
+import type { XurlMentionsResponse, XurlTweetsResponse } from "./types";
+import { upsertTweetAccountEdge } from "./tweet-account-edges";
+import { ensureStubProfileForXUser, upsertProfileFromXUser } from "./x-profile";
+import { searchRecentTweetsEffect } from "./xurl";
+
+export type TweetSearchMode = "auto" | "bird" | "xurl" | "local";
+
+export interface SyncTweetSearchOptions {
+	query: string;
+	account?: string;
+	mode?: TweetSearchMode;
+	limit?: number;
+	maxPages?: number;
+	refresh?: boolean;
+	cacheTtlMs?: number;
+	timeoutMs?: number;
+}
+
+export type SyncTweetSearchResult =
+	| {
+			ok: true;
+			source: "bird" | "xurl" | "cache";
+			accountId: string;
+			query: string;
+			count: number;
+			pageCount: number;
+			tweetIds: string[];
+	  }
+	| {
+			ok: false;
+			source: "bird" | "xurl" | "auto";
+			accountId: string;
+			query: string;
+			error: string;
+	  };
+
+const DEFAULT_SEARCH_LIMIT = 500;
+const DEFAULT_MAX_PAGES = 5;
+const DEFAULT_CACHE_TTL_MS = 2 * 60_000;
+const XURL_PAGE_SIZE = 100;
+
+function toError(error: unknown) {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function trySync<T>(try_: () => T) {
+	return Effect.try({
+		try: try_,
+		catch: toError,
+	});
+}
+
+function normalizeLimit(limit: number | undefined) {
+	if (limit === undefined) return DEFAULT_SEARCH_LIMIT;
+	if (!Number.isFinite(limit) || limit < 1) {
+		throw new Error("--limit must be at least 1");
+	}
+	return Math.floor(limit);
+}
+
+function normalizeMaxPages(maxPages: number | undefined) {
+	if (maxPages === undefined) return DEFAULT_MAX_PAGES;
+	if (!Number.isFinite(maxPages) || maxPages < 1) {
+		throw new Error("--max-pages must be at least 1");
+	}
+	return Math.floor(maxPages);
+}
+
+function normalizeCacheTtlMs(value: number | undefined) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		return DEFAULT_CACHE_TTL_MS;
+	}
+	return Math.floor(value);
+}
+
+function resolveAccount(db: Database, accountId?: string) {
+	const row = accountId
+		? (db.prepare("select id from accounts where id = ?").get(accountId) as
+				| { id: string }
+				| undefined)
+		: (db
+				.prepare(
+					`
+          select id
+          from accounts
+          order by is_default desc, created_at asc
+          limit 1
+          `,
+				)
+				.get() as { id: string } | undefined);
+
+	if (!row) {
+		throw new Error(`Unknown account: ${accountId ?? "default"}`);
+	}
+
+	return row.id;
+}
+
+function replaceTweetFts(db: Database, tweetId: string, text: string) {
+	db.prepare("delete from tweets_fts where tweet_id = ?").run(tweetId);
+	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
+		tweetId,
+		text,
+	);
+}
+
+function mergeTweetSearchIntoLocalStore(
+	db: Database,
+	accountId: string,
+	payload: XurlMentionsResponse,
+	source: "bird" | "xurl" | "cache",
+) {
+	const usersById = new Map(
+		(payload.includes?.users ?? []).map((user) => [user.id, user]),
+	);
+	const upsertTweet = db.prepare(
+		`
+    insert into tweets (
+      id, account_id, author_profile_id, kind, text, created_at,
+      is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+      entities_json, media_json, quoted_tweet_id
+    ) values (?, ?, ?, 'search', ?, ?, 0, ?, ?, ?, 0, 0, ?, ?, ?)
+    on conflict(id) do update set
+      account_id = tweets.account_id,
+      author_profile_id = excluded.author_profile_id,
+      kind = tweets.kind,
+      text = excluded.text,
+      created_at = excluded.created_at,
+      reply_to_id = coalesce(tweets.reply_to_id, excluded.reply_to_id),
+      like_count = excluded.like_count,
+      media_count = max(tweets.media_count, excluded.media_count),
+      entities_json = excluded.entities_json,
+      media_json = case
+        when excluded.media_json not in ('', '[]', 'null') then excluded.media_json
+        else tweets.media_json
+      end,
+      quoted_tweet_id = coalesce(tweets.quoted_tweet_id, excluded.quoted_tweet_id),
+      bookmarked = tweets.bookmarked,
+      liked = tweets.liked
+    `,
+	);
+	const tweetIds: string[] = [];
+
+	db.transaction(() => {
+		const seenAt = new Date().toISOString();
+		for (const tweet of payload.data) {
+			const author =
+				usersById.get(tweet.author_id) ??
+				({
+					id: tweet.author_id,
+					username: `user_${tweet.author_id}`,
+					name: `user_${tweet.author_id}`,
+				} as const);
+			const profile = usersById.has(tweet.author_id)
+				? upsertProfileFromXUser(db, author)
+				: ensureStubProfileForXUser(db, tweet.author_id);
+			const replyToId =
+				tweet.referenced_tweets?.find((item) => item.type === "replied_to")
+					?.id ?? null;
+			const quotedTweetId =
+				tweet.referenced_tweets?.find((item) => item.type === "quoted")?.id ??
+				null;
+			upsertTweet.run(
+				tweet.id,
+				accountId,
+				profile.profile.id,
+				tweet.text,
+				tweet.created_at,
+				replyToId,
+				Number(tweet.public_metrics?.like_count ?? 0),
+				countTweetMedia(tweet),
+				JSON.stringify(tweet.entities ?? {}),
+				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
+				quotedTweetId,
+			);
+			upsertTweetAccountEdge(db, {
+				accountId,
+				tweetId: tweet.id,
+				kind: "search",
+				source,
+				seenAt,
+				rawJson: JSON.stringify(tweet),
+			});
+			replaceTweetFts(db, tweet.id, tweet.text);
+			tweetIds.push(tweet.id);
+		}
+	})();
+
+	return tweetIds;
+}
+
+function toMentionsResponse(payload: XurlTweetsResponse): XurlMentionsResponse {
+	return {
+		data: payload.data,
+		includes: payload.includes,
+		meta: payload.meta,
+	};
+}
+
+function mergeResponses(
+	responses: XurlMentionsResponse[],
+): XurlMentionsResponse {
+	const seenTweetIds = new Set<string>();
+	const data = [];
+	const usersById = new Map();
+	const mediaByKey = new Map();
+	let pageCount = 0;
+
+	for (const response of responses) {
+		pageCount += Number(response.meta?.page_count ?? 1);
+		for (const user of response.includes?.users ?? []) {
+			usersById.set(user.id, user);
+		}
+		for (const media of response.includes?.media ?? []) {
+			mediaByKey.set(media.media_key, media);
+		}
+		for (const tweet of response.data) {
+			if (seenTweetIds.has(tweet.id)) continue;
+			seenTweetIds.add(tweet.id);
+			data.push(tweet);
+		}
+	}
+
+	return {
+		data,
+		includes: {
+			users: [...usersById.values()],
+			media: [...mediaByKey.values()],
+		},
+		meta: {
+			result_count: data.length,
+			page_count: pageCount,
+		},
+	};
+}
+
+function limitResponse(
+	response: XurlMentionsResponse,
+	limit: number,
+): XurlMentionsResponse {
+	if (response.data.length <= limit) {
+		return response;
+	}
+	return {
+		...response,
+		data: response.data.slice(0, limit),
+		meta: {
+			...response.meta,
+			result_count: limit,
+		},
+	};
+}
+
+function cacheKey({
+	query,
+	accountId,
+	mode,
+	limit,
+	maxPages,
+}: {
+	query: string;
+	accountId: string;
+	mode: Exclude<TweetSearchMode, "auto" | "local">;
+	limit: number;
+	maxPages: number;
+}) {
+	return `tweet-search:${mode}:${accountId}:${encodeURIComponent(query)}:${String(limit)}:${String(maxPages)}`;
+}
+
+function fetchBirdSearchEffect({
+	query,
+	limit,
+	maxPages,
+}: {
+	query: string;
+	limit: number;
+	maxPages: number;
+}) {
+	return searchTweetsViaBirdEffect(query, {
+		maxResults: Math.min(limit, XURL_PAGE_SIZE),
+		all: maxPages > 1 || limit > XURL_PAGE_SIZE,
+		maxPages,
+	});
+}
+
+function fetchXurlSearchEffect({
+	query,
+	limit,
+	maxPages,
+	timeoutMs,
+}: {
+	query: string;
+	limit: number;
+	maxPages: number;
+	timeoutMs?: number;
+}): Effect.Effect<XurlMentionsResponse, Error> {
+	return Effect.gen(function* () {
+		const responses: XurlMentionsResponse[] = [];
+		let nextToken: string | undefined;
+		for (let page = 0; page < maxPages; page += 1) {
+			const remaining =
+				limit -
+				responses.reduce((total, response) => total + response.data.length, 0);
+			if (remaining <= 0) break;
+			const response = yield* searchRecentTweetsEffect(query, {
+				maxResults: Math.max(10, Math.min(XURL_PAGE_SIZE, remaining)),
+				paginationToken: nextToken,
+				timeoutMs,
+			});
+			responses.push(toMentionsResponse(response));
+			nextToken =
+				typeof response.meta?.next_token === "string"
+					? String(response.meta.next_token)
+					: undefined;
+			if (!nextToken) break;
+		}
+		return mergeResponses(responses);
+	});
+}
+
+function runModeEffect(
+	mode: Exclude<TweetSearchMode, "auto" | "local">,
+	options: {
+		query: string;
+		accountId: string;
+		limit: number;
+		maxPages: number;
+		refresh: boolean;
+		cacheTtlMs: number;
+		timeoutMs?: number;
+	},
+): Effect.Effect<SyncTweetSearchResult, Error> {
+	return Effect.gen(function* () {
+		const db = getNativeDb();
+		const key = cacheKey({ ...options, mode });
+		const cached = yield* trySync(() =>
+			readSyncCache<XurlMentionsResponse>(key, db),
+		);
+		const ageMs = cached
+			? Date.now() - new Date(cached.updatedAt).getTime()
+			: Number.POSITIVE_INFINITY;
+		const payload =
+			!options.refresh && cached && ageMs <= options.cacheTtlMs
+				? cached.value
+				: yield* (
+						mode === "bird"
+							? fetchBirdSearchEffect(options).pipe(Effect.mapError(toError))
+							: fetchXurlSearchEffect(options)
+					).pipe(
+						Effect.map((response) => limitResponse(response, options.limit)),
+					);
+		if (!cached || options.refresh || ageMs > options.cacheTtlMs) {
+			yield* trySync(() => writeSyncCache(key, payload, db));
+		}
+		const tweetIds = yield* trySync(() =>
+			mergeTweetSearchIntoLocalStore(
+				db,
+				options.accountId,
+				payload,
+				!options.refresh && cached && ageMs <= options.cacheTtlMs
+					? "cache"
+					: mode,
+			),
+		);
+
+		return {
+			ok: true,
+			source:
+				!options.refresh && cached && ageMs <= options.cacheTtlMs
+					? "cache"
+					: mode,
+			accountId: options.accountId,
+			query: options.query,
+			count: tweetIds.length,
+			pageCount: Number(payload.meta?.page_count ?? 1),
+			tweetIds,
+		} as const;
+	});
+}
+
+export function syncTweetSearchEffect({
+	query,
+	account,
+	mode = "auto",
+	limit,
+	maxPages,
+	refresh = false,
+	cacheTtlMs,
+	timeoutMs,
+}: SyncTweetSearchOptions): Effect.Effect<SyncTweetSearchResult, Error> {
+	return Effect.gen(function* () {
+		const normalizedQuery = query.trim();
+		if (!normalizedQuery) {
+			return yield* Effect.fail(new Error("Search query is required"));
+		}
+		const normalizedLimit = normalizeLimit(limit);
+		const normalizedMaxPages = normalizeMaxPages(maxPages);
+		const ttlMs = normalizeCacheTtlMs(cacheTtlMs);
+		const db = getNativeDb();
+		const accountId = yield* trySync(() => resolveAccount(db, account));
+		if (mode === "local") {
+			return {
+				ok: true,
+				source: "cache",
+				accountId,
+				query: normalizedQuery,
+				count: 0,
+				pageCount: 0,
+				tweetIds: [],
+			} as const;
+		}
+
+		const runOptions = {
+			query: normalizedQuery,
+			accountId,
+			limit: normalizedLimit,
+			maxPages: normalizedMaxPages,
+			refresh,
+			cacheTtlMs: ttlMs,
+			timeoutMs,
+		};
+		if (mode === "bird" || mode === "xurl") {
+			return yield* runModeEffect(mode, runOptions).pipe(
+				Effect.catchAll((error) =>
+					Effect.succeed({
+						ok: false,
+						source: mode,
+						accountId,
+						query: normalizedQuery,
+						error: error.message,
+					} as const),
+				),
+			);
+		}
+
+		const birdResult = yield* runModeEffect("bird", runOptions).pipe(
+			Effect.either,
+		);
+		if (birdResult._tag === "Right") {
+			return birdResult.right;
+		}
+		return yield* runModeEffect("xurl", runOptions).pipe(
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false,
+					source: "auto",
+					accountId,
+					query: normalizedQuery,
+					error: `${birdResult.left.message}; ${error.message}`,
+				} as const),
+			),
+		);
+	});
+}
+
+export function syncTweetSearch(options: SyncTweetSearchOptions) {
+	return runEffectPromise(syncTweetSearchEffect(options));
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type ResourceKind = "home" | "mentions" | "authored" | "dms";
+export type ResourceKind = "home" | "mentions" | "authored" | "search" | "dms";
 export type InboxKind = "mixed" | "mentions" | "dms";
 
 export type ReplyFilter = "all" | "replied" | "unreplied";
@@ -165,7 +165,7 @@ export interface TimelineItem {
 	id: string;
 	accountId: string;
 	accountHandle: string;
-	kind: "home" | "mention" | "authored" | "like" | "bookmark";
+	kind: "home" | "mention" | "authored" | "search" | "like" | "bookmark";
 	text: string;
 	searchSnippet?: string;
 	createdAt: string;

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -1028,6 +1028,46 @@ export function searchRecentByConversationId(
 	);
 }
 
+export function searchRecentTweetsEffect(
+	searchQuery: string,
+	{
+		maxResults,
+		paginationToken,
+		timeoutMs,
+	}: {
+		maxResults: number;
+		paginationToken?: string;
+		timeoutMs?: number;
+	},
+): Effect.Effect<XurlTweetsResponse, Error> {
+	const query = new URLSearchParams({
+		query: searchQuery,
+		max_results: String(maxResults),
+		expansions: AUTHOR_MEDIA_EXPANSIONS,
+		"tweet.fields": THREAD_TWEET_FIELDS,
+		"media.fields": MEDIA_FIELDS,
+		"user.fields": RICH_USER_FIELDS,
+	});
+	if (paginationToken) {
+		query.set("pagination_token", paginationToken);
+	}
+
+	return runJsonCommandEffect([`/2/tweets/search/recent?${query.toString()}`], {
+		timeoutMs,
+	}).pipe(Effect.map(toXurlTweetsResponse));
+}
+
+export function searchRecentTweets(
+	searchQuery: string,
+	options: {
+		maxResults: number;
+		paginationToken?: string;
+		timeoutMs?: number;
+	},
+): Promise<XurlTweetsResponse> {
+	return runEffectPromise(searchRecentTweetsEffect(searchQuery, options));
+}
+
 export function getTweetByIdEffect(
 	id: string,
 	{ timeoutMs }: { timeoutMs?: number } = {},

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,11 +15,13 @@ import { Route as LinksRouteImport } from './routes/links'
 import { Route as LikesRouteImport } from './routes/likes'
 import { Route as InboxRouteImport } from './routes/inbox'
 import { Route as DmsRouteImport } from './routes/dms'
+import { Route as DiscussRouteImport } from './routes/discuss'
 import { Route as BookmarksRouteImport } from './routes/bookmarks'
 import { Route as BlocksRouteImport } from './routes/blocks'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiSyncRouteImport } from './routes/api/sync'
 import { Route as ApiStatusRouteImport } from './routes/api/status'
+import { Route as ApiSearchDiscussionRouteImport } from './routes/api/search-discussion'
 import { Route as ApiQueryRouteImport } from './routes/api/query'
 import { Route as ApiProfileHydrateRouteImport } from './routes/api/profile-hydrate'
 import { Route as ApiPeriodDigestRouteImport } from './routes/api/period-digest'
@@ -61,6 +63,11 @@ const DmsRoute = DmsRouteImport.update({
   path: '/dms',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DiscussRoute = DiscussRouteImport.update({
+  id: '/discuss',
+  path: '/discuss',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BookmarksRoute = BookmarksRouteImport.update({
   id: '/bookmarks',
   path: '/bookmarks',
@@ -84,6 +91,11 @@ const ApiSyncRoute = ApiSyncRouteImport.update({
 const ApiStatusRoute = ApiStatusRouteImport.update({
   id: '/api/status',
   path: '/api/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSearchDiscussionRoute = ApiSearchDiscussionRouteImport.update({
+  id: '/api/search-discussion',
+  path: '/api/search-discussion',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiQueryRoute = ApiQueryRouteImport.update({
@@ -141,6 +153,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/blocks': typeof BlocksRoute
   '/bookmarks': typeof BookmarksRoute
+  '/discuss': typeof DiscussRoute
   '/dms': typeof DmsRoute
   '/inbox': typeof InboxRoute
   '/likes': typeof LikesRoute
@@ -157,6 +170,7 @@ export interface FileRoutesByFullPath {
   '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
+  '/api/search-discussion': typeof ApiSearchDiscussionRoute
   '/api/status': typeof ApiStatusRoute
   '/api/sync': typeof ApiSyncRoute
 }
@@ -164,6 +178,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/blocks': typeof BlocksRoute
   '/bookmarks': typeof BookmarksRoute
+  '/discuss': typeof DiscussRoute
   '/dms': typeof DmsRoute
   '/inbox': typeof InboxRoute
   '/likes': typeof LikesRoute
@@ -180,6 +195,7 @@ export interface FileRoutesByTo {
   '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
+  '/api/search-discussion': typeof ApiSearchDiscussionRoute
   '/api/status': typeof ApiStatusRoute
   '/api/sync': typeof ApiSyncRoute
 }
@@ -188,6 +204,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/blocks': typeof BlocksRoute
   '/bookmarks': typeof BookmarksRoute
+  '/discuss': typeof DiscussRoute
   '/dms': typeof DmsRoute
   '/inbox': typeof InboxRoute
   '/likes': typeof LikesRoute
@@ -204,6 +221,7 @@ export interface FileRoutesById {
   '/api/period-digest': typeof ApiPeriodDigestRoute
   '/api/profile-hydrate': typeof ApiProfileHydrateRoute
   '/api/query': typeof ApiQueryRoute
+  '/api/search-discussion': typeof ApiSearchDiscussionRoute
   '/api/status': typeof ApiStatusRoute
   '/api/sync': typeof ApiSyncRoute
 }
@@ -213,6 +231,7 @@ export interface FileRouteTypes {
     | '/'
     | '/blocks'
     | '/bookmarks'
+    | '/discuss'
     | '/dms'
     | '/inbox'
     | '/likes'
@@ -229,6 +248,7 @@ export interface FileRouteTypes {
     | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
+    | '/api/search-discussion'
     | '/api/status'
     | '/api/sync'
   fileRoutesByTo: FileRoutesByTo
@@ -236,6 +256,7 @@ export interface FileRouteTypes {
     | '/'
     | '/blocks'
     | '/bookmarks'
+    | '/discuss'
     | '/dms'
     | '/inbox'
     | '/likes'
@@ -252,6 +273,7 @@ export interface FileRouteTypes {
     | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
+    | '/api/search-discussion'
     | '/api/status'
     | '/api/sync'
   id:
@@ -259,6 +281,7 @@ export interface FileRouteTypes {
     | '/'
     | '/blocks'
     | '/bookmarks'
+    | '/discuss'
     | '/dms'
     | '/inbox'
     | '/likes'
@@ -275,6 +298,7 @@ export interface FileRouteTypes {
     | '/api/period-digest'
     | '/api/profile-hydrate'
     | '/api/query'
+    | '/api/search-discussion'
     | '/api/status'
     | '/api/sync'
   fileRoutesById: FileRoutesById
@@ -283,6 +307,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BlocksRoute: typeof BlocksRoute
   BookmarksRoute: typeof BookmarksRoute
+  DiscussRoute: typeof DiscussRoute
   DmsRoute: typeof DmsRoute
   InboxRoute: typeof InboxRoute
   LikesRoute: typeof LikesRoute
@@ -299,6 +324,7 @@ export interface RootRouteChildren {
   ApiPeriodDigestRoute: typeof ApiPeriodDigestRoute
   ApiProfileHydrateRoute: typeof ApiProfileHydrateRoute
   ApiQueryRoute: typeof ApiQueryRoute
+  ApiSearchDiscussionRoute: typeof ApiSearchDiscussionRoute
   ApiStatusRoute: typeof ApiStatusRoute
   ApiSyncRoute: typeof ApiSyncRoute
 }
@@ -347,6 +373,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DmsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/discuss': {
+      id: '/discuss'
+      path: '/discuss'
+      fullPath: '/discuss'
+      preLoaderRoute: typeof DiscussRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/bookmarks': {
       id: '/bookmarks'
       path: '/bookmarks'
@@ -380,6 +413,13 @@ declare module '@tanstack/react-router' {
       path: '/api/status'
       fullPath: '/api/status'
       preLoaderRoute: typeof ApiStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/search-discussion': {
+      id: '/api/search-discussion'
+      path: '/api/search-discussion'
+      fullPath: '/api/search-discussion'
+      preLoaderRoute: typeof ApiSearchDiscussionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/query': {
@@ -459,6 +499,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlocksRoute: BlocksRoute,
   BookmarksRoute: BookmarksRoute,
+  DiscussRoute: DiscussRoute,
   DmsRoute: DmsRoute,
   InboxRoute: InboxRoute,
   LikesRoute: LikesRoute,
@@ -475,6 +516,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPeriodDigestRoute: ApiPeriodDigestRoute,
   ApiProfileHydrateRoute: ApiProfileHydrateRoute,
   ApiQueryRoute: ApiQueryRoute,
+  ApiSearchDiscussionRoute: ApiSearchDiscussionRoute,
   ApiStatusRoute: ApiStatusRoute,
   ApiSyncRoute: ApiSyncRoute,
 }

--- a/src/routes/api/search-discussion.test.ts
+++ b/src/routes/api/search-discussion.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRouteHandler } from "#/test/route-handlers";
+
+const maybeAutoUpdateBackupMock = vi.fn();
+const streamSearchDiscussionMock = vi.fn();
+
+vi.mock("#/lib/backup", () => ({
+	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
+	maybeAutoUpdateBackupEffect: () =>
+		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+}));
+vi.mock("#/lib/search-discussion", () => ({
+	streamSearchDiscussionEffect: (...args: unknown[]) =>
+		Effect.promise(() => streamSearchDiscussionMock(...args)),
+}));
+
+import { Route } from "./search-discussion";
+
+const GET = getRouteHandler(Route, "GET");
+
+describe("api search discussion route", () => {
+	beforeEach(() => {
+		maybeAutoUpdateBackupMock.mockReset();
+		streamSearchDiscussionMock.mockReset();
+		maybeAutoUpdateBackupMock.mockResolvedValue({ skipped: true });
+		streamSearchDiscussionMock.mockImplementation(
+			async (
+				_options: unknown,
+				handlers?: {
+					onEvent?: (event: unknown) => void;
+				},
+			) => {
+				handlers?.onEvent?.({ type: "delta", delta: "# Search\n" });
+				handlers?.onEvent?.({
+					type: "done",
+					result: {
+						markdown: "# Search",
+						model: "gpt-5.5",
+						cached: false,
+						serviceTier: "priority",
+						context: {
+							query: "ChatGPT",
+							source: "search",
+							includeDms: true,
+							counts: { search: 3, home: 0, mentions: 0, authored: 0 },
+						},
+						discussion: { title: "Search" },
+					},
+				});
+			},
+		);
+	});
+
+	it("streams NDJSON and passes query options to the discussion runner", async () => {
+		const response = await GET({
+			request: new Request(
+				"http://localhost/api/search-discussion?query=ChatGPT&source=home&mode=bird&account=acct_primary&includeDms=yes&since=2026-05-01&until=2026-05-16&question=themes&originalsOnly=1&hideLowQuality=true&refresh=1&model=gpt-5.5&limit=42&maxPages=7",
+			),
+		});
+
+		expect(response.headers.get("content-type")).toContain(
+			"application/x-ndjson",
+		);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(await response.text()).toContain('"type":"done"');
+		expect(maybeAutoUpdateBackupMock).toHaveBeenCalledWith();
+		expect(streamSearchDiscussionMock).toHaveBeenCalledWith(
+			{
+				query: "ChatGPT",
+				account: "acct_primary",
+				source: "home",
+				mode: "bird",
+				includeDms: true,
+				since: "2026-05-01",
+				until: "2026-05-16",
+				question: "themes",
+				originalsOnly: true,
+				hideLowQuality: true,
+				refresh: true,
+				model: "gpt-5.5",
+				limit: 42,
+				maxPages: 7,
+				signal: expect.any(AbortSignal),
+			},
+			expect.objectContaining({ onEvent: expect.any(Function) }),
+		);
+	});
+
+	it("defaults invalid query options and emits runner errors", async () => {
+		streamSearchDiscussionMock.mockRejectedValueOnce(new Error("live failed"));
+
+		const response = await GET({
+			request: new Request(
+				"http://localhost/api/search-discussion?source=bad&mode=bad&includeDms=no&limit=50000&maxPages=nope",
+			),
+		});
+
+		expect(await response.text()).toContain('"error":"live failed"');
+		expect(streamSearchDiscussionMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				query: "",
+				source: "search",
+				mode: "auto",
+				includeDms: false,
+				limit: 1000,
+				maxPages: undefined,
+			}),
+			expect.any(Object),
+		);
+	});
+});

--- a/src/routes/api/search-discussion.tsx
+++ b/src/routes/api/search-discussion.tsx
@@ -1,0 +1,157 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Effect } from "effect";
+import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { runEffectBackground } from "#/lib/effect-runtime";
+import {
+	parseBoundedInteger,
+	runRouteEffect,
+	sensitiveRequestErrorResponse,
+} from "#/lib/http-effect";
+import {
+	streamSearchDiscussionEffect,
+	type SearchDiscussionOptions,
+	type SearchDiscussionSource,
+	type SearchDiscussionStreamEvent,
+} from "#/lib/search-discussion";
+import type { TweetSearchMode } from "#/lib/tweet-search-live";
+
+const encoder = new TextEncoder();
+
+function parseBoolean(value: string | null) {
+	return value === "true" || value === "1" || value === "yes";
+}
+
+function parseSource(value: string | null): SearchDiscussionSource {
+	if (
+		value === "all" ||
+		value === "home" ||
+		value === "mentions" ||
+		value === "authored" ||
+		value === "search" ||
+		value === "likes" ||
+		value === "bookmarks"
+	) {
+		return value;
+	}
+	return "search";
+}
+
+function parseMode(value: string | null): TweetSearchMode {
+	if (
+		value === "auto" ||
+		value === "bird" ||
+		value === "xurl" ||
+		value === "local"
+	) {
+		return value;
+	}
+	return "auto";
+}
+
+function parseOptions(url: URL): SearchDiscussionOptions {
+	return {
+		query: url.searchParams.get("query") ?? "",
+		account: url.searchParams.get("account") ?? undefined,
+		source: parseSource(url.searchParams.get("source")),
+		mode: parseMode(url.searchParams.get("mode")),
+		includeDms: parseBoolean(url.searchParams.get("includeDms")),
+		since: url.searchParams.get("since") ?? undefined,
+		until: url.searchParams.get("until") ?? undefined,
+		question: url.searchParams.get("question") ?? undefined,
+		originalsOnly: parseBoolean(url.searchParams.get("originalsOnly")),
+		hideLowQuality: parseBoolean(url.searchParams.get("hideLowQuality")),
+		refresh: parseBoolean(url.searchParams.get("refresh")),
+		model: url.searchParams.get("model") === "gpt-5.5" ? "gpt-5.5" : undefined,
+		limit: parseBoundedInteger(url.searchParams.get("limit"), {
+			max: 1000,
+		}),
+		maxPages: parseBoundedInteger(url.searchParams.get("maxPages"), {
+			max: 20,
+		}),
+	};
+}
+
+function encodeEvent(event: SearchDiscussionStreamEvent) {
+	return encoder.encode(`${JSON.stringify(event)}\n`);
+}
+
+export const Route = createFileRoute("/api/search-discussion")({
+	server: {
+		handlers: {
+			GET: ({ request }) =>
+				runRouteEffect(
+					Effect.gen(function* () {
+						const denied = sensitiveRequestErrorResponse(request);
+						if (denied) return denied;
+
+						yield* maybeAutoUpdateBackupEffect();
+						const url = new URL(request.url);
+						const options = parseOptions(url);
+						let abortDiscussion: (() => void) | undefined;
+
+						return new Response(
+							new ReadableStream({
+								cancel() {
+									abortDiscussion?.();
+								},
+								start(controller) {
+									const abortController = new AbortController();
+									let closed = false;
+									const close = () => {
+										closed = true;
+										abortController.abort();
+									};
+									const closeController = () => {
+										request.signal.removeEventListener("abort", onAbort);
+										if (!closed) {
+											closed = true;
+											controller.close();
+										}
+									};
+									const onAbort = () => close();
+									request.signal.addEventListener("abort", onAbort, {
+										once: true,
+									});
+									abortDiscussion = close;
+									const enqueue = (event: SearchDiscussionStreamEvent) => {
+										if (closed) return;
+										try {
+											controller.enqueue(encodeEvent(event));
+										} catch {
+											close();
+										}
+									};
+
+									runEffectBackground(
+										streamSearchDiscussionEffect(
+											{ ...options, signal: abortController.signal },
+											{ onEvent: enqueue },
+										),
+										{
+											onSuccess: closeController,
+											onFailure: (error) => {
+												enqueue({
+													type: "error",
+													error:
+														error instanceof Error
+															? error.message
+															: "Discussion failed",
+												});
+												closeController();
+											},
+										},
+									);
+								},
+							}),
+							{
+								headers: {
+									"cache-control": "no-store",
+									"content-type": "application/x-ndjson; charset=utf-8",
+								},
+							},
+						);
+					}),
+				),
+		},
+	},
+});

--- a/src/routes/discuss.test.tsx
+++ b/src/routes/discuss.test.tsx
@@ -1,0 +1,187 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route } from "./discuss";
+
+const DiscussRoute = Route.options.component as ComponentType;
+
+function discussionResult(markdown: string) {
+	return {
+		context: {
+			query: "ChatGPT",
+			source: "search",
+			includeDms: true,
+			counts: {
+				search: 3,
+				home: 1,
+				mentions: 1,
+				authored: 0,
+				likes: 1,
+				bookmarks: 0,
+				dms: 2,
+			},
+			tweets: [
+				{
+					id: "tweet_1",
+					url: "https://x.com/alice/status/tweet_1",
+					source: "search",
+					author: "alice",
+					name: "Alice",
+					authorProfile: {
+						id: "profile_alice",
+						handle: "alice",
+						displayName: "Alice",
+						bio: "Builds useful things.",
+						followersCount: 12,
+						followingCount: 3,
+						avatarHue: 42,
+						createdAt: "2026-01-01T00:00:00.000Z",
+					},
+					createdAt: "2026-05-23T08:18:00.000Z",
+					text: "ChatGPT is useful for summaries.",
+					likeCount: 4,
+					liked: false,
+					bookmarked: false,
+					needsReply: false,
+				},
+			],
+			dms: [],
+			liveSearch: {
+				ok: true,
+				source: "bird",
+				accountId: "acct_primary",
+				query: "ChatGPT",
+				count: 3,
+				pageCount: 1,
+				tweetIds: ["tweet_1"],
+			},
+			hash: "hash",
+		},
+		discussion: {
+			title: "ChatGPT",
+			summary: "People discuss practical AI workflows.",
+			themes: [],
+			tensions: [],
+			followUps: [],
+			sourceTweetIds: ["tweet_1"],
+			sourceDmConversationIds: [],
+		},
+		markdown,
+		model: "gpt-5.5",
+		reasoningEffort: "medium",
+		serviceTier: "priority",
+		cached: false,
+		updatedAt: "2026-05-23T08:20:00.000Z",
+	};
+}
+
+function ndjsonResponse(events: unknown[]) {
+	const body = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+	return new Response(body, {
+		headers: { "content-type": "application/x-ndjson" },
+	});
+}
+
+describe("discuss route", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
+	});
+
+	it("streams a keyword discussion and refreshes the submitted query", async () => {
+		const urls: URL[] = [];
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = new URL(String(input));
+			urls.push(url);
+			const query = url.searchParams.get("query") ?? "";
+			const markdown = `# ${query}\n\n## Themes\n\n- Practical workflows`;
+			return ndjsonResponse([
+				{
+					type: "start",
+					context: discussionResult(markdown).context,
+					cached: false,
+				},
+				{ type: "delta", delta: markdown },
+				{ type: "done", result: discussionResult(markdown) },
+			]);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DiscussRoute />);
+
+		expect(
+			screen.getByRole("heading", { name: "Discuss", level: 1 }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Search to begin.")).toBeInTheDocument();
+
+		fireEvent.change(screen.getByPlaceholderText("Keywords"), {
+			target: { value: "ChatGPT" },
+		});
+		fireEvent.change(screen.getByPlaceholderText("Question"), {
+			target: { value: "Useful takeaways" },
+		});
+		fireEvent.change(screen.getAllByRole("combobox")[1]!, {
+			target: { value: "bird" },
+		});
+		fireEvent.click(screen.getByLabelText("DMs"));
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+
+		expect(
+			await screen.findByRole("heading", { name: "ChatGPT", level: 1 }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Practical workflows")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"bird 3 fetched · 3 search · 2 timeline · 1 saved · 2 DMs",
+			),
+		).toBeInTheDocument();
+		expect(urls[0]?.searchParams.get("mode")).toBe("bird");
+		expect(urls[0]?.searchParams.get("includeDms")).toBe("true");
+		expect(urls[0]?.searchParams.get("question")).toBe("Useful takeaways");
+
+		fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		expect(urls[1]?.searchParams.get("refresh")).toBe("true");
+	});
+
+	it("renders request and stream errors", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ message: "no api key" }), {
+					status: 500,
+					statusText: "Server Error",
+					headers: { "content-type": "application/json" },
+				}),
+			)
+			.mockResolvedValueOnce(
+				ndjsonResponse([{ type: "error", error: "live failed" }]),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DiscussRoute />);
+		fireEvent.change(screen.getByPlaceholderText("Keywords"), {
+			target: { value: "OpenAI" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+
+		expect(
+			await screen.findByText(
+				"Discussion request failed (500 Server Error): no api key",
+			),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+		expect(await screen.findByText("live failed")).toBeInTheDocument();
+	});
+});

--- a/src/routes/discuss.test.tsx
+++ b/src/routes/discuss.test.tsx
@@ -156,6 +156,10 @@ describe("discuss route", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 		expect(urls[1]?.searchParams.get("refresh")).toBe("true");
+
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+		expect(urls[2]?.searchParams.get("refresh")).toBe("true");
 	});
 
 	it("renders request and stream errors", async () => {

--- a/src/routes/discuss.test.tsx
+++ b/src/routes/discuss.test.tsx
@@ -133,6 +133,9 @@ describe("discuss route", () => {
 		fireEvent.change(screen.getAllByRole("combobox")[1]!, {
 			target: { value: "bird" },
 		});
+		fireEvent.change(screen.getAllByRole("combobox")[0]!, {
+			target: { value: "all" },
+		});
 		fireEvent.click(screen.getByLabelText("DMs"));
 		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
 
@@ -145,6 +148,7 @@ describe("discuss route", () => {
 				"bird 3 fetched · 3 search · 2 timeline · 1 saved · 2 DMs",
 			),
 		).toBeInTheDocument();
+		expect(urls[0]?.searchParams.get("source")).toBe("all");
 		expect(urls[0]?.searchParams.get("mode")).toBe("bird");
 		expect(urls[0]?.searchParams.get("includeDms")).toBe("true");
 		expect(urls[0]?.searchParams.get("question")).toBe("Useful takeaways");
@@ -183,5 +187,78 @@ describe("discuss route", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
 		expect(await screen.findByText("live failed")).toBeInTheDocument();
+	});
+
+	it("renders non-json and empty-body request failures", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("plain failure", {
+					status: 503,
+					statusText: "",
+				}),
+			)
+			.mockResolvedValueOnce(new Response(null, { status: 204 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DiscussRoute />);
+		fireEvent.change(screen.getByPlaceholderText("Keywords"), {
+			target: { value: "OpenAI" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+
+		expect(
+			await screen.findByText("Discussion request failed (503): plain failure"),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+		expect(
+			await screen.findByText("Discussion request failed: empty response body"),
+		).toBeInTheDocument();
+	});
+
+	it("renders json error payloads and malformed responses", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ error: "xurl unauthorized" }), {
+					status: 401,
+					statusText: "Unauthorized",
+					headers: { "content-type": "application/json" },
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response("{not-json", {
+					status: 502,
+					statusText: "Bad Gateway",
+					headers: { "content-type": "application/json" },
+				}),
+			)
+			.mockResolvedValueOnce(new Response("{not-json\n"));
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<DiscussRoute />);
+		fireEvent.change(screen.getByPlaceholderText("Keywords"), {
+			target: { value: "OpenAI" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+
+		expect(
+			await screen.findByText(
+				"Discussion request failed (401 Unauthorized): xurl unauthorized",
+			),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+		expect(
+			await screen.findByText("Discussion request failed (502 Bad Gateway)"),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Discuss" }));
+		expect(
+			await screen.findByText((content) =>
+				/JSON|Unexpected|Expected|not valid/.test(content),
+			),
+		).toBeInTheDocument();
 	});
 });

--- a/src/routes/discuss.tsx
+++ b/src/routes/discuss.tsx
@@ -1,0 +1,390 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+	CheckCircle2,
+	Loader2,
+	RefreshCw,
+	Search,
+	Sparkles,
+} from "lucide-react";
+import {
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { MarkdownViewer } from "#/components/MarkdownViewer";
+import type {
+	SearchDiscussionContext,
+	SearchDiscussionRunResult,
+	SearchDiscussionSource,
+	SearchDiscussionStreamEvent,
+} from "#/lib/search-discussion";
+import type { TweetSearchMode } from "#/lib/tweet-search-live";
+import {
+	cx,
+	errorCopyClass,
+	pageHeaderActionsClass,
+	pageHeaderClass,
+	pageHeaderRowClass,
+	pageSubtitleClass,
+	pageTitleClass,
+	primaryButtonClass,
+	searchFieldIconClass,
+	searchFieldInputClass,
+	searchFieldShellClass,
+	secondaryButtonClass,
+	selectFieldClass,
+	textFieldClass,
+} from "#/lib/ui";
+
+export const Route = createFileRoute("/discuss")({
+	component: DiscussRoute,
+});
+
+const sources: Array<{ value: SearchDiscussionSource; label: string }> = [
+	{ value: "search", label: "Live search" },
+	{ value: "all", label: "All local" },
+	{ value: "home", label: "Home" },
+	{ value: "mentions", label: "Mentions" },
+	{ value: "authored", label: "Authored" },
+	{ value: "likes", label: "Likes" },
+	{ value: "bookmarks", label: "Bookmarks" },
+];
+
+const modes: Array<{ value: TweetSearchMode; label: string }> = [
+	{ value: "auto", label: "Auto" },
+	{ value: "bird", label: "Bird" },
+	{ value: "xurl", label: "xurl" },
+	{ value: "local", label: "Local" },
+];
+
+function discussionUrl(
+	query: string,
+	options: {
+		source: SearchDiscussionSource;
+		mode: TweetSearchMode;
+		includeDms: boolean;
+		question: string;
+		refresh: boolean;
+	},
+) {
+	const url = new URL("/api/search-discussion", window.location.origin);
+	url.searchParams.set("query", query);
+	url.searchParams.set("source", options.source);
+	url.searchParams.set("mode", options.mode);
+	url.searchParams.set("includeDms", String(options.includeDms));
+	url.searchParams.set("limit", "500");
+	url.searchParams.set("maxPages", "5");
+	if (options.question.trim()) {
+		url.searchParams.set("question", options.question.trim());
+	}
+	if (options.refresh) {
+		url.searchParams.set("refresh", "true");
+	}
+	return url;
+}
+
+async function discussionRequestError(response: Response) {
+	const status = `${String(response.status)}${response.statusText ? ` ${response.statusText}` : ""}`;
+	let detail = "";
+	try {
+		const contentType = response.headers.get("content-type") ?? "";
+		if (contentType.includes("application/json")) {
+			const payload = (await response.json()) as {
+				error?: unknown;
+				message?: unknown;
+			};
+			if (typeof payload.message === "string") detail = payload.message;
+			else if (typeof payload.error === "string") detail = payload.error;
+		} else {
+			detail = (await response.text()).trim();
+		}
+	} catch {
+		detail = "";
+	}
+	return new Error(
+		detail
+			? `Discussion request failed (${status}): ${detail}`
+			: `Discussion request failed (${status})`,
+	);
+}
+
+function formatCounts(context: SearchDiscussionContext | null) {
+	if (!context) return "Live keyword search with local memory.";
+	const counts = context.counts;
+	const live = context.liveSearch
+		? context.liveSearch.ok
+			? `${context.liveSearch.source} ${String(context.liveSearch.count)} fetched`
+			: `${context.liveSearch.source} failed`
+		: "local";
+	return [
+		live,
+		`${String(counts.search)} search`,
+		`${String(counts.home + counts.mentions + counts.authored)} timeline`,
+		`${String(counts.likes + counts.bookmarks)} saved`,
+		context.includeDms ? `${String(counts.dms)} DMs` : null,
+	]
+		.filter(Boolean)
+		.join(" · ");
+}
+
+function useDiscussionStream(
+	query: string,
+	source: SearchDiscussionSource,
+	mode: TweetSearchMode,
+	includeDms: boolean,
+	question: string,
+) {
+	const [markdown, setMarkdown] = useState("");
+	const [context, setContext] = useState<SearchDiscussionContext | null>(null);
+	const [result, setResult] = useState<SearchDiscussionRunResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+	const abortRef = useRef<AbortController | null>(null);
+	const requestIdRef = useRef(0);
+
+	const run = useCallback(
+		(refresh = false) => {
+			const trimmed = query.trim();
+			if (!trimmed) return;
+			abortRef.current?.abort();
+			const controller = new AbortController();
+			const requestId = requestIdRef.current + 1;
+			requestIdRef.current = requestId;
+			abortRef.current = controller;
+			const isActiveRequest = () =>
+				abortRef.current === controller &&
+				requestIdRef.current === requestId &&
+				!controller.signal.aborted;
+			setMarkdown("");
+			setContext(null);
+			setResult(null);
+			setError(null);
+			setLoading(true);
+
+			fetch(
+				discussionUrl(trimmed, {
+					source,
+					mode,
+					includeDms,
+					question,
+					refresh,
+				}),
+				{ signal: controller.signal },
+			)
+				.then(async (response) => {
+					if (!response.ok) {
+						throw await discussionRequestError(response);
+					}
+					if (!response.body) {
+						throw new Error("Discussion request failed: empty response body");
+					}
+					const reader = response.body.getReader();
+					const decoder = new TextDecoder();
+					let buffer = "";
+					const pump = (): Promise<void> =>
+						reader.read().then(({ done, value }) => {
+							if (!isActiveRequest()) return;
+							if (done) return;
+							buffer += decoder.decode(value, { stream: true });
+							let newline = buffer.indexOf("\n");
+							while (newline >= 0) {
+								const line = buffer.slice(0, newline).trim();
+								buffer = buffer.slice(newline + 1);
+								if (line) {
+									const event = JSON.parse(line) as SearchDiscussionStreamEvent;
+									if (!isActiveRequest()) return;
+									if (event.type === "start") {
+										setContext(event.context);
+									} else if (event.type === "delta") {
+										setMarkdown((current) => current + event.delta);
+									} else if (event.type === "done") {
+										setResult(event.result);
+										setContext(event.result.context);
+										setMarkdown(event.result.markdown);
+									} else if (event.type === "error") {
+										setError(event.error);
+									}
+								}
+								newline = buffer.indexOf("\n");
+							}
+							return pump();
+						});
+					return pump();
+				})
+				.catch((cause: unknown) => {
+					if (!isActiveRequest()) return;
+					setError(
+						cause instanceof Error ? cause.message : "Discussion failed",
+					);
+				})
+				.finally(() => {
+					if (isActiveRequest()) {
+						setLoading(false);
+					}
+				});
+		},
+		[includeDms, mode, query, question, source],
+	);
+
+	useEffect(() => () => abortRef.current?.abort(), []);
+
+	return { context, error, loading, markdown, result, run };
+}
+
+function DiscussRoute() {
+	const [query, setQuery] = useState("");
+	const [submittedQuery, setSubmittedQuery] = useState("");
+	const [question, setQuestion] = useState("");
+	const [source, setSource] = useState<SearchDiscussionSource>("search");
+	const [mode, setMode] = useState<TweetSearchMode>("auto");
+	const [includeDms, setIncludeDms] = useState(false);
+	const pendingSubmitRef = useRef(false);
+	const { context, error, loading, markdown, result, run } =
+		useDiscussionStream(submittedQuery, source, mode, includeDms, question);
+	const sourceLabel = useMemo(
+		() => formatCounts(result?.context ?? context),
+		[context, result],
+	);
+
+	function submit(event: FormEvent) {
+		event.preventDefault();
+		const trimmed = query.trim();
+		if (!trimmed) return;
+		pendingSubmitRef.current = true;
+		setSubmittedQuery(trimmed);
+		if (trimmed === submittedQuery) {
+			pendingSubmitRef.current = false;
+			run(true);
+		}
+	}
+
+	useEffect(() => {
+		if (!submittedQuery || !pendingSubmitRef.current) return;
+		pendingSubmitRef.current = false;
+		run(true);
+	}, [run, submittedQuery]);
+
+	return (
+		<div className="flex min-h-screen flex-col">
+			<header className={pageHeaderClass}>
+				<div className={pageHeaderRowClass}>
+					<div className="min-w-0">
+						<h1 className={pageTitleClass}>Discuss</h1>
+						<p className={pageSubtitleClass}>{sourceLabel}</p>
+					</div>
+					<div className={pageHeaderActionsClass}>
+						<button
+							type="button"
+							className={secondaryButtonClass}
+							onClick={() => run(true)}
+							disabled={loading || !submittedQuery}
+						>
+							<RefreshCw
+								className={cx("size-4", loading && "animate-spin")}
+								aria-hidden="true"
+							/>
+							Refresh
+						</button>
+					</div>
+				</div>
+				<form
+					className="grid gap-2 px-4 pb-3 md:grid-cols-[minmax(220px,1fr)_minmax(180px,0.8fr)_auto]"
+					onSubmit={submit}
+				>
+					<label className={searchFieldShellClass}>
+						<Search className={searchFieldIconClass} strokeWidth={2} />
+						<input
+							className={searchFieldInputClass}
+							placeholder="Keywords"
+							value={query}
+							onChange={(event) => setQuery(event.currentTarget.value)}
+						/>
+					</label>
+					<input
+						className={textFieldClass}
+						placeholder="Question"
+						value={question}
+						onChange={(event) => setQuestion(event.currentTarget.value)}
+					/>
+					<button
+						type="submit"
+						className={primaryButtonClass}
+						disabled={loading || !query.trim()}
+					>
+						<Sparkles className="size-4" aria-hidden="true" />
+						Discuss
+					</button>
+					<div className="flex flex-wrap gap-2 md:col-span-3">
+						<select
+							className={selectFieldClass}
+							value={source}
+							onChange={(event) =>
+								setSource(event.currentTarget.value as SearchDiscussionSource)
+							}
+						>
+							{sources.map((item) => (
+								<option key={item.value} value={item.value}>
+									{item.label}
+								</option>
+							))}
+						</select>
+						<select
+							className={selectFieldClass}
+							value={mode}
+							onChange={(event) =>
+								setMode(event.currentTarget.value as TweetSearchMode)
+							}
+						>
+							{modes.map((item) => (
+								<option key={item.value} value={item.value}>
+									{item.label}
+								</option>
+							))}
+						</select>
+						<label className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] px-3 py-1 text-[13px] font-medium text-[var(--ink-soft)]">
+							<input
+								type="checkbox"
+								checked={includeDms}
+								onChange={(event) => setIncludeDms(event.currentTarget.checked)}
+							/>
+							DMs
+						</label>
+					</div>
+				</form>
+			</header>
+
+			{error ? <div className={errorCopyClass}>{error}</div> : null}
+
+			<div className="border-b border-[var(--line)] px-4 py-2 text-[13px] text-[var(--ink-soft)]">
+				<span className="inline-flex items-center gap-1">
+					{loading ? (
+						<Loader2 className="size-4 animate-spin" aria-hidden="true" />
+					) : markdown ? (
+						<CheckCircle2 className="size-4" aria-hidden="true" />
+					) : (
+						<Sparkles className="size-4" aria-hidden="true" />
+					)}
+					{loading
+						? "Searching and streaming"
+						: result
+							? `${result.cached ? "Cached" : "Ready"} · ${result.context.query}`
+							: "Ready"}
+				</span>
+			</div>
+
+			{markdown ? (
+				<MarkdownViewer
+					context={(result?.context ?? context) as never}
+					markdown={markdown}
+				/>
+			) : (
+				<div className="px-4 py-5 text-[14px] text-[var(--ink-soft)]">
+					{loading ? "Waiting for the first tokens..." : "Search to begin."}
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- add `birdclaw discuss` live keyword search backed by bird/xurl, with AI summary/discussion streaming
- persist live search tweets as `search` edges in SQLite/FTS and backup shards
- add `/discuss` web UI plus `/api/search-discussion` NDJSON stream

## Verification
- `BIRDCLAW_BACKUP_AUTO_SYNC=0 pnpm --silent cli discuss "ChatGPT" --mode bird --limit 40 --max-pages 1 --question "Summarize recurring topics and useful takeaways in 5 bullets." --refresh`
- `sqlite3 ~/.birdclaw/birdclaw.sqlite "select kind, source, count(*) from tweet_account_edges where kind='search' group by kind, source order by source;"` -> `search|bird|40`
- `/discuss` local route smoke via Playwright desktop/mobile
- `pnpm test src/lib/search-discussion.test.ts src/lib/tweet-search-live.test.ts src/cli.test.ts src/routes/api/query.test.ts`
- `pnpm test src/lib/tweet-search-live.test.ts src/lib/bird.test.ts src/lib/search-discussion.test.ts src/cli.test.ts`
- `pnpm test src/lib/backup.test.ts -t "exports JSONL shards"`
- `pnpm run check`
- `pnpm run typecheck`
- `pnpm build`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean

## Notes
- Local full `pnpm test` hit timeout-only failures in existing archive/backup/authored shards; focused changed-path tests are green and this PR is opened to let GitHub Actions be the full-suite source of truth.
- Local `xurl search "ChatGPT" -n 5` currently returns 401 with the configured xurl app; `bird` live search path works and `auto` keeps xurl fallback support in code/tests.
