### PR TITLE
[codex] Show full tweets in citation popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Show full tweet text in Today citation popovers instead of truncating long posts after six lines.
 - Show inline tweet images in Today citation popovers instead of leaving media-only `t.co` links in the preview text.
 
 ## 0.8.5 - 2026-06-21

--- a/src/components/MarkdownCitations.tsx
+++ b/src/components/MarkdownCitations.tsx
@@ -319,7 +319,7 @@ function TweetPreviewToken({
 								</span>
 							</span>
 						</span>
-						<span className="line-clamp-6 whitespace-pre-wrap [overflow-wrap:anywhere]">
+						<span className="whitespace-pre-wrap [overflow-wrap:anywhere]">
 							{previewText}
 						</span>
 						<TweetPreviewMedia items={media} />

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -639,6 +639,43 @@ describe("MarkdownViewer", () => {
 		expect(screen.queryByRole("tooltip")).toBeNull();
 	});
 
+	it("shows the full text of long tweets in citation popovers", () => {
+		const longText =
+			"Great explanation of one of the biggest issues in Europe and why they can't build startups is they can't recruit early talent and compete with American startups by paying them stock options because the taxing of them means it makes no sense to take European stock options so you better take the American startup offer.";
+		const longTweetContext = {
+			...context,
+			tweets: [
+				{
+					...context.tweets[0],
+					id: "2068909347585884176",
+					url: "https://x.com/levelsio/status/2068909347585884176",
+					author: "levelsio",
+					name: "@levelsio",
+					text: longText,
+					entities: { urls: [] },
+				},
+			],
+		} satisfies PeriodDigestContext;
+		render(
+			<MarkdownViewer
+				context={longTweetContext}
+				markdown={
+					"European startup equity drew attention (tweet_2068909347585884176)."
+				}
+			/>,
+		);
+
+		fireEvent.pointerEnter(
+			screen.getByRole("link", {
+				name: "European startup equity drew attention",
+			}).parentElement as Element,
+		);
+
+		const tweetText = screen.getByText(longText);
+		expect(tweetText).not.toHaveClass("line-clamp-6");
+		expect(tweetText).toHaveClass("whitespace-pre-wrap");
+	});
+
 	it("expands Twitter Articles inside citation popovers", () => {
 		const articleContext = {
 			...context,


### PR DESCRIPTION
## Summary

- show complete tweet text in Today citation popovers
- retain the existing viewport max-height and vertical scrolling guard
- cover the long `@levelsio` tweet that exposed the truncation

## Root cause

Tweet preview text had a six-line CSS clamp even though the popover itself was already constrained to the viewport and scrollable.

## Validation

- `pnpm run check`
- `pnpm run build`
- `pnpm test src/components/MarkdownViewer.test.tsx` (23 tests)
- full suite: 1,175 tests passed; one unrelated moderation-state timeout passed when rerun alone (4 tests)
- existing Chrome visual check against https://x.com/levelsio/status/2068909347585884176: full final sentence visible; viewport scrolling retained
- structured Codex autoreview: clean, no accepted/actionable findings
