### PR TITLE
[codex] preload hover-preview avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Centralize SQLite writes and migrations, unify live-sync ingestion, and move retained web server state to TanStack Query for faster sidebar navigation and fewer duplicate reads.
 
+### Fixed
+
+- Preload hover-preview avatars after page load so citation and profile cards open with cached thumbnails.
+
 ## 0.8.2 - 2026-06-15
 
 ### Fixed

--- a/src/components/AvatarChip.tsx
+++ b/src/components/AvatarChip.tsx
@@ -49,7 +49,7 @@ export function AvatarChip({
 	);
 }
 
-function avatarPath(profileId: string, avatarUrl: string) {
+export function avatarPath(profileId: string, avatarUrl: string) {
 	const query = new URLSearchParams({
 		profileId,
 		v: avatarUrl,

--- a/src/components/AvatarPreload.test.ts
+++ b/src/components/AvatarPreload.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __test__ } from "./AvatarPreload";
+
+class MockImage {
+	static instances: MockImage[] = [];
+
+	decoding = "auto";
+	onerror: ((event: Event) => void) | null = null;
+	onload: ((event: Event) => void) | null = null;
+	src = "";
+
+	constructor() {
+		MockImage.instances.push(this);
+	}
+
+	decode() {
+		return Promise.resolve();
+	}
+}
+
+function setReadyState(value: DocumentReadyState) {
+	Object.defineProperty(document, "readyState", {
+		configurable: true,
+		value,
+	});
+}
+
+function installBrowserMocks() {
+	const idleCallbacks: IdleRequestCallback[] = [];
+	vi.stubGlobal("Image", MockImage);
+	vi.stubGlobal(
+		"requestIdleCallback",
+		vi.fn((callback: IdleRequestCallback) => {
+			idleCallbacks.push(callback);
+			return idleCallbacks.length;
+		}),
+	);
+	vi.stubGlobal("cancelIdleCallback", vi.fn());
+	return idleCallbacks;
+}
+
+function runIdle(callback: IdleRequestCallback | undefined) {
+	if (!callback) throw new Error("Missing idle callback");
+	callback({ didTimeout: false, timeRemaining: () => 50 });
+}
+
+afterEach(() => {
+	__test__.resetPreloader();
+	MockImage.instances = [];
+	vi.unstubAllGlobals();
+	Reflect.deleteProperty(document, "readyState");
+});
+
+describe("avatar preloading", () => {
+	it("waits for the page load and an idle turn", () => {
+		setReadyState("loading");
+		const idleCallbacks = installBrowserMocks();
+
+		__test__.queueAvatarPreload(
+			"profile_sam",
+			"https://pbs.twimg.com/profile_images/123/avatar.jpg",
+		);
+		expect(idleCallbacks).toHaveLength(0);
+		expect(MockImage.instances).toHaveLength(0);
+
+		window.dispatchEvent(new Event("load"));
+		expect(idleCallbacks).toHaveLength(1);
+		expect(MockImage.instances).toHaveLength(0);
+
+		runIdle(idleCallbacks.shift());
+		expect(MockImage.instances).toHaveLength(1);
+		expect(MockImage.instances[0]).toMatchObject({
+			decoding: "async",
+			src: "/api/avatar?profileId=profile_sam&v=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F123%2Favatar.jpg",
+		});
+	});
+
+	it("deduplicates matching hover avatars", () => {
+		setReadyState("complete");
+		const idleCallbacks = installBrowserMocks();
+		const avatarUrl = "https://pbs.twimg.com/profile_images/123/avatar.jpg";
+
+		__test__.queueAvatarPreload("profile_sam", avatarUrl);
+		__test__.queueAvatarPreload("profile_sam", avatarUrl);
+		runIdle(idleCallbacks.shift());
+
+		expect(MockImage.instances).toHaveLength(1);
+	});
+
+	it("limits concurrent preloads and continues as images decode", async () => {
+		setReadyState("complete");
+		const idleCallbacks = installBrowserMocks();
+
+		for (let index = 0; index < 5; index += 1) {
+			__test__.queueAvatarPreload(
+				`profile_${String(index)}`,
+				`https://pbs.twimg.com/profile_images/${String(index)}/avatar.jpg`,
+			);
+		}
+		runIdle(idleCallbacks.shift());
+		expect(MockImage.instances).toHaveLength(4);
+
+		MockImage.instances[0]?.onload?.(new Event("load"));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(MockImage.instances).toHaveLength(5);
+	});
+});

--- a/src/components/AvatarPreload.test.ts
+++ b/src/components/AvatarPreload.test.ts
@@ -1,5 +1,6 @@
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __test__ } from "./AvatarPreload";
+import { __test__, useAvatarPreload } from "./AvatarPreload";
 
 class MockImage {
 	static instances: MockImage[] = [];
@@ -37,6 +38,22 @@ function installBrowserMocks() {
 	);
 	vi.stubGlobal("cancelIdleCallback", vi.fn());
 	return idleCallbacks;
+}
+
+function installIntersectionObserverMock() {
+	const callbacks: IntersectionObserverCallback[] = [];
+	const disconnect = vi.fn();
+	const observe = vi.fn();
+	class MockIntersectionObserver {
+		constructor(callback: IntersectionObserverCallback) {
+			callbacks.push(callback);
+		}
+
+		disconnect = disconnect;
+		observe = observe;
+	}
+	vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+	return { callbacks, disconnect, observe };
 }
 
 function runIdle(callback: IdleRequestCallback | undefined) {
@@ -84,6 +101,36 @@ describe("avatar preloading", () => {
 		__test__.queueAvatarPreload("profile_sam", avatarUrl);
 		runIdle(idleCallbacks.shift());
 
+		expect(MockImage.instances).toHaveLength(1);
+	});
+
+	it("waits until a hover trigger is near the viewport", () => {
+		setReadyState("complete");
+		const idleCallbacks = installBrowserMocks();
+		const intersection = installIntersectionObserverMock();
+		const node = document.createElement("span");
+
+		renderHook(() =>
+			useAvatarPreload(
+				{ current: node },
+				"profile_sam",
+				"https://pbs.twimg.com/profile_images/123/avatar.jpg",
+			),
+		);
+
+		expect(intersection.observe).toHaveBeenCalledWith(node);
+		expect(idleCallbacks).toHaveLength(0);
+		const observer = {
+			disconnect: intersection.disconnect,
+		} as unknown as IntersectionObserver;
+		intersection.callbacks[0]?.(
+			[{ isIntersecting: true } as IntersectionObserverEntry],
+			observer,
+		);
+		expect(intersection.disconnect).toHaveBeenCalled();
+		expect(idleCallbacks).toHaveLength(1);
+
+		runIdle(idleCallbacks.shift());
 		expect(MockImage.instances).toHaveLength(1);
 	});
 

--- a/src/components/AvatarPreload.ts
+++ b/src/components/AvatarPreload.ts
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 import { avatarPath } from "./AvatarChip";
 
 const MAX_CONCURRENT_PRELOADS = 4;
 const IDLE_TIMEOUT_MS = 2500;
+const PRELOAD_ROOT_MARGIN = "800px 0px";
 
 const queuedSources: string[] = [];
 const knownSources = new Set<string>();
@@ -93,10 +94,30 @@ function queueAvatarPreload(profileId?: string, avatarUrl?: string) {
 	scheduleAfterPageLoad();
 }
 
-export function useAvatarPreload(profileId?: string, avatarUrl?: string) {
+export function useAvatarPreload(
+	reference: RefObject<Element | null>,
+	profileId?: string,
+	avatarUrl?: string,
+) {
 	useEffect(() => {
-		queueAvatarPreload(profileId, avatarUrl);
-	}, [avatarUrl, profileId]);
+		if (!profileId || !avatarUrl) return;
+		const node = reference.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			queueAvatarPreload(profileId, avatarUrl);
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries.some((entry) => entry.isIntersecting)) return;
+				observer.disconnect();
+				queueAvatarPreload(profileId, avatarUrl);
+			},
+			{ rootMargin: PRELOAD_ROOT_MARGIN },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [avatarUrl, profileId, reference]);
 }
 
 function resetPreloader() {

--- a/src/components/AvatarPreload.ts
+++ b/src/components/AvatarPreload.ts
@@ -1,0 +1,128 @@
+import { useEffect } from "react";
+import { avatarPath } from "./AvatarChip";
+
+const MAX_CONCURRENT_PRELOADS = 4;
+const IDLE_TIMEOUT_MS = 2500;
+
+const queuedSources: string[] = [];
+const knownSources = new Set<string>();
+const activeImages = new Set<HTMLImageElement>();
+
+let activePreloads = 0;
+let listeningForLoad = false;
+let idleId: number | null = null;
+let fallbackTimerId: number | null = null;
+
+function finishPreload(image: HTMLImageElement) {
+	if (!activeImages.delete(image)) return;
+	activePreloads -= 1;
+	drainPreloads();
+}
+
+function drainPreloads() {
+	while (activePreloads < MAX_CONCURRENT_PRELOADS && queuedSources.length > 0) {
+		const src = queuedSources.shift();
+		if (!src) return;
+
+		const image = new Image();
+		activePreloads += 1;
+		activeImages.add(image);
+		image.decoding = "async";
+		image.onerror = () => finishPreload(image);
+		image.onload = () => {
+			if (typeof image.decode !== "function") {
+				finishPreload(image);
+				return;
+			}
+			void image
+				.decode()
+				.catch(() => undefined)
+				.finally(() => finishPreload(image));
+		};
+		image.src = src;
+	}
+}
+
+function runIdlePreloads() {
+	idleId = null;
+	fallbackTimerId = null;
+	drainPreloads();
+}
+
+function scheduleIdlePreloads() {
+	if (
+		queuedSources.length === 0 ||
+		idleId !== null ||
+		fallbackTimerId !== null
+	) {
+		return;
+	}
+
+	const requestIdle = window.requestIdleCallback?.bind(window);
+	if (requestIdle) {
+		idleId = requestIdle(runIdlePreloads, {
+			timeout: IDLE_TIMEOUT_MS,
+		});
+		return;
+	}
+
+	fallbackTimerId = window.setTimeout(runIdlePreloads, 0);
+}
+
+function handleWindowLoad() {
+	listeningForLoad = false;
+	scheduleIdlePreloads();
+}
+
+function scheduleAfterPageLoad() {
+	if (document.readyState === "complete") {
+		scheduleIdlePreloads();
+		return;
+	}
+	if (listeningForLoad) return;
+	listeningForLoad = true;
+	window.addEventListener("load", handleWindowLoad, { once: true });
+}
+
+function queueAvatarPreload(profileId?: string, avatarUrl?: string) {
+	if (!profileId || !avatarUrl || typeof window === "undefined") return;
+	const src = avatarPath(profileId, avatarUrl);
+	if (knownSources.has(src)) return;
+	knownSources.add(src);
+	queuedSources.push(src);
+	scheduleAfterPageLoad();
+}
+
+export function useAvatarPreload(profileId?: string, avatarUrl?: string) {
+	useEffect(() => {
+		queueAvatarPreload(profileId, avatarUrl);
+	}, [avatarUrl, profileId]);
+}
+
+function resetPreloader() {
+	if (listeningForLoad) {
+		window.removeEventListener("load", handleWindowLoad);
+	}
+	if (idleId !== null && "cancelIdleCallback" in window) {
+		window.cancelIdleCallback(idleId);
+	}
+	if (fallbackTimerId !== null) {
+		window.clearTimeout(fallbackTimerId);
+	}
+	for (const image of activeImages) {
+		image.onload = null;
+		image.onerror = null;
+	}
+	queuedSources.length = 0;
+	knownSources.clear();
+	activeImages.clear();
+	activePreloads = 0;
+	listeningForLoad = false;
+	idleId = null;
+	fallbackTimerId = null;
+}
+
+export const __test__ = {
+	queueAvatarPreload,
+	resetPreloader,
+};

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -140,7 +140,11 @@ function TweetPreviewToken({
 	children: ReactNode;
 }) {
 	const preview = useFloatingPreview();
-	useAvatarPreload(tweet.authorProfile.id, tweet.authorProfile.avatarUrl);
+	useAvatarPreload(
+		preview.referenceRef,
+		tweet.authorProfile.id,
+		tweet.authorProfile.avatarUrl,
+	);
 
 	const article = tweet.entities?.article;
 	const renderedText = renderTweetPlainText(tweet.text, tweet.entities ?? {});

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -7,6 +7,7 @@ import type { ProfileRecord } from "#/lib/types";
 import { cx, tweetLinkClass, tweetMentionClass } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { AvatarChip } from "./AvatarChip";
+import { useAvatarPreload } from "./AvatarPreload";
 import { useFloatingPreview } from "./FloatingPreview";
 import { ProfilePreview } from "./ProfilePreview";
 import { SmartTimestamp } from "./SmartTimestamp";
@@ -139,6 +140,7 @@ function TweetPreviewToken({
 	children: ReactNode;
 }) {
 	const preview = useFloatingPreview();
+	useAvatarPreload(tweet.authorProfile.id, tweet.authorProfile.avatarUrl);
 
 	const article = tweet.entities?.article;
 	const renderedText = renderTweetPlainText(tweet.text, tweet.entities ?? {});

--- a/src/components/ProfilePreview.tsx
+++ b/src/components/ProfilePreview.tsx
@@ -19,6 +19,7 @@ import {
 } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { AvatarChip } from "./AvatarChip";
+import { useAvatarPreload } from "./AvatarPreload";
 import { useFloatingPreview } from "./FloatingPreview";
 
 function ProfilePreviewBio({ profile }: { profile: ProfileRecord }) {
@@ -75,6 +76,7 @@ export function ProfilePreview({
 	className?: string;
 }) {
 	const preview = useFloatingPreview();
+	useAvatarPreload(profile.id, profile.avatarUrl);
 
 	return (
 		<span

--- a/src/components/ProfilePreview.tsx
+++ b/src/components/ProfilePreview.tsx
@@ -76,7 +76,7 @@ export function ProfilePreview({
 	className?: string;
 }) {
 	const preview = useFloatingPreview();
-	useAvatarPreload(profile.id, profile.avatarUrl);
+	useAvatarPreload(preview.referenceRef, profile.id, profile.avatarUrl);
 
 	return (
 		<span


### PR DESCRIPTION
## Summary

- warm profile and citation-preview avatar thumbnails after the page finishes loading
- deduplicate requests and cap concurrent preloads at four
- limit automatic work to hover triggers near the viewport so retained timeline history stays lazy
- add regression coverage and a changelog entry

## Why

Hover previews currently appear before their avatar reaches the browser cache, producing a visible thumbnail delay. This uses the same `/api/avatar` URL as `AvatarChip`, so opening a preview can reuse the warmed browser and server cache.

## Checks

- touched files formatted with `oxfmt`
- structured autoreview clean after addressing the unbounded-queue finding
- GitHub CI requested for full current-main test, typecheck, lint, and build proof