### PR TITLE
fix: prevent theme toggle icon overlap

### DIFF
--- a/src/lib/theme-transition.test.ts
+++ b/src/lib/theme-transition.test.ts
@@ -140,6 +140,44 @@ describe("startThemeTransition", () => {
 		expect(root.style.getPropertyValue("--theme-switch-y")).toBe("");
 	});
 
+	it("marks the trigger while an animated transition is active", async () => {
+		const setTheme = vi.fn();
+		let finishTransition!: () => void;
+		window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+		documentWithTransition.startViewTransition = vi.fn(
+			(callback: () => void) => {
+				callback();
+				return {
+					finished: new Promise<void>((resolve) => {
+						finishTransition = resolve;
+					}),
+				};
+			},
+		);
+
+		const element = document.createElement("button");
+		document.body.append(element);
+
+		startThemeTransition({
+			nextTheme: "dark",
+			currentTheme: "light",
+			setTheme,
+			context: { element },
+		});
+
+		expect(setTheme).toHaveBeenCalledWith("dark");
+		expect(root.classList.contains("theme-transition")).toBe(true);
+		expect(element).toHaveAttribute("data-theme-transition-target");
+
+		finishTransition();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(root.classList.contains("theme-transition")).toBe(false);
+		expect(element).not.toHaveAttribute("data-theme-transition-target");
+		element.remove();
+	});
+
 	it("falls back when the transition handle is incomplete or throws", () => {
 		const setTheme = vi.fn();
 		window.matchMedia = vi.fn().mockReturnValue({ matches: false });

--- a/src/lib/theme-transition.ts
+++ b/src/lib/theme-transition.ts
@@ -29,6 +29,11 @@ const cleanupThemeTransition = (root: HTMLElement) => {
 	root.classList.remove("theme-transition");
 	root.style.removeProperty("--theme-switch-x");
 	root.style.removeProperty("--theme-switch-y");
+	root
+		.querySelectorAll("[data-theme-transition-target]")
+		.forEach((element) =>
+			element.removeAttribute("data-theme-transition-target"),
+		);
 };
 
 export function startThemeTransition({
@@ -92,6 +97,7 @@ export function startThemeTransition({
 	root.style.setProperty("--theme-switch-x", `${xPercent * 100}%`);
 	root.style.setProperty("--theme-switch-y", `${yPercent * 100}%`);
 	root.classList.add("theme-transition");
+	context?.element?.setAttribute("data-theme-transition-target", "");
 
 	try {
 		const transition = startViewTransition?.(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -225,6 +225,10 @@ html.theme-transition {
 	view-transition-name: theme;
 }
 
+html.theme-transition [data-theme-transition-target] {
+	view-transition-name: theme-toggle;
+}
+
 /* View transition pseudo-element. */
 html.theme-transition::view-transition-old(theme) {
 	animation: none;
@@ -239,6 +243,20 @@ html.theme-transition::view-transition-new(theme) {
 	z-index: 2;
 }
 
+/* View transition pseudo-element. */
+html.theme-transition::view-transition-old(theme-toggle) {
+	animation: none;
+	mix-blend-mode: normal;
+	opacity: 0;
+}
+
+/* View transition pseudo-element. */
+html.theme-transition::view-transition-new(theme-toggle) {
+	animation: none;
+	mix-blend-mode: normal;
+	z-index: 3;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	/* View transition pseudo-element. */
 	html.theme-transition::view-transition-old(theme) {
@@ -247,6 +265,12 @@ html.theme-transition::view-transition-new(theme) {
 
 	/* View transition pseudo-element. */
 	html.theme-transition::view-transition-new(theme) {
+		animation: none !important;
+	}
+
+	/* View transition pseudo-element. */
+	html.theme-transition::view-transition-old(theme-toggle),
+	html.theme-transition::view-transition-new(theme-toggle) {
 		animation: none !important;
 	}
 


### PR DESCRIPTION
## Summary

- fixes #80
- marks the clicked theme toggle as its own View Transition target while the theme reveal is active
- hides the old toggle snapshot so the old and new icons do not stack during the light/dark transition
- adds regression coverage for the temporary transition marker cleanup

## Verification

- `./node_modules/.bin/oxfmt --check src/lib/theme-transition.ts src/lib/theme-transition.test.ts src/styles.css`
- `./node_modules/.bin/oxlint src/lib/theme-transition.ts src/lib/theme-transition.test.ts`
- `npx --yes node@25.8.1 ./node_modules/@typescript/native-preview/bin/tsgo --noEmit`
- `npx --yes node@25.8.1 ./node_modules/vitest/vitest.mjs run src/components/ThemeSlider.test.tsx src/lib/theme-transition.test.ts`
- `npx --yes node@25.8.1 ./node_modules/@playwright/test/cli.js test playwright/app.spec.ts -g "switches theme"`