### PR TITLE
fix: clarify Today period selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Make the Today digest's selected period visually distinct and expose its pressed state to assistive technology. (#72 - thanks @Gatsby1s)
 - Keep backup Git commits inside the configured repository root and pin hashed backup text files to LF line endings. (#79 - thanks @rodriguez46p-ui)
 - Persist profile avatars exposed by Bird's full live-sync payloads. (#75 - thanks @RajvardhanPatil07)
 - Persist quoted tweet payloads returned by Bird-backed live syncs so quote cards render without a separate hydrate. (#76 - thanks @lukaskawerau)

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -160,7 +160,7 @@ export const segmentClass =
 export const segmentActiveClass = "bg-[var(--bg-active)] text-[var(--ink)]";
 
 export const segmentAccentActiveClass =
-	"bg-[var(--accent-soft)] text-[var(--accent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--accent)_36%,transparent)]";
+	"bg-[var(--accent-soft)]! text-[var(--accent)]! shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--accent)_36%,transparent)]";
 
 /* Composer (reply textarea). */
 export const composerShellClass =

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -159,6 +159,9 @@ export const segmentClass =
 
 export const segmentActiveClass = "bg-[var(--bg-active)] text-[var(--ink)]";
 
+export const segmentAccentActiveClass =
+	"bg-[var(--accent-soft)] text-[var(--accent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--accent)_36%,transparent)]";
+
 /* Composer (reply textarea). */
 export const composerShellClass =
 	"mt-2 flex flex-col gap-2 border-t border-[var(--line)] pt-3";

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -180,8 +180,8 @@ describe("today route", () => {
 		const weekButton = screen.getByRole("button", { name: "Week" });
 		expect(todayButton).toHaveAttribute("aria-pressed", "true");
 		expect(todayButton).toHaveClass(
-			"bg-[var(--accent-soft)]",
-			"text-[var(--accent)]",
+			"bg-[var(--accent-soft)]!",
+			"text-[var(--accent)]!",
 		);
 		expect(weekButton).toHaveAttribute("aria-pressed", "false");
 		await waitFor(() =>
@@ -203,8 +203,8 @@ describe("today route", () => {
 		expect(todayButton).toHaveAttribute("aria-pressed", "false");
 		expect(weekButton).toHaveAttribute("aria-pressed", "true");
 		expect(weekButton).toHaveClass(
-			"bg-[var(--accent-soft)]",
-			"text-[var(--accent)]",
+			"bg-[var(--accent-soft)]!",
+			"text-[var(--accent)]!",
 		);
 
 		fireEvent.click(screen.getByLabelText("DMs"));

--- a/src/routes/today.test.tsx
+++ b/src/routes/today.test.tsx
@@ -176,6 +176,14 @@ describe("today route", () => {
 		expect(
 			screen.getByText("3 home · 2 mentions · 4 links"),
 		).toBeInTheDocument();
+		const todayButton = screen.getByRole("button", { name: "Today" });
+		const weekButton = screen.getByRole("button", { name: "Week" });
+		expect(todayButton).toHaveAttribute("aria-pressed", "true");
+		expect(todayButton).toHaveClass(
+			"bg-[var(--accent-soft)]",
+			"text-[var(--accent)]",
+		);
+		expect(weekButton).toHaveAttribute("aria-pressed", "false");
 		await waitFor(() =>
 			expect(urls.some((url) => url.pathname === "/api/profile-hydrate")).toBe(
 				true,
@@ -192,6 +200,12 @@ describe("today route", () => {
 		expect(
 			await screen.findByRole("heading", { name: "Last 7 days", level: 1 }),
 		).toBeInTheDocument();
+		expect(todayButton).toHaveAttribute("aria-pressed", "false");
+		expect(weekButton).toHaveAttribute("aria-pressed", "true");
+		expect(weekButton).toHaveClass(
+			"bg-[var(--accent-soft)]",
+			"text-[var(--accent)]",
+		);
 
 		fireEvent.click(screen.getByLabelText("DMs"));
 		expect(

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -33,7 +33,7 @@ import {
 	pageSubtitleClass,
 	pageTitleClass,
 	secondaryButtonClass,
-	segmentActiveClass,
+	segmentAccentActiveClass,
 	segmentClass,
 	segmentedClass,
 } from "#/lib/ui";
@@ -361,9 +361,10 @@ export function TodayRouteView({
 							<button
 								key={item.value}
 								type="button"
+								aria-pressed={period === item.value}
 								className={cx(
 									segmentClass,
-									period === item.value && segmentActiveClass,
+									period === item.value && segmentAccentActiveClass,
 								)}
 								onClick={() =>
 									updateSearch({ ...searchState, period: item.value })


### PR DESCRIPTION
## Summary
- make the selected Today period visually distinct while preserving the shared segmented control
- expose the active period through `aria-pressed`
- add focused route regression coverage for the selected state
- force the active background and text utilities to win the Tailwind cascade over base segment utilities

Fixes #72 (active-state portion). Custom date ranges remain a separate product decision.

## Validation
- `pnpm test src/routes/today.test.tsx` — 5 passed
- `pnpm test` — 141 files and 1,182 tests passed
- `pnpm check` — formatting, lint, and typecheck passed
- `pnpm build` — client, server, and CLI builds passed
- structured maintainer autoreview — no accepted/actionable findings
- existing-profile Chrome proof on exact head `661c922edf607e999135c983a300ebb8441531f3`: selecting Week moved `aria-pressed`; selected dark state computed to `rgba(29, 155, 240, 0.18)` / `rgb(29, 155, 240)`; selected light state to `rgba(29, 155, 240, 0.1)` / `rgb(29, 155, 240)`; unselected controls remained transparent

Screenshots were retained locally only; no image destination approval was provided.