### PR TITLE
fix: keep init alive when `searchDirectoryEffect` scan throws

### DIFF
--- a/src/lib/archive-finder.test.ts
+++ b/src/lib/archive-finder.test.ts
@@ -179,6 +179,18 @@ describe("archive finder", () => {
 		expect(mocks.readdir).not.toHaveBeenCalled();
 	});
 
+	it("skips downloads when readdir fails (e.g. EPERM from macOS TCC)", async () => {
+		mocks.existsSync.mockReturnValue(true);
+		const err = Object.assign(
+			new Error("EPERM: operation not permitted, scandir '/Users/x/Downloads'"),
+			{ code: "EPERM" },
+		);
+		mocks.readdir.mockRejectedValue(err);
+		mocks.execAsync.mockResolvedValue({ stdout: "" });
+
+		await expect(findArchives()).resolves.toEqual([]);
+	});
+
 	it("returns empty on non-darwin hosts", async () => {
 		Object.defineProperty(process, "platform", {
 			configurable: true,

--- a/src/lib/archive-finder.ts
+++ b/src/lib/archive-finder.ts
@@ -75,7 +75,7 @@ function searchDirectoryEffect(directoryPath: string) {
 		);
 
 		return candidates.filter((item) => item !== null);
-	});
+	}).pipe(Effect.catchAll(() => Effect.succeed([])));
 }
 
 function searchSpotlightEffect(query: string) {


### PR DESCRIPTION
The `~/Downloads` folder access is requested for the terminal app at initial visit. I seemed to have clicked "Don't Allow" along time ago. Cumbersome to change this in the MacOs accessibility settings. However, this missing permission should not cause the birdclaw cli to crash.

I ran into this issue:
```
birdclaw init
EPERM: operation not permitted, scandir '/Users/mnml/Downloads'
```

Even prevents other stuff later on as it's reused.

```
birdclaw auth status --json

EPERM: operation not permitted, scandir '/Users/mnml/Downloads'
```

--- 

`birdclaw init` triggers an opportunistic archive scan of ~/Downloads. On macOS, if the calling terminal lacks TCC permission for Downloads, `fs.readdir` throws EPERM and the whole `init` command crashes with:

  EPERM: operation not permitted, scandir '/Users/<user>/Downloads'

The sibling discovery paths in the same module (`searchSpotlightEffect`, `getCandidateEffect`) already swallow errors and degrade to empty results. `searchDirectoryEffect` was the lone outlier — `existsSync` guarded ENOENT but nothing caught EPERM/EACCES.

Match the sibling contract: wrap the directory scan in `Effect.catchAll(() => Effect.succeed([]))`. Downloads becomes a best-effort source; Spotlight picks up the slack. `init` no longer crashes, and `archive find` returns `[]` instead of throwing when Downloads is unreadable.

Adds a regression test covering the exact EPERM failure mode.