### PR TITLE
feat: add relative timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Refresh dependency backstop updates for `@steipete/sweet-cookie`, `@types/node`, the adopted TypeScript native-preview toolchain, and the pnpm 10 package-manager pin.
 - Remove the separate public read-only web profile; deployments can expose the full private app behind an external authentication boundary.
+- Show recent web timestamps as live relative time, then switch to calendar dates with exact local time on hover.
 
 ## 0.8.0 - 2026-06-10
 

--- a/src/components/ConversationThread.tsx
+++ b/src/components/ConversationThread.tsx
@@ -1,5 +1,4 @@
 import { MessageCircle } from "lucide-react";
-import { formatShortTimestamp } from "#/lib/present";
 import type { EmbeddedTweet } from "#/lib/types";
 import {
 	cx,
@@ -11,6 +10,7 @@ import {
 import { AvatarChip } from "./AvatarChip";
 import { BirdclawEmpty, BirdclawLoading } from "./BrandMark";
 import { ProfilePreview } from "./ProfilePreview";
+import { SmartTimestamp } from "./SmartTimestamp";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -101,9 +101,10 @@ export function ConversationThread({
 										</span>
 									</ProfilePreview>
 									<span className="text-[var(--ink-soft)]">·</span>
-									<span className={feedRowTimestampClass}>
-										{formatShortTimestamp(tweet.createdAt)}
-									</span>
+									<SmartTimestamp
+										className={feedRowTimestampClass}
+										value={tweet.createdAt}
+									/>
 									{isAnchor ? (
 										<span className="ml-auto rounded-full bg-[var(--accent)] px-2 py-0.5 text-[11px] font-bold text-white">
 											selected

--- a/src/components/DmWorkspace.tsx
+++ b/src/components/DmWorkspace.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Circle } from "lucide-react";
-import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
+import { formatCompactNumber } from "#/lib/present";
 import type { DmConversationItem, DmMessageItem } from "#/lib/types";
 import {
 	composerBarClass,
@@ -39,6 +39,7 @@ import {
 } from "#/lib/ui";
 import { AvatarChip } from "./AvatarChip";
 import { BirdclawEmpty } from "./BrandMark";
+import { SmartTimestamp } from "./SmartTimestamp";
 
 function MessageBubble({ message }: { message: DmMessageItem }) {
 	const outbound = message.direction === "outbound";
@@ -57,7 +58,7 @@ function MessageBubble({ message }: { message: DmMessageItem }) {
 			<div className={dmMessageMetaClass}>
 				<span>{message.sender.displayName}</span>
 				<span>·</span>
-				<span>{formatShortTimestamp(message.createdAt)}</span>
+				<SmartTimestamp value={message.createdAt} />
 			</div>
 		</div>
 	);
@@ -81,9 +82,13 @@ export function DmWorkspace({
 	onReplySend: (conversationId: string) => void;
 }) {
 	const participant = selectedConversation?.participant ?? null;
-	const subtitle = selectedConversation
-		? `${selectedConversation.isMessageRequest ? "Message request" : selectedConversation.needsReply ? "Reply open" : "We replied"} · last message ${formatShortTimestamp(selectedConversation.lastMessageAt)}`
-		: "No conversation selected";
+	const selectedStatus = selectedConversation
+		? selectedConversation.isMessageRequest
+			? "Message request"
+			: selectedConversation.needsReply
+				? "Reply open"
+				: "We replied"
+		: null;
 
 	return (
 		<section aria-label="DM workspace" className={dmShellClass}>
@@ -119,9 +124,10 @@ export function DmWorkspace({
 											@{conversation.participant.handle}
 										</span>
 									</div>
-									<span className={dmListTimestampClass}>
-										{formatShortTimestamp(conversation.lastMessageAt)}
-									</span>
+									<SmartTimestamp
+										className={dmListTimestampClass}
+										value={conversation.lastMessageAt}
+									/>
 								</div>
 								<p className={dmListPreviewClass}>
 									{conversation.lastMessagePreview}
@@ -176,7 +182,18 @@ export function DmWorkspace({
 									<div className={dmThreadNameClass}>
 										{selectedConversation.participant.displayName}
 									</div>
-									<div className={dmThreadSubtitleClass}>{subtitle}</div>
+									<div className={dmThreadSubtitleClass}>
+										{selectedStatus && selectedConversation ? (
+											<>
+												{selectedStatus} · last message{" "}
+												<SmartTimestamp
+													value={selectedConversation.lastMessageAt}
+												/>
+											</>
+										) : (
+											"No conversation selected"
+										)}
+									</div>
 								</div>
 							</div>
 							<button

--- a/src/components/EmbeddedTweetCard.tsx
+++ b/src/components/EmbeddedTweetCard.tsx
@@ -1,4 +1,3 @@
-import { formatShortTimestamp } from "#/lib/present";
 import type { EmbeddedTweet } from "#/lib/types";
 import {
 	embeddedCardBodyClass,
@@ -10,6 +9,7 @@ import {
 	feedRowTimestampClass,
 } from "#/lib/ui";
 import { ProfilePreview } from "./ProfilePreview";
+import { SmartTimestamp } from "./SmartTimestamp";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -35,9 +35,10 @@ export function EmbeddedTweetCard({
 					</span>
 				</ProfilePreview>
 				<span className="text-[var(--ink-soft)]">·</span>
-				<span className={feedRowTimestampClass}>
-					{formatShortTimestamp(item.createdAt)}
-				</span>
+				<SmartTimestamp
+					className={feedRowTimestampClass}
+					value={item.createdAt}
+				/>
 			</header>
 			<TweetRichText
 				className={embeddedCardCopyClass}

--- a/src/components/InboxCard.tsx
+++ b/src/components/InboxCard.tsx
@@ -5,7 +5,7 @@ import {
 	ExternalLink,
 	MessageCircle,
 } from "lucide-react";
-import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
+import { formatCompactNumber } from "#/lib/present";
 import type { InboxItem } from "#/lib/types";
 import {
 	composerBarClass,
@@ -30,6 +30,7 @@ import {
 	timestampClass,
 } from "#/lib/ui";
 import { AvatarChip } from "./AvatarChip";
+import { SmartTimestamp } from "./SmartTimestamp";
 
 export function InboxCard({
 	item,
@@ -65,9 +66,10 @@ export function InboxCard({
 						</span>
 					</span>
 					<span className={feedRowDotClass}>·</span>
-					<span className={feedRowTimestampClass}>
-						{formatShortTimestamp(item.createdAt)}
-					</span>
+					<SmartTimestamp
+						className={feedRowTimestampClass}
+						value={item.createdAt}
+					/>
 					<span className="ml-auto flex items-center gap-1.5">
 						<span className={cx(pillClass, pillSoftClass)}>
 							{item.entityKind}

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -6,7 +6,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
+import { formatCompactNumber } from "#/lib/present";
 import type { PeriodDigestContext } from "#/lib/period-digest";
 import type { ProfileAnalysisContext } from "#/lib/profile-analysis";
 import { renderTweetPlainText } from "#/lib/tweet-render";
@@ -15,6 +15,7 @@ import { cx, tweetLinkClass, tweetMentionClass } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { AvatarChip } from "./AvatarChip";
 import { ProfilePreview } from "./ProfilePreview";
+import { SmartTimestamp } from "./SmartTimestamp";
 
 type CitationTweet = PeriodDigestContext["tweets"][number];
 type CitationContext = PeriodDigestContext | ProfileAnalysisContext;
@@ -231,7 +232,7 @@ function TweetPreviewToken({
 					<span className="min-w-0">
 						<span className="block truncate font-bold">{tweet.name}</span>
 						<span className="block truncate text-[12px] text-[var(--ink-soft)]">
-							@{tweet.author} · {formatShortTimestamp(tweet.createdAt)}
+							@{tweet.author} · <SmartTimestamp value={tweet.createdAt} />
 						</span>
 					</span>
 				</span>

--- a/src/components/SmartTimestamp.test.tsx
+++ b/src/components/SmartTimestamp.test.tsx
@@ -1,0 +1,29 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SmartTimestamp } from "./SmartTimestamp";
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
+
+describe("SmartTimestamp", () => {
+	it("renders semantic exact metadata and updates relative time", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 5, 13, 16, 0, 0));
+		const value = new Date(2026, 5, 13, 15, 59, 40).toISOString();
+
+		render(<SmartTimestamp value={value} />);
+
+		const timestamp = screen.getByText("just now");
+		expect(timestamp.tagName).toBe("TIME");
+		expect(timestamp).toHaveAttribute("datetime", value);
+		expect(timestamp).toHaveAttribute(
+			"title",
+			expect.stringContaining("June 13, 2026"),
+		);
+
+		act(() => vi.advanceTimersByTime(60_000));
+		expect(screen.getByText("1 min ago")).toBeInTheDocument();
+	});
+});

--- a/src/components/SmartTimestamp.tsx
+++ b/src/components/SmartTimestamp.tsx
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+import {
+	formatExactTimestamp,
+	formatShortTimestamp,
+	formatSmartTimestamp,
+} from "#/lib/present";
+
+const CLOCK_INTERVAL_MS = 30_000;
+
+type ClockSnapshot = number | null;
+
+const listeners = new Set<() => void>();
+let currentNow = Date.now();
+let clockInterval: ReturnType<typeof setInterval> | null = null;
+
+function updateClock() {
+	currentNow = Date.now();
+	for (const listener of listeners) listener();
+}
+
+function subscribeToClock(listener: () => void) {
+	listeners.add(listener);
+
+	if (clockInterval === null) {
+		currentNow = Date.now();
+		clockInterval = setInterval(updateClock, CLOCK_INTERVAL_MS);
+	}
+
+	return () => {
+		listeners.delete(listener);
+		if (listeners.size === 0 && clockInterval !== null) {
+			clearInterval(clockInterval);
+			clockInterval = null;
+		}
+	};
+}
+
+function getClockSnapshot(): ClockSnapshot {
+	return currentNow;
+}
+
+function getServerClockSnapshot(): ClockSnapshot {
+	return null;
+}
+
+export function SmartTimestamp({
+	className,
+	value,
+}: {
+	className?: string;
+	value: string;
+}) {
+	const now = useSyncExternalStore(
+		subscribeToClock,
+		getClockSnapshot,
+		getServerClockSnapshot,
+	);
+	const exactTimestamp = formatExactTimestamp(value);
+
+	return (
+		<time
+			aria-label={exactTimestamp}
+			className={className}
+			dateTime={value}
+			title={exactTimestamp}
+		>
+			{now === null
+				? formatShortTimestamp(value)
+				: formatSmartTimestamp(value, now)}
+		</time>
+	);
+}

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -8,7 +8,7 @@ import {
 	Repeat2,
 	UserSearch,
 } from "lucide-react";
-import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
+import { formatCompactNumber } from "#/lib/present";
 import { normalizeTweetUrlEntityRangeForText } from "#/lib/tweet-render";
 import type {
 	TimelineItem,
@@ -41,6 +41,7 @@ import { ConversationThread } from "./ConversationThread";
 import { EmbeddedTweetCard } from "./EmbeddedTweetCard";
 import { LinkPreviewCard } from "./LinkPreviewCard";
 import { ProfilePreview } from "./ProfilePreview";
+import { SmartTimestamp } from "./SmartTimestamp";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -312,9 +313,10 @@ export function TimelineCard({
 						</span>
 					</ProfilePreview>
 					<span className={feedRowDotClass}>·</span>
-					<span className={feedRowTimestampClass}>
-						{formatShortTimestamp(displayTweet.createdAt)}
-					</span>
+					<SmartTimestamp
+						className={feedRowTimestampClass}
+						value={displayTweet.createdAt}
+					/>
 					{canReply || hasConversation ? (
 						<span className="ml-auto inline-flex items-center gap-1">
 							{hasConversation ? (

--- a/src/lib/present.test.ts
+++ b/src/lib/present.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
 	formatCompactNumber,
+	formatExactTimestamp,
 	formatShortTimestamp,
+	formatSmartTimestamp,
 	getInitials,
 } from "./present";
 
@@ -13,5 +15,63 @@ describe("present helpers", () => {
 		expect(getInitials("Sam Altman")).toBe("SA");
 		expect(getInitials("A")).toBe("A");
 		expect(getInitials(" Sam")).toBe("S");
+	});
+
+	it("uses relative labels for recent timestamps", () => {
+		const now = new Date(2026, 5, 13, 16, 0, 0).getTime();
+
+		expect(
+			formatSmartTimestamp(new Date(now - 20_000).toISOString(), now),
+		).toBe("just now");
+		expect(
+			formatSmartTimestamp(new Date(now - 70_000).toISOString(), now),
+		).toBe("1 min ago");
+		expect(
+			formatSmartTimestamp(new Date(now - 42 * 60_000).toISOString(), now),
+		).toBe("42 min ago");
+		expect(
+			formatSmartTimestamp(new Date(now - 60 * 60_000).toISOString(), now),
+		).toBe("1 hour ago");
+		expect(
+			formatSmartTimestamp(new Date(now - 3 * 60 * 60_000).toISOString(), now),
+		).toBe("3 hours ago");
+	});
+
+	it("switches recent history to calendar labels", () => {
+		const now = new Date(2026, 5, 13, 16, 0, 0);
+
+		expect(
+			formatSmartTimestamp(
+				new Date(2026, 5, 12, 15, 0, 0).toISOString(),
+				now.getTime(),
+			),
+		).toBe("Yesterday at 3:00 PM");
+		expect(
+			formatSmartTimestamp(
+				new Date(2026, 5, 10, 15, 0, 0).toISOString(),
+				now.getTime(),
+			),
+		).toBe("Wednesday at 3:00 PM");
+		expect(
+			formatSmartTimestamp(
+				new Date(2026, 4, 10, 15, 0, 0).toISOString(),
+				now.getTime(),
+			),
+		).toBe("May 10 at 3:00 PM");
+		expect(
+			formatSmartTimestamp(
+				new Date(2025, 4, 10, 15, 0, 0).toISOString(),
+				now.getTime(),
+			),
+		).toBe("May 10, 2025 at 3:00 PM");
+	});
+
+	it("provides exact timestamps and preserves invalid values", () => {
+		const value = new Date(2026, 5, 13, 16, 3, 12).toISOString();
+
+		expect(formatExactTimestamp(value)).toContain("June 13, 2026");
+		expect(formatExactTimestamp(value)).toContain("4:03:12 PM");
+		expect(formatSmartTimestamp("not-a-date")).toBe("not-a-date");
+		expect(formatExactTimestamp("not-a-date")).toBe("not-a-date");
 	});
 });

--- a/src/lib/present.ts
+++ b/src/lib/present.ts
@@ -2,13 +2,111 @@ export function formatCompactNumber(value: number) {
 	return new Intl.NumberFormat("en", { notation: "compact" }).format(value);
 }
 
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+const timeFormatter = new Intl.DateTimeFormat("en", {
+	hour: "numeric",
+	minute: "2-digit",
+});
+
+const weekdayFormatter = new Intl.DateTimeFormat("en", {
+	weekday: "long",
+});
+
+const sameYearDateFormatter = new Intl.DateTimeFormat("en", {
+	month: "short",
+	day: "numeric",
+});
+
+const otherYearDateFormatter = new Intl.DateTimeFormat("en", {
+	year: "numeric",
+	month: "short",
+	day: "numeric",
+});
+
+const exactTimestampFormatter = new Intl.DateTimeFormat("en", {
+	year: "numeric",
+	month: "long",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
+	second: "2-digit",
+	timeZoneName: "short",
+});
+
+function parseTimestamp(value: string) {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function localCalendarDay(date: Date) {
+	return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / DAY_MS;
+}
+
+function formatCalendarTimestamp(date: Date, now: Date) {
+	const time = timeFormatter.format(date);
+	const dayDifference = localCalendarDay(now) - localCalendarDay(date);
+
+	if (dayDifference === 1) {
+		return `Yesterday at ${time}`;
+	}
+
+	if (dayDifference >= 2 && dayDifference <= 6) {
+		return `${weekdayFormatter.format(date)} at ${time}`;
+	}
+
+	const dateFormatter =
+		date.getFullYear() === now.getFullYear()
+			? sameYearDateFormatter
+			: otherYearDateFormatter;
+	return `${dateFormatter.format(date)} at ${time}`;
+}
+
 export function formatShortTimestamp(value: string) {
+	const date = parseTimestamp(value);
+	if (!date) return value;
+
 	return new Intl.DateTimeFormat("en", {
 		hour: "numeric",
 		minute: "2-digit",
 		month: "short",
 		day: "numeric",
-	}).format(new Date(value));
+	}).format(date);
+}
+
+export function formatExactTimestamp(value: string) {
+	const date = parseTimestamp(value);
+	return date ? exactTimestampFormatter.format(date) : value;
+}
+
+export function formatSmartTimestamp(value: string, nowValue = Date.now()) {
+	const date = parseTimestamp(value);
+	const now = new Date(nowValue);
+	if (!date || Number.isNaN(now.getTime())) return value;
+
+	const elapsed = now.getTime() - date.getTime();
+	if (elapsed >= -45 * SECOND_MS && elapsed < 45 * SECOND_MS) {
+		return "just now";
+	}
+
+	if (elapsed < 0) {
+		return formatCalendarTimestamp(date, now);
+	}
+
+	if (elapsed < HOUR_MS) {
+		const minutes = Math.max(1, Math.floor(elapsed / MINUTE_MS));
+		return `${minutes} min ago`;
+	}
+
+	if (elapsed < DAY_MS) {
+		const hours = Math.max(1, Math.floor(elapsed / HOUR_MS));
+		return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+	}
+
+	return formatCalendarTimestamp(date, now);
 }
 
 export function getInitials(value: string) {

--- a/src/routes/links.tsx
+++ b/src/routes/links.tsx
@@ -18,7 +18,8 @@ import {
 	LinkSkeletonRows,
 } from "#/components/FeedState";
 import { ProfilePreview } from "#/components/ProfilePreview";
-import { formatCompactNumber, formatShortTimestamp } from "#/lib/present";
+import { SmartTimestamp } from "#/components/SmartTimestamp";
+import { formatCompactNumber } from "#/lib/present";
 import type {
 	LinkInsightItem,
 	LinkInsightKind,
@@ -393,7 +394,7 @@ function MentionCard({
 					rel="noreferrer"
 					target="_blank"
 				>
-					{formatShortTimestamp(mention.createdAt)}
+					<SmartTimestamp value={mention.createdAt} />
 				</a>
 			</div>
 			<p className="m-0 whitespace-pre-wrap text-[14px] leading-[1.45] text-[var(--ink)] [overflow-wrap:anywhere]">
@@ -633,7 +634,7 @@ function LinkInsightRow({
 						<span>/</span>
 						<SharerStrip item={item} />
 						<span>/</span>
-						<span>{formatShortTimestamp(item.lastSeenAt)}</span>
+						<SmartTimestamp value={item.lastSeenAt} />
 					</div>
 					<VideoPreview item={item} />
 				</div>


### PR DESCRIPTION
## Summary

- show recent archive timestamps as live relative labels such as `just now`, `21 min ago`, and `1 hour ago`
- switch older timestamps to readable calendar labels such as `Yesterday at 4:03 PM` and `Thursday at 10:22 AM`
- expose exact local timestamps through semantic `<time>` metadata and hover text across timeline, thread, inbox, DM, link, and citation surfaces

## Implementation

- add a shared client clock so all visible timestamps update from one 30-second interval
- preserve deterministic SSR markup, then activate relative labels after hydration
- add pure formatting helpers and regression coverage for thresholds, calendar transitions, invalid input, semantic metadata, and live updates

## Verification

- `pnpm test` (112 files, 1,052 tests)
- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- structured Codex autoreview: clean, no accepted/actionable findings
- existing-profile Chrome verification on the local archive, including visual inspection, exact timestamp metadata, and a clean browser console
