### PR TITLE
fix: bundle production server runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Installed package smoke test
+        run: pnpm pack:smoke
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Bundle the TanStack Start H3 runtime into production server artifacts so installed npm packages can start without undeclared transitive dependencies.
 - Add completed Today digest PDF export with route-scoped print styling, while excluding partial failed streams. (#77 - thanks @Gatsby1s)
 - Make the Today digest's selected period visually distinct and expose its pressed state to assistive technology. (#72 - thanks @Gatsby1s)
 - Keep backup Git commits inside the configured repository root and pin hashed backup text files to LF line endings. (#79 - thanks @rodriguez46p-ui)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ const config = defineConfig({
 	resolve: {
 		tsconfigPaths: true,
 	},
+	ssr: {
+		noExternal: ["h3-v2", "rou3", "srvx"],
+	},
 	server: {
 		allowedHosts: ["clawmac.sheep-coho.ts.net", ...extraAllowedHosts],
 	},


### PR DESCRIPTION
## Summary

- bundle TanStack Start's H3 server runtime and its direct runtime packages into production SSR artifacts
- prevent the installed npm package from depending on undeclared transitive modules after the Vite 8.1 refresh
- run the installed-package smoke test in CI so packaging regressions block future PRs
- record the packaging fix in the changelog

## Failure reproduced

`pnpm pack:smoke` failed from a clean tarball install because `dist/server/server.js` imported `h3-v2`, then `rou3`, outside the published dependency contract.

## Validation

- `pnpm check`
- `pnpm test` — 141 files, 1,189 tests passed
- `pnpm pack:smoke` — 98 packaged files; installed production server started successfully
- autoreview: no accepted or actionable findings