### PR TITLE
fix: keep hover previews clear of wrapped links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.2 - Unreleased
 
+### Fixed
+
+- Keep tweet and profile hover previews outside wrapped links, flip them to the roomier vertical side, and constrain them to the viewport.
+
 ## 0.8.1 - 2026-06-13
 
 ### Changed

--- a/src/components/FloatingPreview.test.ts
+++ b/src/components/FloatingPreview.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { __test__ } from "./FloatingPreview";
+
+const viewport = {
+	top: 0,
+	right: 800,
+	bottom: 600,
+	left: 0,
+	width: 800,
+	height: 600,
+};
+
+const wrappedReference = [
+	{ top: 100, right: 650, bottom: 120, left: 300, width: 350, height: 20 },
+	{ top: 125, right: 650, bottom: 145, left: 100, width: 550, height: 20 },
+	{ top: 150, right: 340, bottom: 170, left: 100, width: 240, height: 20 },
+];
+
+describe("floating preview placement", () => {
+	it("places a preview below the final fragment of a wrapped link", () => {
+		const position = __test__.calculatePreviewPosition({
+			referenceRects: wrappedReference,
+			floatingWidth: 360,
+			floatingHeight: 220,
+			viewport,
+		});
+
+		expect(position.side).toBe("bottom");
+		expect(position.top).toBe(180);
+		expect(position.left).toBe(40);
+	});
+
+	it("places a preview above the first fragment when space below is tight", () => {
+		const position = __test__.calculatePreviewPosition({
+			referenceRects: wrappedReference.map((rect) => ({
+				...rect,
+				top: rect.top + 300,
+				bottom: rect.bottom + 300,
+			})),
+			floatingWidth: 360,
+			floatingHeight: 220,
+			viewport,
+		});
+
+		expect(position.side).toBe("top");
+		expect(position.top).toBe(170);
+		expect(position.top + 220).toBe(390);
+	});
+
+	it("uses the roomier side and constrains height when neither side fits", () => {
+		const position = __test__.calculatePreviewPosition({
+			referenceRects: wrappedReference.map((rect) => ({
+				...rect,
+				top: rect.top + 100,
+				bottom: rect.bottom + 100,
+			})),
+			floatingWidth: 360,
+			floatingHeight: 500,
+			viewport: { ...viewport, bottom: 420, height: 420 },
+		});
+
+		expect(position.side).toBe("top");
+		expect(position.maxHeight).toBe(178);
+		expect(position.top).toBe(12);
+	});
+
+	it("keeps wide previews inside a narrow viewport gutter", () => {
+		const position = __test__.calculatePreviewPosition({
+			referenceRects: [
+				{ top: 100, right: 315, bottom: 120, left: 275, width: 40, height: 20 },
+			],
+			floatingWidth: 360,
+			floatingHeight: 180,
+			viewport: {
+				...viewport,
+				right: 320,
+				bottom: 480,
+				width: 320,
+				height: 480,
+			},
+		});
+
+		expect(position.maxWidth).toBe(296);
+		expect(position.left).toBe(12);
+	});
+
+	it("applies width constraints while a narrow preview is still hidden", () => {
+		expect(
+			__test__.floatingStyle({
+				top: 130,
+				left: 12,
+				maxWidth: 296,
+				maxHeight: 320,
+				side: "bottom",
+				measured: true,
+				ready: false,
+			}),
+		).toMatchObject({
+			maxWidth: 296,
+			maxHeight: 320,
+			visibility: "hidden",
+		});
+	});
+
+	it("hides a preview when every wrapped-link fragment leaves the viewport", () => {
+		expect(
+			__test__.referenceIntersectsViewport(
+				wrappedReference.map((rect) => ({
+					...rect,
+					top: rect.top - 300,
+					bottom: rect.bottom - 300,
+				})),
+				viewport,
+			),
+		).toBe(false);
+		expect(
+			__test__.referenceIntersectsViewport(wrappedReference, viewport),
+		).toBe(true);
+	});
+});

--- a/src/components/FloatingPreview.tsx
+++ b/src/components/FloatingPreview.tsx
@@ -1,0 +1,382 @@
+import {
+	type CSSProperties,
+	type FocusEvent,
+	type KeyboardEvent,
+	type PointerEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useId,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+
+type PreviewSide = "top" | "bottom";
+
+type Rect = {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+	width: number;
+	height: number;
+};
+
+type PreviewPosition = {
+	top: number;
+	left: number;
+	maxWidth: number;
+	maxHeight: number;
+	side: PreviewSide;
+	measured: boolean;
+	ready: boolean;
+};
+
+type PlacementInput = {
+	referenceRects: Rect[];
+	floatingWidth: number;
+	floatingHeight: number;
+	viewport: Rect;
+	gap?: number;
+	gutter?: number;
+};
+
+const DEFAULT_GAP = 10;
+const DEFAULT_GUTTER = 12;
+const DEFAULT_CLOSE_DELAY_MS = 120;
+
+const initialPosition: PreviewPosition = {
+	top: 0,
+	left: 0,
+	maxWidth: 0,
+	maxHeight: 0,
+	side: "bottom",
+	measured: false,
+	ready: false,
+};
+
+function edgeRect(rects: Rect[], side: PreviewSide) {
+	return rects.reduce((best, rect) => {
+		if (side === "bottom") {
+			if (rect.bottom > best.bottom) return rect;
+			if (rect.bottom === best.bottom && rect.width > best.width) return rect;
+			return best;
+		}
+		if (rect.top < best.top) return rect;
+		if (rect.top === best.top && rect.width > best.width) return rect;
+		return best;
+	});
+}
+
+function clamp(value: number, minimum: number, maximum: number) {
+	if (maximum < minimum) return minimum;
+	return Math.min(Math.max(value, minimum), maximum);
+}
+
+function calculatePreviewPosition({
+	referenceRects,
+	floatingWidth,
+	floatingHeight,
+	viewport,
+	gap = DEFAULT_GAP,
+	gutter = DEFAULT_GUTTER,
+}: PlacementInput): PreviewPosition {
+	const referenceTop = Math.min(...referenceRects.map((rect) => rect.top));
+	const referenceBottom = Math.max(
+		...referenceRects.map((rect) => rect.bottom),
+	);
+	const availableBelow = Math.max(
+		0,
+		viewport.bottom - gutter - referenceBottom - gap,
+	);
+	const availableAbove = Math.max(
+		0,
+		referenceTop - viewport.top - gutter - gap,
+	);
+	const side: PreviewSide =
+		availableBelow >= floatingHeight || availableBelow >= availableAbove
+			? "bottom"
+			: "top";
+	const availableHeight = side === "bottom" ? availableBelow : availableAbove;
+	const renderedHeight = Math.min(floatingHeight, availableHeight);
+	const anchor = edgeRect(referenceRects, side);
+	const maxWidth = Math.max(0, viewport.width - gutter * 2);
+	const renderedWidth = Math.min(floatingWidth, maxWidth);
+	const minimumLeft = viewport.left + gutter;
+	const maximumLeft = viewport.right - gutter - renderedWidth;
+	const left = clamp(
+		anchor.left + anchor.width / 2 - renderedWidth / 2,
+		minimumLeft,
+		maximumLeft,
+	);
+	const top =
+		side === "bottom"
+			? referenceBottom + gap
+			: referenceTop - gap - renderedHeight;
+
+	return {
+		top,
+		left,
+		maxWidth,
+		maxHeight: availableHeight,
+		side,
+		measured: true,
+		ready: true,
+	};
+}
+
+function viewportRect(): Rect {
+	const viewport = window.visualViewport;
+	const left = viewport?.offsetLeft ?? 0;
+	const top = viewport?.offsetTop ?? 0;
+	const width = viewport?.width ?? window.innerWidth;
+	const height = viewport?.height ?? window.innerHeight;
+	return {
+		top,
+		right: left + width,
+		bottom: top + height,
+		left,
+		width,
+		height,
+	};
+}
+
+function elementRects(element: HTMLElement): Rect[] {
+	const fragments = Array.from(element.getClientRects()).filter(
+		(rect) => rect.width > 0 || rect.height > 0,
+	);
+	return fragments.length > 0 ? fragments : [element.getBoundingClientRect()];
+}
+
+function referenceIntersectsViewport(rects: Rect[], viewport: Rect) {
+	return rects.some(
+		(rect) =>
+			rect.right >= viewport.left &&
+			rect.left <= viewport.right &&
+			rect.bottom >= viewport.top &&
+			rect.top <= viewport.bottom,
+	);
+}
+
+function samePosition(left: PreviewPosition, right: PreviewPosition) {
+	return (
+		left.top === right.top &&
+		left.left === right.left &&
+		left.maxWidth === right.maxWidth &&
+		left.maxHeight === right.maxHeight &&
+		left.side === right.side &&
+		left.measured === right.measured &&
+		left.ready === right.ready
+	);
+}
+
+function floatingStyle(position: PreviewPosition): CSSProperties {
+	return {
+		position: "fixed",
+		top: position.top,
+		left: position.left,
+		// Apply constraints during the hidden first pass so remeasurement can settle.
+		maxWidth: position.measured ? position.maxWidth : undefined,
+		maxHeight: position.measured ? position.maxHeight : undefined,
+		visibility: position.ready ? "visible" : "hidden",
+	};
+}
+
+function containsTarget(
+	target: EventTarget | null,
+	...elements: Array<HTMLElement | null>
+) {
+	return (
+		target instanceof Node &&
+		elements.some((element) => element?.contains(target))
+	);
+}
+
+export function useFloatingPreview(options: { closeDelayMs?: number } = {}): {
+	open: boolean;
+	referenceRef: RefObject<HTMLSpanElement | null>;
+	floatingRef: RefObject<HTMLSpanElement | null>;
+	floatingStyle: CSSProperties;
+	referenceProps: {
+		onPointerEnter: (event: PointerEvent<HTMLElement>) => void;
+		onPointerLeave: (event: PointerEvent<HTMLElement>) => void;
+		onFocus: (event: FocusEvent<HTMLElement>) => void;
+		onBlur: (event: FocusEvent<HTMLElement>) => void;
+		onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+	};
+	floatingProps: {
+		onPointerEnter: (event: PointerEvent<HTMLElement>) => void;
+		onPointerLeave: (event: PointerEvent<HTMLElement>) => void;
+		onFocus: (event: FocusEvent<HTMLElement>) => void;
+		onBlur: (event: FocusEvent<HTMLElement>) => void;
+		onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+	};
+	floatingId: string;
+	closePreview: () => void;
+} {
+	const closeDelayMs = options.closeDelayMs ?? DEFAULT_CLOSE_DELAY_MS;
+	const [open, setOpen] = useState(false);
+	const [position, setPosition] = useState(initialPosition);
+	const floatingId = useId();
+	const referenceRef = useRef<HTMLSpanElement | null>(null);
+	const floatingRef = useRef<HTMLSpanElement | null>(null);
+	const closeTimerRef = useRef<number | null>(null);
+
+	const clearCloseTimer = useCallback(() => {
+		if (closeTimerRef.current === null) return;
+		window.clearTimeout(closeTimerRef.current);
+		closeTimerRef.current = null;
+	}, []);
+
+	const openPreview = useCallback(() => {
+		clearCloseTimer();
+		if (!open) setPosition(initialPosition);
+		setOpen(true);
+	}, [clearCloseTimer, open]);
+
+	const closePreview = useCallback(() => {
+		clearCloseTimer();
+		setOpen(false);
+	}, [clearCloseTimer]);
+
+	const scheduleClose = useCallback(() => {
+		clearCloseTimer();
+		closeTimerRef.current = window.setTimeout(() => {
+			closeTimerRef.current = null;
+			const reference = referenceRef.current;
+			const floating = floatingRef.current;
+			const focusInside = containsTarget(
+				document.activeElement,
+				reference,
+				floating,
+			);
+			const pointerInside =
+				Boolean(reference?.matches(":hover")) ||
+				Boolean(floating?.matches(":hover"));
+			if (!focusInside && !pointerInside) setOpen(false);
+		}, closeDelayMs);
+	}, [clearCloseTimer, closeDelayMs]);
+
+	const handleBlur = useCallback(
+		(event: FocusEvent<HTMLElement>) => {
+			if (
+				containsTarget(
+					event.relatedTarget,
+					referenceRef.current,
+					floatingRef.current,
+				)
+			) {
+				return;
+			}
+			scheduleClose();
+		},
+		[scheduleClose],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLElement>) => {
+			if (event.key !== "Escape") return;
+			closePreview();
+			referenceRef.current?.querySelector<HTMLElement>("a,button")?.focus();
+		},
+		[closePreview],
+	);
+
+	const updatePlacement = useCallback(() => {
+		const reference = referenceRef.current;
+		const floating = floatingRef.current;
+		if (!reference || !floating) return;
+		const viewport = viewportRect();
+		const referenceRects = elementRects(reference);
+		if (!referenceIntersectsViewport(referenceRects, viewport)) {
+			setPosition((current) =>
+				current.ready ? { ...current, ready: false } : current,
+			);
+			return;
+		}
+		const floatingRect = floating.getBoundingClientRect();
+		const content = floating.querySelector<HTMLElement>(
+			"[data-floating-preview-content]",
+		);
+		const style = window.getComputedStyle(floating);
+		const verticalChrome = [
+			style.paddingTop,
+			style.paddingBottom,
+			style.borderTopWidth,
+			style.borderBottomWidth,
+		].reduce((total, value) => total + (Number.parseFloat(value) || 0), 0);
+		// Measure the unclipped child so a previously constrained card can grow again.
+		const naturalHeight = Math.max(
+			floatingRect.height,
+			(content?.getBoundingClientRect().height ?? 0) + verticalChrome,
+		);
+		const next = calculatePreviewPosition({
+			referenceRects,
+			floatingWidth: floatingRect.width,
+			floatingHeight: naturalHeight,
+			viewport,
+		});
+		if (floatingRect.width > next.maxWidth + 0.5) next.ready = false;
+		setPosition((current) => (samePosition(current, next) ? current : next));
+	}, []);
+
+	useLayoutEffect(() => {
+		if (!open) return;
+		updatePlacement();
+		let frame = 0;
+		const trackLayout = () => {
+			updatePlacement();
+			frame = window.requestAnimationFrame(trackLayout);
+		};
+		// Fixed positioning needs explicit tracking when surrounding content shifts.
+		frame = window.requestAnimationFrame(trackLayout);
+		const viewport = window.visualViewport;
+		window.addEventListener("resize", updatePlacement);
+		window.addEventListener("scroll", updatePlacement, true);
+		viewport?.addEventListener("resize", updatePlacement);
+		viewport?.addEventListener("scroll", updatePlacement);
+		const observer =
+			typeof ResizeObserver === "undefined"
+				? null
+				: new ResizeObserver(updatePlacement);
+		if (referenceRef.current) observer?.observe(referenceRef.current);
+		if (floatingRef.current) observer?.observe(floatingRef.current);
+
+		return () => {
+			window.cancelAnimationFrame(frame);
+			window.removeEventListener("resize", updatePlacement);
+			window.removeEventListener("scroll", updatePlacement, true);
+			viewport?.removeEventListener("resize", updatePlacement);
+			viewport?.removeEventListener("scroll", updatePlacement);
+			observer?.disconnect();
+		};
+	}, [open, updatePlacement]);
+
+	useEffect(() => () => clearCloseTimer(), [clearCloseTimer]);
+
+	const interactionProps = {
+		onPointerEnter: (_event: PointerEvent<HTMLElement>) => openPreview(),
+		onPointerLeave: (_event: PointerEvent<HTMLElement>) => scheduleClose(),
+		onFocus: (_event: FocusEvent<HTMLElement>) => openPreview(),
+		onBlur: handleBlur,
+		onKeyDown: handleKeyDown,
+	};
+
+	return {
+		open,
+		referenceRef,
+		floatingRef,
+		floatingStyle: floatingStyle(position),
+		referenceProps: interactionProps,
+		floatingProps: interactionProps,
+		floatingId,
+		closePreview,
+	};
+}
+
+export const __test__ = {
+	calculatePreviewPosition,
+	floatingStyle,
+	referenceIntersectsViewport,
+};

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -1,10 +1,4 @@
-import {
-	cleanup,
-	fireEvent,
-	render,
-	screen,
-	waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { PeriodDigestContext } from "#/lib/period-digest";
 import type { ProfileAnalysisContext } from "#/lib/profile-analysis";
@@ -259,14 +253,14 @@ describe("MarkdownViewer", () => {
 			"href",
 			"https://x.com/steipete/status/2055621934319030779",
 		);
-		expect(
-			screen.getByRole("link", {
-				name: "describes the OpenClaw team structure",
-			}),
-		).toHaveAttribute(
+		const openClawCitation = screen.getByRole("link", {
+			name: "describes the OpenClaw team structure",
+		});
+		expect(openClawCitation).toHaveAttribute(
 			"href",
 			"https://x.com/openclaw/status/2055858095759229148",
 		);
+		fireEvent.pointerEnter(openClawCitation.parentElement as Element);
 		expect(screen.getByAltText("OpenClaw")).toHaveAttribute(
 			"src",
 			"/api/avatar?profileId=profile_user_42&v=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2Fopenclaw_normal.jpg",
@@ -515,15 +509,13 @@ describe("MarkdownViewer", () => {
 			/>,
 		);
 
-		expect(screen.getByRole("link", { name: "@OpenAI" })).toHaveAttribute(
-			"href",
-			"/profiles/OpenAI",
-		);
-		expect(screen.getByRole("link", { name: "@openclaw" })).toHaveAttribute(
-			"href",
-			"/profiles/openclaw",
-		);
+		const openAiLink = screen.getByRole("link", { name: "@OpenAI" });
+		expect(openAiLink).toHaveAttribute("href", "/profiles/OpenAI");
+		const openClawLink = screen.getByRole("link", { name: "@openclaw" });
+		expect(openClawLink).toHaveAttribute("href", "/profiles/openclaw");
+		fireEvent.pointerEnter(openAiLink.parentElement as Element);
 		expect(screen.getByText("AI research and products.")).toBeInTheDocument();
+		fireEvent.pointerEnter(openClawLink.parentElement as Element);
 		expect(screen.getByText("Agent tooling")).toBeInTheDocument();
 	});
 
@@ -632,176 +624,15 @@ describe("MarkdownViewer", () => {
 			name: "“autonomous agents running on goAT”",
 		});
 		const wrapper = link.parentElement;
-		const preview = screen
-			.getByText(/https:\/\/goat\.network\/agents/)
-			.closest("[aria-hidden]");
-
-		expect(preview).toHaveAttribute("aria-hidden", "true");
 		expect(wrapper).not.toBeNull();
+		expect(screen.queryByText(/https:\/\/goat\.network\/agents/)).toBeNull();
 
 		fireEvent.pointerEnter(wrapper as Element);
-		expect(preview).toHaveAttribute("aria-hidden", "false");
+		expect(screen.getByRole("tooltip")).toHaveTextContent(
+			/https:\/\/goat\.network\/agents/,
+		);
 
 		fireEvent.click(link, { metaKey: true });
-		expect(preview).toHaveAttribute("aria-hidden", "true");
-	});
-
-	it("places tweet previews above the citation when the viewport is tight below", async () => {
-		const originalInnerHeight = window.innerHeight;
-		const originalRect = HTMLElement.prototype.getBoundingClientRect;
-		const originalOffsetHeight = Object.getOwnPropertyDescriptor(
-			HTMLElement.prototype,
-			"offsetHeight",
-		);
-		Object.defineProperty(window, "innerHeight", {
-			configurable: true,
-			value: 220,
-		});
-		HTMLElement.prototype.getBoundingClientRect = () =>
-			({
-				bottom: 196,
-				height: 18,
-				left: 120,
-				right: 220,
-				top: 178,
-				width: 100,
-				x: 120,
-				y: 178,
-				toJSON: () => ({}),
-			}) as DOMRect;
-		Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-			configurable: true,
-			get() {
-				return 160;
-			},
-		});
-
-		try {
-			render(
-				<MarkdownViewer
-					context={context}
-					markdown={
-						"ChainZenit reacted positively to “autonomous agents running on goAT” (tweet_2056286865875935400)."
-					}
-				/>,
-			);
-
-			const link = screen.getByRole("link", {
-				name: "“autonomous agents running on goAT”",
-			});
-			const wrapper = link.parentElement;
-			const preview = screen
-				.getByText(/https:\/\/goat\.network\/agents/)
-				.closest("[aria-hidden]");
-			expect(wrapper).not.toBeNull();
-
-			fireEvent.pointerEnter(wrapper as Element);
-
-			await waitFor(() => {
-				expect(preview).toHaveClass("bottom-[calc(100%+10px)]");
-			});
-		} finally {
-			Object.defineProperty(window, "innerHeight", {
-				configurable: true,
-				value: originalInnerHeight,
-			});
-			HTMLElement.prototype.getBoundingClientRect = originalRect;
-			if (originalOffsetHeight) {
-				Object.defineProperty(
-					HTMLElement.prototype,
-					"offsetHeight",
-					originalOffsetHeight,
-				);
-			}
-		}
-	});
-
-	it("places tweet previews above when a clipping container is tight below", async () => {
-		const originalInnerHeight = window.innerHeight;
-		const originalRect = HTMLElement.prototype.getBoundingClientRect;
-		const originalOffsetHeight = Object.getOwnPropertyDescriptor(
-			HTMLElement.prototype,
-			"offsetHeight",
-		);
-		Object.defineProperty(window, "innerHeight", {
-			configurable: true,
-			value: 800,
-		});
-		HTMLElement.prototype.getBoundingClientRect = function () {
-			if (this instanceof HTMLElement && this.dataset.testid === "clip-box") {
-				return {
-					bottom: 260,
-					height: 220,
-					left: 0,
-					right: 680,
-					top: 40,
-					width: 680,
-					x: 0,
-					y: 40,
-					toJSON: () => ({}),
-				} as DOMRect;
-			}
-			return {
-				bottom: 230,
-				height: 18,
-				left: 120,
-				right: 220,
-				top: 212,
-				width: 100,
-				x: 120,
-				y: 212,
-				toJSON: () => ({}),
-			} as DOMRect;
-		};
-		Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-			configurable: true,
-			get() {
-				return 260;
-			},
-		});
-
-		try {
-			render(
-				<div
-					data-testid="clip-box"
-					style={{ height: 220, overflowY: "hidden" }}
-				>
-					<MarkdownViewer
-						context={context}
-						markdown={
-							"ChainZenit reacted positively to “autonomous agents running on goAT” (tweet_2056286865875935400)."
-						}
-					/>
-				</div>,
-			);
-
-			const link = screen.getByRole("link", {
-				name: "“autonomous agents running on goAT”",
-			});
-			const wrapper = link.parentElement;
-			const preview = screen
-				.getByText(/https:\/\/goat\.network\/agents/)
-				.closest("[aria-hidden]");
-			expect(wrapper).not.toBeNull();
-
-			fireEvent.pointerEnter(wrapper as Element);
-
-			await waitFor(() => {
-				expect(preview).toHaveClass("bottom-[calc(100%+10px)]");
-			});
-		} finally {
-			Object.defineProperty(window, "innerHeight", {
-				configurable: true,
-				value: originalInnerHeight,
-			});
-			HTMLElement.prototype.getBoundingClientRect = originalRect;
-			if (originalOffsetHeight) {
-				Object.defineProperty(
-					HTMLElement.prototype,
-					"offsetHeight",
-					originalOffsetHeight,
-				);
-			}
-		}
+		expect(screen.queryByRole("tooltip")).toBeNull();
 	});
 });

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -1,11 +1,4 @@
-import {
-	Fragment,
-	type MouseEventHandler,
-	type ReactNode,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { Fragment, type MouseEventHandler, type ReactNode } from "react";
 import { formatCompactNumber } from "#/lib/present";
 import type { PeriodDigestContext } from "#/lib/period-digest";
 import type { ProfileAnalysisContext } from "#/lib/profile-analysis";
@@ -14,34 +7,16 @@ import type { ProfileRecord } from "#/lib/types";
 import { cx, tweetLinkClass, tweetMentionClass } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { AvatarChip } from "./AvatarChip";
+import { useFloatingPreview } from "./FloatingPreview";
 import { ProfilePreview } from "./ProfilePreview";
 import { SmartTimestamp } from "./SmartTimestamp";
 
 type CitationTweet = PeriodDigestContext["tweets"][number];
 type CitationContext = PeriodDigestContext | ProfileAnalysisContext;
-type VerticalBounds = { top: number; bottom: number };
-
 type InlineLookup = {
 	tweetsById: Map<string, CitationTweet>;
 	profilesByHandle: Map<string, ProfileRecord>;
 };
-
-function nearestVerticalClipBounds(element: HTMLElement): VerticalBounds {
-	let top = 0;
-	let bottom = window.innerHeight;
-	for (
-		let current = element.parentElement;
-		current;
-		current = current.parentElement
-	) {
-		const style = window.getComputedStyle(current);
-		if (!/(auto|scroll|hidden|clip)/.test(style.overflowY)) continue;
-		const rect = current.getBoundingClientRect();
-		top = Math.max(top, rect.top);
-		bottom = Math.min(bottom, rect.bottom);
-	}
-	return { top, bottom };
-}
 
 function normalizeTweetReference(value: string) {
 	return value
@@ -135,13 +110,16 @@ function TweetSourceLink({
 	children,
 	href,
 	onClick,
+	describedBy,
 }: {
 	children: ReactNode;
 	href: string;
 	onClick?: MouseEventHandler<HTMLAnchorElement>;
+	describedBy?: string;
 }) {
 	return (
 		<a
+			aria-describedby={describedBy}
 			className="rounded-sm px-0.5 text-[var(--accent)] hover:bg-[var(--accent-soft)] hover:no-underline"
 			href={href}
 			onClick={onClick}
@@ -160,93 +138,64 @@ function TweetPreviewToken({
 	tweet: CitationTweet;
 	children: ReactNode;
 }) {
-	const [open, setOpen] = useState(false);
-	const [placeAbove, setPlaceAbove] = useState(false);
-	const shellRef = useRef<HTMLSpanElement | null>(null);
-	const cardRef = useRef<HTMLSpanElement | null>(null);
-
-	useLayoutEffect(() => {
-		if (!open) return;
-		const updatePlacement = () => {
-			const shell = shellRef.current;
-			if (!shell) return;
-			const shellRect = shell.getBoundingClientRect();
-			const card = cardRef.current;
-			const cardRect = card?.getBoundingClientRect();
-			const cardHeight = Math.max(
-				card?.offsetHeight ?? 0,
-				cardRect?.height ?? 0,
-				220,
-			);
-			const bounds = nearestVerticalClipBounds(shell);
-			const belowSpace = bounds.bottom - shellRect.bottom;
-			const aboveSpace = shellRect.top - bounds.top;
-			setPlaceAbove(belowSpace < cardHeight + 18 && aboveSpace >= belowSpace);
-		};
-		updatePlacement();
-		const frame = window.requestAnimationFrame(updatePlacement);
-		return () => window.cancelAnimationFrame(frame);
-	}, [open]);
-
-	function closePreview() {
-		setOpen(false);
-	}
+	const preview = useFloatingPreview();
 
 	const previewText = renderTweetPlainText(tweet.text, tweet.entities ?? {});
 
 	return (
 		<span
-			ref={shellRef}
-			className="relative inline align-baseline"
-			onBlur={closePreview}
-			onFocus={() => setOpen(true)}
-			onPointerEnter={() => setOpen(true)}
-			onPointerLeave={closePreview}
+			ref={preview.referenceRef}
+			className="inline align-baseline"
+			{...preview.referenceProps}
 		>
 			<TweetSourceLink
+				describedBy={preview.open ? preview.floatingId : undefined}
 				href={getTweetUrl(tweet)}
 				onClick={(event) => {
-					closePreview();
+					preview.closePreview();
 					event.currentTarget.blur();
 				}}
 			>
 				{children}
 			</TweetSourceLink>
-			<span
-				ref={cardRef}
-				aria-hidden={!open}
-				className={cx(
-					"absolute left-1/2 z-40 w-[360px] -translate-x-1/2 rounded-2xl border border-[var(--line)] bg-[var(--bg-elevated)] p-3 text-left text-[14px] leading-[1.4] text-[var(--ink)] shadow-[0_14px_40px_var(--shadow-strong)]",
-					placeAbove ? "bottom-[calc(100%+10px)]" : "top-[calc(100%+10px)]",
-					open ? "block" : "hidden",
-				)}
-			>
-				<span className="mb-2 flex items-center gap-2">
-					<AvatarChip
-						avatarUrl={tweet.authorProfile.avatarUrl}
-						hue={tweet.authorProfile.avatarHue}
-						name={tweet.name}
-						profileId={tweet.authorProfile.id}
-						size="small"
-					/>
-					<span className="min-w-0">
-						<span className="block truncate font-bold">{tweet.name}</span>
-						<span className="block truncate text-[12px] text-[var(--ink-soft)]">
-							@{tweet.author} · <SmartTimestamp value={tweet.createdAt} />
+			{preview.open ? (
+				<span
+					id={preview.floatingId}
+					ref={preview.floatingRef}
+					className="fixed z-40 w-[360px] overflow-y-auto rounded-2xl border border-[var(--line)] bg-[var(--bg-elevated)] p-3 text-left text-[14px] leading-[1.4] text-[var(--ink)] shadow-[0_14px_40px_var(--shadow-strong)]"
+					role="tooltip"
+					style={preview.floatingStyle}
+					{...preview.floatingProps}
+				>
+					<span className="block" data-floating-preview-content>
+						<span className="mb-2 flex items-center gap-2">
+							<AvatarChip
+								avatarUrl={tweet.authorProfile.avatarUrl}
+								hue={tweet.authorProfile.avatarHue}
+								name={tweet.name}
+								profileId={tweet.authorProfile.id}
+								size="small"
+							/>
+							<span className="min-w-0">
+								<span className="block truncate font-bold">{tweet.name}</span>
+								<span className="block truncate text-[12px] text-[var(--ink-soft)]">
+									@{tweet.author} · <SmartTimestamp value={tweet.createdAt} />
+								</span>
+							</span>
+						</span>
+						<span className="line-clamp-6 whitespace-pre-wrap [overflow-wrap:anywhere]">
+							{previewText}
+						</span>
+						<span className="mt-2 flex gap-3 text-[12px] text-[var(--ink-soft)]">
+							<span>{tweet.source}</span>
+							{tweet.likeCount > 0 ? (
+								<span>{formatCompactNumber(tweet.likeCount)} likes</span>
+							) : null}
+							{tweet.needsReply ? <span>reply open</span> : null}
 						</span>
 					</span>
 				</span>
-				<span className="line-clamp-6 whitespace-pre-wrap [overflow-wrap:anywhere]">
-					{previewText}
-				</span>
-				<span className="mt-2 flex gap-3 text-[12px] text-[var(--ink-soft)]">
-					<span>{tweet.source}</span>
-					{tweet.likeCount > 0 ? (
-						<span>{formatCompactNumber(tweet.likeCount)} likes</span>
-					) : null}
-					{tweet.needsReply ? <span>reply open</span> : null}
-				</span>
-			</span>
+			) : null}
 		</span>
 	);
 }

--- a/src/components/ProfilePreview.test.tsx
+++ b/src/components/ProfilePreview.test.tsx
@@ -1,0 +1,102 @@
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProfilePreview } from "./ProfilePreview";
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("ProfilePreview", () => {
+	it("stays open after pointer leave while its trigger retains focus", () => {
+		vi.useFakeTimers();
+		render(
+			<ProfilePreview
+				profile={{
+					id: "profile_amelia",
+					handle: "amelia",
+					displayName: "Amelia",
+					bio: "Design systems",
+					followersCount: 4200,
+					avatarHue: 320,
+					createdAt: "2026-03-08T12:00:00.000Z",
+				}}
+			>
+				@amelia
+			</ProfilePreview>,
+		);
+
+		const link = screen.getByRole("link", { name: "@amelia" });
+		const wrapper = link.parentElement as HTMLElement;
+		act(() => link.focus());
+		expect(screen.getByRole("group")).toHaveTextContent("Design systems");
+
+		fireEvent.pointerEnter(wrapper);
+		fireEvent.pointerLeave(wrapper);
+		act(() => vi.advanceTimersByTime(150));
+		expect(screen.getByRole("group")).toBeInTheDocument();
+
+		act(() => link.blur());
+		act(() => vi.advanceTimersByTime(150));
+		expect(screen.queryByRole("group")).toBeNull();
+	});
+
+	it("tracks layout-only movement while open", () => {
+		let referenceTop = 100;
+		const frames: FrameRequestCallback[] = [];
+		const originalClientRects = HTMLElement.prototype.getClientRects;
+		vi.spyOn(HTMLElement.prototype, "getClientRects").mockImplementation(
+			function (this: HTMLElement) {
+				if (!this.classList.contains("relative")) {
+					return originalClientRects.call(this);
+				}
+				return [
+					{
+						top: referenceTop,
+						right: 180,
+						bottom: referenceTop + 20,
+						left: 100,
+						width: 80,
+						height: 20,
+					} as DOMRect,
+				] as unknown as DOMRectList;
+			},
+		);
+		vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+		render(
+			<ProfilePreview
+				profile={{
+					id: "profile_amelia",
+					handle: "amelia",
+					displayName: "Amelia",
+					bio: "",
+					followersCount: 4200,
+					avatarHue: 320,
+					createdAt: "2026-03-08T12:00:00.000Z",
+				}}
+			>
+				@amelia
+			</ProfilePreview>,
+		);
+
+		act(() => screen.getByRole("link", { name: "@amelia" }).focus());
+		const preview = screen.getByRole("group");
+		expect(preview).toHaveStyle({ top: "130px" });
+
+		referenceTop = 240;
+		act(() => frames.shift()?.(16));
+		expect(preview).toHaveStyle({ top: "270px" });
+	});
+});

--- a/src/components/ProfilePreview.tsx
+++ b/src/components/ProfilePreview.tsx
@@ -1,10 +1,4 @@
-import {
-	Fragment,
-	type ReactNode,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { Fragment, type ReactNode } from "react";
 import { formatCompactNumber } from "#/lib/present";
 import {
 	collectTweetSegmentsForText,
@@ -25,25 +19,7 @@ import {
 } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { AvatarChip } from "./AvatarChip";
-
-type VerticalBounds = { top: number; bottom: number };
-
-function nearestVerticalClipBounds(element: HTMLElement): VerticalBounds {
-	let top = 0;
-	let bottom = window.innerHeight;
-	for (
-		let current = element.parentElement;
-		current;
-		current = current.parentElement
-	) {
-		const style = window.getComputedStyle(current);
-		if (!/(auto|scroll|hidden|clip)/.test(style.overflowY)) continue;
-		const rect = current.getBoundingClientRect();
-		top = Math.max(top, rect.top);
-		bottom = Math.min(bottom, rect.bottom);
-	}
-	return { top, bottom };
-}
+import { useFloatingPreview } from "./FloatingPreview";
 
 function ProfilePreviewBio({ profile }: { profile: ProfileRecord }) {
 	const segments = collectTweetSegmentsForText(
@@ -98,74 +74,56 @@ export function ProfilePreview({
 	children: ReactNode;
 	className?: string;
 }) {
-	const [placeAbove, setPlaceAbove] = useState(false);
-	const shellRef = useRef<HTMLSpanElement | null>(null);
-	const cardRef = useRef<HTMLSpanElement | null>(null);
-
-	function updatePlacement() {
-		const shell = shellRef.current;
-		if (!shell) return;
-		const shellRect = shell.getBoundingClientRect();
-		const card = cardRef.current;
-		const cardRect = card?.getBoundingClientRect();
-		const cardHeight = Math.max(
-			card?.offsetHeight ?? 0,
-			cardRect?.height ?? 0,
-			180,
-		);
-		const bounds = nearestVerticalClipBounds(shell);
-		const belowSpace = bounds.bottom - shellRect.bottom;
-		const aboveSpace = shellRect.top - bounds.top;
-		setPlaceAbove(belowSpace < cardHeight + 18 && aboveSpace >= belowSpace);
-	}
-
-	useLayoutEffect(() => {
-		updatePlacement();
-		const frame = window.requestAnimationFrame(updatePlacement);
-		return () => window.cancelAnimationFrame(frame);
-	}, []);
+	const preview = useFloatingPreview();
 
 	return (
 		<span
-			ref={shellRef}
-			className={cx(profilePreviewClass, "group", className)}
-			onFocus={updatePlacement}
-			onPointerEnter={updatePlacement}
+			ref={preview.referenceRef}
+			className={cx(profilePreviewClass, className)}
+			{...preview.referenceProps}
 		>
 			<a
+				aria-controls={preview.open ? preview.floatingId : undefined}
+				aria-expanded={preview.open}
 				className={profilePreviewTriggerClass}
 				href={`/profiles/${encodeURIComponent(profile.handle)}`}
 			>
 				{children}
 			</a>
-			<span
-				ref={cardRef}
-				className={cx(
-					profilePreviewCardClass,
-					placeAbove
-						? "bottom-[calc(100%+8px)] -translate-y-1 group-hover:translate-y-0 group-focus-within:translate-y-0"
-						: "top-[calc(100%+8px)] translate-y-1 group-hover:translate-y-0 group-focus-within:translate-y-0",
-				)}
-			>
-				<span className={profilePreviewHeaderClass}>
-					<AvatarChip
-						avatarUrl={profile.avatarUrl}
-						hue={profile.avatarHue}
-						name={profile.displayName}
-						profileId={profile.id}
-					/>
-					<span className="flex min-w-0 flex-col">
-						<span className={profilePreviewNameClass}>
-							{profile.displayName}
+			{preview.open ? (
+				<span
+					aria-label={`${profile.displayName} profile preview`}
+					id={preview.floatingId}
+					ref={preview.floatingRef}
+					className={profilePreviewCardClass}
+					role="group"
+					style={preview.floatingStyle}
+					{...preview.floatingProps}
+				>
+					<span className="grid gap-2" data-floating-preview-content>
+						<span className={profilePreviewHeaderClass}>
+							<AvatarChip
+								avatarUrl={profile.avatarUrl}
+								hue={profile.avatarHue}
+								name={profile.displayName}
+								profileId={profile.id}
+							/>
+							<span className="flex min-w-0 flex-col">
+								<span className={profilePreviewNameClass}>
+									{profile.displayName}
+								</span>
+								<span className={profilePreviewHandleClass}>
+									@{profile.handle}
+								</span>
+							</span>
 						</span>
-						<span className={profilePreviewHandleClass}>@{profile.handle}</span>
+						{profile.bio ? <ProfilePreviewBio profile={profile} /> : null}
+						<span className={profilePreviewMetaClass}>
+							{formatCompactNumber(profile.followersCount)} followers
+						</span>
 					</span>
 				</span>
-				{profile.bio ? <ProfilePreviewBio profile={profile} /> : null}
-				<span className={profilePreviewMetaClass}>
-					{formatCompactNumber(profile.followersCount)} followers
-				</span>
-			</span>
+			) : null}
 		</span>
 	);
 }

--- a/src/components/TweetRichText.test.tsx
+++ b/src/components/TweetRichText.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { TweetRichText } from "./TweetRichText";
 
@@ -50,11 +50,15 @@ describe("TweetRichText", () => {
 			/>,
 		);
 
-		expect(screen.getAllByText("@amelia")[0]).toBeInTheDocument();
+		const mention = screen.getAllByText("@amelia")[0];
+		expect(mention).toBeInTheDocument();
 		expect(
 			screen.getByRole("link", { name: "example.com/demo" }),
 		).toHaveAttribute("href", "https://example.com/demo");
 		expect(screen.getByText("#birdclaw")).toBeInTheDocument();
+		fireEvent.pointerEnter(
+			mention.closest(".profile-preview-trigger")?.parentElement as Element,
+		);
 		expect(screen.getByText("Design systems")).toBeInTheDocument();
 	});
 

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -311,7 +311,7 @@ export const profilePreviewTriggerClass =
 	"profile-preview-trigger inline-flex text-inherit";
 
 export const profilePreviewCardClass =
-	"pointer-events-none absolute left-0 z-30 grid w-[280px] gap-2 rounded-2xl border border-[var(--line)] bg-[var(--bg-elevated)] p-3 opacity-0 shadow-[0_8px_28px_var(--shadow-strong)] transition-all duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100";
+	"fixed z-40 w-[280px] overflow-y-auto rounded-2xl border border-[var(--line)] bg-[var(--bg-elevated)] p-3 shadow-[0_8px_28px_var(--shadow-strong)]";
 
 export const profilePreviewHeaderClass = "flex items-center gap-3";
 

--- a/src/routes/profiles.$handle.test.tsx
+++ b/src/routes/profiles.$handle.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProfileRouteView } from "./profiles.$handle";
 
@@ -199,13 +205,17 @@ describe("profile route", () => {
 			"href",
 			"/profiles/Qantas",
 		);
-		expect(await screen.findByText("Agent tooling.")).toBeInTheDocument();
-		expect(screen.getByText("Business news.")).toBeInTheDocument();
-		expect(
-			screen.getByText("Massachusetts Institute of Technology."),
-		).toBeInTheDocument();
-		expect(screen.getByText("Technology company.")).toBeInTheDocument();
-		expect(screen.getByText("Airline.")).toBeInTheDocument();
+		for (const [handle, bio] of [
+			["@openclaw", "Agent tooling."],
+			["@forbes", "Business news."],
+			["@MIT", "Massachusetts Institute of Technology."],
+			["@Microsoft", "Technology company."],
+			["@Qantas", "Airline."],
+		] as const) {
+			const link = screen.getByRole("link", { name: handle });
+			fireEvent.pointerEnter(link.parentElement as Element);
+			expect(screen.getByText(bio)).toBeInTheDocument();
+		}
 		expect(
 			await screen.findByText("Peter ships agent tools with practical taste."),
 		).toBeInTheDocument();

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -176,10 +176,8 @@ describe("today route", () => {
 		expect(screen.queryByText(/Action items/i)).toBeNull();
 		expect(screen.queryByText("# Today")).not.toBeInTheDocument();
 		expect(screen.getByText("Reply:")).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "@alice" })).toHaveAttribute(
-			"href",
-			"/profiles/alice",
-		);
+		const aliceLink = screen.getByRole("link", { name: "@alice" });
+		expect(aliceLink).toHaveAttribute("href", "/profiles/alice");
 		expect(screen.getByRole("link", { name: "tweet_1" })).toHaveAttribute(
 			"href",
 			"https://x.com/alice/status/tweet_1",
@@ -188,11 +186,13 @@ describe("today route", () => {
 			screen.getByText("3 home · 2 mentions · 4 links"),
 		).toBeInTheDocument();
 		await waitFor(() =>
-			expect(screen.getAllByText("Alice Fresh").length).toBeGreaterThan(0),
+			expect(urls.some((url) => url.pathname === "/api/profile-hydrate")).toBe(
+				true,
+			),
 		);
-		expect(
-			screen.getAllByRole("img", { name: "Alice Fresh" })[0],
-		).toHaveAttribute(
+		fireEvent.pointerEnter(aliceLink.parentElement as Element);
+		await screen.findByText("Alice Fresh");
+		expect(screen.getByRole("img", { name: "Alice Fresh" })).toHaveAttribute(
 			"src",
 			expect.stringContaining("/api/avatar?profileId=profile_alice&v="),
 		);


### PR DESCRIPTION
## Summary

- Position tweet and profile hover previews against the first or final rendered line of wrapped references.
- Prefer placement below, flip above when needed, and constrain previews to viewport gutters and available height.
- Share pointer, focus, escape, scroll, resize, and layout-shift behavior across both preview types.

## Why

The previous absolutely positioned preview used a fragmented inline wrapper as its containing block. For multi-line citation links, that could anchor the card after an early line and cover the remaining text.

## Validation

- `pnpm test` (1 unrelated timeout; isolated rerun passed)
- `pnpm test src/components/FloatingPreview.test.ts src/components/ProfilePreview.test.tsx src/components/MarkdownViewer.test.tsx src/components/TweetRichText.test.tsx src/routes/today.test.tsx src/routes/profiles.$handle.test.tsx`
- `pnpm typecheck`
- `pnpm check`
- Autoreview clean after addressing offscreen-anchor and layout-shift findings
