### PR TITLE
fix: keep digest streams alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Remove the separate public read-only web profile; deployments can expose the full private app behind an external authentication boundary.
 - Show recent web timestamps as live relative time, then switch to calendar dates with exact local time on hover.
 
+### Fixed
+
+- Keep long-running AI streams alive through reverse proxies and show actionable Today retry errors when a connection is interrupted.
+
 ## 0.8.0 - 2026-06-10
 
 ### Added

--- a/src/lib/ndjson-stream.test.ts
+++ b/src/lib/ndjson-stream.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEffectNdjsonResponse } from "./ndjson-stream";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("createEffectNdjsonResponse", () => {
+	it("opens immediately and sends heartbeats while work is pending", async () => {
+		vi.useFakeTimers();
+		let resolveRun: (() => void) | undefined;
+		type TestEvent =
+			| { type: "status"; label: string }
+			| { type: "error"; error: string };
+		const response = createEffectNdjsonResponse<TestEvent>({
+			request: new Request("http://localhost/api/stream"),
+			initialEvents: [{ type: "status", label: "Starting" }],
+			run: () =>
+				Effect.promise(
+					() =>
+						new Promise<void>((resolve) => {
+							resolveRun = resolve;
+						}),
+				),
+			errorEvent: (error) => ({ type: "error", error: String(error) }),
+		});
+		const reader = response.body?.getReader();
+		expect(reader).toBeDefined();
+
+		const first = await reader!.read();
+		expect(new TextDecoder().decode(first.value)).toBe(
+			'{"type":"status","label":"Starting"}\n',
+		);
+
+		const heartbeat = reader!.read();
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(new TextDecoder().decode((await heartbeat).value)).toBe("\n");
+
+		resolveRun?.();
+		await reader!.cancel();
+	});
+
+	it("does not start work for an already-aborted request", async () => {
+		const requestController = new AbortController();
+		requestController.abort();
+		const run = vi.fn(() => Effect.void);
+		type TestEvent =
+			| { type: "status"; label: string }
+			| { type: "error"; error: string };
+
+		const response = createEffectNdjsonResponse<TestEvent>({
+			request: new Request("http://localhost/api/stream", {
+				signal: requestController.signal,
+			}),
+			initialEvents: [{ type: "status", label: "Starting" }],
+			run,
+			errorEvent: (error) => ({ type: "error", error: String(error) }),
+		});
+
+		expect(run).not.toHaveBeenCalled();
+		expect(await response.text()).toBe("");
+	});
+});

--- a/src/lib/ndjson-stream.ts
+++ b/src/lib/ndjson-stream.ts
@@ -1,0 +1,89 @@
+import { Effect } from "effect";
+import { runEffectBackground } from "./effect-runtime";
+
+const encoder = new TextEncoder();
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+export function createEffectNdjsonResponse<Event>({
+	request,
+	initialEvents = [],
+	run,
+	errorEvent,
+}: {
+	request: Request;
+	initialEvents?: Event[];
+	run: (context: {
+		signal: AbortSignal;
+		emit: (event: Event) => void;
+	}) => Effect.Effect<unknown, unknown>;
+	errorEvent: (error: unknown) => Event;
+}) {
+	let abortStream: (() => void) | undefined;
+
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			cancel() {
+				abortStream?.();
+			},
+			start(controller) {
+				const abortController = new AbortController();
+				let closed = false;
+				let heartbeat: ReturnType<typeof setInterval> | undefined;
+
+				const cleanup = () => {
+					request.signal.removeEventListener("abort", abort);
+					if (heartbeat !== undefined) clearInterval(heartbeat);
+				};
+				const abort = () => {
+					if (closed) return;
+					closed = true;
+					cleanup();
+					abortController.abort();
+				};
+				const close = () => {
+					if (closed) return;
+					closed = true;
+					cleanup();
+					abortController.abort();
+					controller.close();
+				};
+				const enqueue = (value: string) => {
+					if (closed) return;
+					try {
+						controller.enqueue(encoder.encode(value));
+					} catch {
+						abort();
+					}
+				};
+				const emit = (event: Event) => {
+					enqueue(`${JSON.stringify(event)}\n`);
+				};
+
+				request.signal.addEventListener("abort", abort, { once: true });
+				abortStream = abort;
+				if (request.signal.aborted) {
+					abort();
+					controller.close();
+					return;
+				}
+				for (const event of initialEvents) emit(event);
+				heartbeat = setInterval(() => enqueue("\n"), HEARTBEAT_INTERVAL_MS);
+
+				runEffectBackground(run({ signal: abortController.signal, emit }), {
+					onSuccess: close,
+					onFailure: (error) => {
+						emit(errorEvent(error));
+						close();
+					},
+				});
+			},
+		}),
+		{
+			headers: {
+				"cache-control": "no-store",
+				"content-type": "application/x-ndjson; charset=utf-8",
+				"x-accel-buffering": "no",
+			},
+		},
+	);
+}

--- a/src/routes/api/period-digest.test.ts
+++ b/src/routes/api/period-digest.test.ts
@@ -111,6 +111,30 @@ describe("api period digest route", () => {
 		expect(streamPeriodDigestMock).not.toHaveBeenCalled();
 	});
 
+	it("opens the stream before backup auto-update completes", async () => {
+		let resolveBackup: ((value: unknown) => void) | undefined;
+		maybeAutoUpdateBackupMock.mockReturnValue(
+			new Promise((resolve) => {
+				resolveBackup = resolve;
+			}),
+		);
+
+		const response = await GET({
+			request: new Request("http://localhost/api/period-digest?period=today"),
+		});
+		const reader = response.body?.getReader();
+		expect(reader).toBeDefined();
+
+		const first = await reader!.read();
+		const text = new TextDecoder().decode(first.value);
+		expect(text).toContain('"type":"status"');
+		expect(text).toContain("Preparing local archive");
+		expect(streamPeriodDigestMock).not.toHaveBeenCalled();
+
+		resolveBackup?.({ skipped: true });
+		await reader!.cancel();
+	});
+
 	it("emits an error event when the digest runner rejects", async () => {
 		streamPeriodDigestMock.mockRejectedValueOnce(new Error("no api key"));
 

--- a/src/routes/api/period-digest.tsx
+++ b/src/routes/api/period-digest.tsx
@@ -1,21 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
-import { runEffectBackground } from "#/lib/effect-runtime";
 import {
 	jsonResponse,
 	parseBoundedInteger,
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
+import { createEffectNdjsonResponse } from "#/lib/ndjson-stream";
 import {
 	normalizeDigestLanguage,
 	streamPeriodDigestEffect,
 	type PeriodDigestOptions,
 	type PeriodDigestStreamEvent,
 } from "#/lib/period-digest";
-
-const encoder = new TextEncoder();
 
 function parseBoolean(value: string | null) {
 	return value === "true" || value === "1" || value === "yes";
@@ -52,16 +50,12 @@ function parseOptions(url: URL): PeriodDigestOptions {
 	};
 }
 
-function encodeEvent(event: PeriodDigestStreamEvent) {
-	return encoder.encode(`${JSON.stringify(event)}\n`);
-}
-
 export const Route = createFileRoute("/api/period-digest")({
 	server: {
 		handlers: {
 			GET: ({ request }) =>
 				runRouteEffect(
-					Effect.gen(function* () {
+					Effect.sync(() => {
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
@@ -78,70 +72,28 @@ export const Route = createFileRoute("/api/period-digest")({
 								{ status: 400 },
 							);
 						}
-						yield* maybeAutoUpdateBackupEffect();
-						let abortDigest: (() => void) | undefined;
-
-						return new Response(
-							new ReadableStream({
-								cancel() {
-									abortDigest?.();
+						return createEffectNdjsonResponse<PeriodDigestStreamEvent>({
+							request,
+							initialEvents: [
+								{
+									type: "status",
+									label: "Preparing local archive",
+									detail: "Checking for backup updates.",
 								},
-								start(controller) {
-									const abortController = new AbortController();
-									let closed = false;
-									const close = () => {
-										closed = true;
-										abortController.abort();
-									};
-									const closeController = () => {
-										request.signal.removeEventListener("abort", onAbort);
-										if (!closed) {
-											closed = true;
-											controller.close();
-										}
-									};
-									const onAbort = () => close();
-									request.signal.addEventListener("abort", onAbort, {
-										once: true,
-									});
-									abortDigest = close;
-									const enqueue = (event: PeriodDigestStreamEvent) => {
-										if (closed) return;
-										try {
-											controller.enqueue(encodeEvent(event));
-										} catch {
-											close();
-										}
-									};
-
-									runEffectBackground(
-										streamPeriodDigestEffect(
-											{ ...options, signal: abortController.signal },
-											{ onEvent: enqueue },
-										),
-										{
-											onSuccess: closeController,
-											onFailure: (error) => {
-												enqueue({
-													type: "error",
-													error:
-														error instanceof Error
-															? error.message
-															: "Digest failed",
-												});
-												closeController();
-											},
-										},
+							],
+							run: ({ signal, emit }) =>
+								Effect.gen(function* () {
+									yield* maybeAutoUpdateBackupEffect();
+									return yield* streamPeriodDigestEffect(
+										{ ...options, signal },
+										{ onEvent: emit },
 									);
-								},
+								}),
+							errorEvent: (error) => ({
+								type: "error",
+								error: error instanceof Error ? error.message : "Digest failed",
 							}),
-							{
-								headers: {
-									"cache-control": "no-store",
-									"content-type": "application/x-ndjson; charset=utf-8",
-								},
-							},
-						);
+						});
 					}),
 				),
 		},

--- a/src/routes/api/profile-analysis.tsx
+++ b/src/routes/api/profile-analysis.tsx
@@ -1,19 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
-import { runEffectBackground } from "#/lib/effect-runtime";
 import {
 	parseBoundedInteger,
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
+import { createEffectNdjsonResponse } from "#/lib/ndjson-stream";
 import {
 	streamProfileAnalysisEffect,
 	type ProfileAnalysisOptions,
 	type ProfileAnalysisStreamEvent,
 } from "#/lib/profile-analysis";
-
-const encoder = new TextEncoder();
 
 function parseBoolean(value: string | null) {
 	return value === "true" || value === "1" || value === "yes";
@@ -57,10 +55,6 @@ function parseOptions(url: URL): ProfileAnalysisOptions {
 	};
 }
 
-function encodeEvent(event: ProfileAnalysisStreamEvent) {
-	return encoder.encode(`${JSON.stringify(event)}\n`);
-}
-
 export const Route = createFileRoute("/api/profile-analysis")({
 	server: {
 		handlers: {
@@ -72,79 +66,30 @@ export const Route = createFileRoute("/api/profile-analysis")({
 
 						const url = new URL(request.url);
 						const options = parseOptions(url);
-						let abortAnalysis: (() => void) | undefined;
-
-						return new Response(
-							new ReadableStream({
-								cancel() {
-									abortAnalysis?.();
+						return createEffectNdjsonResponse<ProfileAnalysisStreamEvent>({
+							request,
+							initialEvents: [
+								{
+									type: "status",
+									label: "Starting profile analysis",
 								},
-								start(controller) {
-									const abortController = new AbortController();
-									let closed = false;
-									const close = () => {
-										closed = true;
-										abortController.abort();
-									};
-									const closeController = () => {
-										request.signal.removeEventListener("abort", onAbort);
-										if (!closed) {
-											closed = true;
-											controller.close();
-										}
-									};
-									const onAbort = () => close();
-									request.signal.addEventListener("abort", onAbort, {
-										once: true,
-									});
-									abortAnalysis = close;
-									const enqueue = (event: ProfileAnalysisStreamEvent) => {
-										if (closed) return;
-										try {
-											controller.enqueue(encodeEvent(event));
-										} catch {
-											close();
-										}
-									};
-									enqueue({
-										type: "status",
-										label: "Starting profile analysis",
-									});
-
-									runEffectBackground(
-										Effect.gen(function* () {
-											yield* maybeAutoUpdateBackupEffect();
-											return yield* streamProfileAnalysisEffect(
-												{
-													...options,
-													signal: abortController.signal,
-												},
-												{ onEvent: enqueue },
-											);
-										}),
-										{
-											onSuccess: closeController,
-											onFailure: (error) => {
-												enqueue({
-													type: "error",
-													error:
-														error instanceof Error
-															? error.message
-															: "Profile analysis failed",
-												});
-												closeController();
-											},
-										},
+							],
+							run: ({ signal, emit }) =>
+								Effect.gen(function* () {
+									yield* maybeAutoUpdateBackupEffect();
+									return yield* streamProfileAnalysisEffect(
+										{ ...options, signal },
+										{ onEvent: emit },
 									);
-								},
+								}),
+							errorEvent: (error) => ({
+								type: "error",
+								error:
+									error instanceof Error
+										? error.message
+										: "Profile analysis failed",
 							}),
-							{
-								headers: {
-									"cache-control": "no-store",
-									"content-type": "application/x-ndjson; charset=utf-8",
-								},
-							},
-						);
+						});
 					}),
 				),
 		},

--- a/src/routes/api/search-discussion.tsx
+++ b/src/routes/api/search-discussion.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
-import { runEffectBackground } from "#/lib/effect-runtime";
 import {
 	parseBoundedInteger,
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
+import { createEffectNdjsonResponse } from "#/lib/ndjson-stream";
 import {
 	streamSearchDiscussionEffect,
 	type SearchDiscussionOptions,
@@ -15,7 +15,6 @@ import {
 } from "#/lib/search-discussion";
 import type { TweetSearchMode } from "#/lib/tweet-search-live";
 
-const encoder = new TextEncoder();
 const MAX_DISCUSSION_SEARCH_LIMIT = 20_000;
 const MAX_DISCUSSION_SEARCH_PAGES = 200;
 
@@ -73,10 +72,6 @@ function parseOptions(url: URL): SearchDiscussionOptions {
 	};
 }
 
-function encodeEvent(event: SearchDiscussionStreamEvent) {
-	return encoder.encode(`${JSON.stringify(event)}\n`);
-}
-
 export const Route = createFileRoute("/api/search-discussion")({
 	server: {
 		handlers: {
@@ -88,80 +83,29 @@ export const Route = createFileRoute("/api/search-discussion")({
 
 						const url = new URL(request.url);
 						const options = parseOptions(url);
-						let abortDiscussion: (() => void) | undefined;
-
-						return new Response(
-							new ReadableStream({
-								cancel() {
-									abortDiscussion?.();
-								},
-								start(controller) {
-									const abortController = new AbortController();
-									let closed = false;
-									const close = () => {
-										closed = true;
-										abortController.abort();
-									};
-									const closeController = () => {
-										request.signal.removeEventListener("abort", onAbort);
-										if (!closed) {
-											closed = true;
-											controller.close();
-										}
-									};
-									const onAbort = () => close();
-									request.signal.addEventListener("abort", onAbort, {
-										once: true,
-									});
-									abortDiscussion = close;
-									const enqueue = (event: SearchDiscussionStreamEvent) => {
-										if (closed) return;
-										try {
-											controller.enqueue(encodeEvent(event));
-										} catch {
-											close();
-										}
-									};
-
-									runEffectBackground(
-										maybeAutoUpdateBackupEffect().pipe(
-											Effect.flatMap(() => {
-												if (closed || abortController.signal.aborted) {
-													return Effect.succeed(undefined);
-												}
-												return streamSearchDiscussionEffect(
+						return createEffectNdjsonResponse<SearchDiscussionStreamEvent>({
+							request,
+							run: ({ signal, emit }) =>
+								maybeAutoUpdateBackupEffect().pipe(
+									Effect.flatMap(() =>
+										signal.aborted
+											? Effect.succeed(undefined)
+											: streamSearchDiscussionEffect(
 													{
 														...options,
-														signal: abortController.signal,
+														signal,
 														prefetchAvatars: true,
 													},
-													{ onEvent: enqueue },
-												);
-											}),
-										),
-										{
-											onSuccess: closeController,
-											onFailure: (error) => {
-												enqueue({
-													type: "error",
-													error:
-														error instanceof Error
-															? error.message
-															: "Discussion failed",
-												});
-												closeController();
-											},
-										},
-									);
-								},
+													{ onEvent: emit },
+												),
+									),
+								),
+							errorEvent: (error) => ({
+								type: "error",
+								error:
+									error instanceof Error ? error.message : "Discussion failed",
 							}),
-							{
-								headers: {
-									"cache-control": "no-store",
-									"content-type": "application/x-ndjson; charset=utf-8",
-								},
-							},
-						);
+						});
 					}),
 				),
 		},

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -253,6 +253,31 @@ describe("today route", () => {
 		).toBeInTheDocument();
 	});
 
+	it("shows an actionable message when the digest connection drops", async () => {
+		const fetchMock = vi.fn(async () => {
+			throw new TypeError("network error");
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<TodayRoute />);
+
+		expect(
+			await screen.findByText(
+				"Digest connection was interrupted while starting digest. Retry to continue.",
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("Digest failed")).toBeInTheDocument();
+		expect(
+			screen.getByText("No digest was generated. Retry to start a new run."),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Waiting for the first tokens..."),
+		).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+	});
+
 	it("shows fetch status before the first markdown token", async () => {
 		let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
 		const encoder = new TextEncoder();

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -77,11 +77,30 @@ async function digestRequestError(response: Response) {
 	} catch {
 		detail = "";
 	}
+	if (response.status === 524) {
+		return new Error(
+			"Digest startup timed out at Cloudflare (524). Retry to open a new stream.",
+		);
+	}
 	return new Error(
 		detail
 			? `Digest request failed (${status}): ${detail}`
 			: `Digest request failed (${status})`,
 	);
+}
+
+function digestStreamError(cause: unknown, phase: string) {
+	const message = cause instanceof Error ? cause.message : String(cause);
+	if (
+		cause instanceof TypeError &&
+		/network error|failed to fetch|load failed/i.test(message)
+	) {
+		return `Digest connection was interrupted while ${phase.toLowerCase()}. Retry to continue.`;
+	}
+	if (cause instanceof SyntaxError) {
+		return `Digest stream returned invalid data while ${phase.toLowerCase()}. Retry to continue.`;
+	}
+	return message || "Digest failed";
 }
 
 function formatCounts(context: PeriodDigestContext | null) {
@@ -200,8 +219,11 @@ function useDigestStream(period: PeriodOption, includeDms: boolean) {
 			setError(null);
 			setStatus("Starting digest");
 			setLoading(true);
+			let latestStatus = "Starting digest";
+			let completed = false;
 
 			fetch(digestUrl(period, includeDms, refresh), {
+				cache: "no-store",
 				signal: controller.signal,
 			})
 				.then(async (response) => {
@@ -217,7 +239,14 @@ function useDigestStream(period: PeriodOption, includeDms: boolean) {
 					const pump = (): Promise<void> =>
 						reader.read().then(({ done, value }) => {
 							if (!isActiveRequest()) return;
-							if (done) return;
+							if (done) {
+								if (!completed) {
+									throw new Error(
+										`Digest connection closed while ${latestStatus.toLowerCase()}. Retry to continue.`,
+									);
+								}
+								return;
+							}
 							buffer += decoder.decode(value, { stream: true });
 							let newline = buffer.indexOf("\n");
 							while (newline >= 0) {
@@ -227,17 +256,18 @@ function useDigestStream(period: PeriodOption, includeDms: boolean) {
 									const event = JSON.parse(line) as PeriodDigestStreamEvent;
 									if (!isActiveRequest()) return;
 									if (event.type === "status") {
-										setStatus(
-											event.detail
-												? `${event.label} · ${event.detail}`
-												: event.label,
-										);
+										latestStatus = event.detail
+											? `${event.label} · ${event.detail}`
+											: event.label;
+										setStatus(latestStatus);
 									} else if (event.type === "start") {
 										setContext(event.context);
 									} else if (event.type === "delta") {
-										setStatus("Streaming AI summary");
+										latestStatus = "Streaming AI summary";
+										setStatus(latestStatus);
 										setMarkdown((current) => current + event.delta);
 									} else if (event.type === "done") {
+										completed = true;
 										setResult(event.result);
 										setContext(event.result.context);
 										setMarkdown(event.result.markdown);
@@ -245,6 +275,7 @@ function useDigestStream(period: PeriodOption, includeDms: boolean) {
 											event.result.cached ? "Loaded cached report" : "Ready",
 										);
 									} else if (event.type === "error") {
+										completed = true;
 										setError(event.error);
 										setStatus("Digest failed");
 									}
@@ -257,7 +288,7 @@ function useDigestStream(period: PeriodOption, includeDms: boolean) {
 				})
 				.catch((cause: unknown) => {
 					if (!isActiveRequest()) return;
-					setError(cause instanceof Error ? cause.message : "Digest failed");
+					setError(digestStreamError(cause, latestStatus));
 					setStatus("Digest failed");
 				})
 				.finally(() => {
@@ -421,7 +452,24 @@ function TodayRoute() {
 				</div>
 			</header>
 
-			{error ? <div className={errorCopyClass}>{error}</div> : null}
+			{error ? (
+				<div
+					className={cx(
+						errorCopyClass,
+						"flex items-center justify-between gap-3",
+					)}
+					role="alert"
+				>
+					<span>{error}</span>
+					<button
+						className="shrink-0 font-semibold underline underline-offset-2"
+						onClick={() => run(true)}
+						type="button"
+					>
+						Retry
+					</button>
+				</div>
+			) : null}
 
 			<div className="border-b border-[var(--line)] px-4 py-2 text-[13px] text-[var(--ink-soft)]">
 				<span className="inline-flex items-center gap-1">
@@ -436,7 +484,9 @@ function TodayRoute() {
 						? status
 						: result
 							? `${result.cached ? "Cached" : "Ready"} · ${result.context.window.label}`
-							: "Ready"}
+							: error
+								? "Digest failed"
+								: "Ready"}
 				</span>
 			</div>
 
@@ -447,7 +497,11 @@ function TodayRoute() {
 				/>
 			) : (
 				<div className="px-4 py-5 text-[14px] text-[var(--ink-soft)]">
-					{loading ? status : "Waiting for the first tokens..."}
+					{loading
+						? status
+						: error
+							? "No digest was generated. Retry to start a new run."
+							: "Waiting for the first tokens..."}
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
## Summary

- open long-running NDJSON responses before backup synchronization
- send proxy keepalives for digest, profile analysis, and discussion streams
- replace generic Today network failures with phase-aware retry messaging

## Root cause

The Today endpoint completed backup auto-update before creating its response. Production took about 96.7 seconds to send the first byte, then the quiet HTTP/3 stream was terminated by Cloudflare with a 524 / `ERR_QUIC_PROTOCOL_ERROR`.

## Verification

- `pnpm test` (1,056 tests)
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- isolated endpoint probe: HTTP 200 and first status byte in 71 ms
- autoreview: clean, no accepted/actionable findings
