### PR TITLE
feat: paginate saved feeds with a Load more control

### DIFF
--- a/src/components/SavedTimelineView.tsx
+++ b/src/components/SavedTimelineView.tsx
@@ -41,14 +41,24 @@ export function SavedTimelineView({
 	searchPlaceholder,
 }: SavedTimelineViewProps) {
 	const [search, setSearch] = useState("");
-	const { meta, items, loading, error, retry, refreshLocalView, replyToTweet } =
-		useTimelineRouteData({
-			resource: "home",
-			search,
-			errorFallback: `${TITLES[filter]} unavailable`,
-			likedOnly: filter === "liked",
-			bookmarkedOnly: filter === "bookmarked",
-		});
+	const {
+		meta,
+		items,
+		loading,
+		error,
+		retry,
+		refreshLocalView,
+		replyToTweet,
+		hasMore,
+		loadingMore,
+		loadMore,
+	} = useTimelineRouteData({
+		resource: "home",
+		search,
+		errorFallback: `${TITLES[filter]} unavailable`,
+		likedOnly: filter === "liked",
+		bookmarkedOnly: filter === "bookmarked",
+	});
 
 	const subtitle = useMemo(() => {
 		if (!meta) {
@@ -126,6 +136,18 @@ export function SavedTimelineView({
 							showReplyControls={false}
 						/>
 					))}
+					{!loading && !error && hasMore ? (
+						<div className="flex justify-center py-4">
+							<button
+								className="rounded-full bg-[var(--accent)] px-5 py-1.5 text-[14px] font-bold text-white disabled:opacity-60"
+								disabled={loadingMore}
+								onClick={loadMore}
+								type="button"
+							>
+								{loadingMore ? "Loading…" : "Load more"}
+							</button>
+						</div>
+					) : null}
 				</section>
 			</ConversationSurfaceScope>
 		</>

--- a/src/components/TimelineRouteFrame.tsx
+++ b/src/components/TimelineRouteFrame.tsx
@@ -78,6 +78,9 @@ export function TimelineRouteFrame({
 		retry,
 		refreshLocalView,
 		replyToTweet,
+		hasMore,
+		loadingMore,
+		loadMore,
 	} = useTimelineRouteData({
 		resource,
 		replyFilter,
@@ -164,6 +167,18 @@ export function TimelineRouteFrame({
 					{items.map((item) => (
 						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
 					))}
+					{!loading && !error && hasMore ? (
+						<div className="flex justify-center py-4">
+							<button
+								className="rounded-full bg-[var(--accent)] px-5 py-1.5 text-[14px] font-bold text-white disabled:opacity-60"
+								disabled={loadingMore}
+								onClick={loadMore}
+								type="button"
+							>
+								{loadingMore ? "Loading…" : "Load more"}
+							</button>
+						</div>
+					) : null}
 				</section>
 			</ConversationSurfaceScope>
 		</>

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -12,6 +12,8 @@ import {
 } from "#/lib/api-client";
 import { useSelectedAccountId } from "./account-selection";
 
+const PAGE_SIZE = 50;
+
 interface UseTimelineRouteDataOptions {
 	resource: Exclude<ResourceKind, "dms">;
 	search: string;
@@ -35,6 +37,8 @@ export function useTimelineRouteData({
 	const [error, setError] = useState<string | null>(null);
 	const [replyError, setReplyError] = useState<string | null>(null);
 	const [refreshTick, setRefreshTick] = useState(0);
+	const [hasMore, setHasMore] = useState(false);
+	const [loadingMore, setLoadingMore] = useState(false);
 	const selectedAccountId = useSelectedAccountId(meta?.accounts);
 
 	async function loadStatus() {
@@ -45,10 +49,13 @@ export function useTimelineRouteData({
 		void loadStatus();
 	}, []);
 
-	useEffect(() => {
+	// Build the /api/query URL for the current filters. `until` requests the next
+	// (older) page via the server's created_at cursor (created_at < until).
+	function buildQueryUrl(until?: string) {
 		const url = new URL("/api/query", window.location.origin);
 		url.searchParams.set("resource", resource);
 		url.searchParams.set("refresh", String(refreshTick));
+		url.searchParams.set("limit", String(PAGE_SIZE));
 		if (selectedAccountId) {
 			url.searchParams.set("account", selectedAccountId);
 		}
@@ -64,16 +71,24 @@ export function useTimelineRouteData({
 		if (search.trim()) {
 			url.searchParams.set("search", search.trim());
 		}
+		if (until) {
+			url.searchParams.set("until", until);
+		}
+		return url;
+	}
 
+	useEffect(() => {
 		const controller = new AbortController();
 		let active = true;
 		setError(null);
 		setLoading(true);
-		fetchQueryResponse(url, { signal: controller.signal })
+		setLoadingMore(false);
+		fetchQueryResponse(buildQueryUrl(), { signal: controller.signal })
 			.then((data) => {
-				if (active) {
-					setItems(data.items as TimelineItem[]);
-				}
+				if (!active) return;
+				const next = data.items as TimelineItem[];
+				setItems(next);
+				setHasMore(next.length >= PAGE_SIZE);
 			})
 			.catch((fetchError: unknown) => {
 				if (
@@ -87,6 +102,7 @@ export function useTimelineRouteData({
 					fetchError instanceof Error ? fetchError.message : errorFallback,
 				);
 				setItems([]);
+				setHasMore(false);
 			})
 			.finally(() => {
 				if (active) {
@@ -108,6 +124,28 @@ export function useTimelineRouteData({
 		search,
 		selectedAccountId,
 	]);
+
+	async function loadMore() {
+		if (loading || loadingMore || !hasMore || items.length === 0) return;
+		const until = items[items.length - 1]?.createdAt;
+		if (!until) return;
+		setLoadingMore(true);
+		try {
+			const data = await fetchQueryResponse(buildQueryUrl(until));
+			const page = data.items as TimelineItem[];
+			setItems((prev) => {
+				const seen = new Set(prev.map((item) => item.id));
+				return [...prev, ...page.filter((item) => !seen.has(item.id))];
+			});
+			setHasMore(page.length >= PAGE_SIZE);
+		} catch (loadError) {
+			setError(
+				loadError instanceof Error ? loadError.message : errorFallback,
+			);
+		} finally {
+			setLoadingMore(false);
+		}
+	}
 
 	function retry() {
 		setRefreshTick((value) => value + 1);
@@ -149,5 +187,8 @@ export function useTimelineRouteData({
 		refreshLocalView,
 		replyToTweet,
 		selectedAccountId,
+		hasMore,
+		loadingMore,
+		loadMore,
 	};
 }

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
 	QueryEnvelope,
 	ReplyFilter,
@@ -40,6 +40,11 @@ export function useTimelineRouteData({
 	const [hasMore, setHasMore] = useState(false);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const selectedAccountId = useSelectedAccountId(meta?.accounts);
+	// Bumped whenever the active filters change. A `loadMore` request that
+	// resolves against a stale generation is discarded so its older page is
+	// never appended to a freshly loaded feed.
+	const generationRef = useRef(0);
+	const loadMoreControllerRef = useRef<AbortController | null>(null);
 
 	async function loadStatus() {
 		setMeta(await fetchQueryEnvelope());
@@ -49,9 +54,10 @@ export function useTimelineRouteData({
 		void loadStatus();
 	}, []);
 
-	// Build the /api/query URL for the current filters. `until` requests the next
-	// (older) page via the server's created_at cursor (created_at < until).
-	function buildQueryUrl(until?: string) {
+	// Build the /api/query URL for the current filters. Passing the last item's
+	// (createdAt, id) requests the next (older) page via the server's keyset
+	// cursor, which is deterministic across duplicate timestamps.
+	function buildQueryUrl(until?: string, untilId?: string) {
 		const url = new URL("/api/query", window.location.origin);
 		url.searchParams.set("resource", resource);
 		url.searchParams.set("refresh", String(refreshTick));
@@ -74,10 +80,15 @@ export function useTimelineRouteData({
 		if (until) {
 			url.searchParams.set("until", until);
 		}
+		if (untilId) {
+			url.searchParams.set("untilId", untilId);
+		}
 		return url;
 	}
 
 	useEffect(() => {
+		generationRef.current += 1;
+		loadMoreControllerRef.current?.abort();
 		const controller = new AbortController();
 		let active = true;
 		setError(null);
@@ -127,11 +138,20 @@ export function useTimelineRouteData({
 
 	async function loadMore() {
 		if (loading || loadingMore || !hasMore || items.length === 0) return;
-		const until = items[items.length - 1]?.createdAt;
-		if (!until) return;
+		const lastItem = items[items.length - 1];
+		const until = lastItem?.createdAt;
+		const untilId = lastItem?.id;
+		if (!until || !untilId) return;
+		const generation = generationRef.current;
+		const controller = new AbortController();
+		loadMoreControllerRef.current = controller;
 		setLoadingMore(true);
 		try {
-			const data = await fetchQueryResponse(buildQueryUrl(until));
+			const data = await fetchQueryResponse(buildQueryUrl(until, untilId), {
+				signal: controller.signal,
+			});
+			// Discard if the filters changed (new generation) while in flight.
+			if (generation !== generationRef.current) return;
 			const page = data.items as TimelineItem[];
 			setItems((prev) => {
 				const seen = new Set(prev.map((item) => item.id));
@@ -139,11 +159,18 @@ export function useTimelineRouteData({
 			});
 			setHasMore(page.length >= PAGE_SIZE);
 		} catch (loadError) {
-			setError(
-				loadError instanceof Error ? loadError.message : errorFallback,
-			);
+			if (
+				loadError instanceof DOMException &&
+				loadError.name === "AbortError"
+			) {
+				return;
+			}
+			if (generation !== generationRef.current) return;
+			setError(loadError instanceof Error ? loadError.message : errorFallback);
 		} finally {
-			setLoadingMore(false);
+			if (generation === generationRef.current) {
+				setLoadingMore(false);
+			}
 		}
 	}
 

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -672,6 +672,58 @@ describe("birdclaw queries", () => {
 		expect(bookmarked.every((item) => item.bookmarked)).toBe(true);
 	});
 
+	it("paginates past a shared created_at boundary using the id cursor", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		db.exec(`
+      delete from tweet_account_edges;
+      delete from tweet_collections;
+      delete from tweets_fts;
+      delete from tweets;
+    `);
+		const insertTweet = db.prepare(`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, 'acct_primary', 'profile_me', 'bookmark', ?, ?, 0, null, 0, 0, 1, 0, '{}', '[]', null)
+    `);
+		const boundary = "2026-03-09T00:00:00.000Z";
+		// Two bookmarks with an identical created_at; tweet_b sorts after tweet_a by id.
+		insertTweet.run("tweet_a", "shared-timestamp a", boundary);
+		insertTweet.run("tweet_b", "shared-timestamp b", boundary);
+
+		const firstPage = listTimelineItems({
+			resource: "home",
+			bookmarkedOnly: true,
+			limit: 1,
+		});
+		expect(firstPage.map((item) => item.id)).toEqual(["tweet_b"]);
+
+		const last = firstPage[0];
+		if (!last) throw new Error("expected a first page item");
+
+		// Keyset cursor (created_at + id) must return the tie row, not skip it.
+		const secondPage = listTimelineItems({
+			resource: "home",
+			bookmarkedOnly: true,
+			limit: 1,
+			until: last.createdAt,
+			untilId: last.id,
+		});
+		expect(secondPage.map((item) => item.id)).toEqual(["tweet_a"]);
+
+		// A created_at-only cursor (no untilId) silently drops the tie row — the
+		// regression this fix prevents.
+		const createdAtOnly = listTimelineItems({
+			resource: "home",
+			bookmarkedOnly: true,
+			limit: 1,
+			until: last.createdAt,
+		});
+		expect(createdAtOnly).toEqual([]);
+	});
+
 	it("hides low-quality timeline noise for summary queries", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -786,6 +786,7 @@ export function listTimelineItems({
 	replyFilter = "all",
 	since,
 	until,
+	untilId,
 	includeReplies = true,
 	qualityFilter = "all",
 	lowQualityThreshold,
@@ -969,8 +970,17 @@ export function listTimelineItems({
 	}
 
 	if (until?.trim()) {
-		where += " and t.created_at < ?";
-		params.push(until.trim());
+		// Deterministic keyset cursor: page on (created_at, id) so rows that share
+		// the boundary timestamp are not skipped. Uses the same text comparison as
+		// the `order by t.created_at desc, t.id desc` below, which is a total order
+		// because t.id is unique.
+		if (untilId?.trim()) {
+			where += " and (t.created_at < ? or (t.created_at = ? and t.id < ?))";
+			params.push(until.trim(), until.trim(), untilId.trim());
+		} else {
+			where += " and t.created_at < ?";
+			params.push(until.trim());
+		}
 	}
 
 	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
@@ -1075,7 +1085,7 @@ export function listTimelineItems({
       left join profiles qp on qp.id = qt.author_profile_id
       ${join}
       ${where}
-      order by t.created_at desc
+      order by t.created_at desc, t.id desc
       limit ?
       `;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -356,6 +356,7 @@ export interface TimelineQuery {
 	replyFilter?: ReplyFilter;
 	since?: string;
 	until?: string;
+	untilId?: string;
 	includeReplies?: boolean;
 	qualityFilter?: TimelineQualityFilter;
 	lowQualityThreshold?: number;

--- a/src/routes/api/query.tsx
+++ b/src/routes/api/query.tsx
@@ -105,6 +105,7 @@ export const Route = createFileRoute("/api/query")({
 							queryResource(resource, {
 								...baseFilters,
 								resource,
+								untilId: url.searchParams.get("untilId") ?? undefined,
 							}),
 						);
 					}),


### PR DESCRIPTION
Saved feeds (bookmarks, likes, home, mentions) only ever showed the server-default 18 items with no way to page further. This adds cursor pagination: the shared useTimelineRouteData hook requests limit=50 and exposes loadMore/hasMore/loadingMore using the existing until (created_at) query cursor, and SavedTimelineView/TimelineRouteFrame render a "Load more" button. this only uses existing locally saved data from the SQLite DB, never syncing against the live API.

happy to make any changes necessary!