### PR TITLE
fix: wait for concurrent sqlite writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Wait for concurrent SQLite writers before starting write transactions and avoid unnecessary legacy backfill writes during normal startup.
 - Retain timeline and DM data across sidebar navigation, deduplicate status reads, debounce searches, skip unused Spotlight archive scans in web status, and remove TanStack debug controls.
 - Keep tweet and profile hover previews outside wrapped links, flip them to the roomier vertical side, and constrain them to the viewport.
 - Expand Twitter Articles into titled preview cards and citation popovers instead of showing bare `t.co` links.

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,13 +1,70 @@
 // @vitest-environment node
+import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import NativeSqliteDatabase from "./sqlite";
+import NativeSqliteDatabase, { SQLITE_BUSY_TIMEOUT_MS } from "./sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 
 const tempDirs: string[] = [];
+
+async function waitForOutput(child: ChildProcess, expected: string) {
+	await new Promise<void>((resolve, reject) => {
+		let output = "";
+		const onData = (chunk: Buffer) => {
+			output += chunk.toString();
+			if (output.includes(expected)) {
+				cleanup();
+				resolve();
+			}
+		};
+		const onExit = (code: number | null) => {
+			cleanup();
+			reject(new Error(`lock holder exited before ready (${code})`));
+		};
+		const cleanup = () => {
+			child.stdout?.off("data", onData);
+			child.off("exit", onExit);
+		};
+		child.stdout?.on("data", onData);
+		child.on("exit", onExit);
+	});
+}
+
+async function stopChild(child: ChildProcess) {
+	if (child.exitCode !== null) return;
+	await new Promise<void>((resolve) => {
+		child.once("exit", () => resolve());
+		child.kill();
+	});
+}
+
+function spawnWriteLockHolder(dbPath: string, holdMs: number) {
+	return spawn(
+		process.execPath,
+		[
+			"-e",
+			`
+        const { DatabaseSync } = require("node:sqlite");
+        const db = new DatabaseSync(process.argv[1], { timeout: 1000 });
+        db.exec("pragma journal_mode = wal; begin immediate");
+        db.prepare(
+          "insert or replace into sync_cache (cache_key, value_json, updated_at) values ('test:lock', '{}', '2026-06-15T00:00:00.000Z')"
+        ).run();
+        process.stdout.write("locked\\n");
+        setTimeout(() => {
+          db.exec("commit");
+          db.close();
+        }, Number(process.argv[2]));
+      `,
+			dbPath,
+			String(holdMs),
+		],
+		{ stdio: ["ignore", "pipe", "inherit"] },
+	);
+}
 
 afterEach(() => {
 	resetDatabaseForTests();
@@ -238,7 +295,28 @@ describe("database init", () => {
 		const busyTimeout = db.pragma("busy_timeout", {
 			simple: true,
 		}) as number;
-		expect(busyTimeout).toBe(5000);
+		expect(busyTimeout).toBe(SQLITE_BUSY_TIMEOUT_MS);
+	});
+
+	it("does not request a write lock for completed startup backfills", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-lock-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		getNativeDb();
+		resetDatabaseForTests();
+
+		const dbPath = path.join(tempDir, "birdclaw.sqlite");
+		const holder = spawnWriteLockHolder(dbPath, 1500);
+		await waitForOutput(holder, "locked");
+
+		const startedAt = Date.now();
+		try {
+			getNativeDb({ seedDemoData: false });
+			expect(Date.now() - startedAt).toBeLessThan(900);
+		} finally {
+			await stopChild(holder);
+		}
 	});
 });
 
@@ -247,9 +325,49 @@ describe("native sqlite compatibility wrapper", () => {
 		const db = new NativeSqliteDatabase(":memory:");
 
 		try {
-			expect(db.pragma("busy_timeout", { simple: true })).toBe(5000);
+			expect(db.pragma("busy_timeout", { simple: true })).toBe(
+				SQLITE_BUSY_TIMEOUT_MS,
+			);
 		} finally {
 			db.close();
+		}
+	});
+
+	it("waits for the writer slot before a transaction reads and writes", async () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "birdclaw-sqlite-lock-"),
+		);
+		tempDirs.push(tempDir);
+		const dbPath = path.join(tempDir, "database.sqlite");
+		const setupDb = new NativeSqliteDatabase(dbPath);
+		setupDb.exec(`
+      pragma journal_mode = wal;
+      create table sync_cache (
+        cache_key text primary key,
+        value_json text not null,
+        updated_at text not null
+      );
+      create table events (name text);
+    `);
+		setupDb.close();
+
+		const holder = spawnWriteLockHolder(dbPath, 500);
+		await waitForOutput(holder, "locked");
+		const contender = new NativeSqliteDatabase(dbPath, { timeout: 2000 });
+		const startedAt = Date.now();
+
+		try {
+			contender.transaction(() => {
+				contender.prepare("select count(*) from events").get();
+				contender.prepare("insert into events (name) values (?)").run("waited");
+			})();
+			expect(Date.now() - startedAt).toBeGreaterThanOrEqual(250);
+			expect(contender.prepare("select name from events").all()).toEqual([
+				{ name: "waited" },
+			]);
+		} finally {
+			contender.close();
+			await stopChild(holder);
 		}
 	});
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,7 @@
-import NativeSqliteDatabase, { type Database } from "./sqlite";
+import NativeSqliteDatabase, {
+	type Database,
+	SQLITE_BUSY_TIMEOUT_MS,
+} from "./sqlite";
 import { Kysely, SqliteDialect } from "kysely";
 import { ensureBirdclawDirs, getBirdclawPaths } from "./config";
 import { seedDemoData } from "./seed";
@@ -326,7 +329,7 @@ export interface InitDatabaseOptions {
 
 const BASE_SCHEMA_SQL = `
   pragma journal_mode = wal;
-  pragma busy_timeout = 5000;
+  pragma busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};
   pragma foreign_keys = on;
 
   create table if not exists accounts (
@@ -948,6 +951,34 @@ function ensureFollowGraphTables(db: Database) {
 }
 
 function backfillTweetCollections(db: Database) {
+	const missingKinds = (
+		[
+			["likes", "liked"],
+			["bookmarks", "bookmarked"],
+		] as const
+	).filter(([, column]) =>
+		db
+			.prepare(
+				`
+        select 1
+        from tweets as tweet
+        where tweet.${column} = 1
+          and not exists (
+            select 1
+            from tweet_collections as collection
+            where collection.account_id = tweet.account_id
+              and collection.tweet_id = tweet.id
+              and collection.kind = ?
+          )
+        limit 1
+      `,
+			)
+			.get(column === "liked" ? "likes" : "bookmarks"),
+	);
+	if (missingKinds.length === 0) {
+		return;
+	}
+
 	const now = new Date().toISOString();
 	const insert = db.prepare(`
     insert or ignore into tweet_collections (
@@ -963,12 +994,34 @@ function backfillTweetCollections(db: Database) {
   `);
 
 	db.transaction(() => {
-		insert.run("likes", now, "likes");
-		insert.run("bookmarks", now, "bookmarks");
+		for (const [kind] of missingKinds) {
+			insert.run(kind, now, kind);
+		}
 	})();
 }
 
 function backfillTweetAccountEdges(db: Database) {
+	const missing = db
+		.prepare(
+			`
+      select 1
+      from tweets as tweet
+      where tweet.kind in ('home', 'mention')
+        and not exists (
+          select 1
+          from tweet_account_edges as edge
+          where edge.account_id = tweet.account_id
+            and edge.tweet_id = tweet.id
+            and edge.kind = tweet.kind
+        )
+      limit 1
+    `,
+		)
+		.get();
+	if (!missing) {
+		return;
+	}
+
 	const now = new Date().toISOString();
 	db.prepare(`
     insert or ignore into tweet_account_edges (

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -5,6 +5,7 @@ export type Database = NativeSqliteDatabase;
 type DatabaseOptions = {
 	readonly?: boolean;
 	fileMustExist?: boolean;
+	timeout?: number;
 };
 
 type PragmaOptions = {
@@ -15,6 +16,8 @@ type RunResult = {
 	changes: number;
 	lastInsertRowid: number;
 };
+
+export const SQLITE_BUSY_TIMEOUT_MS = 30_000;
 
 function bindArgs(parameters: unknown[]) {
 	if (parameters.length === 1 && Array.isArray(parameters[0])) {
@@ -87,7 +90,7 @@ export class NativeSqliteDatabase {
 	constructor(path: string, options: DatabaseOptions = {}) {
 		this.db = new DatabaseSync(path, {
 			readOnly: options.readonly,
-			timeout: 5000,
+			timeout: options.timeout ?? SQLITE_BUSY_TIMEOUT_MS,
 		});
 	}
 
@@ -123,7 +126,7 @@ export class NativeSqliteDatabase {
 		return (...args: TArgs) => {
 			const nested = this.db.isTransaction;
 			const savepoint = `__birdclaw_tx_${++this.transactionDepth}`;
-			this.exec(nested ? `savepoint ${savepoint}` : "begin");
+			this.exec(nested ? `savepoint ${savepoint}` : "begin immediate");
 			try {
 				const result = fn(...args);
 				this.exec(nested ? `release ${savepoint}` : "commit");


### PR DESCRIPTION
## Summary

- wait up to 30 seconds for SQLite's writer slot and acquire it before transaction reads
- avoid unconditional legacy collection/edge backfill writes during normal process startup
- add cross-process lock regression tests for startup and read-then-write transactions

## Production evidence

The clawmac web process logged `database is locked` from `backfillTweetCollections` while the scheduled sync process held SQLite's single writer slot. The previous five-second timeout and deferred transaction start did not cover that contention reliably.

## Testing

- `pnpm exec vitest run src/lib/db.test.ts` (7 tests)
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (1,084 tests)
- `pnpm build`
- autoreview: clean, no accepted/actionable findings
