### PR TITLE
feat: export completed Today digests as PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Add completed Today digest PDF export with route-scoped print styling, while excluding partial failed streams. (#77 - thanks @Gatsby1s)
 - Keep backup Git commits inside the configured repository root and pin hashed backup text files to LF line endings. (#79 - thanks @rodriguez46p-ui)
 - Persist profile avatars exposed by Bird's full live-sync payloads. (#75 - thanks @RajvardhanPatil07)
 - Persist quoted tweet payloads returned by Bird-backed live syncs so quote cards render without a separate hydrate. (#76 - thanks @lukaskawerau)

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -217,6 +217,41 @@ describe("today route", () => {
 		).toBe(true);
 	});
 
+	it("exports a completed digest through the browser PDF flow", async () => {
+		document.title = "birdclaw";
+		const printMock = vi.spyOn(window, "print").mockImplementation(() => {
+			expect(document.title).toBe("BirdClaw Today digest");
+			window.dispatchEvent(new Event("afterprint"));
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = new URL(String(input));
+				if (url.pathname === "/api/profile-hydrate") {
+					return new Response(JSON.stringify({ ok: true, results: [] }), {
+						headers: { "content-type": "application/json" },
+					});
+				}
+				const markdown = "# Today\n\nDone.";
+				return ndjsonResponse([
+					{ type: "delta", delta: markdown },
+					{ type: "done", result: digestResult("Today", markdown) },
+				]);
+			}),
+		);
+
+		render(<TodayRoute />);
+
+		await screen.findByRole("heading", { name: "Today", level: 1 });
+		const exportButton = screen.getByRole("button", { name: "Export PDF" });
+		expect(exportButton).toBeEnabled();
+
+		fireEvent.click(exportButton);
+
+		expect(printMock).toHaveBeenCalledTimes(1);
+		expect(document.title).toBe("birdclaw");
+	});
+
 	it("shows request errors", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -252,6 +252,26 @@ describe("today route", () => {
 		expect(document.title).toBe("birdclaw");
 	});
 
+	it("does not export a partial digest after the stream fails", async () => {
+		const printMock = vi.spyOn(window, "print").mockImplementation(() => {});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				ndjsonResponse([
+					{ type: "delta", delta: "# Partial digest" },
+					{ type: "error", error: "Digest generation failed" },
+				]),
+			),
+		);
+
+		render(<TodayRoute />);
+
+		await screen.findByRole("heading", { name: "Partial digest", level: 1 });
+		await screen.findByRole("alert");
+		expect(screen.queryByRole("button", { name: "Export PDF" })).toBeNull();
+		expect(printMock).not.toHaveBeenCalled();
+	});
+
 	it("shows request errors", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -1,6 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import {
+	CheckCircle2,
+	FileDown,
+	Loader2,
+	RefreshCw,
+	Sparkles,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MarkdownViewer } from "#/components/MarkdownViewer";
 import { useNdjsonRun } from "#/components/useNdjsonRun";
@@ -56,6 +62,26 @@ const periods: Array<{ value: PeriodOption; label: string }> = [
 	{ value: "yesterday", label: "Yesterday" },
 	{ value: "week", label: "Week" },
 ];
+
+function periodLabel(period: PeriodOption) {
+	return periods.find((item) => item.value === period)?.label ?? "Digest";
+}
+
+function exportCurrentDigestPdf(title: string) {
+	const previousTitle = document.title;
+	let cleanedUp = false;
+	const cleanup = () => {
+		if (cleanedUp) return;
+		cleanedUp = true;
+		document.title = previousTitle;
+		window.removeEventListener("afterprint", cleanup);
+	};
+
+	document.title = title;
+	window.addEventListener("afterprint", cleanup, { once: true });
+	window.setTimeout(cleanup, 3000);
+	window.print();
+}
 
 function digestUrl(
 	period: PeriodOption,
@@ -331,16 +357,41 @@ export function TodayRouteView({
 		() => formatCounts(result?.context ?? context),
 		[context, result],
 	);
+	const digestLabel =
+		result?.context.window.label ??
+		context?.window.label ??
+		periodLabel(period);
+	const canExportPdf = Boolean(markdown.trim()) && !loading;
+	const exportTitle = `BirdClaw ${digestLabel} digest`;
+	const exportUpdatedAt = result
+		? new Date(result.updatedAt).toLocaleString(undefined, {
+				dateStyle: "medium",
+				timeStyle: "short",
+			})
+		: null;
+	const handleExportPdf = useCallback(() => {
+		if (!canExportPdf) return;
+		exportCurrentDigestPdf(exportTitle);
+	}, [canExportPdf, exportTitle]);
 
 	return (
-		<div className="flex min-h-screen flex-col">
-			<header className={pageHeaderClass}>
+		<div className="today-pdf-root flex min-h-screen flex-col">
+			<header className={cx("today-pdf-header", pageHeaderClass)}>
 				<div className={pageHeaderRowClass}>
 					<div className="min-w-0">
 						<h1 className={pageTitleClass}>What happened</h1>
 						<p className={pageSubtitleClass}>{sourceLabel}</p>
 					</div>
-					<div className={pageHeaderActionsClass}>
+					<div className={cx("today-screen-only", pageHeaderActionsClass)}>
+						<button
+							type="button"
+							className={secondaryButtonClass}
+							onClick={handleExportPdf}
+							disabled={!canExportPdf}
+						>
+							<FileDown className="size-4" aria-hidden="true" />
+							Export PDF
+						</button>
 						<button
 							type="button"
 							className={secondaryButtonClass}
@@ -355,7 +406,18 @@ export function TodayRouteView({
 						</button>
 					</div>
 				</div>
-				<div className="flex flex-wrap items-center gap-2 px-4 pb-3">
+				<div className="today-pdf-meta" aria-hidden="true">
+					<span>{digestLabel}</span>
+					<span>·</span>
+					<span>Sources: {sourceLabel}</span>
+					{exportUpdatedAt ? (
+						<>
+							<span>·</span>
+							<span>Generated {exportUpdatedAt}</span>
+						</>
+					) : null}
+				</div>
+				<div className="today-screen-only flex flex-wrap items-center gap-2 px-4 pb-3">
 					<div className={segmentedClass} aria-label="Digest period">
 						{periods.map((item) => (
 							<button
@@ -408,7 +470,7 @@ export function TodayRouteView({
 				</div>
 			) : null}
 
-			<div className="border-b border-[var(--line)] px-4 py-2 text-[13px] text-[var(--ink-soft)]">
+			<div className="today-screen-only border-b border-[var(--line)] px-4 py-2 text-[13px] text-[var(--ink-soft)]">
 				<span className="inline-flex items-center gap-1">
 					{loading ? (
 						<Loader2 className="size-4 animate-spin" aria-hidden="true" />

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -353,6 +353,11 @@ export function TodayRouteView({
 	const { period, includeDms } = searchState;
 	const { context, error, loading, markdown, result, run, status } =
 		useDigestStream(period, includeDms);
+	useEffect(() => {
+		const root = document.documentElement;
+		root.classList.add("today-pdf-route");
+		return () => root.classList.remove("today-pdf-route");
+	}, []);
 	const sourceLabel = useMemo(
 		() => formatCounts(result?.context ?? context),
 		[context, result],
@@ -361,7 +366,7 @@ export function TodayRouteView({
 		result?.context.window.label ??
 		context?.window.label ??
 		periodLabel(period);
-	const canExportPdf = Boolean(markdown.trim()) && !loading;
+	const canExportPdf = Boolean(result?.markdown.trim()) && !loading;
 	const exportTitle = `BirdClaw ${digestLabel} digest`;
 	const exportUpdatedAt = result
 		? new Date(result.updatedAt).toLocaleString(undefined, {
@@ -383,15 +388,16 @@ export function TodayRouteView({
 						<p className={pageSubtitleClass}>{sourceLabel}</p>
 					</div>
 					<div className={cx("today-screen-only", pageHeaderActionsClass)}>
-						<button
-							type="button"
-							className={secondaryButtonClass}
-							onClick={handleExportPdf}
-							disabled={!canExportPdf}
-						>
-							<FileDown className="size-4" aria-hidden="true" />
-							Export PDF
-						</button>
+						{canExportPdf ? (
+							<button
+								type="button"
+								className={secondaryButtonClass}
+								onClick={handleExportPdf}
+							>
+								<FileDown className="size-4" aria-hidden="true" />
+								Export PDF
+							</button>
+						) : null}
 						<button
 							type="button"
 							className={secondaryButtonClass}

--- a/src/styles.css
+++ b/src/styles.css
@@ -221,6 +221,10 @@ textarea {
 	animation: birdclaw-load-glow 1.7s ease-in-out infinite;
 }
 
+.today-pdf-meta {
+	display: none;
+}
+
 html.theme-transition {
 	view-transition-name: theme;
 }
@@ -253,5 +257,80 @@ html.theme-transition::view-transition-new(theme) {
 	.birdclaw-mark-animated,
 	.birdclaw-mark-animated::before {
 		animation: none !important;
+	}
+}
+
+@media print {
+	@page {
+		margin: 16mm;
+	}
+
+	html,
+	body {
+		min-height: auto !important;
+		background: #fff !important;
+		color: #0f1419 !important;
+	}
+
+	body * {
+		box-shadow: none !important;
+		text-shadow: none !important;
+	}
+
+	aside,
+	button,
+	input,
+	.today-screen-only {
+		display: none !important;
+	}
+
+	main {
+		width: 100% !important;
+		max-width: none !important;
+		border: 0 !important;
+		background: #fff !important;
+	}
+
+	.today-pdf-root {
+		min-height: auto !important;
+		color: #0f1419 !important;
+	}
+
+	.today-pdf-header {
+		position: static !important;
+		z-index: auto !important;
+		border-bottom: 1px solid #d8dee5 !important;
+		background: #fff !important;
+		backdrop-filter: none !important;
+	}
+
+	.today-pdf-meta {
+		display: flex !important;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		padding: 0 1rem 0.75rem;
+		font-size: 12px;
+		color: #536471;
+	}
+
+	.today-pdf-root article {
+		padding: 1rem !important;
+		font-size: 12pt !important;
+		line-height: 1.55 !important;
+		color: #0f1419 !important;
+	}
+
+	.today-pdf-root article p,
+	.today-pdf-root article li,
+	.today-pdf-root article h1,
+	.today-pdf-root article h2,
+	.today-pdf-root article h3 {
+		break-inside: avoid;
+		color: #0f1419 !important;
+	}
+
+	.today-pdf-root a {
+		color: #0f1419 !important;
+		text-decoration: underline;
 	}
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -285,30 +285,26 @@ html.theme-transition::view-transition-new(theme-toggle) {
 }
 
 @media print {
-	@page {
-		margin: 16mm;
-	}
-
-	html,
-	body {
+	html.today-pdf-route,
+	html.today-pdf-route body {
 		min-height: auto !important;
 		background: #fff !important;
 		color: #0f1419 !important;
 	}
 
-	body * {
+	html.today-pdf-route body * {
 		box-shadow: none !important;
 		text-shadow: none !important;
 	}
 
-	aside,
-	button,
-	input,
-	.today-screen-only {
+	html.today-pdf-route aside,
+	html.today-pdf-route button,
+	html.today-pdf-route input,
+	html.today-pdf-route .today-screen-only {
 		display: none !important;
 	}
 
-	main {
+	html.today-pdf-route main {
 		width: 100% !important;
 		max-width: none !important;
 		border: 0 !important;


### PR DESCRIPTION
## Summary

- add an Export PDF action only after a Today digest reaches its terminal completed result
- preserve the previous document title around browser printing
- scope print rules to the Today route so printing another route is unchanged
- include digest title, source counts, generation time, and summary body in print output
- keep partial markdown visible after failure without offering it as a completed PDF
- merge current `main`, preserving the selected-period accessibility/styling fix

## Validation

- `pnpm test src/routes/today.test.tsx` — 7 passed
- `pnpm test` — 141 files and 1,184 tests passed
- `pnpm check` — formatting, lint, and typecheck passed
- `pnpm build` — client, server, and CLI builds passed
- exact-branch structured maintainer autoreview — no accepted/actionable findings
- existing-profile Chrome completed-state proof: Export PDF appeared only after the terminal `done` event; click entered the print path with title `BirdClaw Today digest`, route-scoped print class, source counts, and generated timestamp; title restored afterward
- existing-profile Chrome failure-state proof: partial markdown remained visible after a terminal error, with no Export PDF action
- actual Chromium print artifact: one-page tagged Letter PDF, 99,209 bytes, title `BirdClaw Today digest`; Poppler text extraction and 144-DPI rendered-page inspection showed complete, legible content with navigation and controls omitted

Local proof artifacts were not uploaded because no image destination approval was provided.