### PR TITLE
feat: stream birdclaw import archive progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Stream live `birdclaw import archive` progress to stderr: per-slice parsing ticks (tweets, DMs, likes, bookmarks, follows, media) and chunked write-phase progress every 1,000 rows for profiles, tweets, likes+bookmarks, and DM messages. `--json` still keeps stdout clean for scripting.
 - Add `birdclaw discuss <query>` and a Discuss web view for live keyword search via `bird`/`xurl`, persisted search-result tweets, and streaming OpenAI summaries with optional private DM context.
 - Prefetch cached avatars for Discuss hover citations so source previews avoid fallback initials once profile metadata includes an avatar URL.
 - Refresh Today digests from live `xurl` home timelines, mentions, and mention conversations before AI analysis so reports see more current context and reply parents.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1164,6 +1164,89 @@ describe("cli", () => {
 		expect(findArchivesMock).not.toHaveBeenCalled();
 	});
 
+	it("streams archive import progress to stderr for human imports", async () => {
+		const stderrWriteMock = vi
+			.spyOn(process.stderr, "write")
+			.mockImplementation(() => true);
+		importArchiveMock.mockImplementation(async (_path, options) => {
+			options.onProgress?.({ kind: "scanned", entryCount: 12 });
+			options.onProgress?.({
+				kind: "slice-start",
+				slice: "tweets",
+				files: 2,
+			});
+			options.onProgress?.({
+				kind: "slice-file",
+				slice: "tweets",
+				processed: 1,
+				files: 2,
+			});
+			options.onProgress?.({ kind: "slice-done", slice: "tweets", count: 3 });
+			options.onProgress?.({ kind: "writing" });
+			options.onProgress?.({
+				kind: "write-start",
+				phase: "tweets",
+				total: 3,
+			});
+			options.onProgress?.({
+				kind: "write-progress",
+				phase: "tweets",
+				processed: 3,
+				total: 3,
+			});
+			options.onProgress?.({ kind: "done" });
+			return { ok: true, archivePath: _path };
+		});
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"import",
+			"archive",
+			"/tmp/explicit.zip",
+		]);
+
+		expect(importArchiveMock).toHaveBeenCalledWith("/tmp/explicit.zip", {
+			select: undefined,
+			onProgress: expect.any(Function),
+		});
+		expect(stderrWriteMock).toHaveBeenCalledWith(
+			"Scanning archive… 12 entries\n",
+		);
+		expect(stderrWriteMock).toHaveBeenCalledWith("Parsing tweets… (2 files)\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("  tweets 1/2\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("  tweets: 3\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("Writing to database…\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("Writing tweets… (3)\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("  tweets 3/3\n");
+		expect(stderrWriteMock).toHaveBeenCalledWith("Import complete.\n");
+		stderrWriteMock.mockRestore();
+	});
+
+	it("keeps archive import progress off stderr for json output", async () => {
+		const stderrWriteMock = vi
+			.spyOn(process.stderr, "write")
+			.mockImplementation(() => true);
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"archive",
+			"/tmp/explicit.zip",
+		]);
+
+		expect(importArchiveMock).toHaveBeenCalledWith("/tmp/explicit.zip", {
+			select: undefined,
+			onProgress: undefined,
+		});
+		expect(stderrWriteMock).not.toHaveBeenCalled();
+		stderrWriteMock.mockRestore();
+	});
+
 	it("passes selected archive slices to import archive", async () => {
 		const { runCli } = await loadCli();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,9 @@ import { findArchives } from "#/lib/archive-finder";
 import {
 	ARCHIVE_IMPORT_SLICES,
 	type ArchiveImportSlice,
+	type ImportProgressEvent,
+	type ImportProgressSlice,
+	type ImportWritePhase,
 	importArchive,
 } from "#/lib/archive-import";
 import {
@@ -117,6 +120,71 @@ function printError(error: string) {
 
 function errorMessage(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
+}
+
+const IMPORT_SLICE_LABELS: Record<ImportProgressSlice, string> = {
+	tweets: "tweets",
+	noteTweets: "note tweets",
+	directMessages: "direct messages",
+	likes: "likes",
+	bookmarks: "bookmarks",
+	media: "media files",
+	followers: "followers",
+	following: "following",
+};
+
+const IMPORT_WRITE_LABELS: Record<ImportWritePhase, string> = {
+	profiles: "profiles",
+	tweets: "tweets",
+	collections: "likes+bookmarks",
+	dmMessages: "DM messages",
+};
+
+function logImportProgress(event: ImportProgressEvent) {
+	switch (event.kind) {
+		case "scanned":
+			process.stderr.write(
+				`Scanning archive… ${String(event.entryCount)} entries\n`,
+			);
+			return;
+		case "slice-start":
+			if (event.slice === "media") {
+				process.stderr.write("Indexing media files…\n");
+				return;
+			}
+			process.stderr.write(
+				`Parsing ${IMPORT_SLICE_LABELS[event.slice]}… (${String(event.files)} file${event.files === 1 ? "" : "s"})\n`,
+			);
+			return;
+		case "slice-file":
+			if (event.files > 1) {
+				process.stderr.write(
+					`  ${IMPORT_SLICE_LABELS[event.slice]} ${String(event.processed)}/${String(event.files)}\n`,
+				);
+			}
+			return;
+		case "slice-done":
+			process.stderr.write(
+				`  ${IMPORT_SLICE_LABELS[event.slice]}: ${event.count.toLocaleString()}\n`,
+			);
+			return;
+		case "writing":
+			process.stderr.write("Writing to database…\n");
+			return;
+		case "write-start":
+			process.stderr.write(
+				`Writing ${IMPORT_WRITE_LABELS[event.phase]}… (${event.total.toLocaleString()})\n`,
+			);
+			return;
+		case "write-progress":
+			process.stderr.write(
+				`  ${IMPORT_WRITE_LABELS[event.phase]} ${event.processed.toLocaleString()}/${event.total.toLocaleString()}\n`,
+			);
+			return;
+		case "done":
+			process.stderr.write("Import complete.\n");
+			return;
+	}
 }
 
 function formatLinkSearchItems(items: ReturnType<typeof searchLinks>) {
@@ -599,9 +667,13 @@ importCommand
 			);
 		}
 
-		const result = await importArchive(resolvedArchivePath, { select });
+		const asJson = Boolean(program.opts().json);
+		const result = await importArchive(resolvedArchivePath, {
+			select,
+			onProgress: asJson ? undefined : logImportProgress,
+		});
 		await autoSyncAfterWrite();
-		print(result, program.opts().json ?? false);
+		print(result, asJson);
 	});
 
 importCommand

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -61,8 +61,45 @@ export const ARCHIVE_IMPORT_SLICES = [
 
 export type ArchiveImportSlice = (typeof ARCHIVE_IMPORT_SLICES)[number];
 
+export type ImportProgressSlice =
+	| "tweets"
+	| "noteTweets"
+	| "directMessages"
+	| "likes"
+	| "bookmarks"
+	| "media"
+	| "followers"
+	| "following";
+
+export type ImportWritePhase =
+	| "profiles"
+	| "tweets"
+	| "collections"
+	| "dmMessages";
+
+export type ImportProgressEvent =
+	| { kind: "scanned"; entryCount: number }
+	| { kind: "slice-start"; slice: ImportProgressSlice; files: number }
+	| {
+			kind: "slice-file";
+			slice: ImportProgressSlice;
+			processed: number;
+			files: number;
+	  }
+	| { kind: "slice-done"; slice: ImportProgressSlice; count: number }
+	| { kind: "writing" }
+	| { kind: "write-start"; phase: ImportWritePhase; total: number }
+	| {
+			kind: "write-progress";
+			phase: ImportWritePhase;
+			processed: number;
+			total: number;
+	  }
+	| { kind: "done" };
+
 export interface ImportArchiveOptions {
 	select?: ArchiveImportSlice[];
+	onProgress?: (event: ImportProgressEvent) => void;
 }
 
 type ArchiveRecord = Record<string, unknown>;
@@ -662,7 +699,9 @@ function importArchiveInternalEffect(
 	options: ImportArchiveOptions = {},
 ): Effect.Effect<ImportedArchiveSummary, unknown> {
 	return Effect.gen(function* () {
+		const onProgress = options.onProgress ?? (() => {});
 		const entries = yield* listArchiveEntriesEffect(archivePath);
+		onProgress({ kind: "scanned", entryCount: entries.length });
 		const selection = selectedSlices(options);
 		const includeTweets = includesSlice(selection, "tweets");
 		const includeLikes = includesSlice(selection, "likes");
@@ -770,7 +809,14 @@ function importArchiveInternalEffect(
 			tweetRowsById.set(row.id, row);
 		}
 
-		for (const entry of tweetEntries) {
+		if (tweetEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "tweets",
+				files: tweetEntries.length,
+			});
+		}
+		for (const [tweetFileIndex, entry] of tweetEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			for (const wrapper of parseArchiveArray(content)) {
 				const tweet = asRecord(wrapper.tweet);
@@ -821,9 +867,30 @@ function importArchiveInternalEffect(
 						: null,
 				});
 			}
+			onProgress({
+				kind: "slice-file",
+				slice: "tweets",
+				processed: tweetFileIndex + 1,
+				files: tweetEntries.length,
+			});
+		}
+		if (tweetEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "tweets",
+				count: tweetRows.length,
+			});
 		}
 
-		for (const entry of noteTweetEntries) {
+		if (noteTweetEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "noteTweets",
+				files: noteTweetEntries.length,
+			});
+		}
+		const tweetRowsBeforeNotes = tweetRows.length;
+		for (const [noteFileIndex, entry] of noteTweetEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			for (const wrapper of parseArchiveArray(content)) {
 				const noteTweet = asRecord(wrapper.noteTweet);
@@ -846,6 +913,19 @@ function importArchiveInternalEffect(
 					quotedTweetId: null,
 				});
 			}
+			onProgress({
+				kind: "slice-file",
+				slice: "noteTweets",
+				processed: noteFileIndex + 1,
+				files: noteTweetEntries.length,
+			});
+		}
+		if (noteTweetEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "noteTweets",
+				count: tweetRows.length - tweetRowsBeforeNotes,
+			});
 		}
 		const authoredTweetCount = tweetRows.length;
 
@@ -1275,7 +1355,14 @@ function importArchiveInternalEffect(
 			return resolved;
 		}
 
-		for (const entry of dmEntries) {
+		if (dmEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "directMessages",
+				files: dmEntries.length,
+			});
+		}
+		for (const [dmFileIndex, entry] of dmEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			for (const wrapper of parseArchiveArray(content)) {
 				const dmConversation = asRecord(wrapper.dmConversation);
@@ -1458,10 +1545,30 @@ function importArchiveInternalEffect(
 					needsReply: lastMessage.direction === "inbound" ? 1 : 0,
 				});
 			}
+			onProgress({
+				kind: "slice-file",
+				slice: "directMessages",
+				processed: dmFileIndex + 1,
+				files: dmEntries.length,
+			});
+		}
+		if (dmEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "directMessages",
+				count: dmMessages.length,
+			});
 		}
 
+		if (likeEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "likes",
+				files: likeEntries.length,
+			});
+		}
 		let likeCount = 0;
-		for (const entry of likeEntries) {
+		for (const [likeFileIndex, entry] of likeEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			const likes = parseArchiveArray(content);
 			for (const like of likes) {
@@ -1492,10 +1599,26 @@ function importArchiveInternalEffect(
 				});
 			}
 			likeCount += likes.length;
+			onProgress({
+				kind: "slice-file",
+				slice: "likes",
+				processed: likeFileIndex + 1,
+				files: likeEntries.length,
+			});
+		}
+		if (likeEntries.length > 0) {
+			onProgress({ kind: "slice-done", slice: "likes", count: likeCount });
 		}
 
+		if (bookmarkEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "bookmarks",
+				files: bookmarkEntries.length,
+			});
+		}
 		let bookmarkCount = 0;
-		for (const entry of bookmarkEntries) {
+		for (const [bookmarkFileIndex, entry] of bookmarkEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			const bookmarks = parseArchiveArray(content);
 			for (const bookmark of bookmarks) {
@@ -1526,29 +1649,91 @@ function importArchiveInternalEffect(
 				});
 			}
 			bookmarkCount += bookmarks.length;
+			onProgress({
+				kind: "slice-file",
+				slice: "bookmarks",
+				processed: bookmarkFileIndex + 1,
+				files: bookmarkEntries.length,
+			});
+		}
+		if (bookmarkEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "bookmarks",
+				count: bookmarkCount,
+			});
 		}
 
+		onProgress({ kind: "slice-start", slice: "media", files: 0 });
 		const mediaFileCounts = yield* extractArchiveMediaFilesEffect(
 			archivePath,
 			selectedArchiveMediaKinds(selection),
 		);
+		onProgress({
+			kind: "slice-done",
+			slice: "media",
+			count: Object.values(mediaFileCounts).reduce(
+				(total, value) => total + value,
+				0,
+			),
+		});
 
-		for (const entry of followerEntries) {
+		if (followerEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "followers",
+				files: followerEntries.length,
+			});
+		}
+		for (const [followerFileIndex, entry] of followerEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			for (const row of getArchiveFollowRows(content, "follower")) {
 				if (followerIds.has(row.externalUserId)) continue;
 				followerIds.add(row.externalUserId);
 				followerRows.push(row);
 			}
+			onProgress({
+				kind: "slice-file",
+				slice: "followers",
+				processed: followerFileIndex + 1,
+				files: followerEntries.length,
+			});
+		}
+		if (followerEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "followers",
+				count: followerRows.length,
+			});
 		}
 
-		for (const entry of followingEntries) {
+		if (followingEntries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "following",
+				files: followingEntries.length,
+			});
+		}
+		for (const [followingFileIndex, entry] of followingEntries.entries()) {
 			const content = yield* readArchiveEntryEffect(archivePath, entry);
 			for (const row of getArchiveFollowRows(content, "following")) {
 				if (followingIds.has(row.externalUserId)) continue;
 				followingIds.add(row.externalUserId);
 				followingRows.push(row);
 			}
+			onProgress({
+				kind: "slice-file",
+				slice: "following",
+				processed: followingFileIndex + 1,
+				files: followingEntries.length,
+			});
+		}
+		if (followingEntries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "following",
+				count: followingRows.length,
+			});
 		}
 
 		for (const row of [...followerRows, ...followingRows]) {
@@ -2255,6 +2440,17 @@ function importArchiveInternalEffect(
 			deleteArchiveFollowEdges.run("acct_primary", direction);
 		}
 
+		onProgress({ kind: "writing" });
+		const WRITE_PROGRESS_INTERVAL = 1000;
+		function tickWrite(
+			phase: ImportWritePhase,
+			processed: number,
+			total: number,
+		) {
+			if (processed === total || processed % WRITE_PROGRESS_INTERVAL === 0) {
+				onProgress({ kind: "write-progress", phase, processed, total });
+			}
+		}
 		db.transaction(() => {
 			if (!selection) {
 				clearImportedData(db);
@@ -2339,6 +2535,15 @@ function importArchiveInternalEffect(
 
 			const writeProfile =
 				!selection || includeProfiles ? insertProfile : insertProfileIfMissing;
+			const profilesTotal = profiles.size;
+			if (profilesTotal > 0) {
+				onProgress({
+					kind: "write-start",
+					phase: "profiles",
+					total: profilesTotal,
+				});
+			}
+			let profileIndex = 0;
 			for (const profile of profiles.values()) {
 				writeProfile.run(
 					profile.id,
@@ -2357,8 +2562,18 @@ function importArchiveInternalEffect(
 					profile.rawJson,
 					profile.createdAt,
 				);
+				profileIndex += 1;
+				tickWrite("profiles", profileIndex, profilesTotal);
 			}
 
+			if (tweetRows.length > 0) {
+				onProgress({
+					kind: "write-start",
+					phase: "tweets",
+					total: tweetRows.length,
+				});
+			}
+			let tweetWriteIndex = 0;
 			for (const tweet of tweetRows) {
 				const authorProfileId =
 					tweet.authorProfileId === "profile_me"
@@ -2406,9 +2621,19 @@ function importArchiveInternalEffect(
 					| { text: string }
 					| undefined;
 				insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
+				tweetWriteIndex += 1;
+				tickWrite("tweets", tweetWriteIndex, tweetRows.length);
 			}
 
 			const importedAt = new Date().toISOString();
+			if (collectionRows.length > 0) {
+				onProgress({
+					kind: "write-start",
+					phase: "collections",
+					total: collectionRows.length,
+				});
+			}
+			let collectionIndex = 0;
 			for (const collection of collectionRows) {
 				insertCollection.run(
 					"acct_primary",
@@ -2419,6 +2644,8 @@ function importArchiveInternalEffect(
 					collection.rawJson,
 					importedAt,
 				);
+				collectionIndex += 1;
+				tickWrite("collections", collectionIndex, collectionRows.length);
 			}
 
 			for (const conversation of conversations.values()) {
@@ -2433,6 +2660,14 @@ function importArchiveInternalEffect(
 				);
 			}
 
+			if (dmMessages.length > 0) {
+				onProgress({
+					kind: "write-start",
+					phase: "dmMessages",
+					total: dmMessages.length,
+				});
+			}
+			let dmWriteIndex = 0;
 			for (const message of dmMessages) {
 				insertMessage.run(
 					message.id,
@@ -2445,6 +2680,8 @@ function importArchiveInternalEffect(
 					message.mediaCount,
 				);
 				insertDmFts.run(message.id, message.text);
+				dmWriteIndex += 1;
+				tickWrite("dmMessages", dmWriteIndex, dmMessages.length);
 			}
 
 			if (includeFollowers && followerEntries.length > 0) {
@@ -2468,6 +2705,7 @@ function importArchiveInternalEffect(
 				clearArchiveFollowRows("following");
 			}
 		})();
+		onProgress({ kind: "done" });
 
 		return {
 			ok: true,


### PR DESCRIPTION
## Summary

- `birdclaw import archive` is silent today; for large archives that means minutes of no output between the SQLite experimental warning and the final summary. This PR adds live progress on stderr.
- Adds an optional `onProgress` hook to `importArchive` / `importArchiveEffect` and emits typed events at every meaningful milestone:
  - **Parsing**: per-slice ticks (tweets, note tweets, direct messages, likes, bookmarks, media, followers, following) with file counts and final per-slice totals.
  - **Writing**: chunked per-row ticks every 1,000 rows for the heavy transaction loops — profiles, tweets, likes+bookmarks collections, DM messages. (These four loops dominate write time on real archives; e.g. 110k likes / 11k DMs / 3k profiles became a long opaque pause before.)
  - Scan / writing / done transitions.
- The CLI installs a stderr printer by default. `--json` suppresses progress so stdout stays clean for scripting.

Sample output for a ~183 MB archive:

```
Scanning archive… 6716 entries
Parsing tweets… (2 files)
  tweets 1/2
  tweets 2/2
  tweets: 22
Parsing direct messages… (2 files)
  direct messages: 11,675
Parsing likes… (1 file)
  likes: 110,642
Indexing media files…
  media files: 0
Writing to database…
Writing profiles… (3,182)
  profiles 1,000/3,182
  profiles 3,182/3,182
Writing tweets… (110,664)
  tweets 1,000/110,664
  …
Writing likes+bookmarks… (110,642)
  …
Writing DM messages… (11,675)
  …
Import complete.
```

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/lib/archive-import.test.ts src/cli.test.ts` — all 88 pass
- [x] Manual run against a 183 MB Twitter archive: progress now visible end-to-end, `--json` output unchanged.

## Notes

- Public API change: `ImportArchiveOptions` gains an optional `onProgress?: (event: ImportProgressEvent) => void`. New exported types: `ImportProgressEvent`, `ImportProgressSlice`, `ImportWritePhase`. No existing callers needed updates.
- The write-progress throttle is a constant (`WRITE_PROGRESS_INTERVAL = 1000`) inside `importArchiveInternalEffect`; happy to plumb it through options if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)