### PR TITLE
feat: add secure public reader profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.1 - Unreleased
 
+### Added
+
+- Add a production `public-readonly` web profile with loopback-only serving, read-only SQLite, an explicit API allowlist, sanitized timeline data, and a reduced reader UI for identity-aware reverse proxies.
+
 ## 0.8.0 - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -277,6 +277,20 @@ Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs to run the match
 
 When running behind a trusted reverse proxy such as Tailscale Serve, add any extra proxy hostnames to `BIRDCLAW_ALLOWED_HOSTS`. The clawmac Tailscale hostname is allowed by default.
 
+For an identity-aware external reader, build and run the separate read-only
+profile behind a trusted loopback proxy:
+
+```bash
+pnpm build:public
+pnpm start:public
+```
+
+The public profile only serves status, Home/Mentions timeline queries,
+public-timeline conversations, and already-cached avatar reads. It blocks every
+write/private API, omits accounts, DMs, archives, transport state, and private
+tweet state, and opens SQLite read-only. Keep the full UI on a separate private
+endpoint.
+
 First moderation pass:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,11 +82,14 @@ See [Backup](backup.md). When `autoSync` is enabled, read commands pull + merge 
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `BIRDCLAW_HOME`                | Override the storage root (`~/.birdclaw` by default)                                                                                   |
 | `BIRDCLAW_CONFIG`              | Read and write config at a non-default path                                                                                            |
-| `BIRDCLAW_ACTIONS_TRANSPORT`   | Override moderation action transport with `auto`, `xurl`, or `bird` for one process                                                     |
+| `BIRDCLAW_ACTIONS_TRANSPORT`   | Override moderation action transport with `auto`, `xurl`, or `bird` for one process                                                    |
 | `BIRDCLAW_ALLOWED_HOSTS`       | Comma-separated extra Vite dev-server hostnames for `birdclaw serve` behind a trusted reverse proxy                                    |
 | `BIRDCLAW_LOCAL_WEB`           | Internal `birdclaw serve` marker for direct local-only loopback web APIs; forwarded/proxied requests still require remote-token config |
 | `BIRDCLAW_WEB_TOKEN`           | Optional app-level token for remote web API access; send as `x-birdclaw-token` or `birdclaw_token`                                     |
 | `BIRDCLAW_ALLOW_REMOTE_WEB`    | Set to `1` to allow remote access through a trusted private proxy                                                                      |
+| `BIRDCLAW_WEB_PROFILE`         | Set to `public-readonly` at build and runtime for the allowlisted, sanitized reader surface                                            |
+| `BIRDCLAW_HOST`                | Built server bind host; only loopback addresses are accepted                                                                           |
+| `BIRDCLAW_PORT`                | Built server port (`3100` by default)                                                                                                  |
 | `BIRDCLAW_DISABLE_LIVE_WRITES` | Set to `1` to block any live mutation (used by tests and CI)                                                                           |
 | `BIRDCLAW_BACKUP_AUTO_SYNC`    | Set to `0` to disable auto-sync for one process                                                                                        |
 | `NO_COLOR`                     | Disable ANSI color in human output                                                                                                     |

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 	"scripts": {
 		"dev": "BIRDCLAW_LOCAL_WEB=1 vite dev --host 127.0.0.1 --port 3000",
 		"build": "vite build",
+		"build:public": "BIRDCLAW_WEB_PROFILE=public-readonly vite build",
+		"start:public": "BIRDCLAW_WEB_PROFILE=public-readonly node scripts/serve-build.mjs",
 		"preview": "vite preview",
 		"test": "node ./scripts/run-vitest.mjs run",
 		"coverage": "node ./scripts/run-vitest.mjs run --coverage",

--- a/scripts/serve-build.mjs
+++ b/scripts/serve-build.mjs
@@ -1,0 +1,151 @@
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+const host = process.env.BIRDCLAW_HOST || "127.0.0.1";
+const port = Number(process.env.BIRDCLAW_PORT || "3100");
+const clientRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../dist/client",
+);
+const contentTypes = new Map([
+	[".css", "text/css; charset=utf-8"],
+	[".html", "text/html; charset=utf-8"],
+	[".ico", "image/x-icon"],
+	[".js", "text/javascript; charset=utf-8"],
+	[".json", "application/json; charset=utf-8"],
+	[".map", "application/json; charset=utf-8"],
+	[".png", "image/png"],
+	[".svg", "image/svg+xml"],
+	[".txt", "text/plain; charset=utf-8"],
+	[".webmanifest", "application/manifest+json; charset=utf-8"],
+	[".woff", "font/woff"],
+	[".woff2", "font/woff2"],
+]);
+
+if (process.env.BIRDCLAW_WEB_PROFILE !== "public-readonly") {
+	throw new Error(
+		"Built Birdclaw server requires BIRDCLAW_WEB_PROFILE=public-readonly",
+	);
+}
+if (host !== "127.0.0.1" && host !== "::1") {
+	throw new Error("Built Birdclaw server must bind to loopback");
+}
+if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+	throw new Error(`Invalid BIRDCLAW_PORT: ${process.env.BIRDCLAW_PORT}`);
+}
+
+const { default: serverEntry } = await import("../dist/server/server.js");
+
+function addSecurityHeaders(headers) {
+	headers["permissions-policy"] =
+		"camera=(), microphone=(), geolocation=(), payment=()";
+	headers["referrer-policy"] = "no-referrer";
+	headers["x-content-type-options"] = "nosniff";
+	headers["x-frame-options"] = "DENY";
+	return headers;
+}
+
+async function serveStatic(requestUrl, method, outgoing) {
+	if (method !== "GET" && method !== "HEAD") return false;
+
+	let decodedPath;
+	try {
+		decodedPath = decodeURIComponent(requestUrl.pathname);
+	} catch {
+		return false;
+	}
+	const filePath = path.resolve(clientRoot, `.${decodedPath}`);
+	if (
+		filePath === clientRoot ||
+		!filePath.startsWith(`${clientRoot}${path.sep}`)
+	) {
+		return false;
+	}
+
+	let fileStat;
+	try {
+		fileStat = await stat(filePath);
+	} catch {
+		return false;
+	}
+	if (!fileStat.isFile()) return false;
+
+	const extension = path.extname(filePath).toLowerCase();
+	const headers = addSecurityHeaders({
+		"cache-control": decodedPath.startsWith("/assets/")
+			? "public, max-age=31536000, immutable"
+			: "public, max-age=3600",
+		"content-length": String(fileStat.size),
+		"content-type": contentTypes.get(extension) || "application/octet-stream",
+		"last-modified": fileStat.mtime.toUTCString(),
+	});
+	outgoing.writeHead(200, headers);
+	if (method === "HEAD") {
+		outgoing.end();
+		return true;
+	}
+	createReadStream(filePath)
+		.on("error", (error) => outgoing.destroy(error))
+		.pipe(outgoing);
+	return true;
+}
+
+const server = http.createServer(async (incoming, outgoing) => {
+	const abortController = new AbortController();
+	incoming.once("aborted", () => abortController.abort());
+
+	try {
+		const method = incoming.method || "GET";
+		const requestUrl = new URL(
+			incoming.url || "/",
+			`http://${incoming.headers.host || host}`,
+		);
+		if (await serveStatic(requestUrl, method, outgoing)) return;
+
+		const request = new Request(requestUrl, {
+			method,
+			headers: incoming.headers,
+			body:
+				method === "GET" || method === "HEAD"
+					? undefined
+					: Readable.toWeb(incoming),
+			duplex: "half",
+			signal: abortController.signal,
+		});
+		const response = await serverEntry.fetch(request);
+		const headers = addSecurityHeaders(Object.fromEntries(response.headers));
+		if (
+			process.env.BIRDCLAW_WEB_PROFILE === "public-readonly" &&
+			!response.headers.has("cache-control")
+		) {
+			headers["cache-control"] = "private, no-store";
+		}
+		const getSetCookie = response.headers.getSetCookie?.bind(response.headers);
+		if (getSetCookie) {
+			const cookies = getSetCookie();
+			if (cookies.length > 0) headers["set-cookie"] = cookies;
+		}
+		outgoing.writeHead(response.status, headers);
+		if (!response.body || method === "HEAD") {
+			outgoing.end();
+			return;
+		}
+		Readable.fromWeb(response.body).pipe(outgoing);
+	} catch (error) {
+		if (abortController.signal.aborted) return;
+		console.error(error);
+		outgoing.writeHead(500, {
+			"content-type": "text/plain; charset=utf-8",
+			"x-content-type-options": "nosniff",
+		});
+		outgoing.end("Internal Server Error");
+	}
+});
+
+server.listen(port, host, () => {
+	console.log(`Birdclaw listening on http://${host}:${String(port)}`);
+});

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -34,6 +34,7 @@ import {
 	sidebarNavClass,
 	sidebarShellClass,
 } from "#/lib/ui";
+import { isPublicReadonlyBuild } from "#/lib/web-profile";
 import { AccountSwitcher } from "./AccountSwitcher";
 import { BirdclawMark } from "./BrandMark";
 import { ThemeSlider } from "./ThemeSlider";
@@ -54,6 +55,10 @@ const links = [
 	{ to: "/dms", label: "DMs", icon: Mail },
 	{ to: "/blocks", label: "Blocks", icon: ShieldOff },
 ] as const;
+
+const publicLinks = links.filter(
+	(link) => link.to === "/" || link.to === "/mentions",
+);
 
 export function AppNav({ compact = false }: { compact?: boolean }) {
 	const pathname = useRouterState({
@@ -79,7 +84,7 @@ export function AppNav({ compact = false }: { compact?: boolean }) {
 					</span>
 				</Link>
 				<nav className={sidebarNavClass} aria-label="Primary">
-					{links.map((link) => {
+					{(isPublicReadonlyBuild ? publicLinks : links).map((link) => {
 						const active = pathname === link.to;
 						const Icon = link.icon;
 						return (
@@ -111,7 +116,14 @@ export function AppNav({ compact = false }: { compact?: boolean }) {
 				</nav>
 			</div>
 			<div className={sidebarFooterClass}>
-				<AccountSwitcher action={<ThemeSlider compact />} />
+				{isPublicReadonlyBuild ? (
+					<div className="flex flex-col items-center gap-2 px-2 text-[11px] font-medium text-[var(--ink-soft)] min-[1100px]:items-start">
+						<span>Read-only</span>
+						<ThemeSlider compact />
+					</div>
+				) : (
+					<AccountSwitcher action={<ThemeSlider compact />} />
+				)}
 			</div>
 		</aside>
 	);

--- a/src/components/ProfilePreview.tsx
+++ b/src/components/ProfilePreview.tsx
@@ -24,6 +24,7 @@ import {
 	tweetLinkClass,
 } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
+import { isPublicReadonlyBuild } from "#/lib/web-profile";
 import { AvatarChip } from "./AvatarChip";
 
 type VerticalBounds = { top: number; bottom: number };
@@ -134,7 +135,13 @@ export function ProfilePreview({
 		>
 			<a
 				className={profilePreviewTriggerClass}
-				href={`/profiles/${encodeURIComponent(profile.handle)}`}
+				href={
+					isPublicReadonlyBuild
+						? `https://x.com/${encodeURIComponent(profile.handle)}`
+						: `/profiles/${encodeURIComponent(profile.handle)}`
+				}
+				rel={isPublicReadonlyBuild ? "noreferrer" : undefined}
+				target={isPublicReadonlyBuild ? "_blank" : undefined}
 			>
 				{children}
 			</a>

--- a/src/components/TimelineCard.test.tsx
+++ b/src/components/TimelineCard.test.tsx
@@ -130,6 +130,20 @@ describe("TimelineCard", () => {
 		expect(onReply).toHaveBeenCalledWith("tweet_1");
 	});
 
+	it("can hide profile analysis controls", () => {
+		render(
+			<TimelineCard
+				item={item}
+				onReply={vi.fn()}
+				showAnalysisControls={false}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("link", { name: "Analyse @sam" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("renders retweets as the original tweet with repost attribution", () => {
 		const fetchMock = vi.fn().mockResolvedValue({
 			ok: true,

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -227,10 +227,12 @@ function isInteractiveTarget(target: EventTarget | null) {
 export function TimelineCard({
 	item,
 	onReply,
+	showAnalysisControls = true,
 	showReplyControls = true,
 }: {
 	item: TimelineItem;
 	onReply: (tweetId: string) => void;
+	showAnalysisControls?: boolean;
 	showReplyControls?: boolean;
 }) {
 	const canReply =
@@ -446,20 +448,25 @@ export function TimelineCard({
 								<span className="text-[13px]">Reply</span>
 							</button>
 						) : null}
-						<a
-							aria-label={`Analyse @${displayAuthor.handle}`}
-							className={feedActionButtonClass}
-							href={`/profiles/${encodeURIComponent(displayAuthor.handle)}`}
-							onClick={(event) => {
-								event.stopPropagation();
-							}}
-							title={`Analyse @${displayAuthor.handle}`}
-						>
-							<span className={feedActionIconWrapClass}>
-								<UserSearch className={feedActionIconClass} strokeWidth={1.7} />
-							</span>
-							<span className="text-[13px]">Analyse</span>
-						</a>
+						{showAnalysisControls ? (
+							<a
+								aria-label={`Analyse @${displayAuthor.handle}`}
+								className={feedActionButtonClass}
+								href={`/profiles/${encodeURIComponent(displayAuthor.handle)}`}
+								onClick={(event) => {
+									event.stopPropagation();
+								}}
+								title={`Analyse @${displayAuthor.handle}`}
+							>
+								<span className={feedActionIconWrapClass}>
+									<UserSearch
+										className={feedActionIconClass}
+										strokeWidth={1.7}
+									/>
+								</span>
+								<span className="text-[13px]">Analyse</span>
+							</a>
+						) : null}
 						{showLikeIndicator ? (
 							<span
 								aria-label={`${formatCompactNumber(displayLikeCount)} likes`}

--- a/src/components/TimelineRouteFrame.tsx
+++ b/src/components/TimelineRouteFrame.tsx
@@ -11,6 +11,7 @@ import { TimelineCard } from "#/components/TimelineCard";
 import { ConversationSurfaceScope } from "#/lib/conversation-surface";
 import type { QueryEnvelope, ReplyFilter } from "#/lib/types";
 import type { WebSyncKind } from "#/lib/web-sync";
+import { isPublicReadonlyBuild } from "#/lib/web-profile";
 import {
 	cx,
 	feedClass,
@@ -66,8 +67,9 @@ export function TimelineRouteFrame({
 	emptyDetail,
 	subtitle,
 }: TimelineRouteFrameProps) {
-	const [replyFilter, setReplyFilter] =
-		useState<ReplyFilter>(initialReplyFilter);
+	const [replyFilter, setReplyFilter] = useState<ReplyFilter>(
+		isPublicReadonlyBuild ? "all" : initialReplyFilter,
+	);
 	const [search, setSearch] = useState("");
 	const {
 		meta,
@@ -97,13 +99,15 @@ export function TimelineRouteFrame({
 						<h1 className={pageTitleClass}>{title}</h1>
 						<p className={pageSubtitleClass}>{subtitleText}</p>
 					</div>
-					<SyncNowButton
-						accounts={meta?.accounts}
-						kind={syncKind}
-						label={syncLabel}
-						onSynced={refreshLocalView}
-						showAccountPicker
-					/>
+					{isPublicReadonlyBuild ? null : (
+						<SyncNowButton
+							accounts={meta?.accounts}
+							kind={syncKind}
+							label={syncLabel}
+							onSynced={refreshLocalView}
+							showAccountPicker
+						/>
+					)}
 				</div>
 				<div className="px-4 pb-3">
 					<label className={searchFieldShellClass}>
@@ -116,25 +120,29 @@ export function TimelineRouteFrame({
 						/>
 					</label>
 				</div>
-				<div className={tabStripClass}>
-					{TABS.map((tab) => {
-						const active = replyFilter === tab.value;
-						return (
-							<button
-								key={tab.value}
-								type="button"
-								aria-pressed={active}
-								className={cx(tabButtonClass, active && tabButtonActiveClass)}
-								onClick={() => setReplyFilter(tab.value)}
-							>
-								<span className="relative inline-flex flex-col items-center justify-center py-1">
-									{tab.label}
-									{active ? <span className={tabButtonIndicatorClass} /> : null}
-								</span>
-							</button>
-						);
-					})}
-				</div>
+				{isPublicReadonlyBuild ? null : (
+					<div className={tabStripClass}>
+						{TABS.map((tab) => {
+							const active = replyFilter === tab.value;
+							return (
+								<button
+									key={tab.value}
+									type="button"
+									aria-pressed={active}
+									className={cx(tabButtonClass, active && tabButtonActiveClass)}
+									onClick={() => setReplyFilter(tab.value)}
+								>
+									<span className="relative inline-flex flex-col items-center justify-center py-1">
+										{tab.label}
+										{active ? (
+											<span className={tabButtonIndicatorClass} />
+										) : null}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+				)}
 			</header>
 			{replyError ? (
 				<p className={cx(timestampClass, "px-4 py-2 text-red-500")}>
@@ -165,7 +173,13 @@ export function TimelineRouteFrame({
 						<FeedEmpty detail={emptyDetail} label={emptyLabel} />
 					) : null}
 					{items.map((item) => (
-						<TimelineCard key={item.id} item={item} onReply={replyToTweet} />
+						<TimelineCard
+							key={item.id}
+							item={item}
+							onReply={replyToTweet}
+							showAnalysisControls={!isPublicReadonlyBuild}
+							showReplyControls={!isPublicReadonlyBuild}
+						/>
 					))}
 					{!loading && !error && hasMore ? (
 						<div className="flex justify-center py-4">

--- a/src/lib/avatar-cache.ts
+++ b/src/lib/avatar-cache.ts
@@ -32,6 +32,10 @@ function getAvatarCacheDir() {
 	return dir;
 }
 
+function getExistingAvatarCacheDir() {
+	return path.join(getBirdclawPaths().mediaThumbsDir, "avatars");
+}
+
 function getExtensionFromContentType(contentType: string | null) {
 	const mime = contentType?.split(";")[0].trim().toLowerCase() ?? "";
 	if (mime === "image/png") return ".png";
@@ -207,6 +211,25 @@ export function getAvatarCachePath(profileId: string, avatarUrl: string) {
 	);
 }
 
+function getExistingAvatarCachePath(profileId: string, avatarUrl: string) {
+	const normalizedAvatarUrl = normalizeAvatarUrl(avatarUrl);
+	if (!normalizedAvatarUrl) {
+		throw new Error("Missing avatar URL");
+	}
+
+	const hash = createHash("sha1").update(normalizedAvatarUrl).digest("hex");
+	const extension = normalizedAvatarUrl.startsWith("data:")
+		? getExtensionFromContentType(
+				/^data:([^;,]+)/i.exec(normalizedAvatarUrl)?.[1] ?? null,
+			)
+		: getExtensionFromAvatarUrl(normalizedAvatarUrl);
+
+	return path.join(
+		getExistingAvatarCacheDir(),
+		`${sanitizeFileToken(profileId)}-${hash}${extension}`,
+	);
+}
+
 function fetchRemoteAvatarEffect(avatarUrl: string) {
 	return Effect.gen(function* () {
 		const safeUrl = yield* trySync(() => assertSafeRemoteAvatarUrl(avatarUrl));
@@ -280,6 +303,35 @@ export function readCachedAvatarEffect(profileId: string) {
 		return {
 			buffer: payload.buffer,
 			contentType: payload.contentType,
+			cachePath,
+			avatarUrl: normalizedAvatarUrl,
+		};
+	});
+}
+
+export function readCachedAvatarOnlyEffect(profileId: string) {
+	return Effect.gen(function* () {
+		const avatarUrl = yield* trySync(() => getAvatarUrlForProfile(profileId));
+		if (!avatarUrl) {
+			return null;
+		}
+
+		const normalizedAvatarUrl = normalizeAvatarUrl(avatarUrl);
+		if (!normalizedAvatarUrl) {
+			return null;
+		}
+
+		const cachePath = yield* trySync(() =>
+			getExistingAvatarCachePath(profileId, normalizedAvatarUrl),
+		);
+		const buffer = yield* trySync(() => readFileSync(cachePath)).pipe(
+			Effect.catchAll(() => Effect.succeed(null)),
+		);
+		if (!buffer) return null;
+
+		return {
+			buffer,
+			contentType: getContentTypeFromExtension(path.extname(cachePath)),
 			cachePath,
 			avatarUrl: normalizedAvatarUrl,
 		};

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -13,6 +13,7 @@ afterEach(() => {
 	resetDatabaseForTests();
 	resetBirdclawPathsForTests();
 	delete process.env.BIRDCLAW_HOME;
+	delete process.env.BIRDCLAW_WEB_PROFILE;
 
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -20,6 +21,30 @@ afterEach(() => {
 });
 
 describe("database init", () => {
+	it("keeps repeated public reader access read-only", () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const writableDb = getNativeDb();
+		expect(
+			writableDb.prepare("select count(*) as count from accounts").get(),
+		).toEqual({ count: 2 });
+		resetDatabaseForTests();
+
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		const readonlyDb = getNativeDb();
+		expect(
+			readonlyDb.prepare("select count(*) as count from accounts").get(),
+		).toEqual({ count: 2 });
+		expect(getNativeDb()).toBe(readonlyDb);
+		expect(() =>
+			readonlyDb
+				.prepare("insert into accounts (id, name, handle) values (?, ?, ?)")
+				.run("forbidden", "Forbidden", "@forbidden"),
+		).toThrow(/readonly/i);
+	});
+
 	it("seeds demo data after an initial unseeded open", () => {
 		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-"));
 		tempDirs.push(tempDir);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,7 @@ import NativeSqliteDatabase, { type Database } from "./sqlite";
 import { Kysely, SqliteDialect } from "kysely";
 import { ensureBirdclawDirs, getBirdclawPaths } from "./config";
 import { seedDemoData } from "./seed";
+import { isPublicReadonlyWeb } from "./web-profile";
 
 export interface AccountsTable {
 	id: string;
@@ -1010,7 +1011,18 @@ function initDatabase(options: InitDatabaseOptions = {}) {
 
 	if (!nativeDb) {
 		const { dbPath } = getBirdclawPaths();
-		nativeDb = new NativeSqliteDatabase(dbPath);
+		const publicReadonly = isPublicReadonlyWeb();
+		nativeDb = new NativeSqliteDatabase(dbPath, {
+			readonly: publicReadonly,
+		});
+		if (publicReadonly) {
+			kyselyDb = new Kysely<BirdclawDatabase>({
+				dialect: new SqliteDialect({
+					database: nativeDb,
+				}),
+			});
+			return;
+		}
 		nativeDb.exec(BASE_SCHEMA_SQL);
 		ensureAccountExternalUserIdColumn(nativeDb);
 		ensureDmConversationInboxColumns(nativeDb);
@@ -1031,7 +1043,7 @@ function initDatabase(options: InitDatabaseOptions = {}) {
 			backfillTweetCollections(nativeDb);
 			backfillTweetAccountEdges(nativeDb);
 		}
-	} else if (options.seedDemoData !== false) {
+	} else if (!isPublicReadonlyWeb() && options.seedDemoData !== false) {
 		ensureDemoData(nativeDb);
 	}
 

--- a/src/lib/http-effect.test.ts
+++ b/src/lib/http-effect.test.ts
@@ -75,6 +75,92 @@ describe("http Effect helpers", () => {
 		await expect(runRouteEffect(Effect.succeed("ok"))).resolves.toBe("ok");
 	});
 
+	it("blocks private and write APIs in public read-only mode", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+
+		try {
+			const response = sensitiveRequestErrorResponse(
+				new Request("http://localhost/api/action", {
+					method: "POST",
+				}),
+			);
+
+			expect(response?.status).toBe(403);
+			await expect(response?.json()).resolves.toEqual({
+				ok: false,
+				message: "This Birdclaw deployment is read-only",
+			});
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
+	});
+
+	it("allows public read-only API routes through the profile allowlist", () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+
+		try {
+			expect(
+				sensitiveRequestErrorResponse(
+					new Request("http://localhost/api/query"),
+				),
+			).toBeNull();
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
+	});
+
+	it("allows public read-only GETs through a loopback reverse proxy", () => {
+		const originalNodeEnv = process.env.NODE_ENV;
+		const originalVitest = process.env.VITEST;
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		const originalRemote = process.env.BIRDCLAW_ALLOW_REMOTE_WEB;
+		const originalToken = process.env.BIRDCLAW_WEB_TOKEN;
+		delete process.env.VITEST;
+		process.env.NODE_ENV = "production";
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		delete process.env.BIRDCLAW_ALLOW_REMOTE_WEB;
+		delete process.env.BIRDCLAW_WEB_TOKEN;
+
+		try {
+			expect(
+				sensitiveRequestErrorResponse(
+					new Request("http://reader.birdclaw.sh/api/query", {
+						headers: {
+							origin: "https://reader.birdclaw.sh",
+							"sec-fetch-site": "same-origin",
+							"x-forwarded-for": "203.0.113.10",
+							"x-forwarded-host": "reader.birdclaw.sh",
+							"x-forwarded-proto": "https",
+						},
+					}),
+				),
+			).toBeNull();
+		} finally {
+			if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = originalNodeEnv;
+			if (originalVitest === undefined) delete process.env.VITEST;
+			else process.env.VITEST = originalVitest;
+			if (originalProfile === undefined)
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			else process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			if (originalRemote === undefined)
+				delete process.env.BIRDCLAW_ALLOW_REMOTE_WEB;
+			else process.env.BIRDCLAW_ALLOW_REMOTE_WEB = originalRemote;
+			if (originalToken === undefined) delete process.env.BIRDCLAW_WEB_TOKEN;
+			else process.env.BIRDCLAW_WEB_TOKEN = originalToken;
+		}
+	});
+
 	it("bounds numeric and string integers", () => {
 		expect(parseBoundedInteger(8, { defaultValue: 4, max: 20 })).toBe(8);
 		expect(parseBoundedInteger("42", { defaultValue: 4, max: 20 })).toBe(20);

--- a/src/lib/http-effect.ts
+++ b/src/lib/http-effect.ts
@@ -1,7 +1,14 @@
 import { Effect } from "effect";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { isPublicReadonlyWeb } from "./web-profile";
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const PUBLIC_READONLY_API_PATHS = new Set([
+	"/api/avatar",
+	"/api/conversation",
+	"/api/query",
+	"/api/status",
+]);
 
 export function jsonResponse(data: unknown, init?: ResponseInit) {
 	const headers = new Headers(init?.headers);
@@ -132,6 +139,18 @@ function sameRequestOrigin(request: Request, origin: string, url: URL) {
 
 export function sensitiveRequestErrorResponse(request: Request) {
 	const url = new URL(request.url);
+	if (
+		isPublicReadonlyWeb() &&
+		(request.method !== "GET" || !PUBLIC_READONLY_API_PATHS.has(url.pathname))
+	) {
+		return jsonResponse(
+			{
+				ok: false,
+				message: "This Birdclaw deployment is read-only",
+			},
+			{ status: 403 },
+		);
+	}
 	const token = requestWebTokenStatus(request);
 	const isLocalRequest =
 		allowsUnauthenticatedLocalWeb() &&
@@ -140,7 +159,8 @@ export function sensitiveRequestErrorResponse(request: Request) {
 	const fetchSite = request.headers.get("sec-fetch-site");
 	const origin = request.headers.get("origin");
 	const allowRemoteEnv = process.env.BIRDCLAW_ALLOW_REMOTE_WEB === "1";
-	const allowTrustedRemote = allowRemoteEnv && !token.configured;
+	const allowTrustedRemote =
+		(allowRemoteEnv || isPublicReadonlyWeb()) && !token.configured;
 
 	if (isTestEnvironment() && !token.valid) return null;
 
@@ -181,7 +201,7 @@ export function sensitiveRequestErrorResponse(request: Request) {
 		);
 	}
 
-	const allowRemote = allowRemoteEnv && (token.valid || allowTrustedRemote);
+	const allowRemote = allowTrustedRemote || (allowRemoteEnv && token.valid);
 	if (!allowRemote && !isLocalRequest) {
 		return jsonResponse(
 			{ ok: false, message: "Remote web API access is disabled" },

--- a/src/lib/public-tweet.test.ts
+++ b/src/lib/public-tweet.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePublicEmbeddedTweet } from "./public-tweet";
+
+describe("public tweet sanitization", () => {
+	it("strips private state and enriched mention profiles", () => {
+		const tweet = sanitizePublicEmbeddedTweet({
+			id: "tweet_1",
+			text: "@alice hello",
+			createdAt: "2026-06-13T12:00:00.000Z",
+			isReplied: true,
+			bookmarked: true,
+			liked: true,
+			author: {
+				id: "profile_author",
+				handle: "author",
+				displayName: "Author",
+				bio: "",
+				followersCount: 1,
+				avatarHue: 1,
+				createdAt: "2026-06-13T12:00:00.000Z",
+			},
+			entities: {
+				mentions: [
+					{
+						username: "alice",
+						start: 0,
+						end: 6,
+						profile: {
+							id: "profile_private",
+							handle: "alice",
+							displayName: "Alice",
+							bio: "private enrichment",
+							followersCount: 42,
+							avatarHue: 2,
+							createdAt: "2026-06-13T12:00:00.000Z",
+						},
+					},
+				],
+			},
+			media: [],
+		});
+
+		expect(tweet).toMatchObject({
+			isReplied: false,
+			bookmarked: false,
+			liked: false,
+			entities: {
+				mentions: [{ username: "alice", start: 0, end: 6 }],
+			},
+		});
+		expect(tweet.entities.mentions?.[0]).not.toHaveProperty("profile");
+	});
+});

--- a/src/lib/public-tweet.ts
+++ b/src/lib/public-tweet.ts
@@ -1,0 +1,24 @@
+import type { EmbeddedTweet, TweetEntities } from "./types";
+
+export function sanitizePublicTweetEntities(
+	entities: TweetEntities,
+): TweetEntities {
+	return {
+		...entities,
+		mentions: entities.mentions?.map(
+			({ profile: _profile, ...mention }) => mention,
+		),
+	};
+}
+
+export function sanitizePublicEmbeddedTweet(
+	tweet: EmbeddedTweet,
+): EmbeddedTweet {
+	return {
+		...tweet,
+		isReplied: false,
+		bookmarked: false,
+		liked: false,
+		entities: sanitizePublicTweetEntities(tweet.entities),
+	};
+}

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -19,6 +19,8 @@ import {
 	getQueryEnvelope,
 	getQueryEnvelopeEffect,
 	getTweetConversation,
+	isProfileInPublicTimeline,
+	isTweetInPublicTimeline,
 	listDmConversations,
 	listTimelineItems,
 	queryResource,
@@ -1111,6 +1113,52 @@ describe("birdclaw queries", () => {
 			"conv_child",
 		]);
 		expect(conversation?.items[1]?.replyToId).toBe("conv_root");
+	});
+
+	it("only marks public timeline tweets as public conversation anchors", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const insertTweet = db.prepare(`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (?, 'acct_primary', 'profile_me', ?, ?, ?, 0, null, 0, 0, 0, 0, '{}', '[]', null)
+    `);
+
+		insertTweet.run(
+			"public_anchor",
+			"home",
+			"Public",
+			"2026-03-10T10:00:00.000Z",
+		);
+		insertTweet.run(
+			"context_only",
+			"thread_context",
+			"Context",
+			"2026-03-10T10:01:00.000Z",
+		);
+
+		expect(isTweetInPublicTimeline("public_anchor")).toBe(true);
+		expect(isTweetInPublicTimeline("context_only")).toBe(false);
+		expect(isProfileInPublicTimeline("profile_me")).toBe(true);
+		expect(isProfileInPublicTimeline("missing_profile")).toBe(false);
+
+		db.prepare(
+			`
+      insert into tweet_account_edges (
+        account_id, tweet_id, kind, first_seen_at, last_seen_at,
+        seen_count, source, raw_json, updated_at
+      ) values (
+        'acct_primary', 'context_only', 'mention', ?, ?, 1, 'test', '{}', ?
+      )
+      `,
+		).run(
+			"2026-03-10T10:01:00.000Z",
+			"2026-03-10T10:01:00.000Z",
+			"2026-03-10T10:01:00.000Z",
+		);
+		expect(isTweetInPublicTimeline("context_only")).toBe(true);
 	});
 
 	it("preserves the selected reply chain before broad thread context", () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -775,6 +775,38 @@ export function getQueryEnvelopeEffect(): Effect.Effect<
 	});
 }
 
+export function getPublicQueryEnvelopeEffect(): Effect.Effect<
+	QueryEnvelope,
+	unknown
+> {
+	return Effect.gen(function* () {
+		const nativeDb = yield* trySync(() => getNativeDb());
+		const homeCount = yield* trySync(() =>
+			countTimelineEdges(nativeDb, "home"),
+		);
+		const mentionCount = yield* trySync(() =>
+			countTimelineEdges(nativeDb, "mention"),
+		);
+
+		return {
+			stats: {
+				home: homeCount,
+				mentions: mentionCount,
+				dms: 0,
+				needsReply: 0,
+				inbox: 0,
+			},
+			accounts: [],
+			archives: [],
+			transport: {
+				installed: false,
+				availableTransport: "local",
+				statusText: "Read-only archive",
+			},
+		};
+	});
+}
+
 export function getQueryEnvelope(): Promise<QueryEnvelope> {
 	return runEffectPromise(getQueryEnvelopeEffect());
 }
@@ -1409,6 +1441,49 @@ export function getTweetConversation(
 		anchorId: anchor.id,
 		items,
 	};
+}
+
+export function isTweetInPublicTimeline(tweetId: string): boolean {
+	const db = getNativeDb();
+	const row = db
+		.prepare(
+			`
+      select 1
+      from tweet_account_edges
+      where tweet_id = ?
+        and kind in ('home', 'mention')
+      union all
+      select 1
+      from tweets
+      where id = ?
+        and kind in ('home', 'mention')
+      limit 1
+      `,
+		)
+		.get(tweetId, tweetId);
+	return Boolean(row);
+}
+
+export function isProfileInPublicTimeline(profileId: string): boolean {
+	const db = getNativeDb();
+	const row = db
+		.prepare(
+			`
+      select 1
+      from tweets t
+      join tweet_account_edges edge on edge.tweet_id = t.id
+      where t.author_profile_id = ?
+        and edge.kind in ('home', 'mention')
+      union all
+      select 1
+      from tweets
+      where author_profile_id = ?
+        and kind in ('home', 'mention')
+      limit 1
+      `,
+		)
+		.get(profileId, profileId);
+	return Boolean(row);
 }
 
 export function listDmConversations({

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -4,7 +4,6 @@ export type Database = NativeSqliteDatabase;
 
 type DatabaseOptions = {
 	readonly?: boolean;
-	fileMustExist?: boolean;
 };
 
 type PragmaOptions = {

--- a/src/lib/web-profile.ts
+++ b/src/lib/web-profile.ts
@@ -1,0 +1,13 @@
+declare const __BIRDCLAW_PUBLIC_READONLY__: boolean;
+
+export const isPublicReadonlyBuild =
+	typeof __BIRDCLAW_PUBLIC_READONLY__ !== "undefined" &&
+	__BIRDCLAW_PUBLIC_READONLY__;
+
+export function isPublicReadonlyWeb() {
+	return (
+		isPublicReadonlyBuild ||
+		(typeof process !== "undefined" &&
+			process.env.BIRDCLAW_WEB_PROFILE === "public-readonly")
+	);
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import {
 	siteShellClass,
 	siteShellDmClass,
 } from "#/lib/ui";
+import { isPublicReadonlyBuild } from "#/lib/web-profile";
 
 import appCss from "../styles.css?url";
 
@@ -58,6 +59,7 @@ function RootDocument({ children }: { children: ReactNode }) {
 	});
 	const wideMode =
 		pathname.startsWith("/dms") || pathname.startsWith("/network-map");
+	const publicPathAllowed = pathname === "/" || pathname === "/mentions";
 
 	return (
 		<html lang="en" suppressHydrationWarning>
@@ -70,7 +72,13 @@ function RootDocument({ children }: { children: ReactNode }) {
 					<div className={wideMode ? siteShellDmClass : siteShellClass}>
 						<AppNav compact={wideMode} />
 						<main className={wideMode ? mainColumnDmClass : mainColumnClass}>
-							{children}
+							{isPublicReadonlyBuild && !publicPathAllowed ? (
+								<div className="px-4 py-10 text-[var(--ink-soft)]">
+									This view is not available in the read-only reader.
+								</div>
+							) : (
+								children
+							)}
 						</main>
 					</div>
 				</ThemeProvider>

--- a/src/routes/api/avatar.test.tsx
+++ b/src/routes/api/avatar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -15,6 +15,7 @@ afterEach(() => {
 	resetDatabaseForTests();
 	resetBirdclawPathsForTests();
 	delete process.env.BIRDCLAW_HOME;
+	delete process.env.BIRDCLAW_WEB_PROFILE;
 
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -62,6 +63,50 @@ describe("avatar api route", () => {
 		expect(response.headers.get("content-type")).toBe("image/png");
 		expect(Buffer.from(await response.arrayBuffer())).toEqual(
 			Buffer.from(onePixelPng, "base64"),
+		);
+	});
+
+	it("does not populate avatar cache in public read-only mode", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-avatar-api-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const db = getNativeDb();
+		db.prepare(
+			"insert into profiles (id, handle, display_name, bio, followers_count, avatar_hue, avatar_url, created_at) values (?, ?, ?, ?, ?, ?, ?, ?)",
+		).run(
+			"profile_public",
+			"public",
+			"Public",
+			"",
+			0,
+			18,
+			`data:image/png;base64,${onePixelPng}`,
+			"2026-03-08T12:00:00.000Z",
+		);
+		db.prepare(
+			`
+      insert into tweets (
+        id, account_id, author_profile_id, kind, text, created_at,
+        is_replied, reply_to_id, like_count, media_count, bookmarked, liked,
+        entities_json, media_json, quoted_tweet_id
+      ) values (
+        'tweet_public', 'acct_primary', 'profile_public', 'home', 'hello', ?,
+        0, null, 0, 0, 0, 0, '{}', '[]', null
+      )
+      `,
+		).run("2026-03-08T12:00:00.000Z");
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+
+		const response = await GET({
+			request: new Request(
+				"http://birdclaw.test/api/avatar?profileId=profile_public",
+			),
+		});
+
+		expect(response.status).toBe(404);
+		expect(existsSync(path.join(tempDir, "media", "thumbs", "avatars"))).toBe(
+			false,
 		);
 	});
 

--- a/src/routes/api/avatar.tsx
+++ b/src/routes/api/avatar.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
-import { readCachedAvatarEffect } from "#/lib/avatar-cache";
+import {
+	readCachedAvatarEffect,
+	readCachedAvatarOnlyEffect,
+} from "#/lib/avatar-cache";
 import {
 	jsonResponse,
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
+import { isProfileInPublicTimeline } from "#/lib/queries";
+import { isPublicReadonlyWeb } from "#/lib/web-profile";
 
 export const Route = createFileRoute("/api/avatar")({
 	server: {
@@ -26,9 +31,18 @@ export const Route = createFileRoute("/api/avatar")({
 							);
 						}
 
-						const avatar = yield* readCachedAvatarEffect(profileId).pipe(
-							Effect.catchAll(() => Effect.succeed(null)),
-						);
+						const publicReadonly = isPublicReadonlyWeb();
+						if (publicReadonly && !isProfileInPublicTimeline(profileId)) {
+							return jsonResponse(
+								{ ok: false, message: "Avatar not found" },
+								{ status: 404 },
+							);
+						}
+						const avatar = yield* (
+							publicReadonly
+								? readCachedAvatarOnlyEffect(profileId)
+								: readCachedAvatarEffect(profileId)
+						).pipe(Effect.catchAll(() => Effect.succeed(null)));
 						if (!avatar) {
 							return jsonResponse(
 								{ ok: false, message: "Avatar not found" },

--- a/src/routes/api/conversation.test.ts
+++ b/src/routes/api/conversation.test.ts
@@ -4,11 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
 const getTweetConversationMock = vi.fn();
+const isTweetInPublicTimelineMock = vi.fn();
 const maybeAutoUpdateBackupMock = vi.fn();
 
 vi.mock("#/lib/queries", () => ({
 	getTweetConversation: (...args: unknown[]) =>
 		getTweetConversationMock(...args),
+	isTweetInPublicTimeline: (...args: unknown[]) =>
+		isTweetInPublicTimelineMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
 	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
@@ -23,6 +26,8 @@ const GET = getRouteHandler(Route, "GET");
 describe("api conversation route", () => {
 	beforeEach(() => {
 		getTweetConversationMock.mockReset();
+		isTweetInPublicTimelineMock.mockReset();
+		isTweetInPublicTimelineMock.mockReturnValue(true);
 		maybeAutoUpdateBackupMock.mockReset();
 		maybeAutoUpdateBackupMock.mockResolvedValue({ skipped: true });
 	});
@@ -54,5 +59,85 @@ describe("api conversation route", () => {
 			request: new Request("http://localhost/api/conversation?tweetId=missing"),
 		});
 		expect(unknown.status).toBe(404);
+	});
+
+	it("hides conversations outside public timelines in public mode", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		isTweetInPublicTimelineMock.mockReturnValue(false);
+
+		try {
+			const response = await GET({
+				request: new Request(
+					"http://localhost/api/conversation?tweetId=private_tweet",
+				),
+			});
+
+			expect(response.status).toBe(404);
+			expect(isTweetInPublicTimelineMock).toHaveBeenCalledWith("private_tweet");
+			expect(getTweetConversationMock).not.toHaveBeenCalled();
+			expect(maybeAutoUpdateBackupMock).not.toHaveBeenCalled();
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
+	});
+
+	it("filters private thread context from public conversations", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		isTweetInPublicTimelineMock.mockImplementation(
+			(tweetId: string) => tweetId !== "private_context",
+		);
+		getTweetConversationMock.mockReturnValue({
+			anchorId: "public_anchor",
+			items: [
+				{
+					id: "private_context",
+					text: "private",
+					isReplied: true,
+					bookmarked: true,
+					liked: true,
+					entities: {},
+				},
+				{
+					id: "public_anchor",
+					text: "public",
+					isReplied: true,
+					bookmarked: true,
+					liked: true,
+					entities: {},
+				},
+			],
+		});
+
+		try {
+			const response = await GET({
+				request: new Request(
+					"http://localhost/api/conversation?tweetId=public_anchor",
+				),
+			});
+			const body = (await response.json()) as {
+				items: Array<Record<string, unknown>>;
+			};
+
+			expect(body.items).toEqual([
+				expect.objectContaining({
+					id: "public_anchor",
+					isReplied: false,
+					bookmarked: false,
+					liked: false,
+				}),
+			]);
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
 	});
 });

--- a/src/routes/api/conversation.tsx
+++ b/src/routes/api/conversation.tsx
@@ -5,7 +5,9 @@ import {
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
-import { getTweetConversation } from "#/lib/queries";
+import { sanitizePublicEmbeddedTweet } from "#/lib/public-tweet";
+import { getTweetConversation, isTweetInPublicTimeline } from "#/lib/queries";
+import { isPublicReadonlyWeb } from "#/lib/web-profile";
 
 function json(data: unknown, status = 200) {
 	return new Response(JSON.stringify(data), {
@@ -25,11 +27,17 @@ export const Route = createFileRoute("/api/conversation")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						const publicReadonly = isPublicReadonlyWeb();
+						if (!publicReadonly) {
+							yield* maybeAutoUpdateBackupEffect();
+						}
 						const url = new URL(request.url);
 						const tweetId = url.searchParams.get("tweetId")?.trim();
 						if (!tweetId) {
 							return json({ ok: false, error: "Missing tweetId" }, 400);
+						}
+						if (publicReadonly && !isTweetInPublicTimeline(tweetId)) {
+							return json({ ok: false, error: "Tweet not found" }, 404);
 						}
 
 						const conversation = getTweetConversation(tweetId);
@@ -37,7 +45,15 @@ export const Route = createFileRoute("/api/conversation")({
 							return json({ ok: false, error: "Tweet not found" }, 404);
 						}
 
-						return json({ ok: true, ...conversation });
+						return json({
+							ok: true,
+							...conversation,
+							items: publicReadonly
+								? conversation.items
+										.filter((tweet) => isTweetInPublicTimeline(tweet.id))
+										.map(sanitizePublicEmbeddedTweet)
+								: conversation.items,
+						});
 					}),
 				),
 		},

--- a/src/routes/api/query.test.ts
+++ b/src/routes/api/query.test.ts
@@ -4,9 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
 const queryResourceMock = vi.fn();
+const isTweetInPublicTimelineMock = vi.fn();
 const maybeAutoUpdateBackupMock = vi.fn();
 
 vi.mock("#/lib/queries", () => ({
+	isTweetInPublicTimeline: (...args: unknown[]) =>
+		isTweetInPublicTimelineMock(...args),
 	queryResource: (...args: unknown[]) => queryResourceMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
@@ -22,6 +25,8 @@ const GET = getRouteHandler(Route, "GET");
 describe("api query route", () => {
 	beforeEach(() => {
 		queryResourceMock.mockReset();
+		isTweetInPublicTimelineMock.mockReset();
+		isTweetInPublicTimelineMock.mockReturnValue(true);
 		maybeAutoUpdateBackupMock.mockReset();
 		maybeAutoUpdateBackupMock.mockResolvedValue({ skipped: true });
 	});
@@ -117,5 +122,122 @@ describe("api query route", () => {
 				resource: "home",
 			}),
 		);
+	});
+
+	it("denies private resources in public read-only mode", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+
+		try {
+			const response = await GET({
+				request: new Request("http://localhost/api/query?resource=dms"),
+			});
+			const authoredResponse = await GET({
+				request: new Request("http://localhost/api/query?resource=authored"),
+			});
+			const searchResponse = await GET({
+				request: new Request("http://localhost/api/query?resource=search"),
+			});
+
+			expect(response.status).toBe(403);
+			expect(authoredResponse.status).toBe(403);
+			expect(searchResponse.status).toBe(403);
+			expect(queryResourceMock).not.toHaveBeenCalled();
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
+	});
+
+	it("sanitizes timeline state and ignores private filters in public mode", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		queryResourceMock.mockReturnValue({
+			resource: "home",
+			items: [
+				{
+					id: "tweet_1",
+					accountId: "acct_private",
+					accountHandle: "@private",
+					kind: "home",
+					text: "hello",
+					createdAt: "2026-06-13T12:00:00.000Z",
+					isReplied: true,
+					likeCount: 1,
+					mediaCount: 0,
+					bookmarked: true,
+					liked: true,
+					qualityReason: "private score",
+					author: {},
+					entities: {
+						mentions: [
+							{
+								username: "private",
+								start: 0,
+								end: 8,
+								profile: { id: "profile_private", bio: "private" },
+							},
+						],
+					},
+					media: [],
+					replyToTweet: {
+						id: "private_context",
+						text: "private",
+						createdAt: "2026-06-13T11:59:00.000Z",
+						author: {},
+						entities: {},
+						media: [],
+					},
+				},
+			],
+		});
+		isTweetInPublicTimelineMock.mockReturnValue(false);
+
+		try {
+			const response = await GET({
+				request: new Request(
+					"http://localhost/api/query?resource=home&account=acct_private&replyFilter=replied&liked=true&bookmarked=true",
+				),
+			});
+
+			expect(queryResourceMock).toHaveBeenCalledWith(
+				"home",
+				expect.objectContaining({
+					account: undefined,
+					replyFilter: "all",
+					likedOnly: false,
+					bookmarkedOnly: false,
+				}),
+			);
+			const body = (await response.json()) as {
+				items: Array<Record<string, unknown>>;
+			};
+			expect(body).toMatchObject({
+				items: [
+					{
+						accountId: "",
+						accountHandle: "",
+						isReplied: false,
+						bookmarked: false,
+						liked: false,
+						replyToTweet: null,
+					},
+				],
+			});
+			expect(body.items[0]).not.toHaveProperty("qualityReason");
+			const entities = body.items[0]?.entities as
+				| { mentions?: Array<Record<string, unknown>> }
+				| undefined;
+			expect(entities?.mentions?.[0]).not.toHaveProperty("profile");
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
 	});
 });

--- a/src/routes/api/query.tsx
+++ b/src/routes/api/query.tsx
@@ -7,13 +7,45 @@ import {
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
-import { queryResource } from "#/lib/queries";
+import {
+	sanitizePublicEmbeddedTweet,
+	sanitizePublicTweetEntities,
+} from "#/lib/public-tweet";
+import { isTweetInPublicTimeline, queryResource } from "#/lib/queries";
 import type {
 	DmQuery,
+	EmbeddedTweet,
 	ReplyFilter,
 	ResourceKind,
+	TimelineItem,
 	TimelineQualityFilter,
 } from "#/lib/types";
+import { isPublicReadonlyWeb } from "#/lib/web-profile";
+
+const PUBLIC_RESOURCES = new Set<ResourceKind>(["home", "mentions"]);
+
+function sanitizeVisibleEmbeddedTweet(
+	tweet: EmbeddedTweet | null | undefined,
+): EmbeddedTweet | null | undefined {
+	if (!tweet || !isTweetInPublicTimeline(tweet.id)) return null;
+	return sanitizePublicEmbeddedTweet(tweet);
+}
+
+function sanitizeTimelineItem(item: TimelineItem): TimelineItem {
+	return {
+		...item,
+		accountId: "",
+		accountHandle: "",
+		isReplied: false,
+		bookmarked: false,
+		liked: false,
+		qualityReason: undefined,
+		entities: sanitizePublicTweetEntities(item.entities),
+		replyToTweet: sanitizeVisibleEmbeddedTweet(item.replyToTweet),
+		quotedTweet: sanitizeVisibleEmbeddedTweet(item.quotedTweet),
+		retweetedTweet: sanitizeVisibleEmbeddedTweet(item.retweetedTweet),
+	};
+}
 
 function parseReplyFilter(value: string | null): ReplyFilter {
 	if (value === "replied" || value === "unreplied") {
@@ -53,24 +85,38 @@ export const Route = createFileRoute("/api/query")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
 						const url = new URL(request.url);
 						const resource = (url.searchParams.get("resource") ??
 							"home") as ResourceKind;
+						const publicReadonly = isPublicReadonlyWeb();
+						if (publicReadonly && !PUBLIC_RESOURCES.has(resource)) {
+							return jsonResponse(
+								{ ok: false, message: "Resource is not available" },
+								{ status: 403 },
+							);
+						}
+						if (!publicReadonly) {
+							yield* maybeAutoUpdateBackupEffect();
+						}
 						const baseFilters = {
-							account: url.searchParams.get("account") ?? undefined,
+							account: publicReadonly
+								? undefined
+								: (url.searchParams.get("account") ?? undefined),
 							search: url.searchParams.get("search") ?? undefined,
-							replyFilter: parseReplyFilter(
-								url.searchParams.get("replyFilter"),
-							),
+							replyFilter: publicReadonly
+								? ("all" as const)
+								: parseReplyFilter(url.searchParams.get("replyFilter")),
 							since: url.searchParams.get("since") ?? undefined,
 							until: url.searchParams.get("until") ?? undefined,
 							includeReplies: url.searchParams.get("originalsOnly") !== "true",
 							qualityFilter: parseQualityFilter(
 								url.searchParams.get("qualityFilter"),
 							),
-							likedOnly: url.searchParams.get("liked") === "true",
-							bookmarkedOnly: url.searchParams.get("bookmarked") === "true",
+							likedOnly:
+								!publicReadonly && url.searchParams.get("liked") === "true",
+							bookmarkedOnly:
+								!publicReadonly &&
+								url.searchParams.get("bookmarked") === "true",
 							limit: parseBoundedInteger(url.searchParams.get("limit"), {
 								max: 200,
 							}),
@@ -101,12 +147,20 @@ export const Route = createFileRoute("/api/query")({
 							);
 						}
 
+						const response = queryResource(resource, {
+							...baseFilters,
+							resource,
+							untilId: url.searchParams.get("untilId") ?? undefined,
+						});
 						return jsonResponse(
-							queryResource(resource, {
-								...baseFilters,
-								resource,
-								untilId: url.searchParams.get("untilId") ?? undefined,
-							}),
+							publicReadonly
+								? {
+										...response,
+										items: (response.items as TimelineItem[]).map(
+											sanitizeTimelineItem,
+										),
+									}
+								: response,
 						);
 					}),
 				),

--- a/src/routes/api/status.test.tsx
+++ b/src/routes/api/status.test.tsx
@@ -1,10 +1,11 @@
 import { Effect } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
 const mocks = vi.hoisted(() => ({
 	maybeAutoUpdateBackup: vi.fn(),
 	getQueryEnvelope: vi.fn(),
+	getPublicQueryEnvelope: vi.fn(),
 }));
 
 vi.mock("#/lib/backup", () => ({
@@ -17,6 +18,8 @@ vi.mock("#/lib/queries", () => ({
 	getQueryEnvelope: mocks.getQueryEnvelope,
 	getQueryEnvelopeEffect: () =>
 		Effect.promise(() => Promise.resolve(mocks.getQueryEnvelope())),
+	getPublicQueryEnvelopeEffect: () =>
+		Effect.promise(() => Promise.resolve(mocks.getPublicQueryEnvelope())),
 }));
 
 import { Route } from "./status";
@@ -24,6 +27,12 @@ import { Route } from "./status";
 const GET = getRouteHandler(Route, "GET");
 
 describe("status api route", () => {
+	beforeEach(() => {
+		mocks.maybeAutoUpdateBackup.mockReset();
+		mocks.getQueryEnvelope.mockReset();
+		mocks.getPublicQueryEnvelope.mockReset();
+	});
+
 	it("returns the query envelope as json", async () => {
 		mocks.maybeAutoUpdateBackup.mockResolvedValue(undefined);
 		mocks.getQueryEnvelope.mockResolvedValue({
@@ -45,5 +54,45 @@ describe("status api route", () => {
 		});
 		expect(mocks.maybeAutoUpdateBackup).toHaveBeenCalledTimes(1);
 		expect(response.headers.get("content-type")).toBe("application/json");
+	});
+
+	it("returns only public counts in public read-only mode", async () => {
+		const originalProfile = process.env.BIRDCLAW_WEB_PROFILE;
+		process.env.BIRDCLAW_WEB_PROFILE = "public-readonly";
+		mocks.getPublicQueryEnvelope.mockResolvedValue({
+			stats: { home: 4, mentions: 2, dms: 0, needsReply: 0, inbox: 0 },
+			accounts: [],
+			archives: [],
+			transport: {
+				installed: false,
+				availableTransport: "local",
+				statusText: "Read-only archive",
+			},
+		});
+
+		try {
+			const response = await GET({
+				request: new Request("http://localhost/api/status"),
+			});
+
+			await expect(response.json()).resolves.toEqual({
+				stats: { home: 4, mentions: 2, dms: 0, needsReply: 0, inbox: 0 },
+				accounts: [],
+				archives: [],
+				transport: {
+					installed: false,
+					availableTransport: "local",
+					statusText: "Read-only archive",
+				},
+			});
+			expect(mocks.getQueryEnvelope).not.toHaveBeenCalled();
+			expect(mocks.maybeAutoUpdateBackup).not.toHaveBeenCalled();
+		} finally {
+			if (originalProfile === undefined) {
+				delete process.env.BIRDCLAW_WEB_PROFILE;
+			} else {
+				process.env.BIRDCLAW_WEB_PROFILE = originalProfile;
+			}
+		}
 	});
 });

--- a/src/routes/api/status.tsx
+++ b/src/routes/api/status.tsx
@@ -6,7 +6,11 @@ import {
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
-import { getQueryEnvelopeEffect } from "#/lib/queries";
+import {
+	getPublicQueryEnvelopeEffect,
+	getQueryEnvelopeEffect,
+} from "#/lib/queries";
+import { isPublicReadonlyWeb } from "#/lib/web-profile";
 
 export const Route = createFileRoute("/api/status")({
 	server: {
@@ -17,6 +21,9 @@ export const Route = createFileRoute("/api/status")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
+						if (isPublicReadonlyWeb()) {
+							return jsonResponse(yield* getPublicQueryEnvelopeEffect());
+						}
 						yield* maybeAutoUpdateBackupEffect();
 						return jsonResponse(yield* getQueryEnvelopeEffect());
 					}),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,10 @@ const extraAllowedHosts =
 		.filter(Boolean) ?? [];
 
 const config = defineConfig({
+	define: {
+		__BIRDCLAW_PUBLIC_READONLY__:
+			process.env.BIRDCLAW_WEB_PROFILE === "public-readonly",
+	},
 	plugins: [
 		devtools(),
 		tailwindcss(),


### PR DESCRIPTION
## Summary
- Add a production public-readonly profile for the Birdclaw web reader.
- Enforce a server-side Home and Mentions API boundary with private-state sanitization.
- Add a loopback-only production server with static asset and security-header support.

## Test plan
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test: 1061 tests passed
- BIRDCLAW_PLAYWRIGHT_PORT=3200 pnpm e2e: 12 tests passed
- pnpm build:public
- autoreview: no accepted or actionable findings
