### PR TITLE
Fix bird live-sync profile avatars

### DIFF
--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -92,6 +92,19 @@ describe("bird transport wrapper", () => {
 						username: "sam",
 						name: "Sam",
 					},
+					raw: {
+						core: {
+							user_results: {
+								result: {
+									rest_id: "42",
+									avatar: {
+										image_url:
+											"https://pbs.twimg.com/profile_images/42/avatar_normal.jpg",
+									},
+								},
+							},
+						},
+					},
 					media: [
 						{
 							type: "photo",
@@ -107,7 +120,7 @@ describe("bird transport wrapper", () => {
 			maxResults: 12,
 		});
 
-		expectBirdCommandCall(1, ["mentions", "-n", "12", "--json"]);
+		expectBirdCommandCall(1, ["mentions", "-n", "12", "--json-full"]);
 		expect(payload).toEqual({
 			data: [
 				expect.objectContaining({
@@ -137,6 +150,8 @@ describe("bird transport wrapper", () => {
 						id: "42",
 						username: "sam",
 						name: "Sam",
+						profile_image_url:
+							"https://pbs.twimg.com/profile_images/42/avatar_normal.jpg",
 					},
 				],
 			},
@@ -171,7 +186,67 @@ describe("bird transport wrapper", () => {
 				data: [expect.objectContaining({ id: "tweet_effect_1" })],
 			}),
 		);
-		expectBirdCommandCall(1, ["mentions", "-n", "3", "--json"]);
+		expectBirdCommandCall(1, ["mentions", "-n", "3", "--json-full"]);
+	});
+
+	it("falls back to standard JSON when bird lacks --json-full", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdRejectOnce(
+			Object.assign(new Error("Command failed"), {
+				stderr: "error: unknown option '--json-full'",
+			}),
+		);
+		mockBirdStdoutOnce("[]");
+		const { listMentionsViaBird } = await import("./bird");
+
+		await expect(listMentionsViaBird({ maxResults: 5 })).resolves.toMatchObject(
+			{
+				data: [],
+			},
+		);
+		expectBirdCommandCall(1, ["mentions", "-n", "5", "--json-full"]);
+		expectBirdCommandCall(2, ["mentions", "-n", "5", "--json"]);
+	});
+
+	it("keeps an avatar found on a later tweet from the same author", async () => {
+		const { __test__ } = await import("./bird");
+
+		expect(
+			__test__.normalizeBirdTweets([
+				{
+					id: "tweet_without_avatar",
+					text: "first",
+					createdAt: "2026-06-24T00:00:00.000Z",
+					authorId: "42",
+					author: { username: "sam", name: "Sam" },
+				},
+				{
+					id: "tweet_with_avatar",
+					text: "second",
+					createdAt: "2026-06-24T00:01:00.000Z",
+					authorId: "42",
+					raw: {
+						core: {
+							user_results: {
+								result: {
+									rest_id: "42",
+									avatar: { image_url: "https://img.example/sam_normal.jpg" },
+								},
+							},
+						},
+					},
+				},
+			]),
+		).toMatchObject({
+			includes: {
+				users: [
+					{
+						id: "42",
+						profile_image_url: "https://img.example/sam_normal.jpg",
+					},
+				],
+			},
+		});
 	});
 
 	it("omits max-pages for single-page bird search", async () => {
@@ -193,7 +268,7 @@ describe("bird transport wrapper", () => {
 				oldest_id: undefined,
 			},
 		});
-		expectBirdCommandCall(1, ["search", "ChatGPT", "-n", "5", "--json"]);
+		expectBirdCommandCall(1, ["search", "ChatGPT", "-n", "5", "--json-full"]);
 
 		await searchTweetsViaBird("ChatGPT", {
 			maxResults: 5,
@@ -205,10 +280,10 @@ describe("bird transport wrapper", () => {
 			"ChatGPT",
 			"-n",
 			"5",
-			"--json",
 			"--all",
 			"--max-pages",
 			"2",
+			"--json-full",
 		]);
 	});
 
@@ -508,15 +583,15 @@ describe("bird transport wrapper", () => {
 			includes: { users: [{ id: "43", username: "amelia", name: "Amelia" }] },
 			meta: expect.objectContaining({ result_count: 1 }),
 		});
-		expectBirdCommandCall(1, ["likes", "-n", "5", "--json"]);
+		expectBirdCommandCall(1, ["likes", "-n", "5", "--json-full"]);
 		expectBirdCommandCall(2, [
 			"bookmarks",
 			"-n",
 			"7",
-			"--json",
 			"--all",
 			"--max-pages",
 			"2",
+			"--json-full",
 		]);
 	});
 
@@ -542,7 +617,7 @@ describe("bird transport wrapper", () => {
 			includes: { users: [{ id: "45", username: "riley", name: "Riley" }] },
 			meta: expect.objectContaining({ result_count: 1 }),
 		});
-		expectBirdCommandCall(1, ["home", "-n", "9", "--json", "--following"]);
+		expectBirdCommandCall(1, ["home", "-n", "9", "--following", "--json-full"]);
 	});
 
 	it("maps bird follower lists into xurl-compatible users", async () => {
@@ -672,9 +747,9 @@ describe("bird transport wrapper", () => {
 		expectBirdCommandCall(1, [
 			"thread",
 			"reply_1",
-			"--json",
 			"--max-pages",
 			"2",
+			"--json-full",
 		]);
 		expect(execFileAsyncMock.mock.calls[0]?.[2]).toEqual(
 			expect.objectContaining({ timeout: 5000 }),
@@ -741,7 +816,7 @@ describe("bird transport wrapper", () => {
 			includes: { users: [{ id: "42", username: "sam", name: "Sam" }] },
 			meta: expect.objectContaining({ result_count: 1 }),
 		});
-		expectBirdCommandCall(1, ["read", "tweet_1", "--json"]);
+		expectBirdCommandCall(1, ["read", "tweet_1", "--json-full"]);
 	});
 
 	it("looks up profiles through bird user json", async () => {

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -27,6 +27,7 @@ interface BirdTweetMedia {
 interface BirdTweetAuthor {
 	username?: string;
 	name?: string;
+	profileImageUrl?: string;
 }
 
 interface BirdTweetArticle {
@@ -50,6 +51,7 @@ interface BirdTweetItem {
 	retweetedTweet?: { id?: string | null } | null;
 	author?: BirdTweetAuthor;
 	authorId?: string;
+	raw?: unknown;
 	media?: BirdTweetMedia[];
 	article?: BirdTweetArticle | null;
 }
@@ -346,6 +348,17 @@ function runBirdJsonCommandAllowFailureEffect(
 	);
 }
 
+function runBirdTweetJsonCommandEffect(args: string[], timeoutMs?: number) {
+	return runBirdJsonCommandEffect([...args, "--json-full"], timeoutMs).pipe(
+		Effect.catchAll((error) => {
+			if (!isUnsupportedBirdOptionError(error, "--json-full")) {
+				return Effect.fail(error);
+			}
+			return runBirdJsonCommandEffect([...args, "--json"], timeoutMs);
+		}),
+	);
+}
+
 function getBirdTweetItems(payload: unknown, command: string) {
 	if (Array.isArray(payload)) {
 		return payload as BirdTweetItem[];
@@ -444,17 +457,59 @@ function toReferencedTweets(item: BirdTweetItem) {
 	return references.length > 0 ? references : undefined;
 }
 
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object"
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function findGraphqlAvatarUrl(value: unknown, authorId: string) {
+	const pending: unknown[] = [value];
+	const seen = new Set<object>();
+
+	while (pending.length > 0) {
+		const current = pending.pop();
+		const record = getRecord(current);
+		if (!record || seen.has(record)) continue;
+		seen.add(record);
+
+		if (record.rest_id === authorId) {
+			const avatar = getRecord(record.avatar);
+			if (typeof avatar?.image_url === "string" && avatar.image_url) {
+				return avatar.image_url;
+			}
+		}
+
+		for (const child of Object.values(record)) {
+			if (child && typeof child === "object") {
+				pending.push(child);
+			}
+		}
+	}
+
+	return undefined;
+}
+
 function normalizeBirdTweets(items: BirdTweetItem[]): XurlMentionsResponse {
 	const users = new Map<string, XurlMentionUser>();
 	const data = items.map((item): XurlMentionData => {
 		const authorId = String(
 			item.authorId ?? item.author?.username ?? "unknown",
 		);
-		if (!users.has(authorId)) {
+		const profileImageUrl =
+			item.author?.profileImageUrl ?? findGraphqlAvatarUrl(item, authorId);
+		const existingUser = users.get(authorId);
+		if (!existingUser) {
 			users.set(authorId, {
 				id: authorId,
 				username: item.author?.username ?? `user_${authorId}`,
 				name: item.author?.name ?? item.author?.username ?? `user_${authorId}`,
+				...(profileImageUrl ? { profile_image_url: profileImageUrl } : {}),
+			});
+		} else if (profileImageUrl && !existingUser.profile_image_url) {
+			users.set(authorId, {
+				...existingUser,
+				profile_image_url: profileImageUrl,
 			});
 		}
 
@@ -516,11 +571,10 @@ export function listMentionsViaBirdEffect({
 	maxResults: number;
 }): Effect.Effect<XurlMentionsResponse, unknown> {
 	return Effect.gen(function* () {
-		const stdout = yield* runBirdJsonCommandEffect([
+		const stdout = yield* runBirdTweetJsonCommandEffect([
 			"mentions",
 			"-n",
 			String(maxResults),
-			"--json",
 		]);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "mentions");
@@ -545,14 +599,14 @@ function listTweetsViaBirdCommandEffect({
 	maxPages?: number;
 }): Effect.Effect<XurlMentionsResponse, unknown> {
 	return Effect.gen(function* () {
-		const args = [command, "-n", String(maxResults), "--json"];
+		const args = [command, "-n", String(maxResults)];
 		if (all) {
 			args.push("--all");
 		}
 		if (maxPages !== undefined) {
 			args.push("--max-pages", String(maxPages));
 		}
-		const stdout = yield* runBirdJsonCommandEffect(args);
+		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, command);
 	});
@@ -605,14 +659,14 @@ export function searchTweetsViaBirdEffect(
 	},
 ): Effect.Effect<XurlMentionsResponse, unknown> {
 	return Effect.gen(function* () {
-		const args = ["search", query, "-n", String(options.maxResults), "--json"];
+		const args = ["search", query, "-n", String(options.maxResults)];
 		if (options.all) {
 			args.push("--all");
 		}
 		if (options.all && options.maxPages !== undefined) {
 			args.push("--max-pages", String(options.maxPages));
 		}
-		const stdout = yield* runBirdJsonCommandEffect(args);
+		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "search");
 	});
@@ -641,11 +695,7 @@ export function lookupTweetsByIdsViaBirdEffect(
 			ids,
 			(id) =>
 				Effect.gen(function* () {
-					const stdout = yield* runBirdJsonCommandEffect([
-						"read",
-						id,
-						"--json",
-					]);
+					const stdout = yield* runBirdTweetJsonCommandEffect(["read", id]);
 					const payload = yield* parseBirdJsonEffect(stdout);
 					return yield* normalizeBirdTweetItemEffect(payload, "read");
 				}),
@@ -669,11 +719,11 @@ export function listHomeTimelineViaBirdEffect({
 	following?: boolean;
 }): Effect.Effect<XurlMentionsResponse, unknown> {
 	return Effect.gen(function* () {
-		const args = ["home", "-n", String(maxResults), "--json"];
+		const args = ["home", "-n", String(maxResults)];
 		if (following) {
 			args.push("--following");
 		}
-		const stdout = yield* runBirdJsonCommandEffect(args);
+		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "home");
 	});
@@ -783,14 +833,14 @@ export function listThreadViaBirdEffect({
 	timeoutMs?: number;
 }): Effect.Effect<XurlMentionsResponse, unknown> {
 	return Effect.gen(function* () {
-		const args = ["thread", tweetId, "--json"];
+		const args = ["thread", tweetId];
 		if (all) {
 			args.push("--all");
 		}
 		if (maxPages !== undefined) {
 			args.push("--max-pages", String(maxPages));
 		}
-		const stdout = yield* runBirdJsonCommandEffect(args, timeoutMs);
+		const stdout = yield* runBirdTweetJsonCommandEffect(args, timeoutMs);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "thread");
 	});

--- a/src/lib/mentions-live.test.ts
+++ b/src/lib/mentions-live.test.ts
@@ -1549,6 +1549,8 @@ describe("cached live mentions", () => {
 						id: "88",
 						username: "birdsam",
 						name: "Bird Sam",
+						profile_image_url:
+							"https://pbs.twimg.com/profile_images/88/avatar_normal.jpg",
 					},
 				],
 			},
@@ -1577,6 +1579,13 @@ describe("cached live mentions", () => {
 			maxResults: 5,
 		});
 		expect(lookupUsersByHandlesMock).not.toHaveBeenCalled();
+		expect(
+			getNativeDb()
+				.prepare("select avatar_url from profiles where handle = ?")
+				.get("birdsam"),
+		).toEqual({
+			avatar_url: "https://pbs.twimg.com/profile_images/88/avatar.jpg",
+		});
 
 		const mentions = listTimelineItems({
 			resource: "mentions",

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -853,6 +853,17 @@ describe("live timeline collection sync", () => {
 					},
 				},
 			],
+			includes: {
+				users: [
+					{
+						id: "99",
+						username: "birdsam",
+						name: "Bird Sam",
+						profile_image_url:
+							"https://pbs.twimg.com/profile_images/99/avatar_normal.jpg",
+					},
+				],
+			},
 			meta: { result_count: 1 },
 		});
 		const { syncTimelineCollection } =
@@ -888,6 +899,13 @@ describe("live timeline collection sync", () => {
 		expect(row).toMatchObject({
 			media_count: 1,
 			author_profile_id: "profile_user_99",
+		});
+		expect(
+			getNativeDb()
+				.prepare("select avatar_url from profiles where handle = ?")
+				.get("birdsam"),
+		).toEqual({
+			avatar_url: "https://pbs.twimg.com/profile_images/99/avatar.jpg",
 		});
 	});
 

--- a/src/lib/timeline-live.test.ts
+++ b/src/lib/timeline-live.test.ts
@@ -105,7 +105,15 @@ describe("live home timeline sync", () => {
 				},
 			],
 			includes: {
-				users: [{ id: "42", username: "sam", name: "Sam" }],
+				users: [
+					{
+						id: "42",
+						username: "sam",
+						name: "Sam",
+						profile_image_url:
+							"https://pbs.twimg.com/profile_images/42/avatar_normal.jpg",
+					},
+				],
 			},
 			meta: { result_count: 1 },
 		});
@@ -137,6 +145,11 @@ describe("live home timeline sync", () => {
 			account_id: "acct_studio",
 			kind: "home",
 			source: "bird",
+		});
+		expect(
+			db.prepare("select avatar_url from profiles where handle = ?").get("sam"),
+		).toEqual({
+			avatar_url: "https://pbs.twimg.com/profile_images/42/avatar.jpg",
 		});
 		expect(
 			listTimelineItems({


### PR DESCRIPTION
Fixes #71.

## Summary
- request full bird tweet payloads for tweet-backed live reads, with a fallback for older bird versions
- propagate matching GraphQL avatar URLs into the existing profile image field
- preserve an avatar discovered on a later tweet from the same author

## Root cause
Birdclaw normalized only the compact bird payload, which omitted the GraphQL avatar data before profile upsert.

## Validation
- `node ./scripts/run-vitest.mjs run src/lib/bird.test.ts src/lib/timeline-live.test.ts src/lib/timeline-collections-live.test.ts src/lib/mentions-live.test.ts` (4 files, 96 tests)
- `pnpm test` (141 files, 1181 tests)
- `pnpm run check`
- `pnpm build`
- autoreview: no actionable findings

## Live proof

- Built the exact PR head and initialized a fresh isolated Birdclaw home.
- Ran `birdclaw sync timeline --mode bird --limit 20 --refresh --json` through the installed Bird 0.9.1 transport.
- Before refresh: seeded `home` rows with avatars = 4/4. After refresh: `home` rows with avatars = 24/24; all profiles with avatars = 26/26.
- Verified every changed Bird tweet command exposes `--json-full` in 0.9.1. Bird 0.8.0 source also stores the full GraphQL object under `_raw`; the branch test fixture now matches that real contract.
