### PR TITLE
fix: keep Today within proxy limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Keep long-running AI streams alive through reverse proxies and show actionable Today retry errors when a connection is interrupted.
+- Open long-running AI streams immediately, keep the Today digest within proxy limits by using the locally synchronized archive, and show actionable retry errors when a connection is interrupted.
 
 ## 0.8.0 - 2026-06-10
 

--- a/src/lib/ndjson-stream.test.ts
+++ b/src/lib/ndjson-stream.test.ts
@@ -34,9 +34,20 @@ describe("createEffectNdjsonResponse", () => {
 			'{"type":"status","label":"Starting"}\n',
 		);
 
+		const initialPadding = new TextDecoder().decode(
+			(await reader!.read()).value,
+		);
+		expect(initialPadding.trim()).toBe("");
+		expect(initialPadding.length).toBeGreaterThanOrEqual(16_384);
+		expect(resolveRun).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(25);
+		expect(resolveRun).toBeTypeOf("function");
+
 		const heartbeat = reader!.read();
 		await vi.advanceTimersByTimeAsync(15_000);
-		expect(new TextDecoder().decode((await heartbeat).value)).toBe("\n");
+		const heartbeatText = new TextDecoder().decode((await heartbeat).value);
+		expect(heartbeatText.trim()).toBe("");
+		expect(heartbeatText.length).toBeGreaterThanOrEqual(16_384);
 
 		resolveRun?.();
 		await reader!.cancel();

--- a/src/lib/ndjson-stream.ts
+++ b/src/lib/ndjson-stream.ts
@@ -3,6 +3,8 @@ import { runEffectBackground } from "./effect-runtime";
 
 const encoder = new TextEncoder();
 const HEARTBEAT_INTERVAL_MS = 15_000;
+const STREAM_START_DELAY_MS = 25;
+const FLUSH_PADDING = `${" ".repeat(16_384)}\n`;
 
 export function createEffectNdjsonResponse<Event>({
 	request,
@@ -29,10 +31,12 @@ export function createEffectNdjsonResponse<Event>({
 				const abortController = new AbortController();
 				let closed = false;
 				let heartbeat: ReturnType<typeof setInterval> | undefined;
+				let startTimer: ReturnType<typeof setTimeout> | undefined;
 
 				const cleanup = () => {
 					request.signal.removeEventListener("abort", abort);
 					if (heartbeat !== undefined) clearInterval(heartbeat);
+					if (startTimer !== undefined) clearTimeout(startTimer);
 				};
 				const abort = () => {
 					if (closed) return;
@@ -67,20 +71,33 @@ export function createEffectNdjsonResponse<Event>({
 					return;
 				}
 				for (const event of initialEvents) emit(event);
-				heartbeat = setInterval(() => enqueue("\n"), HEARTBEAT_INTERVAL_MS);
+				enqueue(FLUSH_PADDING);
+				heartbeat = setInterval(
+					() => enqueue(FLUSH_PADDING),
+					HEARTBEAT_INTERVAL_MS,
+				);
 
-				runEffectBackground(run({ signal: abortController.signal, emit }), {
-					onSuccess: close,
-					onFailure: (error) => {
+				startTimer = setTimeout(() => {
+					if (closed) return;
+					try {
+						runEffectBackground(run({ signal: abortController.signal, emit }), {
+							onSuccess: close,
+							onFailure: (error) => {
+								emit(errorEvent(error));
+								close();
+							},
+						});
+					} catch (error) {
 						emit(errorEvent(error));
 						close();
-					},
-				});
+					}
+				}, STREAM_START_DELAY_MS);
 			},
 		}),
 		{
 			headers: {
-				"cache-control": "no-store",
+				"cache-control": "no-store, no-transform",
+				"content-encoding": "identity",
 				"content-type": "application/x-ndjson; charset=utf-8",
 				"x-accel-buffering": "no",
 			},

--- a/src/routes/api/period-digest.test.ts
+++ b/src/routes/api/period-digest.test.ts
@@ -70,7 +70,9 @@ describe("api period digest route", () => {
 		expect(response.headers.get("content-type")).toContain(
 			"application/x-ndjson",
 		);
-		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(response.headers.get("cache-control")).toBe(
+			"no-store, no-transform",
+		);
 		expect(await response.text()).toContain('"type":"done"');
 		expect(maybeAutoUpdateBackupMock).toHaveBeenCalledWith();
 		expect(streamPeriodDigestMock).toHaveBeenCalledWith(

--- a/src/routes/api/search-discussion.test.ts
+++ b/src/routes/api/search-discussion.test.ts
@@ -63,7 +63,9 @@ describe("api search discussion route", () => {
 		expect(response.headers.get("content-type")).toContain(
 			"application/x-ndjson",
 		);
-		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(response.headers.get("cache-control")).toBe(
+			"no-store, no-transform",
+		);
 		expect(await response.text()).toContain('"type":"done"');
 		expect(maybeAutoUpdateBackupMock).toHaveBeenCalledWith();
 		expect(streamSearchDiscussionMock).toHaveBeenCalledWith(

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -220,7 +220,8 @@ describe("today route", () => {
 			urls.some(
 				(url) =>
 					url.searchParams.get("period") === "week" &&
-					url.searchParams.get("includeDms") === "true",
+					url.searchParams.get("includeDms") === "true" &&
+					url.searchParams.get("liveSync") === "false",
 			),
 		).toBe(true);
 	});

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -53,6 +53,8 @@ function digestUrl(
 	url.searchParams.set("includeDms", String(includeDms));
 	url.searchParams.set("maxTweets", "5000");
 	url.searchParams.set("maxLinks", "20");
+	// Cloudflare caps proxied requests; live timeline sync remains a separate job/UI action.
+	url.searchParams.set("liveSync", "false");
 	if (refresh) {
 		url.searchParams.set("refresh", "true");
 	}


### PR DESCRIPTION
## Summary

- keep Today digest generation on the locally synchronized archive instead of performing live X sync inside the request
- flush an initial 16 KiB NDJSON padding block before CPU-heavy stream work and send matching proxy heartbeats
- disable response transformations that can buffer long-running streams

## Why

Follow-up to #53. Production verification showed the live timeline sync consumed about 152 seconds before digest generation, exceeding Cloudflare's 120-second proxied request limit. The UI then correctly reported the interruption, but the request architecture still could not complete reliably.

## Verification

- autoreview: clean, no actionable findings
- `pnpm test`: 1056 tests passed
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- authenticated production refresh through `app.birdclaw.sh/today`: immediate preparing status, streaming summary, then Ready in about 90 seconds
