### PR TITLE
[codex] Normalize legacy tweet URL entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Keep large Likes, Bookmarks, and Today digest reads on indexed tweet lookups instead of blocking the web server with quadratic SQLite scans.
+- Normalize legacy tweet URL entities at the API boundary so saved and quoted tweets remain readable without expanded-link metadata.
 
 ## 0.8.4 - 2026-06-19
 

--- a/src/lib/tweet-render.test.ts
+++ b/src/lib/tweet-render.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { TweetEntities } from "./types";
 import {
 	enrichFallbackUrlEntities,
 	profileDescriptionEntitiesFromXurl,
@@ -188,5 +189,31 @@ describe("tweet render helpers", () => {
 			imageUrl: "https://peekaboo.sh/social.png",
 			siteName: "Peekaboo",
 		});
+	});
+
+	it("normalizes legacy url entities without expanded fields", () => {
+		const legacyEntities = {
+			urls: [
+				{
+					url: "https://t.co/demo",
+					start: 10,
+					end: 27,
+				},
+			],
+		} as unknown as TweetEntities;
+		const entities = enrichFallbackUrlEntities(
+			"Check it: https://t.co/demo",
+			legacyEntities,
+		);
+
+		expect(entities.urls).toEqual([
+			{
+				url: "https://t.co/demo",
+				expandedUrl: "https://t.co/demo",
+				displayUrl: "t.co/demo",
+				start: 10,
+				end: 27,
+			},
+		]);
 	});
 });

--- a/src/lib/tweet-render.ts
+++ b/src/lib/tweet-render.ts
@@ -283,18 +283,21 @@ export function enrichFallbackUrlEntities(
 	const existingUrls = entities.urls ?? [];
 	const enrichedExistingUrls = existingUrls.map((entry) => {
 		const expansion = resolveExpansion?.(entry.url);
-		if (!expansion) return entry;
-		const expandedUrl = expansion.expandedUrl || entry.expandedUrl;
+		const expandedUrl =
+			expansion?.expandedUrl || entry.expandedUrl || entry.url;
 		return {
 			...entry,
 			expandedUrl,
-			displayUrl: expansion.displayUrl || displayUrlForLink(expandedUrl),
-			...(expansion.title ? { title: expansion.title } : {}),
+			displayUrl:
+				expansion?.displayUrl ||
+				entry.displayUrl ||
+				displayUrlForLink(expandedUrl),
+			...(expansion?.title ? { title: expansion.title } : {}),
 			...(expansion && "description" in expansion
 				? { description: expansion.description ?? null }
 				: {}),
-			...(expansion.imageUrl ? { imageUrl: expansion.imageUrl } : {}),
-			...(expansion.siteName ? { siteName: expansion.siteName } : {}),
+			...(expansion?.imageUrl ? { imageUrl: expansion.imageUrl } : {}),
+			...(expansion?.siteName ? { siteName: expansion.siteName } : {}),
 		};
 	});
 	const fallbackUrls: TweetUrlEntity[] = [];


### PR DESCRIPTION
## What changed

- Fill missing `expandedUrl` and `displayUrl` values on legacy stored URL entities at the shared rendering boundary.
- Add regression coverage for old `url/start/end`-only rows.
- Document the compatibility fix in the changelog.

## Why

Post-deploy production E2E found the all-time Bookmarks API returning 500 when a quoted tweet contained legacy URL metadata without expanded-link fields. The current API contract requires both fields, but old databases legitimately predate them.

## Impact

Saved and quoted tweets now remain readable without rewriting the local database. Production-data proof changed Bookmarks from HTTP 500 to HTTP 200 in 333 ms.

## Validation

- `pnpm exec vitest run src/lib/tweet-render.test.ts src/lib/queries.test.ts --reporter=verbose` — 59 tests
- `pnpm check`
- `pnpm build`
- Structured autoreview: clean, no actionable findings
- Production-data server smoke: Likes 200/1.21s, Bookmarks 200/333ms