### PR TITLE
perf: retain sidebar data across navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Retain timeline and DM data across sidebar navigation, deduplicate status reads, debounce searches, skip unused Spotlight archive scans in web status, and remove TanStack debug controls.
 - Keep tweet and profile hover previews outside wrapped links, flip them to the roomier vertical side, and constrain them to the viewport.
 - Expand Twitter Articles into titled preview cards and citation popovers instead of showing bare `t.co` links.
 

--- a/package.json
+++ b/package.json
@@ -54,10 +54,7 @@
 	"dependencies": {
 		"@steipete/sweet-cookie": "^0.4.0",
 		"@tailwindcss/vite": "^4.3.0",
-		"@tanstack/devtools-vite": "0.7.0",
-		"@tanstack/react-devtools": "0.10.5",
 		"@tanstack/react-router": "1.170.15",
-		"@tanstack/react-router-devtools": "1.167.0",
 		"@tanstack/react-router-ssr-query": "1.167.1",
 		"@tanstack/react-start": "1.168.25",
 		"@tanstack/router-plugin": "^1.168.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,18 +14,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
-      '@tanstack/devtools-vite':
-        specifier: 0.7.0
-        version: 0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
-      '@tanstack/react-devtools':
-        specifier: 0.10.5
-        version: 0.10.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)
       '@tanstack/react-router':
         specifier: 1.170.15
         version: 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-router-devtools':
-        specifier: 1.167.0
-        version: 1.167.0(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-router-ssr-query':
         specifier: 1.167.1
         version: 1.167.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -504,136 +495,6 @@ packages:
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
 
-  '@oxc-parser/binding-android-arm-eabi@0.120.0':
-    resolution: {integrity: sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.120.0':
-    resolution: {integrity: sha512-SEf80EHdhlbjZEgzeWm0ZA/br4GKMenDW3QB/gtyeTV1gStvvZeFi40ioHDZvds2m4Z9J1bUAUL8yn1/+A6iGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.120.0':
-    resolution: {integrity: sha512-xVrrbCai8R8CUIBu3CjryutQnEYhZqs1maIqDvtUCFZb8vY33H7uh9mHpL3a0JBIKoBUKjPH8+rzyAeXnS2d6A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.120.0':
-    resolution: {integrity: sha512-xyHBbnJ6mydnQUH7MAcafOkkrNzQC6T+LXgDH/3InEq2BWl/g424IMRiJVSpVqGjB+p2bd0h0WRR8iIwzjU7rw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.120.0':
-    resolution: {integrity: sha512-UMnVRllquXUYTeNfFKmxTTEdZ/ix1nLl0ducDzMSREoWYGVIHnOOxoKMWlCOvRr9Wk/HZqo2rh1jeumbPGPV9A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.120.0':
-    resolution: {integrity: sha512-tkvn2CQ7QdcsMnpfiX3fd3wA3EFsWKYlcQzq9cFw/xc89Al7W6Y4O0FgLVkVQpo0Tnq/qtE1XfkJOnRRA9S/NA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.120.0':
-    resolution: {integrity: sha512-WN5y135Ic42gQDk9grbwY9++fDhqf8knN6fnP+0WALlAUh4odY/BDK1nfTJRSfpJD9P3r1BwU0m3pW2DU89whQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.120.0':
-    resolution: {integrity: sha512-1GgQBCcXvFMw99EPdMy+4NZ3aYyXsxjf9kbUUg8HuAy3ZBXzOry5KfFEzT9nqmgZI1cuetvApkiJBZLAPo8uaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.120.0':
-    resolution: {integrity: sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.120.0':
-    resolution: {integrity: sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.120.0':
-    resolution: {integrity: sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.120.0':
-    resolution: {integrity: sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.120.0':
-    resolution: {integrity: sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.120.0':
-    resolution: {integrity: sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-musl@0.120.0':
-    resolution: {integrity: sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-openharmony-arm64@0.120.0':
-    resolution: {integrity: sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.120.0':
-    resolution: {integrity: sha512-WG/FOZgDJCpJnuF3ToG/K28rcOmSY7FmFmfBKYb2fmLyhDzPpUldFGV7/Fz4ru0Iz/v4KPmf8xVgO8N3lO4KHA==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.120.0':
-    resolution: {integrity: sha512-1T0HKGcsz/BKo77t7+89L8Qvu4f9DoleKWHp3C5sJEcbCjDOLx3m9m722bWZTY+hANlUEs+yjlK+lBFsA+vrVQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.120.0':
-    resolution: {integrity: sha512-L7vfLzbOXsjBXV0rv/6Y3Jd9BRjPeCivINZAqrSyAOZN3moCopDN+Psq9ZrGNZtJzP8946MtlRFZ0Als0wBCOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.120.0':
-    resolution: {integrity: sha512-ys+upfqNtSu58huAhJMBKl3XCkGzyVFBlMlGPzHeFKgpFF/OdgNs1MMf8oaJIbgMH8ZxgGF7qfue39eJohmKIg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-project/types@0.120.0':
-    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
-
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -984,36 +845,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@solid-primitives/event-listener@2.4.5':
-    resolution: {integrity: sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/keyboard@1.3.5':
-    resolution: {integrity: sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/resize-observer@2.1.5':
-    resolution: {integrity: sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/rootless@1.5.3':
-    resolution: {integrity: sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/static-store@0.1.3':
-    resolution: {integrity: sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/utils@6.4.0':
-    resolution: {integrity: sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1121,39 +952,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/devtools-client@0.0.6':
-    resolution: {integrity: sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ==}
-    engines: {node: '>=18'}
-
-  '@tanstack/devtools-event-bus@0.4.1':
-    resolution: {integrity: sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA==}
-    engines: {node: '>=18'}
-
-  '@tanstack/devtools-event-client@0.4.3':
-    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@tanstack/devtools-ui@0.5.2':
-    resolution: {integrity: sha512-GtaMk8kaGZ9ZdR8Pu5RAfcse/ZrxzH/xsAIFtHMapLs2VMqSPFfb1NvIDO1MAAfUcub8Ix8XKQEP0uYSPzoFKw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      solid-js: '>=1.9.7'
-
-  '@tanstack/devtools-vite@0.7.0':
-    resolution: {integrity: sha512-VXki7K+Xwnpo3IKdNSWGe7YOvtZv33YlulGqaQ+YCpeQhYg8JFuxP50BXibDoRLj5EOX4r21Hs7COdxbRHXkTw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  '@tanstack/devtools@0.12.2':
-    resolution: {integrity: sha512-Xdl8pLzoDUvXaclQ0poY36WAPx0jEHk8vqUFd8FYFUm1BMshtB7RnTgD1HE9jCAXODxqw9I0gXBiUZLK3o3+Bw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      solid-js: '>=1.9.7'
-
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
@@ -1161,31 +959,10 @@ packages:
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
-  '@tanstack/react-devtools@0.10.5':
-    resolution: {integrity: sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      '@types/react-dom': '>=16.8'
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   '@tanstack/react-query@5.90.21':
     resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^18 || ^19
-
-  '@tanstack/react-router-devtools@1.167.0':
-    resolution: {integrity: sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/react-router': ^1.170.0
-      '@tanstack/router-core': ^1.170.0
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-    peerDependenciesMeta:
-      '@tanstack/router-core':
-        optional: true
 
   '@tanstack/react-router-ssr-query@1.167.1':
     resolution: {integrity: sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==}
@@ -1261,16 +1038,6 @@ packages:
   '@tanstack/router-core@1.171.13':
     resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
     engines: {node: '>=20.19'}
-
-  '@tanstack/router-devtools-core@1.168.0':
-    resolution: {integrity: sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/router-core': ^1.170.0
-      csstype: ^3.0.10
-    peerDependenciesMeta:
-      csstype:
-        optional: true
 
   '@tanstack/router-generator@1.167.17':
     resolution: {integrity: sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA==}
@@ -1589,20 +1356,12 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   cheap-ruler@4.0.0:
     resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
@@ -1635,9 +1394,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1756,11 +1512,6 @@ packages:
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
-  goober@2.1.19:
-    resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
-    peerDependencies:
-      csstype: ^3.0.10
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1866,9 +1617,6 @@ packages:
   kysely@0.29.2:
     resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
     engines: {node: '>=22.0.0'}
-
-  launch-editor@2.14.1:
-    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2004,10 +1752,6 @@ packages:
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
-
-  oxc-parser@0.120.0:
-    resolution: {integrity: sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.54.0:
     resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
@@ -2179,15 +1923,8 @@ packages:
     resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
     engines: {node: '>=0.10.0'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
-    engines: {node: '>= 0.4'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  solid-js@1.9.11:
-    resolution: {integrity: sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==}
 
   sort-asc@0.2.0:
     resolution: {integrity: sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==}
@@ -2451,18 +2188,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2807,73 +2532,6 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
-  '@oxc-parser/binding-android-arm-eabi@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-android-arm64@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.120.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.120.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.120.0':
-    optional: true
-
-  '@oxc-project/types@0.120.0': {}
-
   '@oxc-project/types@0.133.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
@@ -3045,40 +2703,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
-      solid-js: 1.9.11
-
-  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.11)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.11)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
-      solid-js: 1.9.11
-
-  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.11)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.11)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.11)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
-      solid-js: 1.9.11
-
-  '@solid-primitives/rootless@1.5.3(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
-      solid-js: 1.9.11
-
-  '@solid-primitives/static-store@0.1.3(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
-      solid-js: 1.9.11
-
-  '@solid-primitives/utils@6.4.0(solid-js@1.9.11)':
-    dependencies:
-      solid-js: 1.9.11
-
   '@standard-schema/spec@1.1.0': {}
 
   '@steipete/sweet-cookie@0.4.0': {}
@@ -3156,92 +2780,14 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
 
-  '@tanstack/devtools-client@0.0.6':
-    dependencies:
-      '@tanstack/devtools-event-client': 0.4.3
-
-  '@tanstack/devtools-event-bus@0.4.1':
-    dependencies:
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@tanstack/devtools-event-client@0.4.3': {}
-
-  '@tanstack/devtools-ui@0.5.2(csstype@3.2.3)(solid-js@1.9.11)':
-    dependencies:
-      clsx: 2.1.1
-      dayjs: 1.11.21
-      goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.11
-    transitivePeerDependencies:
-      - csstype
-
-  '@tanstack/devtools-vite@0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))':
-    dependencies:
-      '@tanstack/devtools-client': 0.0.6
-      '@tanstack/devtools-event-bus': 0.4.1
-      chalk: 5.6.2
-      launch-editor: 2.14.1
-      magic-string: 0.30.21
-      oxc-parser: 0.120.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      picomatch: 4.0.4
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - bufferutil
-      - utf-8-validate
-
-  '@tanstack/devtools@0.12.2(csstype@3.2.3)(solid-js@1.9.11)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.11)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.11)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.11)
-      '@tanstack/devtools-client': 0.0.6
-      '@tanstack/devtools-event-bus': 0.4.1
-      '@tanstack/devtools-ui': 0.5.2(csstype@3.2.3)(solid-js@1.9.11)
-      clsx: 2.1.1
-      goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.11
-    transitivePeerDependencies:
-      - bufferutil
-      - csstype
-      - utf-8-validate
-
   '@tanstack/history@1.162.0': {}
 
   '@tanstack/query-core@5.90.20': {}
-
-  '@tanstack/react-devtools@0.10.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)':
-    dependencies:
-      '@tanstack/devtools': 0.12.2(csstype@3.2.3)(solid-js@1.9.11)
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    transitivePeerDependencies:
-      - bufferutil
-      - csstype
-      - solid-js
-      - utf-8-validate
 
   '@tanstack/react-query@5.90.21(react@19.2.7)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.7
-
-  '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/router-devtools-core': 1.168.0(@tanstack/router-core@1.171.13)(csstype@3.2.3)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@tanstack/router-core': 1.171.13
-    transitivePeerDependencies:
-      - csstype
 
   '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -3338,14 +2884,6 @@ snapshots:
       cookie-es: 3.1.1
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
-
-  '@tanstack/router-devtools-core@1.168.0(@tanstack/router-core@1.171.13)(csstype@3.2.3)':
-    dependencies:
-      '@tanstack/router-core': 1.171.13
-      clsx: 2.1.1
-      goober: 2.1.19(csstype@3.2.3)
-    optionalDependencies:
-      csstype: 3.2.3
 
   '@tanstack/router-generator@1.167.17':
     dependencies:
@@ -3691,15 +3229,11 @@ snapshots:
 
   chai@6.2.2: {}
 
-  chalk@5.6.2: {}
-
   cheap-ruler@4.0.0: {}
 
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
-
-  clsx@2.1.1: {}
 
   commander@15.0.0: {}
 
@@ -3726,8 +3260,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -3835,10 +3367,6 @@ snapshots:
 
   gl-matrix@3.4.4: {}
 
-  goober@2.1.19(csstype@3.2.3):
-    dependencies:
-      csstype: 3.2.3
-
   graceful-fs@4.2.11: {}
 
   h3@2.0.1-rc.20:
@@ -3932,11 +3460,6 @@ snapshots:
   kdbush@4.1.0: {}
 
   kysely@0.29.2: {}
-
-  launch-editor@2.14.1:
-    dependencies:
-      picocolors: 1.1.1
-      shell-quote: 1.8.4
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4059,34 +3582,6 @@ snapshots:
   node-releases@2.0.47: {}
 
   obug@2.1.2: {}
-
-  oxc-parser@0.120.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@oxc-project/types': 0.120.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.120.0
-      '@oxc-parser/binding-android-arm64': 0.120.0
-      '@oxc-parser/binding-darwin-arm64': 0.120.0
-      '@oxc-parser/binding-darwin-x64': 0.120.0
-      '@oxc-parser/binding-freebsd-x64': 0.120.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.120.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.120.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.120.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.120.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.120.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.120.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.120.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.120.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.120.0
-      '@oxc-parser/binding-linux-x64-musl': 0.120.0
-      '@oxc-parser/binding-openharmony-arm64': 0.120.0
-      '@oxc-parser/binding-wasm32-wasi': 0.120.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-parser/binding-win32-arm64-msvc': 0.120.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.120.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.120.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   oxfmt@0.54.0:
     dependencies:
@@ -4266,15 +3761,7 @@ snapshots:
       is-plain-object: 2.0.4
       split-string: 3.1.0
 
-  shell-quote@1.8.4: {}
-
   siginfo@2.0.0: {}
-
-  solid-js@1.9.11:
-    dependencies:
-      csstype: 3.2.3
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   sort-asc@0.2.0: {}
 
@@ -4469,8 +3956,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/scripts/browser-perf.mjs
+++ b/scripts/browser-perf.mjs
@@ -18,6 +18,33 @@ const SCENARIOS = {
 		path: "/mentions",
 		ready: async (page) => waitForAny(page, ['[data-perf="timeline-card"]']),
 	},
+	"sidebar-roundtrip": {
+		path: "/",
+		ready: async (page) => waitForAny(page, ['[data-perf="timeline-card"]']),
+		action: async (page) => {
+			await page.getByRole("link", { name: "Mentions" }).click();
+			await page.waitForURL("**/mentions");
+			await waitForAny(page, ['[data-perf="timeline-card"]']);
+			const queryCallsBeforeReturn = await page.evaluate(
+				() =>
+					performance
+						.getEntriesByType("resource")
+						.filter((entry) => entry.name.includes("/api/query")).length,
+			);
+			await page.getByRole("link", { name: "Home" }).click();
+			await page.waitForURL((url) => url.pathname === "/");
+			await waitForAny(page, ['[data-perf="timeline-card"]']);
+			const queryCallsAfterReturn = await page.evaluate(
+				() =>
+					performance
+						.getEntriesByType("resource")
+						.filter((entry) => entry.name.includes("/api/query")).length,
+			);
+			if (queryCallsAfterReturn !== queryCallsBeforeReturn) {
+				throw new Error("Returning Home issued a new query request");
+			}
+		},
+	},
 	"mentions-search": {
 		path: "/mentions",
 		ready: async (page) => {

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -284,7 +284,10 @@ export function TimelineCard({
 
 	return (
 		<article
-			className={cx(feedRowClass, "cursor-pointer")}
+			className={cx(
+				feedRowClass,
+				"cursor-pointer [content-visibility:auto] [contain-intrinsic-size:auto_280px]",
+			)}
 			data-perf="timeline-card"
 			onFocus={conversation.prefetch}
 			onMouseEnter={conversation.prefetch}

--- a/src/components/useDebouncedValue.test.tsx
+++ b/src/components/useDebouncedValue.test.tsx
@@ -1,0 +1,26 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+describe("useDebouncedValue", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("retains the previous value until the delay passes", () => {
+		vi.useFakeTimers();
+		const { result, rerender } = renderHook(
+			({ value }) => useDebouncedValue(value, 180),
+			{ initialProps: { value: "" } },
+		);
+
+		rerender({ value: "bird" });
+		expect(result.current).toBe("");
+
+		act(() => vi.advanceTimersByTime(179));
+		expect(result.current).toBe("");
+
+		act(() => vi.advanceTimersByTime(1));
+		expect(result.current).toBe("bird");
+	});
+});

--- a/src/components/useDebouncedValue.ts
+++ b/src/components/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number) {
+	const [debouncedValue, setDebouncedValue] = useState(value);
+
+	useEffect(() => {
+		const timeout = window.setTimeout(() => setDebouncedValue(value), delayMs);
+		return () => window.clearTimeout(timeout);
+	}, [delayMs, value]);
+
+	return debouncedValue;
+}

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -6,13 +6,30 @@ import type {
 	TimelineItem,
 } from "#/lib/types";
 import {
+	fetchCachedQueryResponse,
 	fetchQueryEnvelope,
-	fetchQueryResponse,
+	invalidateCachedQueryResponse,
+	invalidateCachedQueryResponses,
 	postAction,
+	readCachedQueryEnvelope,
 } from "#/lib/api-client";
+import {
+	deleteClientCache,
+	deleteClientCacheByPrefix,
+	readClientCache,
+	writeClientCache,
+} from "#/lib/client-cache";
 import { useSelectedAccountId } from "./account-selection";
+import { useDebouncedValue } from "./useDebouncedValue";
 
 const PAGE_SIZE = 50;
+const TIMELINE_VIEW_CACHE_PREFIX = "timeline-view:";
+const TIMELINE_VIEW_CACHE_MAX_AGE_MS = 5 * 60_000;
+
+interface TimelineViewSnapshot {
+	items: TimelineItem[];
+	hasMore: boolean;
+}
 
 interface UseTimelineRouteDataOptions {
 	resource: Exclude<ResourceKind, "dms">;
@@ -23,6 +40,53 @@ interface UseTimelineRouteDataOptions {
 	bookmarkedOnly?: boolean;
 }
 
+function buildTimelineQueryUrl({
+	resource,
+	search,
+	replyFilter,
+	likedOnly,
+	bookmarkedOnly,
+	selectedAccountId,
+	refreshTick,
+	until,
+	untilId,
+}: {
+	resource: Exclude<ResourceKind, "dms">;
+	search: string;
+	replyFilter?: ReplyFilter;
+	likedOnly: boolean;
+	bookmarkedOnly: boolean;
+	selectedAccountId?: string;
+	refreshTick: number;
+	until?: string;
+	untilId?: string;
+}) {
+	const params = new URLSearchParams({
+		resource,
+		limit: String(PAGE_SIZE),
+	});
+	if (selectedAccountId) params.set("account", selectedAccountId);
+	params.set("refresh", String(refreshTick));
+	if (replyFilter) params.set("replyFilter", replyFilter);
+	if (likedOnly) params.set("liked", "true");
+	if (bookmarkedOnly) params.set("bookmarked", "true");
+	if (search.trim()) params.set("search", search.trim());
+	if (until) params.set("until", until);
+	if (untilId) params.set("untilId", untilId);
+	params.sort();
+	const base =
+		typeof window === "undefined"
+			? "http://birdclaw.local"
+			: window.location.origin;
+	return new URL(`/api/query?${params.toString()}`, base).toString();
+}
+
+function timelineViewCacheKey(requestUrl: string) {
+	const url = new URL(requestUrl, "http://birdclaw.local");
+	url.searchParams.delete("refresh");
+	return `${TIMELINE_VIEW_CACHE_PREFIX}${url.pathname}?${url.searchParams.toString()}`;
+}
+
 export function useTimelineRouteData({
 	resource,
 	search,
@@ -31,75 +95,98 @@ export function useTimelineRouteData({
 	likedOnly = false,
 	bookmarkedOnly = false,
 }: UseTimelineRouteDataOptions) {
-	const [meta, setMeta] = useState<QueryEnvelope | null>(null);
-	const [items, setItems] = useState<TimelineItem[]>([]);
-	const [loading, setLoading] = useState(true);
+	const [meta, setMeta] = useState<QueryEnvelope | null>(
+		() => readCachedQueryEnvelope() ?? null,
+	);
+	const selectedAccountId = useSelectedAccountId(meta?.accounts);
+	const debouncedSearch = useDebouncedValue(search, 180);
+	const initialRequestUrl = buildTimelineQueryUrl({
+		resource,
+		search: debouncedSearch,
+		replyFilter,
+		likedOnly,
+		bookmarkedOnly,
+		selectedAccountId,
+		refreshTick: 0,
+	});
+	const initialSnapshot = useRef(
+		readClientCache<TimelineViewSnapshot>(
+			timelineViewCacheKey(initialRequestUrl),
+			TIMELINE_VIEW_CACHE_MAX_AGE_MS,
+		),
+	);
+	const [items, setItems] = useState<TimelineItem[]>(
+		() => initialSnapshot.current?.items ?? [],
+	);
+	const [loading, setLoading] = useState(() => !initialSnapshot.current);
 	const [error, setError] = useState<string | null>(null);
 	const [replyError, setReplyError] = useState<string | null>(null);
 	const [refreshTick, setRefreshTick] = useState(0);
-	const [hasMore, setHasMore] = useState(false);
+	const [hasMore, setHasMore] = useState(
+		() => initialSnapshot.current?.hasMore ?? false,
+	);
 	const [loadingMore, setLoadingMore] = useState(false);
-	const selectedAccountId = useSelectedAccountId(meta?.accounts);
 	// Bumped whenever the active filters change. A `loadMore` request that
 	// resolves against a stale generation is discarded so its older page is
 	// never appended to a freshly loaded feed.
 	const generationRef = useRef(0);
 	const loadMoreControllerRef = useRef<AbortController | null>(null);
+	const activeRequestUrlRef = useRef(initialRequestUrl);
 
-	async function loadStatus() {
-		setMeta(await fetchQueryEnvelope());
+	async function loadStatus(force = false) {
+		setMeta(await fetchQueryEnvelope(undefined, { force }));
 	}
 
 	useEffect(() => {
 		void loadStatus();
 	}, []);
 
-	// Build the /api/query URL for the current filters. Passing the last item's
-	// (createdAt, id) requests the next (older) page via the server's keyset
-	// cursor, which is deterministic across duplicate timestamps.
-	function buildQueryUrl(until?: string, untilId?: string) {
-		const url = new URL("/api/query", window.location.origin);
-		url.searchParams.set("resource", resource);
-		url.searchParams.set("refresh", String(refreshTick));
-		url.searchParams.set("limit", String(PAGE_SIZE));
-		if (selectedAccountId) {
-			url.searchParams.set("account", selectedAccountId);
-		}
-		if (replyFilter) {
-			url.searchParams.set("replyFilter", replyFilter);
-		}
-		if (likedOnly) {
-			url.searchParams.set("liked", "true");
-		}
-		if (bookmarkedOnly) {
-			url.searchParams.set("bookmarked", "true");
-		}
-		if (search.trim()) {
-			url.searchParams.set("search", search.trim());
-		}
-		if (until) {
-			url.searchParams.set("until", until);
-		}
-		if (untilId) {
-			url.searchParams.set("untilId", untilId);
-		}
-		return url;
-	}
-
 	useEffect(() => {
 		generationRef.current += 1;
 		loadMoreControllerRef.current?.abort();
 		const controller = new AbortController();
 		let active = true;
+		const requestUrl = buildTimelineQueryUrl({
+			resource,
+			search: debouncedSearch,
+			replyFilter,
+			likedOnly,
+			bookmarkedOnly,
+			selectedAccountId,
+			refreshTick,
+		});
+		const viewCacheKey = timelineViewCacheKey(requestUrl);
+		activeRequestUrlRef.current = requestUrl;
 		setError(null);
-		setLoading(true);
 		setLoadingMore(false);
-		fetchQueryResponse(buildQueryUrl(), { signal: controller.signal })
+		const cached = readClientCache<TimelineViewSnapshot>(
+			viewCacheKey,
+			TIMELINE_VIEW_CACHE_MAX_AGE_MS,
+		);
+		if (cached) {
+			setItems(cached.items);
+			setHasMore(cached.hasMore);
+			setLoading(false);
+			return () => {
+				active = false;
+				controller.abort();
+			};
+		}
+
+		setItems([]);
+		setHasMore(false);
+		setLoading(true);
+		fetchCachedQueryResponse(requestUrl, { signal: controller.signal })
 			.then((data) => {
 				if (!active) return;
 				const next = data.items as TimelineItem[];
 				setItems(next);
-				setHasMore(next.length >= PAGE_SIZE);
+				const nextHasMore = next.length >= PAGE_SIZE;
+				setHasMore(nextHasMore);
+				writeClientCache(viewCacheKey, {
+					items: next,
+					hasMore: nextHasMore,
+				});
 			})
 			.catch((fetchError: unknown) => {
 				if (
@@ -127,12 +214,12 @@ export function useTimelineRouteData({
 		};
 	}, [
 		bookmarkedOnly,
+		debouncedSearch,
 		errorFallback,
 		likedOnly,
 		refreshTick,
 		replyFilter,
 		resource,
-		search,
 		selectedAccountId,
 	]);
 
@@ -147,7 +234,13 @@ export function useTimelineRouteData({
 		loadMoreControllerRef.current = controller;
 		setLoadingMore(true);
 		try {
-			const data = await fetchQueryResponse(buildQueryUrl(until, untilId), {
+			const nextPageUrl = new URL(
+				activeRequestUrlRef.current,
+				window.location.origin,
+			);
+			nextPageUrl.searchParams.set("until", until);
+			nextPageUrl.searchParams.set("untilId", untilId);
+			const data = await fetchCachedQueryResponse(nextPageUrl, {
 				signal: controller.signal,
 			});
 			// Discard if the filters changed (new generation) while in flight.
@@ -155,7 +248,12 @@ export function useTimelineRouteData({
 			const page = data.items as TimelineItem[];
 			setItems((prev) => {
 				const seen = new Set(prev.map((item) => item.id));
-				return [...prev, ...page.filter((item) => !seen.has(item.id))];
+				const next = [...prev, ...page.filter((item) => !seen.has(item.id))];
+				writeClientCache(timelineViewCacheKey(activeRequestUrlRef.current), {
+					items: next,
+					hasMore: page.length >= PAGE_SIZE,
+				});
+				return next;
 			});
 			setHasMore(page.length >= PAGE_SIZE);
 		} catch (loadError) {
@@ -175,12 +273,16 @@ export function useTimelineRouteData({
 	}
 
 	function retry() {
+		invalidateCachedQueryResponse(activeRequestUrlRef.current);
+		deleteClientCache(timelineViewCacheKey(activeRequestUrlRef.current));
 		setRefreshTick((value) => value + 1);
 	}
 
 	function refreshLocalView() {
+		invalidateCachedQueryResponses();
+		deleteClientCacheByPrefix(TIMELINE_VIEW_CACHE_PREFIX);
 		setRefreshTick((value) => value + 1);
-		void loadStatus();
+		void loadStatus(true);
 	}
 
 	async function replyToTweet(tweetId: string) {

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { ApiFetchError, fetchJson } from "./api-client";
+import {
+	ApiFetchError,
+	fetchJson,
+	fetchQueryEnvelope,
+	fetchCachedQueryResponse,
+} from "./api-client";
+import { clearClientCache } from "./client-cache";
 
 describe("api client", () => {
 	afterEach(() => {
+		clearClientCache();
 		vi.unstubAllGlobals();
 	});
 
@@ -60,5 +67,46 @@ describe("api client", () => {
 				"Failed",
 			),
 		).rejects.toBe(abortError);
+	});
+
+	it("deduplicates status requests and reuses the fresh response", async () => {
+		const fetchMock = vi.fn(async () =>
+			Response.json({
+				accounts: [],
+				archives: [],
+				transport: { statusText: "local" },
+				stats: { home: 1, mentions: 2, dms: 3, needsReply: 4, inbox: 5 },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const [first, second] = await Promise.all([
+			fetchQueryEnvelope(),
+			fetchQueryEnvelope(),
+		]);
+		const third = await fetchQueryEnvelope();
+
+		expect(first).toEqual(second);
+		expect(third.stats.home).toBe(1);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses cached query responses across remount-style requests", async () => {
+		const fetchMock = vi.fn(async () =>
+			Response.json({
+				resource: "home",
+				items: [{ id: "tweet-1" }],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const url = "/api/query?resource=home&refresh=0";
+
+		const first = await fetchCachedQueryResponse(url);
+		const second = await fetchCachedQueryResponse(
+			"/api/query?refresh=99&resource=home",
+		);
+
+		expect(second).toEqual(first);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,11 @@
 import { Data, Effect } from "effect";
 import { z } from "zod";
+import {
+	deleteClientCache,
+	deleteClientCacheByPrefix,
+	loadClientCache,
+	readClientCache,
+} from "./client-cache";
 import { runEffectPromise } from "./effect-runtime";
 import type {
 	DmConversationItem,
@@ -105,6 +111,15 @@ const webSyncJobSchema = z
 
 const actionResponseSchema = jsonRecordSchema;
 const SYNC_POLL_INTERVAL_MS = 500;
+const STATUS_CACHE_KEY = "api:/status";
+const QUERY_CACHE_PREFIX = "api:/query:";
+const STATUS_CACHE_MAX_AGE_MS = 60_000;
+const QUERY_CACHE_MAX_AGE_MS = 5 * 60_000;
+
+interface ClientFetchCacheOptions {
+	force?: boolean;
+	maxAgeMs?: number;
+}
 
 export class ApiFetchError extends Data.TaggedError("ApiFetchError")<{
 	readonly message: string;
@@ -146,6 +161,55 @@ function readJsonEffect(response: Response) {
 
 function runApiEffect<T, E>(effect: Effect.Effect<T, E>) {
 	return runEffectPromise(effect);
+}
+
+function splitSignal(init?: RequestInit) {
+	if (!init) return { requestInit: undefined, signal: undefined };
+	const { signal, ...requestInit } = init;
+	return { requestInit, signal: signal ?? undefined };
+}
+
+function waitForSignal<T>(promise: Promise<T>, signal?: AbortSignal) {
+	if (!signal) return promise;
+	if (signal.aborted) {
+		return Promise.reject(
+			new DOMException("The operation was aborted.", "AbortError"),
+		);
+	}
+
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			reject(new DOMException("The operation was aborted.", "AbortError"));
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+function queryCacheKey(input: RequestInfo | URL) {
+	const raw =
+		typeof input === "string"
+			? input
+			: input instanceof URL
+				? input.toString()
+				: input.url;
+	const base =
+		typeof window === "undefined"
+			? "http://birdclaw.local"
+			: window.location.origin;
+	const url = new URL(raw, base);
+	url.searchParams.delete("refresh");
+	url.searchParams.sort();
+	return `${QUERY_CACHE_PREFIX}${url.pathname}?${url.searchParams.toString()}`;
 }
 
 export function fetchJsonEffect<T>(
@@ -191,8 +255,27 @@ export function fetchJson<T>(
 	return runApiEffect(fetchJsonEffect(input, init, schema, fallbackMessage));
 }
 
-export function fetchQueryEnvelope(init?: RequestInit) {
-	return runApiEffect(fetchQueryEnvelopeEffect(init));
+export function readCachedQueryEnvelope() {
+	return readClientCache<QueryEnvelope>(
+		STATUS_CACHE_KEY,
+		STATUS_CACHE_MAX_AGE_MS,
+	);
+}
+
+export function fetchQueryEnvelope(
+	init?: RequestInit,
+	{
+		force = false,
+		maxAgeMs = STATUS_CACHE_MAX_AGE_MS,
+	}: ClientFetchCacheOptions = {},
+) {
+	const { requestInit, signal } = splitSignal(init);
+	const request = loadClientCache(
+		STATUS_CACHE_KEY,
+		() => runApiEffect(fetchQueryEnvelopeEffect(requestInit)),
+		{ force, maxAgeMs },
+	);
+	return waitForSignal(request, signal);
 }
 
 export function fetchQueryEnvelopeEffect(init?: RequestInit) {
@@ -209,6 +292,38 @@ export function fetchQueryResponse(
 	init?: RequestInit,
 ) {
 	return runApiEffect(fetchQueryResponseEffect(input, init));
+}
+
+export function readCachedQueryResponse(input: RequestInfo | URL) {
+	return readClientCache<QueryResponse>(
+		queryCacheKey(input),
+		QUERY_CACHE_MAX_AGE_MS,
+	);
+}
+
+export function fetchCachedQueryResponse(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+	{
+		force = false,
+		maxAgeMs = QUERY_CACHE_MAX_AGE_MS,
+	}: ClientFetchCacheOptions = {},
+) {
+	const { requestInit, signal } = splitSignal(init);
+	const request = loadClientCache(
+		queryCacheKey(input),
+		() => runApiEffect(fetchQueryResponseEffect(input, requestInit)),
+		{ force, maxAgeMs },
+	);
+	return waitForSignal(request, signal);
+}
+
+export function invalidateCachedQueryResponse(input: RequestInfo | URL) {
+	deleteClientCache(queryCacheKey(input));
+}
+
+export function invalidateCachedQueryResponses() {
+	deleteClientCacheByPrefix(QUERY_CACHE_PREFIX);
 }
 
 export function fetchQueryResponseEffect(

--- a/src/lib/archive-finder.test.ts
+++ b/src/lib/archive-finder.test.ts
@@ -34,7 +34,12 @@ vi.mock("node:os", () => ({
 	homedir: mocks.homedir,
 }));
 
-import { findArchives, findArchivesEffect } from "./archive-finder";
+import {
+	clearArchiveFinderCacheForTests,
+	findArchives,
+	findArchivesCachedEffect,
+	findArchivesEffect,
+} from "./archive-finder";
 
 const originalPlatform = process.platform;
 
@@ -53,6 +58,7 @@ describe("archive finder", () => {
 	});
 
 	afterEach(() => {
+		clearArchiveFinderCacheForTests();
 		Object.defineProperty(process, "platform", {
 			configurable: true,
 			value: originalPlatform,
@@ -211,5 +217,19 @@ describe("archive finder", () => {
 		expect(mocks.existsSync).not.toHaveBeenCalled();
 		expect(mocks.execAsync).not.toHaveBeenCalled();
 		await expect(Effect.runPromise(effect)).resolves.toEqual([]);
+	});
+
+	it("reuses cached archive discovery for status reads", async () => {
+		mocks.existsSync.mockReturnValue(false);
+		mocks.execAsync.mockResolvedValue({ stdout: "" });
+
+		await expect(
+			Effect.runPromise(findArchivesCachedEffect()),
+		).resolves.toEqual([]);
+		await expect(
+			Effect.runPromise(findArchivesCachedEffect()),
+		).resolves.toEqual([]);
+
+		expect(mocks.execAsync).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/lib/archive-finder.ts
+++ b/src/lib/archive-finder.ts
@@ -8,11 +8,16 @@ import { runEffectPromise, tryPromise } from "./effect-runtime";
 import type { ArchiveCandidate } from "./types";
 
 const execAsync = promisify(exec);
+const ARCHIVE_DISCOVERY_CACHE_MS = 5 * 60_000;
 const ARCHIVE_NAME_PATTERNS = [
 	/^twitter-.*\.zip$/i,
 	/^x-.*\.zip$/i,
 	/archive.*\.zip$/i,
 ];
+let archiveDiscoveryCache:
+	| { value: ArchiveCandidate[]; updatedAt: number }
+	| undefined;
+let archiveDiscoveryInFlight: Promise<ArchiveCandidate[]> | undefined;
 
 function formatFileSize(bytes: number): string {
 	const units = ["B", "KB", "MB", "GB"];
@@ -142,6 +147,39 @@ export function findArchivesEffect(): Effect.Effect<
 	});
 }
 
+export function findArchivesCachedEffect(): Effect.Effect<
+	ArchiveCandidate[],
+	unknown
+> {
+	return Effect.suspend(() => {
+		const cached = archiveDiscoveryCache;
+		if (cached && Date.now() - cached.updatedAt < ARCHIVE_DISCOVERY_CACHE_MS) {
+			return Effect.succeed(cached.value);
+		}
+		if (archiveDiscoveryInFlight) {
+			return Effect.promise(() => archiveDiscoveryInFlight!);
+		}
+
+		const request = runEffectPromise(findArchivesEffect())
+			.then((value) => {
+				archiveDiscoveryCache = { value, updatedAt: Date.now() };
+				return value;
+			})
+			.finally(() => {
+				if (archiveDiscoveryInFlight === request) {
+					archiveDiscoveryInFlight = undefined;
+				}
+			});
+		archiveDiscoveryInFlight = request;
+		return Effect.promise(() => request);
+	});
+}
+
 export function findArchives(): Promise<ArchiveCandidate[]> {
 	return runEffectPromise(findArchivesEffect());
+}
+
+export function clearArchiveFinderCacheForTests() {
+	archiveDiscoveryCache = undefined;
+	archiveDiscoveryInFlight = undefined;
 }

--- a/src/lib/client-cache.test.ts
+++ b/src/lib/client-cache.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clearClientCache,
+	deleteClientCacheByPrefix,
+	loadClientCache,
+	readClientCache,
+	writeClientCache,
+} from "./client-cache";
+
+describe("client cache", () => {
+	afterEach(() => {
+		clearClientCache();
+		vi.useRealTimers();
+	});
+
+	it("returns fresh values and expires stale entries", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-15T00:00:00.000Z"));
+		writeClientCache("status", { ok: true });
+
+		expect(readClientCache("status", 1_000)).toEqual({ ok: true });
+		vi.advanceTimersByTime(1_001);
+		expect(readClientCache("status", 1_000)).toBeUndefined();
+	});
+
+	it("deduplicates concurrent loads", async () => {
+		let resolveLoad: ((value: string) => void) | undefined;
+		const load = vi.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					resolveLoad = resolve;
+				}),
+		);
+
+		const first = loadClientCache("timeline", load);
+		const second = loadClientCache("timeline", load);
+		resolveLoad?.("ready");
+
+		await expect(first).resolves.toBe("ready");
+		await expect(second).resolves.toBe("ready");
+		expect(load).toHaveBeenCalledTimes(1);
+	});
+
+	it("starts a new generation for forced loads", async () => {
+		const resolvers: Array<(value: string) => void> = [];
+		const load = vi.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					resolvers.push(resolve);
+				}),
+		);
+
+		const stale = loadClientCache("status", load);
+		const fresh = loadClientCache("status", load, { force: true });
+		expect(load).toHaveBeenCalledTimes(2);
+
+		resolvers[0]?.("stale");
+		await expect(stale).resolves.toBe("stale");
+		expect(readClientCache("status")).toBeUndefined();
+
+		resolvers[1]?.("fresh");
+		await expect(fresh).resolves.toBe("fresh");
+		expect(readClientCache("status")).toBe("fresh");
+	});
+
+	it("invalidates related entries by prefix", () => {
+		writeClientCache("timeline:home", 1);
+		writeClientCache("timeline:mentions", 2);
+		writeClientCache("status", 3);
+
+		deleteClientCacheByPrefix("timeline:");
+
+		expect(readClientCache("timeline:home")).toBeUndefined();
+		expect(readClientCache("timeline:mentions")).toBeUndefined();
+		expect(readClientCache("status")).toBe(3);
+	});
+});

--- a/src/lib/client-cache.ts
+++ b/src/lib/client-cache.ts
@@ -1,0 +1,109 @@
+const DEFAULT_MAX_ENTRIES = 100;
+
+interface ClientCacheEntry<T> {
+	value: T;
+	updatedAt: number;
+}
+
+interface LoadClientCacheOptions {
+	force?: boolean;
+	maxAgeMs?: number;
+}
+
+const values = new Map<string, ClientCacheEntry<unknown>>();
+const pending = new Map<string, Promise<unknown>>();
+const revisions = new Map<string, number>();
+let generation = 0;
+
+function cacheToken(key: string) {
+	return `${String(generation)}:${String(revisions.get(key) ?? 0)}`;
+}
+
+function invalidateKey(key: string) {
+	revisions.set(key, (revisions.get(key) ?? 0) + 1);
+}
+
+function pruneCache() {
+	while (values.size > DEFAULT_MAX_ENTRIES) {
+		const oldestKey = values.keys().next().value as string | undefined;
+		if (!oldestKey) return;
+		values.delete(oldestKey);
+	}
+}
+
+export function readClientCache<T>(
+	key: string,
+	maxAgeMs = Number.POSITIVE_INFINITY,
+) {
+	const entry = values.get(key) as ClientCacheEntry<T> | undefined;
+	if (!entry) return undefined;
+	if (Date.now() - entry.updatedAt > maxAgeMs) {
+		values.delete(key);
+		return undefined;
+	}
+	return entry.value;
+}
+
+export function writeClientCache<T>(key: string, value: T) {
+	values.delete(key);
+	values.set(key, { value, updatedAt: Date.now() });
+	pruneCache();
+	return value;
+}
+
+export function loadClientCache<T>(
+	key: string,
+	load: () => Promise<T>,
+	{
+		force = false,
+		maxAgeMs = Number.POSITIVE_INFINITY,
+	}: LoadClientCacheOptions = {},
+) {
+	if (force) {
+		invalidateKey(key);
+		values.delete(key);
+		pending.delete(key);
+	} else {
+		const cached = readClientCache<T>(key, maxAgeMs);
+		if (cached !== undefined) return Promise.resolve(cached);
+	}
+
+	const active = pending.get(key) as Promise<T> | undefined;
+	if (active) return active;
+
+	const token = cacheToken(key);
+	let request: Promise<T>;
+	request = load()
+		.then((value) => {
+			if (cacheToken(key) === token) writeClientCache(key, value);
+			return value;
+		})
+		.finally(() => {
+			if (pending.get(key) === request) pending.delete(key);
+		});
+	pending.set(key, request);
+	return request;
+}
+
+export function deleteClientCache(key: string) {
+	invalidateKey(key);
+	values.delete(key);
+	pending.delete(key);
+}
+
+export function deleteClientCacheByPrefix(prefix: string) {
+	const keys = new Set([...values.keys(), ...pending.keys()]);
+	for (const key of keys) {
+		if (!key.startsWith(prefix)) continue;
+		invalidateKey(key);
+		values.delete(key);
+		pending.delete(key);
+	}
+}
+
+export function clearClientCache() {
+	generation += 1;
+	values.clear();
+	pending.clear();
+	revisions.clear();
+}

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -44,6 +44,11 @@ vi.mock("./archive-finder", async () => {
 				try: () => mocks.findArchives(),
 				catch: toError,
 			}),
+		findArchivesCachedEffect: () =>
+			Effect.tryPromise({
+				try: () => mocks.findArchives(),
+				catch: toError,
+			}),
 	};
 });
 
@@ -1214,6 +1219,17 @@ describe("birdclaw queries", () => {
 			transport: { availableTransport: "xurl" },
 		});
 		expect(mocks.findArchives).toHaveBeenCalledTimes(1);
+		expect(mocks.getTransportStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips archive discovery for the web status envelope", async () => {
+		setupTempHome();
+
+		await expect(
+			Effect.runPromise(getQueryEnvelopeEffect({ includeArchives: false })),
+		).resolves.toMatchObject({ archives: [] });
+
+		expect(mocks.findArchives).not.toHaveBeenCalled();
 		expect(mocks.getTransportStatus).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 import type { Database } from "./sqlite";
-import { findArchivesEffect } from "./archive-finder";
+import { findArchivesCachedEffect } from "./archive-finder";
 import { getDb, getNativeDb } from "./db";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { fetchProfileAffiliations } from "./profile-affiliations";
@@ -701,10 +701,9 @@ function getAccountProfileMeta(
 		| undefined;
 }
 
-export function getQueryEnvelopeEffect(): Effect.Effect<
-	QueryEnvelope,
-	unknown
-> {
+export function getQueryEnvelopeEffect({
+	includeArchives = true,
+}: { includeArchives?: boolean } = {}): Effect.Effect<QueryEnvelope, unknown> {
 	return Effect.gen(function* () {
 		const db = yield* trySync(() => getDb());
 		const nativeDb = yield* trySync(() => getNativeDb());
@@ -736,7 +735,9 @@ export function getQueryEnvelopeEffect(): Effect.Effect<
 					.orderBy("name", "asc")
 					.execute(),
 			),
-			archives: findArchivesEffect(),
+			archives: includeArchives
+				? findArchivesCachedEffect()
+				: Effect.succeed([]),
 			transport: getTransportStatusEffect(),
 		});
 

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -7,5 +7,6 @@ describe("router", () => {
 
 		expect(router.options.scrollRestoration).toBe(true);
 		expect(router.options.defaultPreload).toBe("intent");
+		expect(router.options.defaultPreloadStaleTime).toBe(60_000);
 	});
 });

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,7 +7,7 @@ export function getRouter() {
 
 		scrollRestoration: true,
 		defaultPreload: "intent",
-		defaultPreloadStaleTime: 0,
+		defaultPreloadStaleTime: 60_000,
 	});
 
 	return router;

--- a/src/routes/__root.test.tsx
+++ b/src/routes/__root.test.tsx
@@ -16,25 +16,6 @@ vi.mock("@tanstack/react-router", () => ({
 	}) => select({ location: { pathname: routerState.path } }),
 }));
 
-vi.mock("@tanstack/react-devtools", () => ({
-	TanStackDevtools: ({
-		plugins,
-	}: {
-		plugins: Array<{ name: string; render: ReactNode }>;
-	}) => (
-		<div data-testid="devtools">
-			{plugins[0]?.name}
-			{plugins[0]?.render}
-		</div>
-	),
-}));
-
-vi.mock("@tanstack/react-router-devtools", () => ({
-	TanStackRouterDevtoolsPanel: () => (
-		<div data-testid="router-devtools-panel">router panel</div>
-	),
-}));
-
 vi.mock("#/components/AppNav", () => ({
 	AppNav: (props: { compact?: boolean }) => {
 		appNavProps.push(props);
@@ -79,8 +60,7 @@ describe("root route", () => {
 		expect(markup).toContain("max-w-[1280px]");
 		expect(markup).toContain("child content");
 		expect(markup).toContain('data-testid="scripts"');
-		expect(markup).toContain("Tanstack Router");
-		expect(markup).toContain("router panel");
+		expect(markup).not.toContain("Tanstack Router");
 		expect(appNavProps).toEqual([{ compact: false }]);
 	});
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,11 +1,9 @@
-import { TanStackDevtools } from "@tanstack/react-devtools";
 import {
 	createRootRoute,
 	HeadContent,
 	Scripts,
 	useRouterState,
 } from "@tanstack/react-router";
-import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import type { ReactNode } from "react";
 import { AppNav } from "#/components/AppNav";
 import { ThemeProvider, themeScript } from "#/lib/theme";
@@ -74,17 +72,6 @@ function RootDocument({ children }: { children: ReactNode }) {
 						</main>
 					</div>
 				</ThemeProvider>
-				<TanStackDevtools
-					config={{
-						position: "bottom-right",
-					}}
-					plugins={[
-						{
-							name: "Tanstack Router",
-							render: <TanStackRouterDevtoolsPanel />,
-						},
-					]}
-				/>
 				<Scripts />
 			</body>
 		</html>

--- a/src/routes/api/status.tsx
+++ b/src/routes/api/status.tsx
@@ -18,7 +18,9 @@ export const Route = createFileRoute("/api/status")({
 						if (denied) return denied;
 
 						yield* maybeAutoUpdateBackupEffect();
-						return jsonResponse(yield* getQueryEnvelopeEffect());
+						return jsonResponse(
+							yield* getQueryEnvelopeEffect({ includeArchives: false }),
+						);
 					}),
 				),
 		},

--- a/src/routes/dms.test.tsx
+++ b/src/routes/dms.test.tsx
@@ -210,12 +210,16 @@ describe("dms route", () => {
 		await waitFor(() => {
 			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("followers");
 		});
+		const callsBeforeCachedReturn = queryUrls.length;
 
 		fireEvent.click(screen.getByRole("button", { name: "Newest" }));
 
 		await waitFor(() => {
-			expect(queryUrls.at(-1)?.searchParams.get("sort")).toBe("recent");
+			expect(
+				screen.getByRole("button", { name: "Newest" }).className,
+			).toContain("bg-[var(--bg-active)]");
 		});
+		expect(queryUrls).toHaveLength(callsBeforeCachedReturn);
 	});
 
 	it("restores dm draft and shows transport errors", async () => {

--- a/src/routes/dms.tsx
+++ b/src/routes/dms.tsx
@@ -6,9 +6,11 @@ import { FeedEmpty, FeedError, FeedLoading } from "#/components/FeedState";
 import { SyncNowButton } from "#/components/SyncNowButton";
 import { useSelectedAccountId } from "#/components/account-selection";
 import {
+	fetchCachedQueryResponse,
 	fetchQueryEnvelope,
-	fetchQueryResponse,
+	invalidateCachedQueryResponses,
 	postAction,
+	readCachedQueryResponse,
 } from "#/lib/api-client";
 import type {
 	DmConversationItem,
@@ -16,6 +18,7 @@ import type {
 	QueryEnvelope,
 	ReplyFilter,
 } from "#/lib/types";
+import { useDebouncedValue } from "#/components/useDebouncedValue";
 import {
 	cx,
 	pageHeaderClass,
@@ -83,9 +86,10 @@ function DmsRoute() {
 	const [error, setError] = useState<string | null>(null);
 	const [replyError, setReplyError] = useState<string | null>(null);
 	const selectedAccountId = useSelectedAccountId(meta?.accounts);
+	const debouncedSearch = useDebouncedValue(search, 180);
 
-	async function loadStatus() {
-		setMeta(await fetchQueryEnvelope());
+	async function loadStatus(force = false) {
+		setMeta(await fetchQueryEnvelope(undefined, { force }));
 	}
 
 	useEffect(() => {
@@ -113,29 +117,41 @@ function DmsRoute() {
 		if (selectedConversationId) {
 			url.searchParams.set("conversationId", selectedConversationId);
 		}
-		if (search.trim()) {
-			url.searchParams.set("search", search.trim());
+		if (debouncedSearch.trim()) {
+			url.searchParams.set("search", debouncedSearch.trim());
 		}
 
+		const applyResponse = (
+			data: Awaited<ReturnType<typeof fetchCachedQueryResponse>>,
+		) => {
+			const conversations = data.items as DmConversationItem[];
+			const nextSelected =
+				data.selectedConversation?.conversation.id ?? conversations[0]?.id;
+			setLoadedConversationId(data.selectedConversation?.conversation.id);
+			setItems(conversations);
+			setSelectedConversationId((current) => {
+				if (!current) return nextSelected;
+				return conversations.some((conversation) => conversation.id === current)
+					? current
+					: nextSelected;
+			});
+			setMessages(data.selectedConversation?.messages ?? []);
+		};
 		setError(null);
+		const cached = readCachedQueryResponse(url);
+		if (cached) {
+			applyResponse(cached);
+			setLoading(false);
+			return () => {
+				active = false;
+				controller.abort();
+			};
+		}
 		setLoading(true);
-		fetchQueryResponse(url, { signal: controller.signal })
+		fetchCachedQueryResponse(url, { signal: controller.signal })
 			.then((data) => {
 				if (!active) return;
-				const conversations = data.items as DmConversationItem[];
-				const nextSelected =
-					data.selectedConversation?.conversation.id ?? conversations[0]?.id;
-				setLoadedConversationId(data.selectedConversation?.conversation.id);
-				setItems(conversations);
-				setSelectedConversationId((current) => {
-					if (!current) return nextSelected;
-					return conversations.some(
-						(conversation) => conversation.id === current,
-					)
-						? current
-						: nextSelected;
-				});
-				setMessages(data.selectedConversation?.messages ?? []);
+				applyResponse(data);
 			})
 			.catch((fetchError: unknown) => {
 				if (
@@ -170,7 +186,7 @@ function DmsRoute() {
 		inboxFilter,
 		refreshTick,
 		replyFilter,
-		search,
+		debouncedSearch,
 		selectedConversationId,
 		selectedAccountId,
 		sort,
@@ -247,6 +263,7 @@ function DmsRoute() {
 				text,
 			});
 
+			invalidateCachedQueryResponses();
 			setSelectedConversationId(conversationId);
 			setRefreshTick((value) => value + 1);
 		} catch (error) {
@@ -258,8 +275,9 @@ function DmsRoute() {
 	}
 
 	function refreshLocalView() {
+		invalidateCachedQueryResponses();
 		setRefreshTick((value) => value + 1);
-		void loadStatus();
+		void loadStatus(true);
 	}
 
 	return (

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -84,6 +84,39 @@ describe("home route", () => {
 		});
 	});
 
+	it("restores timeline data without refetching after a sidebar-style remount", async () => {
+		let queryCalls = 0;
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) {
+				return Response.json({
+					stats: { home: 1, mentions: 0, dms: 0, needsReply: 0, inbox: 0 },
+					transport: { statusText: "local" },
+					accounts: [],
+					archives: [],
+				});
+			}
+			if (url.includes("/api/query")) {
+				queryCalls += 1;
+				return Response.json({
+					resource: "home",
+					items: [{ id: "tweet_cached", text: "Cached post" }],
+				});
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const first = render(<HomeRoute />);
+		expect(await screen.findByText("Cached post")).toBeInTheDocument();
+		first.unmount();
+
+		render(<HomeRoute />);
+
+		expect(screen.getByText("Cached post")).toBeInTheDocument();
+		expect(queryCalls).toBe(1);
+	});
+
 	it("shows reply transport errors without dropping the timeline", async () => {
 		const fetchMock = vi.fn(
 			async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/src/routes/links.test.tsx
+++ b/src/routes/links.test.tsx
@@ -178,6 +178,26 @@ describe("links route", () => {
 		render(<LinksRoute />);
 
 		expect(await screen.findByText("Example story")).toBeInTheDocument();
+		const defaultCallsBeforeRemount = queryUrls.filter(
+			(url) =>
+				url.pathname === "/api/link-insights" &&
+				url.searchParams.get("kind") === "links" &&
+				url.searchParams.get("range") === "week" &&
+				url.searchParams.get("sort") === "rank",
+		).length;
+		cleanup();
+		render(<LinksRoute />);
+
+		expect(screen.getByText("Example story")).toBeInTheDocument();
+		expect(
+			queryUrls.filter(
+				(url) =>
+					url.pathname === "/api/link-insights" &&
+					url.searchParams.get("kind") === "links" &&
+					url.searchParams.get("range") === "week" &&
+					url.searchParams.get("sort") === "rank",
+			),
+		).toHaveLength(defaultCallsBeforeRemount);
 		await waitFor(
 			() => {
 				const hydrationUrl = queryUrls.find(

--- a/src/routes/links.tsx
+++ b/src/routes/links.tsx
@@ -19,6 +19,11 @@ import {
 } from "#/components/FeedState";
 import { ProfilePreview } from "#/components/ProfilePreview";
 import { SmartTimestamp } from "#/components/SmartTimestamp";
+import {
+	loadClientCache,
+	readClientCache,
+	writeClientCache,
+} from "#/lib/client-cache";
 import { formatCompactNumber } from "#/lib/present";
 import type {
 	LinkInsightItem,
@@ -56,6 +61,10 @@ const LINK_INSIGHTS_LIMIT = 30;
 const LINK_INSIGHTS_COMMENTS_LIMIT = 30;
 const PROFILE_HYDRATION_LIMIT = 30;
 const PROFILE_HYDRATION_DELAY_MS = 1200;
+const LINK_INSIGHTS_CACHE_PREFIX = "link-insights:";
+const LINK_INSIGHTS_CACHE_MAX_AGE_MS = 5 * 60_000;
+const LINK_PROFILE_HYDRATED_CACHE_PREFIX = "link-profile-hydrated:";
+const hydratingLinkProfileHandles = new Set<string>();
 
 const ranges: Array<{ value: LinkInsightRange; label: string }> = [
 	{ value: "today", label: "Today" },
@@ -85,6 +94,19 @@ function insightCacheKey(
 	refreshTick: number,
 ) {
 	return `${kind}:${range}:${sort}:${source}:${refreshTick}`;
+}
+
+function sharedInsightCacheKey(
+	kind: LinkInsightKind,
+	range: LinkInsightRange,
+	sort: LinkInsightSort,
+	source: LinkInsightSource,
+) {
+	return `${LINK_INSIGHTS_CACHE_PREFIX}${kind}:${range}:${sort}:${source}`;
+}
+
+function hydratedProfileCacheKey(handle: string) {
+	return `${LINK_PROFILE_HYDRATED_CACHE_PREFIX}${handle.toLowerCase()}`;
 }
 
 function linkInsightsUrl(
@@ -651,8 +673,16 @@ function LinksRoute() {
 	const [sort, setSort] = useState<LinkInsightSort>("rank");
 	const [search, setSearch] = useState("");
 	const [refreshTick, setRefreshTick] = useState(0);
-	const hydratedHandlesRef = useRef(new Set<string>());
-	const cacheRef = useRef(new Map<string, LinkInsightResponse>());
+	const initialCacheKey = insightCacheKey(kind, range, sort, source, 0);
+	const initialSharedData = readClientCache<LinkInsightResponse>(
+		sharedInsightCacheKey(kind, range, sort, source),
+		LINK_INSIGHTS_CACHE_MAX_AGE_MS,
+	);
+	const cacheRef = useRef(
+		new Map<string, LinkInsightResponse>(
+			initialSharedData ? [[initialCacheKey, initialSharedData]] : [],
+		),
+	);
 	const inFlightRef = useRef(new Set<string>());
 	const mountedRef = useRef(true);
 	const [errorByKey, setErrorByKey] = useState<Record<string, string>>({});
@@ -680,14 +710,35 @@ function LinksRoute() {
 			if (cacheRef.current.has(key) || inFlightRef.current.has(key)) {
 				return;
 			}
+			const sharedKey = sharedInsightCacheKey(fetchKind, range, sort, source);
+			if (refreshTick === 0) {
+				const cached = readClientCache<LinkInsightResponse>(
+					sharedKey,
+					LINK_INSIGHTS_CACHE_MAX_AGE_MS,
+				);
+				if (cached) {
+					cacheRef.current.set(key, cached);
+					bumpCacheVersion((value) => value + 1);
+					return;
+				}
+			}
 			inFlightRef.current.add(key);
 			setErrorByKey((current) => {
 				const rest = { ...current };
 				delete rest[key];
 				return rest;
 			});
-			fetch(linkInsightsUrl(fetchKind, range, sort, source, refreshTick))
-				.then((response) => response.json())
+			loadClientCache(
+				sharedKey,
+				() =>
+					fetch(
+						linkInsightsUrl(fetchKind, range, sort, source, refreshTick),
+					).then((response) => response.json() as Promise<LinkInsightResponse>),
+				{
+					force: refreshTick > 0,
+					maxAgeMs: LINK_INSIGHTS_CACHE_MAX_AGE_MS,
+				},
+			)
 				.then((response: LinkInsightResponse) => {
 					cacheRef.current.set(key, response);
 					if (mountedRef.current) {
@@ -732,7 +783,9 @@ function LinksRoute() {
 
 	useEffect(() => {
 		const handles = collectProfilesForHydration(data).filter(
-			(handle) => !hydratedHandlesRef.current.has(handle.toLowerCase()),
+			(handle) =>
+				!readClientCache<boolean>(hydratedProfileCacheKey(handle)) &&
+				!hydratingLinkProfileHandles.has(handle.toLowerCase()),
 		);
 		if (handles.length === 0) {
 			return;
@@ -742,19 +795,30 @@ function LinksRoute() {
 		const url = new URL("/api/profile-hydrate", window.location.origin);
 		url.searchParams.set("handles", handles.join(","));
 		for (const handle of handles) {
-			hydratedHandlesRef.current.add(handle.toLowerCase());
+			hydratingLinkProfileHandles.add(handle.toLowerCase());
 		}
+		const finishHydration = (succeeded: boolean) => {
+			for (const handle of handles) {
+				const normalized = handle.toLowerCase();
+				hydratingLinkProfileHandles.delete(normalized);
+				if (succeeded) {
+					writeClientCache(hydratedProfileCacheKey(normalized), true);
+				}
+			}
+		};
 
 		let idleId: number | null = null;
 		const runHydration = () => {
 			fetch(url, { signal: controller.signal })
 				.then((response) => response.json())
 				.then((response: { hydratedProfiles?: number }) => {
+					finishHydration(true);
 					if ((response.hydratedProfiles ?? 0) > 0) {
 						setRefreshTick((value) => value + 1);
 					}
 				})
 				.catch((error: unknown) => {
+					finishHydration(false);
 					if (error instanceof DOMException && error.name === "AbortError") {
 						return;
 					}
@@ -771,6 +835,7 @@ function LinksRoute() {
 
 		return () => {
 			controller.abort();
+			finishHydration(false);
 			window.clearTimeout(timer);
 			if (idleId !== null && "cancelIdleCallback" in window) {
 				window.cancelIdleCallback(idleId);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,6 @@
+import { afterEach } from "vitest";
+import { clearClientCache } from "#/lib/client-cache";
+
 process.env.BIRDCLAW_DISABLE_LIVE_WRITES ??= "1";
 
 export {};
@@ -43,3 +46,7 @@ if (typeof window !== "undefined") {
 }
 
 await import("@testing-library/jest-dom/vitest");
+
+afterEach(() => {
+	clearClientCache();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
 import tailwindcss from "@tailwindcss/vite";
-import { devtools } from "@tanstack/devtools-vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -11,7 +10,6 @@ const extraAllowedHosts =
 
 const config = defineConfig({
 	plugins: [
-		devtools(),
 		tailwindcss(),
 		tanstackStart({
 			router: {


### PR DESCRIPTION
## Summary

- retain timeline, DM, and link data across sidebar navigation with bounded TTL caches and request deduplication
- debounce search inputs, preserve loaded pagination, and invalidate caches after explicit sync or writes
- remove TanStack debug controls and dependencies, skip unused web archive discovery, and defer offscreen timeline rendering
- add a browser performance scenario that proves returning Home does not issue another query request

## Testing

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (1,082 tests)
- `pnpm build`
- autoreview: clean, no accepted/actionable findings
