### PR TITLE
feat: add bounded web auto-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.6 - Unreleased
 
+### Added
+
+- Add opt-in, per-account Home and Mentions auto-sync with persisted intervals, overlap protection, hidden-page pauses, visible status, and failure backoff. (#73 - thanks @Gatsby1s)
+
 ### Fixed
 
 - Add completed Today digest PDF export with route-scoped print styling, while excluding partial failed streams. (#77 - thanks @Gatsby1s)

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ private proxy requires `BIRDCLAW_ALLOW_REMOTE_WEB=1`. To require an app-level
 token too, set `BIRDCLAW_WEB_TOKEN` and send it as `x-birdclaw-token` or a
 `birdclaw_token` cookie.
 
-Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs to run the matching live sync from the web UI and then reload the local view. These controls are explicit because live reads can be slow, auth-dependent, or rate-limited.
+Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs to run the matching live sync from the web UI and then reload the local view. Manual sync remains the default because live reads can be slow, auth-dependent, or rate-limited. Home and Mentions also offer opt-in per-account auto-sync at 5m, 10m, 15m, 30m, or 1h intervals; the browser pauses hidden-page runs, prevents overlap, and backs off after failures.
 
 `BIRDCLAW_ALLOWED_HOSTS` applies only to the source `pnpm dev` server, not the
 built server started by `birdclaw serve`.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,40 @@
+# Product vision
+
+Birdclaw is a local-first Twitter memory and operator console. The durable local archive is the product; live transports and AI improve that archive without becoming required read paths.
+
+## Product order
+
+1. Preserve complete, attributable data in SQLite with deterministic backups.
+2. Make local search, timelines, and structured CLI output fast and useful offline.
+3. Refresh through bounded, observable, resumable live reads.
+4. Layer triage and AI workflows over stored source material with citations.
+
+## Live-read policy
+
+- Local reads never trigger surprise network traffic by default.
+- Manual sync remains available everywhere a live collection is shown.
+- Periodic web sync may be opt-in when it has a five-minute minimum, visible state, overlap protection, failure backoff, and no work from hidden pages.
+- Browser scheduling is convenience while a page is mounted. Durable unattended refresh belongs to `birdclaw jobs`, with locks and audit logs.
+- Live writes stay explicit, account-scoped, and transport-aware.
+
+The spec's automatic `serve` sync direction therefore means user-enabled, bounded refresh rather than an unobservable polling loop.
+
+## New data surfaces
+
+A new Twitter surface belongs in Birdclaw when it can provide:
+
+- a stable read transport and explicit rate-limit behavior
+- durable schema, source attribution, freshness, and completeness metadata
+- resumable sync plus backup/export coverage
+- CLI and structured JSON access before UI-only or downstream integrations
+
+Read-only Lists fit this direction once transport support can enumerate owned Lists and membership with trustworthy completeness markers. Birdclaw should expose the stored List filter and metadata; semantic-index products own their own indexing and query UX.
+
+## Boundaries
+
+- No cloud-required backend or multi-tenant service.
+- No hidden live writes.
+- No UI-only state that should survive browser loss.
+- No downstream-specific integration before the underlying local data contract is complete.
+
+Detailed implementation decisions remain in [`docs/spec.md`](docs/spec.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,4 +61,4 @@ Stable `--json` envelopes go to stdout, progress and warnings to stderr — pipe
 
 Active development. Status: real and usable, not finished. Schema churn, transport gaps, and rough edges are expected while the core settles.
 
-The [changelog](https://github.com/steipete/birdclaw/blob/main/CHANGELOG.md) tracks what shipped recently. Goals and non-goals live in the [spec](spec.md). Released under the [MIT license](https://github.com/steipete/birdclaw/blob/main/LICENSE). Not affiliated with X Corp.
+The [changelog](https://github.com/steipete/birdclaw/blob/main/CHANGELOG.md) tracks what shipped recently. Product order and boundaries live in the [vision](https://github.com/steipete/birdclaw/blob/main/VISION.md); detailed goals and decisions live in the [spec](spec.md). Released under the [MIT license](https://github.com/steipete/birdclaw/blob/main/LICENSE). Not affiliated with X Corp.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,7 +86,7 @@ Open <http://localhost:3000>. The default lanes:
 - **Inbox** — let heuristics or OpenAI float likely-important items
 - **Blocks** — maintain a local-first account-scoped blocklist
 
-Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs when you want fresh live data. Browser reloads only reread local SQLite; explicit sync avoids surprise live reads and rate-limit spend.
+Use the Sync button in Home, Mentions, Likes, Bookmarks, or DMs when you want fresh live data. Browser reloads only reread local SQLite; explicit sync avoids surprise live reads and rate-limit spend. Home and Mentions can optionally auto-sync per account at 5m, 10m, 15m, 30m, or 1h intervals. The setting stays in this browser, skips hidden-page runs, prevents overlap, and backs off after failures. Use [`birdclaw jobs`](jobs.md) instead when refresh must continue after the page closes.
 
 ## 6. Run real CLI workflows
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -15,6 +15,12 @@ description: "Sync authored tweets, likes, bookmarks, home timeline, mentions, a
 
 On a fresh database, import your X archive before the first live sync. The archive replaces Birdclaw's bundled demo identity with your account identity; transport authentication alone does not perform that binding.
 
+## Web auto-sync
+
+The Home and Mentions lanes keep manual sync as the default and offer an opt-in `Auto sync` control. The interval is stored per sync kind and account in local browser storage, with choices from 5 minutes to 1 hour. Runs use the same `/api/sync` job path as the manual button, never overlap, skip while the page is hidden, show the latest result, and back off exponentially after failures.
+
+Web auto-sync runs only while the page is mounted. For durable unattended refresh with lock files and audit logs, use [`birdclaw jobs`](jobs.md).
+
 ## Common flags
 
 Most `sync *` commands accept:

--- a/src/components/SyncNowButton.test.tsx
+++ b/src/components/SyncNowButton.test.tsx
@@ -1,4 +1,5 @@
 import {
+	act,
 	cleanup,
 	fireEvent,
 	render,
@@ -637,5 +638,313 @@ describe("SyncNowButton", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Sync timeline" }));
 
 		expect(await screen.findByText("Sync already running")).toBeInTheDocument();
+	});
+
+	it("runs opt-in auto sync on the selected interval and reschedules", async () => {
+		vi.useFakeTimers();
+		const onSynced = vi.fn();
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						id: "sync_timeline_auto",
+						kind: "timeline",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Auto synced 6 items",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							summary: "Auto synced 6 items",
+							steps: [],
+						},
+					}),
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={onSynced}
+			/>,
+		);
+
+		fireEvent.click(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		);
+		fireEvent.change(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+			{ target: { value: String(5 * 60_000) } },
+		);
+
+		await act(async () => vi.advanceTimersByTimeAsync(5 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(onSynced).toHaveBeenCalledTimes(1);
+		expect(screen.getByText(/Last auto sync/)).toBeInTheDocument();
+
+		await act(async () => vi.advanceTimersByTimeAsync(5 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(onSynced).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not overlap auto sync runs", async () => {
+		vi.useFakeTimers();
+		let finishRequest: ((response: Response) => void) | undefined;
+		const fetchMock = vi.fn(
+			async () =>
+				await new Promise<Response>((resolve) => {
+					finishRequest = resolve;
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		);
+		fireEvent.change(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+			{ target: { value: String(5 * 60_000) } },
+		);
+
+		await act(async () => vi.advanceTimersByTimeAsync(5 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await act(async () => vi.advanceTimersByTimeAsync(15 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			finishRequest?.(
+				new Response(
+					JSON.stringify({
+						id: "sync_timeline_auto_slow",
+						kind: "timeline",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Auto sync complete",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							summary: "Auto sync complete",
+							steps: [],
+						},
+					}),
+				),
+			);
+			await Promise.resolve();
+		});
+	});
+
+	it("ignores an auto sync completion after the selected account changes", async () => {
+		vi.useFakeTimers();
+		setStoredAccountId("acct_primary");
+		let finishRequest: ((response: Response) => void) | undefined;
+		const fetchMock = vi.fn(
+			async () =>
+				await new Promise<Response>((resolve) => {
+					finishRequest = resolve;
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const onSynced = vi.fn();
+		const accounts = [
+			{
+				id: "acct_primary",
+				name: "Primary",
+				handle: "@primary",
+				transport: "xurl" as const,
+				isDefault: 1,
+				createdAt: "2026-05-15T12:00:00.000Z",
+			},
+			{
+				id: "acct_studio",
+				name: "Studio",
+				handle: "@studio",
+				transport: "xurl" as const,
+				isDefault: 0,
+				createdAt: "2026-05-15T12:00:00.000Z",
+			},
+		];
+
+		render(
+			<SyncNowButton
+				accounts={accounts}
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={onSynced}
+				showAccountPicker
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		);
+		fireEvent.change(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+			{ target: { value: String(5 * 60_000) } },
+		);
+		await act(async () => vi.advanceTimersByTimeAsync(5 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		act(() => setStoredAccountId("acct_studio"));
+		expect(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		).not.toBeChecked();
+
+		await act(async () => {
+			finishRequest?.(
+				new Response(
+					JSON.stringify({
+						id: "sync_timeline_stale_account",
+						kind: "timeline",
+						accountId: "acct_primary",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Primary account synced",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							accountId: "acct_primary",
+							summary: "Primary account synced",
+							steps: [],
+						},
+					}),
+				),
+			);
+			await Promise.resolve();
+		});
+
+		expect(onSynced).not.toHaveBeenCalled();
+		expect(screen.getByText("Auto sync off")).toBeInTheDocument();
+		expect(screen.queryByText(/Last auto sync/)).toBeNull();
+	});
+
+	it("backs off after auto sync failures", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						id: "sync_timeline_auto_failed",
+						kind: "timeline",
+						status: "failed",
+						startedAt: "2026-05-15T12:00:00.000Z",
+						summary: "Rate limited",
+						inProgress: false,
+						result: {
+							ok: false,
+							kind: "timeline",
+							summary: "Rate limited",
+							error: "Rate limited",
+							steps: [],
+						},
+					}),
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						id: "sync_timeline_auto_recovered",
+						kind: "timeline",
+						status: "succeeded",
+						startedAt: "2026-05-15T12:10:00.000Z",
+						summary: "Recovered",
+						inProgress: false,
+						result: {
+							ok: true,
+							kind: "timeline",
+							summary: "Recovered",
+							steps: [],
+						},
+					}),
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SyncNowButton
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		);
+		fireEvent.change(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+			{ target: { value: String(5 * 60_000) } },
+		);
+
+		await act(async () => vi.advanceTimersByTimeAsync(5 * 60_000));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByText("Auto sync failed: Rate limited"),
+		).toBeInTheDocument();
+		await act(async () => vi.advanceTimersByTimeAsync(10 * 60_000 - 1));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		await act(async () => vi.advanceTimersByTimeAsync(1));
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("restores per-kind auto sync settings after remount", () => {
+		const first = render(
+			<SyncNowButton
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		);
+		fireEvent.change(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+			{ target: { value: String(30 * 60_000) } },
+		);
+		first.unmount();
+
+		render(
+			<SyncNowButton
+				allowAutoSync
+				kind="timeline"
+				label="Sync timeline"
+				onSynced={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("checkbox", { name: "Auto sync timeline" }),
+		).toBeChecked();
+		expect(
+			screen.getByRole("combobox", {
+				name: "Sync timeline auto-sync interval",
+			}),
+		).toHaveValue(String(30 * 60_000));
 	});
 });

--- a/src/components/SyncNowButton.tsx
+++ b/src/components/SyncNowButton.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { postSync } from "#/lib/api-client";
 import type { AccountRecord } from "#/lib/types";
 import { cx, selectFieldClass } from "#/lib/ui";
@@ -19,8 +19,54 @@ interface SyncNowButtonProps {
 	label: string;
 	accounts?: AccountRecord[];
 	onSynced: (result: WebSyncResponse) => void;
+	allowAutoSync?: boolean;
+	autoSyncBlocked?: boolean;
 	showAccountPicker?: boolean;
 	syncOptions?: WebSyncOptions;
+}
+
+const AUTO_SYNC_INTERVALS = [
+	{ label: "5m", value: 5 * 60_000 },
+	{ label: "10m", value: 10 * 60_000 },
+	{ label: "15m", value: 15 * 60_000 },
+	{ label: "30m", value: 30 * 60_000 },
+	{ label: "1h", value: 60 * 60_000 },
+] as const;
+const DEFAULT_AUTO_SYNC_INTERVAL_MS = 10 * 60_000;
+const MAX_AUTO_SYNC_BACKOFF_MS = 60 * 60_000;
+
+interface StoredAutoSyncSettings {
+	enabled: boolean;
+	intervalMs: number;
+}
+
+interface AutoSyncSettings extends StoredAutoSyncSettings {
+	key: string;
+}
+
+function autoSyncStorageKey(kind: WebSyncKind, accountId: string | undefined) {
+	return `birdclaw:auto-sync:${kind}:${accountId ?? "default"}`;
+}
+
+function validAutoSyncInterval(value: unknown): value is number {
+	return AUTO_SYNC_INTERVALS.some((option) => option.value === value);
+}
+
+function readAutoSyncSettings(key: string): StoredAutoSyncSettings {
+	try {
+		const value = JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+			enabled?: unknown;
+			intervalMs?: unknown;
+		} | null;
+		return {
+			enabled: value?.enabled === true,
+			intervalMs: validAutoSyncInterval(value?.intervalMs)
+				? value.intervalMs
+				: DEFAULT_AUTO_SYNC_INTERVAL_MS,
+		};
+	} catch {
+		return { enabled: false, intervalMs: DEFAULT_AUTO_SYNC_INTERVAL_MS };
+	}
 }
 
 export function SyncNowButton({
@@ -28,12 +74,22 @@ export function SyncNowButton({
 	label,
 	accounts,
 	onSynced,
+	allowAutoSync = false,
+	autoSyncBlocked = false,
 	showAccountPicker = false,
 	syncOptions,
 }: SyncNowButtonProps) {
 	const [syncing, setSyncing] = useState(false);
 	const [message, setMessage] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const syncingRef = useRef(false);
+	const onSyncedRef = useRef(onSynced);
+	const [autoSyncing, setAutoSyncing] = useState(false);
+	const [autoSyncError, setAutoSyncError] = useState<string | null>(null);
+	const [autoFailureCount, setAutoFailureCount] = useState(0);
+	const [autoCycle, setAutoCycle] = useState(0);
+	const [lastAutoSyncedAt, setLastAutoSyncedAt] = useState<number | null>(null);
+	const [nextAutoSyncAt, setNextAutoSyncAt] = useState<number | null>(null);
 	const accountList = accounts ?? [];
 	const globalAccountId = useSelectedAccountId(accounts);
 	const defaultAccountId = useMemo(
@@ -41,6 +97,15 @@ export function SyncNowButton({
 		[accounts],
 	);
 	const accountId = globalAccountId ?? defaultAccountId;
+	const autoSyncKey = autoSyncStorageKey(kind, accountId);
+	const autoSyncKeyRef = useRef(autoSyncKey);
+	autoSyncKeyRef.current = autoSyncKey;
+	const [autoSettings, setAutoSettings] = useState<AutoSyncSettings>({
+		key: "",
+		enabled: false,
+		intervalMs: DEFAULT_AUTO_SYNC_INTERVAL_MS,
+	});
+	const autoSettingsReady = autoSettings.key === autoSyncKey;
 	const accountAwareSync = kind !== "dms";
 	const waitingForAccount =
 		accountAwareSync &&
@@ -57,37 +122,178 @@ export function SyncNowButton({
 		: waitingForAccount
 			? "Loading account"
 			: (error ?? message ?? "");
+	const autoStatusMessage = autoSyncError
+		? `Auto sync failed: ${autoSyncError}`
+		: autoSyncing
+			? "Auto syncing..."
+			: lastAutoSyncedAt
+				? `Last auto sync ${new Date(lastAutoSyncedAt).toLocaleTimeString()}`
+				: nextAutoSyncAt
+					? `Next sync ${new Date(nextAutoSyncAt).toLocaleTimeString()}`
+					: autoSettings.enabled
+						? "Auto sync waiting"
+						: "Auto sync off";
+
+	useEffect(() => {
+		onSyncedRef.current = onSynced;
+	}, [onSynced]);
+
+	useEffect(() => {
+		const stored = readAutoSyncSettings(autoSyncKey);
+		setAutoSettings({ key: autoSyncKey, ...stored });
+		setAutoSyncError(null);
+		setAutoSyncing(false);
+		setAutoFailureCount(0);
+		setLastAutoSyncedAt(null);
+		setNextAutoSyncAt(null);
+		setAutoCycle((current) => current + 1);
+	}, [autoSyncKey]);
 
 	function selectAccount(accountId: string) {
 		setStoredAccountId(accountId);
 	}
 
-	async function syncNow() {
-		setSyncing(true);
-		setError(null);
-		setMessage(null);
-		try {
-			const data = await postSync(
-				kind,
-				accountAwareSync ? accountId : undefined,
-				syncOptions,
-			);
-			if (!data.ok) throw new Error(data.summary);
-			setMessage(data.summary);
-			onSynced(data);
-		} catch (syncError) {
-			setError(syncError instanceof Error ? syncError.message : "Sync failed");
-		} finally {
-			setSyncing(false);
+	const syncNow = useCallback(
+		async (source: "manual" | "auto"): Promise<boolean> => {
+			if (
+				syncingRef.current ||
+				waitingForAccount ||
+				birdOnlyWrongAccount ||
+				(source === "auto" && autoSyncBlocked)
+			) {
+				return false;
+			}
+			const launchedAutoSyncKey =
+				source === "auto" ? autoSyncKeyRef.current : null;
+			syncingRef.current = true;
+			setSyncing(true);
+			if (source === "auto") {
+				setAutoSyncing(true);
+				setAutoSyncError(null);
+			} else {
+				setError(null);
+				setMessage(null);
+			}
+			try {
+				const data = await postSync(
+					kind,
+					accountAwareSync ? accountId : undefined,
+					syncOptions,
+				);
+				if (!data.ok) throw new Error(data.summary);
+				if (
+					launchedAutoSyncKey !== null &&
+					autoSyncKeyRef.current !== launchedAutoSyncKey
+				) {
+					return false;
+				}
+				if (source === "auto") {
+					setLastAutoSyncedAt(Date.now());
+					setAutoFailureCount(0);
+				} else {
+					setMessage(data.summary);
+				}
+				onSyncedRef.current(data);
+				return true;
+			} catch (syncError) {
+				if (
+					launchedAutoSyncKey !== null &&
+					autoSyncKeyRef.current !== launchedAutoSyncKey
+				) {
+					return false;
+				}
+				const syncMessage =
+					syncError instanceof Error ? syncError.message : "Sync failed";
+				if (source === "auto") {
+					setAutoSyncError(syncMessage);
+					setAutoFailureCount((current) => current + 1);
+				} else {
+					setError(syncMessage);
+				}
+				return false;
+			} finally {
+				syncingRef.current = false;
+				setSyncing(false);
+				if (source === "auto") setAutoSyncing(false);
+			}
+		},
+		[
+			accountAwareSync,
+			accountId,
+			autoSyncBlocked,
+			birdOnlyWrongAccount,
+			kind,
+			syncOptions,
+			waitingForAccount,
+		],
+	);
+
+	useEffect(() => {
+		if (
+			!allowAutoSync ||
+			!autoSettingsReady ||
+			!autoSettings.enabled ||
+			autoSyncBlocked ||
+			waitingForAccount ||
+			birdOnlyWrongAccount
+		) {
+			setNextAutoSyncAt(null);
+			return;
 		}
+
+		const delayMs = Math.min(
+			autoSettings.intervalMs * 2 ** autoFailureCount,
+			MAX_AUTO_SYNC_BACKOFF_MS,
+		);
+		setNextAutoSyncAt(Date.now() + delayMs);
+		const timer = window.setTimeout(() => {
+			if (document.visibilityState === "hidden" || syncingRef.current) {
+				setAutoCycle((current) => current + 1);
+				return;
+			}
+			void syncNow("auto").finally(() => {
+				setAutoCycle((current) => current + 1);
+			});
+		}, delayMs);
+
+		return () => window.clearTimeout(timer);
+	}, [
+		allowAutoSync,
+		autoCycle,
+		autoFailureCount,
+		autoSettings.enabled,
+		autoSettings.intervalMs,
+		autoSettingsReady,
+		autoSyncBlocked,
+		birdOnlyWrongAccount,
+		syncNow,
+		waitingForAccount,
+	]);
+
+	function updateAutoSettings(next: StoredAutoSyncSettings) {
+		const settings = { key: autoSyncKey, ...next };
+		setAutoSettings(settings);
+		window.localStorage.setItem(
+			autoSyncKey,
+			JSON.stringify({ enabled: next.enabled, intervalMs: next.intervalMs }),
+		);
+		setAutoSyncError(null);
+		setAutoFailureCount(0);
+		setLastAutoSyncedAt(null);
+		setAutoCycle((current) => current + 1);
 	}
 
 	return (
-		<div className="flex shrink-0 items-center gap-2">
+		<div
+			className={cx(
+				"flex shrink-0 flex-wrap items-center justify-end gap-2",
+				allowAutoSync && "w-full lg:w-auto",
+			)}
+		>
 			{showAccountPicker && accountAwareSync && accountList.length > 1 ? (
 				<select
 					aria-label="Sync account"
-					className={cx(selectFieldClass, "h-9 w-[132px]")}
+					className={cx(selectFieldClass, "h-9 w-[132px]!")}
 					disabled={syncing}
 					onChange={(event) => selectAccount(event.target.value)}
 					value={accountId ?? ""}
@@ -116,7 +322,7 @@ export function SyncNowButton({
 							: label
 				}
 				disabled={disabled}
-				onClick={syncNow}
+				onClick={() => void syncNow("manual")}
 			>
 				<RefreshCw
 					className={cx("size-4", syncing && "animate-spin")}
@@ -135,6 +341,52 @@ export function SyncNowButton({
 			>
 				{statusMessage}
 			</span>
+			{allowAutoSync && autoSettingsReady ? (
+				<>
+					<label className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[var(--line)] bg-[var(--bg)] px-2.5 text-[12px] font-medium text-[var(--ink-soft)]">
+						<input
+							aria-label={`Auto sync ${kind}`}
+							type="checkbox"
+							checked={autoSettings.enabled}
+							disabled={waitingForAccount || birdOnlyWrongAccount}
+							onChange={(event) =>
+								updateAutoSettings({
+									enabled: event.currentTarget.checked,
+									intervalMs: autoSettings.intervalMs,
+								})
+							}
+						/>
+						Auto sync
+					</label>
+					<select
+						aria-label={`${label} auto-sync interval`}
+						className={cx(selectFieldClass, "h-9 w-[70px]!")}
+						disabled={!autoSettings.enabled}
+						onChange={(event) =>
+							updateAutoSettings({
+								enabled: autoSettings.enabled,
+								intervalMs: Number(event.currentTarget.value),
+							})
+						}
+						value={autoSettings.intervalMs}
+					>
+						{AUTO_SYNC_INTERVALS.map((option) => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
+					<span
+						className={cx(
+							"max-w-[190px] truncate text-[12px]",
+							autoSyncError ? "text-[var(--alert)]" : "text-[var(--ink-soft)]",
+						)}
+						role="status"
+					>
+						{autoStatusMessage}
+					</span>
+				</>
+			) : null}
 		</div>
 	);
 }

--- a/src/components/TimelineFeedShell.tsx
+++ b/src/components/TimelineFeedShell.tsx
@@ -31,7 +31,7 @@ export function TimelineFeedHeader({
 }) {
 	return (
 		<header className={pageHeaderClass}>
-			<div className={pageHeaderRowClass}>
+			<div className={`${pageHeaderRowClass} flex-wrap`}>
 				<div className="flex min-w-0 flex-col">
 					<h1 className={pageTitleClass}>{title}</h1>
 					{subtitles}

--- a/src/components/TimelineRouteFrame.tsx
+++ b/src/components/TimelineRouteFrame.tsx
@@ -91,6 +91,8 @@ export function TimelineRouteFrame({
 					action={
 						<SyncNowButton
 							accounts={meta?.accounts}
+							allowAutoSync
+							autoSyncBlocked={loading}
 							kind={syncKind}
 							label={syncLabel}
 							onSynced={refreshLocalView}


### PR DESCRIPTION
## Summary

- add opt-in Home and Mentions auto-sync at bounded 5m–1h intervals
- persist settings per account and sync kind, skip hidden pages, prevent overlap, and back off after failures
- keep status visible across responsive layouts without changing DMs
- add `VISION.md` to define local-first live-read policy and the criteria for future data surfaces

Fixes #73

## Validation

- `pnpm test src/components/SyncNowButton.test.tsx` — 18 passed
- `pnpm test` — 141 files, 1,189 tests passed
- `pnpm check`
- `pnpm build`
- existing Chrome profile: Home and Mentions controls, per-account persistence, 600px responsive layout, and DMs regression path verified
- autoreview: no accepted or actionable findings

Local proof screenshots were inspected but not uploaded.