### PR TITLE
[codex] expand Twitter Articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Keep tweet and profile hover previews outside wrapped links, flip them to the roomier vertical side, and constrain them to the viewport.
+- Expand Twitter Articles into titled preview cards and citation popovers instead of showing bare `t.co` links.
 
 ## 0.8.1 - 2026-06-13
 

--- a/src/components/ConversationThread.tsx
+++ b/src/components/ConversationThread.tsx
@@ -11,6 +11,7 @@ import { AvatarChip } from "./AvatarChip";
 import { BirdclawEmpty, BirdclawLoading } from "./BrandMark";
 import { ProfilePreview } from "./ProfilePreview";
 import { SmartTimestamp } from "./SmartTimestamp";
+import { TweetArticleCard } from "./TweetArticleCard";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -117,6 +118,9 @@ export function ConversationThread({
 									text={tweet.text}
 								/>
 								<TweetMediaGrid items={tweet.media} />
+								{tweet.entities.article ? (
+									<TweetArticleCard article={tweet.entities.article} />
+								) : null}
 							</div>
 						</div>
 					);

--- a/src/components/EmbeddedTweetCard.tsx
+++ b/src/components/EmbeddedTweetCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "#/lib/ui";
 import { ProfilePreview } from "./ProfilePreview";
 import { SmartTimestamp } from "./SmartTimestamp";
+import { TweetArticleCard } from "./TweetArticleCard";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -46,6 +47,9 @@ export function EmbeddedTweetCard({
 				text={item.text}
 			/>
 			<TweetMediaGrid items={item.media} />
+			{item.entities.article ? (
+				<TweetArticleCard article={item.entities.article} />
+			) : null}
 		</section>
 	);
 }

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -635,4 +635,46 @@ describe("MarkdownViewer", () => {
 		fireEvent.click(link, { metaKey: true });
 		expect(screen.queryByRole("tooltip")).toBeNull();
 	});
+
+	it("expands Twitter Articles inside citation popovers", () => {
+		const articleContext = {
+			...context,
+			tweets: [
+				{
+					...context.tweets[0],
+					id: "2066182223213293753",
+					url: "https://x.com/satyanadella/status/2066182223213293753",
+					author: "satyanadella",
+					name: "Satya Nadella",
+					text: "https://t.co/vLmiBKTtX3",
+					entities: {
+						article: {
+							title: "A frontier without an ecosystem is not stable",
+							previewText: "I have been thinking about the future of the firm.",
+							url: "https://x.com/satyanadella/status/2066182223213293753",
+						},
+					},
+				},
+			],
+		} satisfies PeriodDigestContext;
+		render(
+			<MarkdownViewer
+				context={articleContext}
+				markdown={"Satya published a new essay (2066182223213293753)."}
+			/>,
+		);
+
+		const link = screen.getByRole("link", {
+			name: "Satya published a new essay",
+		});
+		fireEvent.pointerEnter(link.parentElement as Element);
+
+		expect(screen.getByRole("tooltip")).toHaveTextContent(
+			"A frontier without an ecosystem is not stable",
+		);
+		expect(screen.getByRole("tooltip")).toHaveTextContent(
+			"I have been thinking about the future of the firm.",
+		);
+		expect(screen.getByRole("tooltip")).not.toHaveTextContent("t.co");
+	});
 });

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -140,7 +140,16 @@ function TweetPreviewToken({
 }) {
 	const preview = useFloatingPreview();
 
-	const previewText = renderTweetPlainText(tweet.text, tweet.entities ?? {});
+	const article = tweet.entities?.article;
+	const renderedText = renderTweetPlainText(tweet.text, tweet.entities ?? {});
+	const previewText = article
+		? [article.title, article.previewText]
+				.filter(
+					(value, index, values): value is string =>
+						Boolean(value) && values.indexOf(value) === index,
+				)
+				.join("\n\n")
+		: renderedText;
 
 	return (
 		<span

--- a/src/components/TimelineCard.test.tsx
+++ b/src/components/TimelineCard.test.tsx
@@ -727,6 +727,61 @@ describe("TimelineCard", () => {
 		).toBeNull();
 	});
 
+	it("expands Twitter Articles and hides their shortlinks", () => {
+		const { container } = render(
+			<TimelineCard
+				item={{
+					...item,
+					id: "2066182223213293753",
+					text: "A frontier without an ecosystem is not stable",
+					entities: {
+						urls: [
+							{
+								url: "https://t.co/vLmiBKTtX3",
+								expandedUrl: "https://x.com/i/article/2065582894790365184",
+								displayUrl: "x.com/i/article/2065…",
+								start: 0,
+								end: 0,
+							},
+						],
+						article: {
+							title: "A frontier without an ecosystem is not stable",
+							previewText: "I have been thinking about the future of the firm.",
+							url: "https://x.com/satyanadella/status/2066182223213293753",
+						},
+					},
+					media: [],
+					mediaCount: 0,
+					replyToTweet: null,
+					quotedTweet: null,
+				}}
+				onReply={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("link", {
+				name: "Read article: A frontier without an ecosystem is not stable",
+			}),
+		).toHaveAttribute(
+			"href",
+			"https://x.com/satyanadella/status/2066182223213293753",
+		);
+		expect(
+			screen.getByText("I have been thinking about the future of the firm."),
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByText("A frontier without an ecosystem is not stable"),
+		).toHaveLength(1);
+		expect(screen.queryByText(/t\.co\/vLmiBKTtX3/)).toBeNull();
+		expect(
+			container.querySelectorAll("[data-perf='tweet-article-card']"),
+		).toHaveLength(1);
+		expect(
+			container.querySelector("[data-perf='link-preview-card']"),
+		).toBeNull();
+	});
+
 	it("tolerates archived media URL entities without display URLs", () => {
 		render(
 			<TimelineCard

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -9,7 +9,10 @@ import {
 	UserSearch,
 } from "lucide-react";
 import { formatCompactNumber } from "#/lib/present";
-import { normalizeTweetUrlEntityRangeForText } from "#/lib/tweet-render";
+import {
+	isTweetArticleUrlEntity,
+	normalizeTweetUrlEntityRangeForText,
+} from "#/lib/tweet-render";
 import type {
 	TimelineItem,
 	TweetEntities,
@@ -42,6 +45,7 @@ import { EmbeddedTweetCard } from "./EmbeddedTweetCard";
 import { LinkPreviewCard } from "./LinkPreviewCard";
 import { ProfilePreview } from "./ProfilePreview";
 import { SmartTimestamp } from "./SmartTimestamp";
+import { TweetArticleCard } from "./TweetArticleCard";
 import { TweetMediaGrid } from "./TweetMediaGrid";
 import { TweetRichText } from "./TweetRichText";
 
@@ -213,6 +217,9 @@ function getVisibleUrlCards(
 ) {
 	return (entities.urls ?? []).filter((entry) => {
 		if (isUnresolvedShortUrlEntity(entry)) return false;
+		if (entities.article && isTweetArticleUrlEntity(entry, entities.article)) {
+			return false;
+		}
 		if (!quotedTweetId) return true;
 		return !entry.expandedUrl.includes(quotedTweetId);
 	});
@@ -363,6 +370,9 @@ export function TimelineCard({
 							text={displayTweet.text}
 						/>
 						<TweetMediaGrid items={displayTweet.media} />
+						{displayTweet.entities.article ? (
+							<TweetArticleCard article={displayTweet.entities.article} />
+						) : null}
 						{visibleUrlCards.map((entry, index) => (
 							<LinkPreviewCard
 								key={`${entry.expandedUrl}-${String(index)}`}
@@ -380,6 +390,9 @@ export function TimelineCard({
 							text={item.text}
 						/>
 						<TweetMediaGrid items={item.media} />
+						{item.entities.article ? (
+							<TweetArticleCard article={item.entities.article} />
+						) : null}
 						{item.replyToTweet ? (
 							<div className={embeddedCardClass}>
 								<EmbeddedTweetCard

--- a/src/components/TweetArticleCard.tsx
+++ b/src/components/TweetArticleCard.tsx
@@ -1,0 +1,66 @@
+import { BookOpen, ExternalLink } from "lucide-react";
+import type { TweetArticle } from "#/lib/types";
+import {
+	linkPreviewCardClass,
+	linkPreviewDescClass,
+	linkPreviewHostClass,
+	linkPreviewTitleClass,
+} from "#/lib/ui";
+import { safeHttpUrl } from "#/lib/url-safety";
+
+function safeArticleImageUrl(value: string | undefined) {
+	const url = safeHttpUrl(value);
+	if (!url) return null;
+	try {
+		return new URL(url).hostname === "pbs.twimg.com" ? url : null;
+	} catch {
+		return null;
+	}
+}
+
+export function TweetArticleCard({ article }: { article: TweetArticle }) {
+	const href = safeHttpUrl(article.url);
+	if (!href) return null;
+	const imageUrl = safeArticleImageUrl(article.coverImageUrl);
+
+	return (
+		<a
+			aria-label={`Read article: ${article.title}`}
+			className={linkPreviewCardClass}
+			data-perf="tweet-article-card"
+			href={href}
+			rel="noreferrer"
+			target="_blank"
+		>
+			<div className="flex min-w-0 flex-1 flex-col justify-center gap-1 px-3.5 py-3">
+				<div className="flex min-w-0 items-center gap-2">
+					<BookOpen
+						aria-hidden="true"
+						className="size-3.5 shrink-0 text-[var(--ink-soft)]"
+						strokeWidth={1.8}
+					/>
+					<span className={linkPreviewHostClass}>Article on X</span>
+					<ExternalLink
+						aria-hidden="true"
+						className="size-3.5 shrink-0 text-[var(--ink-soft)] opacity-0 transition-opacity group-hover/link-preview:opacity-100"
+						strokeWidth={1.8}
+					/>
+				</div>
+				<span className={linkPreviewTitleClass}>{article.title}</span>
+				{article.previewText ? (
+					<span className={linkPreviewDescClass}>{article.previewText}</span>
+				) : null}
+			</div>
+			{imageUrl ? (
+				<div className="flex aspect-[1.45] w-40 shrink-0 overflow-hidden border-l border-[var(--line)] bg-[var(--bg-soft)] max-[720px]:w-28">
+					<img
+						alt=""
+						className="size-full object-cover transition-transform duration-200 group-hover/link-preview:scale-[1.03]"
+						loading="lazy"
+						src={imageUrl}
+					/>
+				</div>
+			) : null}
+		</a>
+	);
+}

--- a/src/components/TweetRichText.test.tsx
+++ b/src/components/TweetRichText.test.tsx
@@ -96,6 +96,59 @@ describe("TweetRichText", () => {
 		expect(container).not.toHaveTextContent("Read: example.com/demo");
 	});
 
+	it("hides shortlinks when Twitter Article metadata is available", () => {
+		const { container } = render(
+			<TweetRichText
+				entities={{
+					article: {
+						title: "A frontier without an ecosystem is not stable",
+						previewText: "The future of the firm.",
+						url: "https://x.com/satyanadella/status/2066182223213293753",
+					},
+				}}
+				text="https://t.co/vLmiBKTtX3"
+			/>,
+		);
+
+		expect(container.firstElementChild).toBeEmptyDOMElement();
+		expect(within(container).queryByText(/t\.co/)).toBeNull();
+	});
+
+	it("keeps unrelated shortlinks beside a Twitter Article link", () => {
+		const text =
+			"A frontier without an ecosystem is not stable https://t.co/article https://t.co/other";
+		render(
+			<TweetRichText
+				entities={{
+					urls: [
+						{
+							url: "https://t.co/article",
+							expandedUrl: "https://x.com/i/article/2065582894790365184",
+							displayUrl: "x.com/i/article/2065…",
+							...codePointRange(text, "https://t.co/article"),
+						},
+						{
+							url: "https://t.co/other",
+							expandedUrl: "https://example.com/other",
+							displayUrl: "example.com/other",
+							...codePointRange(text, "https://t.co/other"),
+						},
+					],
+					article: {
+						title: "A frontier without an ecosystem is not stable",
+						url: "https://x.com/satyanadella/status/2066182223213293753",
+					},
+				}}
+				text={text}
+			/>,
+		);
+
+		expect(screen.queryByText("x.com/i/article/2065…")).toBeNull();
+		expect(
+			screen.getByRole("link", { name: "example.com/other" }),
+		).toHaveAttribute("href", "https://example.com/other");
+	});
+
 	it("links mention entities even without hydrated profile previews", () => {
 		render(
 			<TweetRichText

--- a/src/components/TweetRichText.tsx
+++ b/src/components/TweetRichText.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import {
 	collectTweetSegmentsForText,
 	enrichFallbackUrlEntities,
+	isTweetArticleUrlEntity,
 	normalizeTweetUrlEntityRangeForText,
 } from "#/lib/tweet-render";
 import type { TweetEntities } from "#/lib/types";
@@ -17,6 +18,14 @@ import { ProfilePreview } from "./ProfilePreview";
 
 function rangeKey(range: { start: number; end: number }) {
 	return `${range.start}:${range.end}`;
+}
+
+function isShortUrl(value: string) {
+	try {
+		return new URL(value).hostname.replace(/^www\./, "") === "t.co";
+	} catch {
+		return false;
+	}
 }
 
 export function TweetRichText({
@@ -37,6 +46,25 @@ export function TweetRichText({
 	const richEntities = enrichFallbackUrlEntities(text, entities);
 	const segments = collectTweetSegmentsForText(text, richEntities);
 	const hiddenRawRangeKeys = new Set(hiddenUrlRanges.map(rangeKey));
+	const article = entities.article;
+	if (article) {
+		const urlEntries = richEntities.urls ?? [];
+		const articleUrlEntries = urlEntries.filter((entry) =>
+			isTweetArticleUrlEntity(entry, article),
+		);
+		const onlyUrlEntry = urlEntries[0];
+		if (
+			articleUrlEntries.length === 0 &&
+			urlEntries.length === 1 &&
+			onlyUrlEntry &&
+			(isShortUrl(onlyUrlEntry.url) || isShortUrl(onlyUrlEntry.expandedUrl))
+		) {
+			articleUrlEntries.push(onlyUrlEntry);
+		}
+		for (const entry of articleUrlEntries) {
+			hiddenRawRangeKeys.add(rangeKey(entry));
+		}
+	}
 	const hiddenRangeKeys = new Set(hiddenRawRangeKeys);
 	for (const entry of richEntities.urls ?? []) {
 		if (!hiddenRawRangeKeys.has(rangeKey(entry))) continue;
@@ -46,10 +74,13 @@ export function TweetRichText({
 	}
 	const Wrapper = as;
 	let cursor = 0;
+	const hideArticleTitle =
+		entities.article && text.trim() === entities.article.title.trim();
+	const visibleSegments = hideArticleTitle ? [] : segments;
 
 	return (
 		<Wrapper className={className === "body-copy" ? bodyCopyClass : className}>
-			{segments.map((segment, index) => {
+			{visibleSegments.map((segment, index) => {
 				if (
 					segment.start < cursor ||
 					segment.end <= segment.start ||
@@ -122,7 +153,7 @@ export function TweetRichText({
 					</Fragment>
 				);
 			})}
-			{text.slice(cursor)}
+			{hideArticleTitle ? null : text.slice(cursor)}
 		</Wrapper>
 	);
 }

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { getNativeDb } from "./db";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	TweetEntities,
 	TweetMediaItem,
@@ -523,68 +524,7 @@ function toMentionData(tweet: XurlUserTweet, fallbackAuthorId: string) {
 }
 
 function toLocalEntities(tweet: XurlMentionData): TweetEntities {
-	const raw = tweet.entities;
-	if (!raw || typeof raw !== "object") {
-		return {};
-	}
-
-	const entities = raw as Record<string, unknown>;
-	const rawMentions = Array.isArray(entities.mentions) ? entities.mentions : [];
-	const rawUrls = Array.isArray(entities.urls) ? entities.urls : [];
-	const rawHashtags = Array.isArray(entities.hashtags) ? entities.hashtags : [];
-
-	return {
-		...(rawMentions.length
-			? {
-					mentions: rawMentions.map((mention) => {
-						const value =
-							mention && typeof mention === "object"
-								? (mention as Record<string, unknown>)
-								: {};
-						return {
-							username: String(value.username ?? ""),
-							id: typeof value.id === "string" ? String(value.id) : undefined,
-							start: Number(value.start ?? 0),
-							end: Number(value.end ?? 0),
-						};
-					}),
-				}
-			: {}),
-		...(rawUrls.length
-			? {
-					urls: rawUrls.map((url) => {
-						const value =
-							url && typeof url === "object"
-								? (url as Record<string, unknown>)
-								: {};
-						return {
-							url: String(value.url ?? ""),
-							expandedUrl: String(value.expanded_url ?? value.url ?? ""),
-							displayUrl: String(
-								value.display_url ?? value.expanded_url ?? value.url ?? "",
-							),
-							start: Number(value.start ?? 0),
-							end: Number(value.end ?? 0),
-						};
-					}),
-				}
-			: {}),
-		...(rawHashtags.length
-			? {
-					hashtags: rawHashtags.map((hashtag) => {
-						const value =
-							hashtag && typeof hashtag === "object"
-								? (hashtag as Record<string, unknown>)
-								: {};
-						return {
-							tag: String(value.tag ?? ""),
-							start: Number(value.start ?? 0),
-							end: Number(value.end ?? 0),
-						};
-					}),
-				}
-			: {}),
-	};
+	return tweetEntitiesFromXurl(tweet.entities);
 }
 
 function toMediaType(type: string): TweetMediaItem["type"] {

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -956,6 +956,10 @@ describe("bird transport wrapper", () => {
 					authorId: "42",
 					author: { username: "sam" },
 					media: [{ url: "https://img.example/a.jpg" }],
+					article: {
+						title: "A frontier without an ecosystem is not stable",
+						previewText: "I have been thinking about the future of the firm.",
+					},
 					inReplyToStatusId: "",
 				},
 				{
@@ -972,6 +976,12 @@ describe("bird transport wrapper", () => {
 						created_at: "not-a-date",
 						conversation_id: "1",
 						entities: expect.objectContaining({
+							article: {
+								title: "A frontier without an ecosystem is not stable",
+								previewText:
+									"I have been thinking about the future of the firm.",
+								url: "https://x.com/sam/status/1",
+							},
 							urls: [
 								expect.objectContaining({ url: "https://img.example/a.jpg" }),
 							],

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -29,6 +29,12 @@ interface BirdTweetAuthor {
 	name?: string;
 }
 
+interface BirdTweetArticle {
+	title?: string;
+	previewText?: string;
+	coverImageUrl?: string;
+}
+
 interface BirdTweetItem {
 	id: string;
 	text: string;
@@ -45,6 +51,7 @@ interface BirdTweetItem {
 	author?: BirdTweetAuthor;
 	authorId?: string;
 	media?: BirdTweetMedia[];
+	article?: BirdTweetArticle | null;
 }
 
 export interface BirdDmUser {
@@ -385,6 +392,29 @@ function toMediaEntities(media: BirdTweetMedia[] | undefined) {
 	};
 }
 
+function toTweetEntities(item: BirdTweetItem) {
+	const mediaEntities = toMediaEntities(item.media);
+	const title = item.article?.title?.trim();
+	if (!title) return mediaEntities;
+	const handle = item.author?.username?.replace(/^@/, "");
+	const url = handle
+		? `https://x.com/${handle}/status/${item.id}`
+		: `https://x.com/i/status/${item.id}`;
+	return {
+		...mediaEntities,
+		article: {
+			title,
+			url,
+			...(item.article?.previewText?.trim()
+				? { previewText: item.article.previewText.trim() }
+				: {}),
+			...(item.article?.coverImageUrl?.trim()
+				? { coverImageUrl: item.article.coverImageUrl.trim() }
+				: {}),
+		},
+	};
+}
+
 function toReferencedTweets(item: BirdTweetItem) {
 	const references: XurlReferencedTweet[] = [];
 	if (typeof item.inReplyToStatusId === "string" && item.inReplyToStatusId) {
@@ -434,7 +464,7 @@ function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
 			text: item.text,
 			created_at: toIsoTimestamp(item.createdAt),
 			conversation_id: item.conversationId ?? item.id,
-			entities: toMediaEntities(item.media),
+			entities: toTweetEntities(item),
 			referenced_tweets: toReferencedTweets(item),
 			public_metrics: {
 				reply_count: Number(item.replyCount ?? 0),
@@ -1104,6 +1134,7 @@ export const __test__ = {
 	getBirdTweetItems,
 	getBirdTweetItem,
 	toMediaEntities,
+	toTweetEntities,
 	toReferencedTweets,
 	normalizeBirdTweets,
 };

--- a/src/lib/mention-threads-live.ts
+++ b/src/lib/mention-threads-live.ts
@@ -4,6 +4,7 @@ import { listThreadViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	XurlMentionData,
 	XurlMentionsResponse,
@@ -415,7 +416,7 @@ function mergeMentionThreadIntoLocalStore({
 				replyToId ?? null,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				countTweetMedia(tweet),
-				JSON.stringify(tweet.entities ?? {}),
+				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 			);
 			if (writeThreadContextEdges) {

--- a/src/lib/mentions-live.ts
+++ b/src/lib/mentions-live.ts
@@ -11,6 +11,7 @@ import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { serializeMentionItemsAsXurlCompatible } from "./mentions-export";
 import { listTimelineItems } from "./queries";
 import { deleteSyncCache, readSyncCache, writeSyncCache } from "./sync-cache";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	ReplyFilter,
 	TweetEntities,
@@ -521,52 +522,7 @@ function findNewestArchiveMentionId(db: Database, accountId: string) {
 }
 
 function toLocalEntities(tweet: XurlMentionData): TweetEntities {
-	const raw = tweet.entities;
-	if (!raw || typeof raw !== "object") {
-		return {};
-	}
-
-	const entities = raw as Record<string, unknown>;
-	const rawMentions = Array.isArray(entities.mentions) ? entities.mentions : [];
-	const rawUrls = Array.isArray(entities.urls) ? entities.urls : [];
-
-	return {
-		...(rawMentions.length
-			? {
-					mentions: rawMentions.map((mention) => {
-						const value =
-							mention && typeof mention === "object"
-								? (mention as Record<string, unknown>)
-								: {};
-						return {
-							username: String(value.username ?? ""),
-							id: typeof value.id === "string" ? String(value.id) : undefined,
-							start: Number(value.start ?? 0),
-							end: Number(value.end ?? 0),
-						};
-					}),
-				}
-			: {}),
-		...(rawUrls.length
-			? {
-					urls: rawUrls.map((url) => {
-						const value =
-							url && typeof url === "object"
-								? (url as Record<string, unknown>)
-								: {};
-						return {
-							url: String(value.url ?? ""),
-							expandedUrl: String(value.expanded_url ?? value.url ?? ""),
-							displayUrl: String(
-								value.display_url ?? value.expanded_url ?? value.url ?? "",
-							),
-							start: Number(value.start ?? 0),
-							end: Number(value.end ?? 0),
-						};
-					}),
-				}
-			: {}),
-	};
+	return tweetEntitiesFromXurl(tweet.entities);
 }
 
 function replaceTweetFts(db: Database, tweetId: string, text: string) {

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -407,7 +407,7 @@ function mergeXurlTweetsIntoLocalStore(
 				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				countTweetMedia(tweet),
-				JSON.stringify(tweet.entities ?? {}),
+				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 				quotedTweetId,
 			);

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -8,6 +8,7 @@ import { getNativeDb } from "./db";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	XurlMentionData,
 	XurlMentionsResponse,
@@ -310,7 +311,7 @@ function mergeTimelineCollectionIntoLocalStore(
 				countTweetMedia(tweet),
 				bookmarked,
 				liked,
-				JSON.stringify(tweet.entities ?? {}),
+				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 				quotedTweetId,
 			);

--- a/src/lib/timeline-live.test.ts
+++ b/src/lib/timeline-live.test.ts
@@ -206,6 +206,64 @@ describe("live home timeline sync", () => {
 		expect(row.media_json).toBe(existingMediaJson);
 	});
 
+	it("persists Twitter Article metadata for timeline cards and popovers", async () => {
+		makeTempHome();
+		listHomeTimelineViaBirdMock.mockResolvedValueOnce({
+			data: [
+				{
+					id: "2066182223213293753",
+					author_id: "20571756",
+					text: "A frontier without an ecosystem is not stable",
+					created_at: "2026-06-14T15:33:24.000Z",
+					entities: {
+						article: {
+							title: "A frontier without an ecosystem is not stable",
+							previewText: "I have been thinking about the future of the firm.",
+							url: "https://x.com/satyanadella/status/2066182223213293753",
+						},
+					},
+				},
+			],
+			includes: {
+				users: [
+					{
+						id: "20571756",
+						username: "satyanadella",
+						name: "Satya Nadella",
+					},
+				],
+			},
+			meta: { result_count: 1 },
+		});
+		const { syncHomeTimeline } = await import("./timeline-live");
+
+		await syncHomeTimeline({
+			account: "acct_primary",
+			limit: 5,
+			refresh: true,
+		});
+
+		expect(
+			listTimelineItems({
+				resource: "home",
+				account: "acct_primary",
+				search: "frontier",
+				limit: 5,
+			}),
+		).toEqual([
+			expect.objectContaining({
+				id: "2066182223213293753",
+				entities: expect.objectContaining({
+					article: {
+						title: "A frontier without an ecosystem is not stable",
+						previewText: "I have been thinking about the future of the firm.",
+						url: "https://x.com/satyanadella/status/2066182223213293753",
+					},
+				}),
+			}),
+		]);
+	});
+
 	it("fetches paginated xurl home timeline and stores reply context", async () => {
 		makeTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-live.ts
+++ b/src/lib/timeline-live.ts
@@ -5,6 +5,7 @@ import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	XurlMediaItem,
 	XurlMentionUser,
@@ -244,7 +245,7 @@ function mergeHomeTimelineIntoLocalStore(
 				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				countTweetMedia(tweet),
-				JSON.stringify(tweet.entities ?? {}),
+				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 				quotedTweetId,
 			);

--- a/src/lib/tweet-render.test.ts
+++ b/src/lib/tweet-render.test.ts
@@ -56,6 +56,24 @@ describe("tweet render helpers", () => {
 		);
 	});
 
+	it("normalizes Twitter Article metadata", () => {
+		expect(
+			tweetEntitiesFromXurl({
+				article: {
+					title: "A frontier without an ecosystem is not stable",
+					preview_text: "I have been thinking about the future of the firm.",
+					url: "https://x.com/satyanadella/status/2066182223213293753",
+				},
+			}),
+		).toEqual({
+			article: {
+				title: "A frontier without an ecosystem is not stable",
+				previewText: "I have been thinking about the future of the firm.",
+				url: "https://x.com/satyanadella/status/2066182223213293753",
+			},
+		});
+	});
+
 	it("normalizes X API profile description url entities", () => {
 		const entities = profileDescriptionEntitiesFromXurl({
 			description: {

--- a/src/lib/tweet-render.ts
+++ b/src/lib/tweet-render.ts
@@ -1,4 +1,5 @@
 import type {
+	TweetArticle,
 	TweetEntities,
 	TweetHashtagEntity,
 	TweetMentionEntity,
@@ -57,6 +58,34 @@ export function displayUrlForLink(url: string) {
 	}
 }
 
+function comparableUrl(value: string) {
+	try {
+		const parsed = new URL(value);
+		return `${parsed.protocol}//${parsed.hostname.replace(/^www\./, "")}${parsed.pathname}`;
+	} catch {
+		return value.split("?")[0] ?? value;
+	}
+}
+
+export function isTweetArticleUrlEntity(
+	entry: TweetUrlEntity,
+	article: TweetArticle,
+) {
+	if (comparableUrl(entry.expandedUrl) === comparableUrl(article.url)) {
+		return true;
+	}
+	try {
+		const parsed = new URL(entry.expandedUrl);
+		const host = parsed.hostname.replace(/^www\./, "");
+		return (
+			(host === "x.com" || host === "twitter.com") &&
+			parsed.pathname.startsWith("/i/article/")
+		);
+	} catch {
+		return false;
+	}
+}
+
 function asRecord(value: unknown) {
 	return value && typeof value === "object"
 		? (value as Record<string, unknown>)
@@ -68,6 +97,9 @@ export function tweetEntitiesFromXurl(raw: unknown): TweetEntities {
 	const rawMentions = Array.isArray(entities.mentions) ? entities.mentions : [];
 	const rawUrls = Array.isArray(entities.urls) ? entities.urls : [];
 	const rawHashtags = Array.isArray(entities.hashtags) ? entities.hashtags : [];
+	const rawArticle = asRecord(entities.article);
+	const articleTitle = String(rawArticle.title ?? "").trim();
+	const articleUrl = String(rawArticle.url ?? "").trim();
 
 	return {
 		...(rawMentions.length
@@ -102,6 +134,23 @@ export function tweetEntitiesFromXurl(raw: unknown): TweetEntities {
 							),
 							start: Number(value.start ?? 0),
 							end: Number(value.end ?? 0),
+							...(typeof value.title === "string"
+								? { title: value.title }
+								: {}),
+							...(typeof value.description === "string" ||
+							value.description === null
+								? { description: value.description }
+								: {}),
+							...(typeof value.imageUrl === "string"
+								? { imageUrl: value.imageUrl }
+								: typeof value.image_url === "string"
+									? { imageUrl: value.image_url }
+									: {}),
+							...(typeof value.siteName === "string"
+								? { siteName: value.siteName }
+								: typeof value.site_name === "string"
+									? { siteName: value.site_name }
+									: {}),
 						};
 					}),
 				}
@@ -116,6 +165,35 @@ export function tweetEntitiesFromXurl(raw: unknown): TweetEntities {
 							end: Number(value.end ?? 0),
 						};
 					}),
+				}
+			: {}),
+		...(articleTitle && articleUrl
+			? {
+					article: {
+						title: articleTitle,
+						url: articleUrl,
+						...(typeof (rawArticle.previewText ?? rawArticle.preview_text) ===
+							"string" &&
+						String(rawArticle.previewText ?? rawArticle.preview_text).trim()
+							? {
+									previewText: String(
+										rawArticle.previewText ?? rawArticle.preview_text,
+									).trim(),
+								}
+							: {}),
+						...(typeof (
+							rawArticle.coverImageUrl ?? rawArticle.cover_image_url
+						) === "string" &&
+						String(
+							rawArticle.coverImageUrl ?? rawArticle.cover_image_url,
+						).trim()
+							? {
+									coverImageUrl: String(
+										rawArticle.coverImageUrl ?? rawArticle.cover_image_url,
+									).trim(),
+								}
+							: {}),
+					},
 				}
 			: {}),
 	};

--- a/src/lib/tweet-search-live.ts
+++ b/src/lib/tweet-search-live.ts
@@ -5,6 +5,7 @@ import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { tweetEntitiesFromXurl } from "./tweet-render";
 import type { XurlMentionsResponse, XurlTweetsResponse } from "./types";
 import { upsertTweetAccountEdge } from "./tweet-account-edges";
 import { ensureStubProfileForXUser, upsertProfileFromXUser } from "./x-profile";
@@ -190,7 +191,7 @@ function mergeTweetSearchIntoLocalStore(
 				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				countTweetMedia(tweet),
-				JSON.stringify(tweet.entities ?? {}),
+				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 				quotedTweetId,
 			);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,10 +101,18 @@ export interface TweetHashtagEntity {
 	end: number;
 }
 
+export interface TweetArticle {
+	title: string;
+	previewText?: string;
+	url: string;
+	coverImageUrl?: string;
+}
+
 export interface TweetEntities {
 	mentions?: TweetMentionEntity[];
 	urls?: TweetUrlEntity[];
 	hashtags?: TweetHashtagEntity[];
+	article?: TweetArticle;
 }
 
 export interface TweetMediaItem {


### PR DESCRIPTION
## Summary

- preserve Twitter Article metadata from live sync through persisted tweet entities
- expand Articles into title/preview cards in timelines, embedded tweets, threads, and citation popovers
- hide Article shortlinks while preserving unrelated links and preventing duplicate previews

## Verification

- `pnpm test` (115 files, 1,072 tests)
- `pnpm check`
- `pnpm build`
- autoreview: clean, no actionable findings
