### PR TITLE
fix: preserve JSONL rows with unicode separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Preserve backup JSONL rows containing Unicode line or paragraph separators during export and import. (#62 - thanks @uwe-schwarz)
 - Derive unauthenticated local API access from the production server peer socket so spoofed host headers cannot bypass remote-access controls.
 - Normalize legacy stored media types at the API boundary so older archives and backups remain readable through typed response contracts.
 

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -380,6 +380,21 @@ describe("text backup", () => {
 	it("exports JSONL shards and imports them without changing the portable fingerprint", async () => {
 		switchHome("birdclaw-backup-src-");
 		seedBackupFixture();
+		const collectionRawJson = JSON.stringify({
+			id: "tweet_2025",
+			text: "line\u2028separator\u2029done",
+		});
+		getNativeDb()
+			.prepare(
+				`
+        update tweet_collections
+        set raw_json = ?
+        where account_id = 'acct_primary'
+          and tweet_id = 'tweet_2025'
+          and kind = 'likes'
+        `,
+			)
+			.run(collectionRawJson);
 		const before = getBackupDatabaseFingerprint();
 		const repoPath = makeTempDir("birdclaw-store-");
 
@@ -432,6 +447,14 @@ describe("text backup", () => {
 				"utf8",
 			),
 		).toContain('"kind":"bookmarks"');
+		const likesJsonl = readFileSync(
+			path.join(repoPath, "data/collections/likes.jsonl"),
+			"utf8",
+		);
+		expect(likesJsonl).not.toContain("\u2028");
+		expect(likesJsonl).not.toContain("\u2029");
+		expect(likesJsonl).toContain("\\u2028");
+		expect(likesJsonl).toContain("\\u2029");
 		expect(
 			readFileSync(
 				path.join(repoPath, "data/timeline_edges/search.jsonl"),
@@ -518,6 +541,19 @@ describe("text backup", () => {
 			entities_json:
 				'{"hashtags":[{"text":"backup"}],"urls":[{"url":"https://t.co/shared","expandedUrl":"https://example.com/demo","displayUrl":"example.com/demo","start":22,"end":41}]}',
 		});
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare(
+					`
+          select raw_json
+          from tweet_collections
+          where account_id = 'acct_primary'
+            and tweet_id = 'tweet_2025'
+            and kind = 'likes'
+          `,
+				)
+				.get(),
+		).toEqual({ raw_json: collectionRawJson });
 		expect(
 			getNativeDb({ seedDemoData: false })
 				.prepare(

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -216,8 +216,15 @@ function jsonlStringify(row: JsonRecord): string {
 		jsonlKeyOrderCache.set(signature, sortedKeys);
 	}
 	return `{${sortedKeys
-		.map((key) => `${JSON.stringify(key)}:${JSON.stringify(row[key])}`)
+		.map(
+			(key) =>
+				`${JSON.stringify(key)}:${escapeJsonLineSeparators(JSON.stringify(row[key]))}`,
+		)
 		.join(",")}}`;
+}
+
+function escapeJsonLineSeparators(value: string) {
+	return value.replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
 }
 
 function rowsForQuery(db: Database, sql: string, params: unknown[] = []) {

--- a/src/lib/streaming-ingestion.test.ts
+++ b/src/lib/streaming-ingestion.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Readable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { runEffectPromise } from "./effect-runtime";
@@ -6,6 +9,7 @@ import {
 	ingestStreamInBatchesEffect,
 	ingestSourcesInBatchesEffect,
 	streamAssignedJsonArray,
+	streamJsonLines,
 } from "./streaming-ingestion";
 
 async function collect<T>(source: AsyncIterable<T>) {
@@ -15,6 +19,28 @@ async function collect<T>(source: AsyncIterable<T>) {
 }
 
 describe("streaming ingestion", () => {
+	it("preserves unicode separators in physical JSONL records", async () => {
+		const directory = mkdtempSync(path.join(os.tmpdir(), "birdclaw-jsonl-"));
+		const filePath = path.join(directory, "legacy.jsonl");
+		const first = {
+			text: `${"x".repeat(65_526)}\u2028line\u2029paragraph`,
+		};
+		const second = { text: "final record" };
+		try {
+			writeFileSync(
+				filePath,
+				`${JSON.stringify(first)}\r\n\n${JSON.stringify(second)}`,
+			);
+
+			await expect(collect(streamJsonLines(filePath))).resolves.toEqual([
+				{ lineNumber: 1, value: first },
+				{ lineNumber: 3, value: second },
+			]);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it("parses assigned JSON arrays across chunk boundaries", async () => {
 		const source = Readable.from([
 			'window.YTD.tweets.part0 = [{"tweet":{"id":"1",',

--- a/src/lib/streaming-ingestion.ts
+++ b/src/lib/streaming-ingestion.ts
@@ -1,5 +1,4 @@
 import { createReadStream } from "node:fs";
-import { createInterface } from "node:readline";
 import { Effect } from "effect";
 
 export interface IngestionCheckpoint {
@@ -22,7 +21,7 @@ export async function* streamJsonLines(
 	filePath: string,
 ): AsyncGenerator<{ lineNumber: number; value: Record<string, unknown> }> {
 	const input = createReadStream(filePath, { encoding: "utf8" });
-	const lines = createInterface({ input, crlfDelay: Infinity });
+	const lines = splitPhysicalLines(input);
 	let lineNumber = 0;
 	for await (const line of lines) {
 		lineNumber += 1;
@@ -31,6 +30,24 @@ export async function* streamJsonLines(
 			lineNumber,
 			value: JSON.parse(line) as Record<string, unknown>,
 		};
+	}
+}
+
+async function* splitPhysicalLines(
+	source: AsyncIterable<string>,
+): AsyncGenerator<string> {
+	let buffered = "";
+	for await (const chunk of source) {
+		buffered += chunk;
+		let newlineIndex = buffered.indexOf("\n");
+		while (newlineIndex !== -1) {
+			yield buffered.slice(0, newlineIndex).replace(/\r$/, "");
+			buffered = buffered.slice(newlineIndex + 1);
+			newlineIndex = buffered.indexOf("\n");
+		}
+	}
+	if (buffered.length > 0) {
+		yield buffered.replace(/\r$/, "");
 	}
 }
 


### PR DESCRIPTION
## Summary

- escape literal `U+2028` / `U+2029` when writing JSONL backup values
- read backup JSONL using physical `\n` records instead of Node `readline` logical lines
- cover round-trip export/import with Unicode line and paragraph separators in collection raw JSON

Fixes #61.

## Checks

- `pnpm test src/lib/backup.test.ts`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`

## Proof

```
❯ cd ~/dev/forks/birdclaw
git switch fix/jsonl-line-separators
git pull --ff-only
echo "branch: $(git branch --show-current)"
echo "commit: $(git rev-parse --short HEAD)"
pnpm exec tsx src/cli.ts backup sync --repo ~/Documents/Backup/X

Already on 'fix/jsonl-line-separators'
Your branch is up to date with 'origin/fix/jsonl-line-separators'.
Already up to date.
branch: fix/jsonl-line-separators
commit: b30b218
{
  "ok": true,
  "repoPath": "/Users/uwe/Documents/Backup/X",
  "pulled": true,
  "imported": true,
  "importResult": {
    "ok": true,
    "repoPath": "/Users/uwe/Documents/Backup/X",
    "mode": "merge",
    "manifest": {
      "app": "birdclaw",
      "backupHash": "22905214e9205837da8afb1ff0fef7bc737f6d69d7eea020c2c74a263b217a1e",
      "counts": {
        "accounts": 1,
        "collections_bookmarks": 145,
        "collections_likes": 4510,
        "dm_conversations": 262,
        "dm_messages": 458,
        "follow_edges": 1290,
        "follow_events": 1290,
        "follow_snapshot_members": 1290,
        "follow_snapshots": 2,
        "link_occurrences": 3,
        "profile_bio_entities": 1713,
        "profile_snapshots": 1417,
        "profiles": 1999,
        "timeline_edges_authored": 1860,
        "timeline_edges_home": 1723,
        "timeline_edges_mention": 300,
        "timeline_edges_unknown": 397,
        "tweets": 7139,
        "url_expansions": 3
      },
      "files": [
 …
      ],
      "generatedAt": "2026-06-18T14:26:09.124Z",
      "schemaVersion": 1
    },
    "validation": {
      "ok": true,
      "repoPath": "/Users/uwe/Documents/Backup/X",
      "files": [
…
      ],
      "counts": {
…
      },
      "backupHash": "22905214e9205837da8afb1ff0fef7bc737f6d69d7eea020c2c74a263b217a1e",
      "errors": []
    },
    "fingerprint": {
      "counts": {
…
      },
      "hash": "dabe4fb775078768c7c411eca07a0987110df1c2626ca0bd3d8f47f8cb77f29f"
    }
  },
  "exportResult": {
    "ok": true,
    "repoPath": "/Users/uwe/Documents/Backup/X",
    "manifest": {
      "app": "birdclaw",
      "schemaVersion": 2,
      "generatedAt": "2026-06-18T14:50:10.341Z",
      "counts": {
…
      },
      "files": [
…
      ],
      "backupHash": "13f216dcba398a73d9e1cb30563c8206bfba40cccc736d850b5859505fdcd658"
    },
    "validation": {
      "ok": true,
      "repoPath": "/Users/uwe/Documents/Backup/X",
      "files": [
…
      ],
      "counts": {
…
      },
      "backupHash": "13f216dcba398a73d9e1cb30563c8206bfba40cccc736d850b5859505fdcd658",
      "errors": []
    },
    "git": {
      "committed": true,
      "pushed": true,
      "commit": "2032747cc45cd42852a116630a6294e0534f0373"
    }
  }
}
```

I removed files[] and counts[] to make it a little bit shorter and more readable.