### PR TITLE
fix: preserve included quote reply state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Keep backup Git commits inside the configured repository root and pin hashed backup text files to LF line endings. (#79 - thanks @rodriguez46p-ui)
 - Persist profile avatars exposed by Bird's full live-sync payloads. (#75 - thanks @RajvardhanPatil07)
 - Persist quoted tweet payloads returned by Bird-backed live syncs so quote cards render without a separate hydrate. (#76 - thanks @lukaskawerau)
+- Keep included quote-only replies out of local replied/unreplied state during collection and thread-context syncs. (#76 - thanks @lukaskawerau)
 - Show full tweet text in Today citation popovers instead of truncating long posts after six lines.
 - Show inline tweet images in Today citation popovers instead of leaving media-only `t.co` links in the preview text.
 

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+import { ingestTweetPayload } from "./tweet-repository";
+
+let tempRoot: string | undefined;
+
+afterEach(() => {
+	resetDatabaseForTests();
+	resetBirdclawPathsForTests();
+	delete process.env.BIRDCLAW_HOME;
+	if (tempRoot) {
+		rmSync(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+it("marks only primary replies as replied", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb();
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		markRepliesAsReplied: true,
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "liked_reply",
+					author_id: "42",
+					text: "primary reply quoting context",
+					created_at: "2026-07-01T10:00:00.000Z",
+					referenced_tweets: [
+						{ type: "replied_to", id: "primary_parent" },
+						{ type: "quoted", id: "quoted_reply" },
+					],
+				},
+			],
+			includes: {
+				users: [
+					{ id: "42", username: "sam", name: "Sam" },
+					{ id: "43", username: "alex", name: "Alex" },
+				],
+				tweets: [
+					{
+						id: "quoted_reply",
+						author_id: "43",
+						text: "included reply used only as quote context",
+						created_at: "2026-07-01T09:00:00.000Z",
+						referenced_tweets: [{ type: "replied_to", id: "quoted_parent" }],
+					},
+				],
+			},
+		},
+	});
+
+	expect(
+		db
+			.prepare(
+				"select id, is_replied, reply_to_id from tweets where id in (?, ?) order by id",
+			)
+			.all("liked_reply", "quoted_reply"),
+	).toEqual([
+		{ id: "liked_reply", is_replied: 1, reply_to_id: "primary_parent" },
+		{ id: "quoted_reply", is_replied: 0, reply_to_id: "quoted_parent" },
+	]);
+});

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -100,12 +100,15 @@ export function ingestTweetPayload(
 				: ensureStubProfileForXUser(db, tweet.author_id);
 			const replyToId = getReferencedTweetId(tweet, "replied_to");
 			const quotedTweetId = getReferencedTweetId(tweet, "quoted");
+			// Included tweets are reference data, not members of the caller's result set.
+			const shouldMarkReplied =
+				isPrimaryTweet && markRepliesAsReplied && Boolean(replyToId);
 			upsertTweet.run(
 				tweet.id,
 				profile.profile.id,
 				tweet.text,
 				tweet.created_at,
-				markRepliesAsReplied && replyToId ? 1 : 0,
+				shouldMarkReplied ? 1 : 0,
 				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				countTweetMedia(tweet),


### PR DESCRIPTION
## Summary

- limit collection/thread-context reply-state classification to primary payload tweets
- keep hydrated quote-only replies as reference data while preserving their parent IDs
- add a focused regression test and changelog entry

Follow-up to https://github.com/steipete/birdclaw/pull/76#discussion_r3504444859.

## Root cause

PR 76 expanded canonical persistence to `includes.tweets`, but `markRepliesAsReplied` still applied to every canonical row before primary membership was considered. Because `is_replied` merges with `max`, an included quote reply could remain permanently classified as replied when it later appeared as a primary mention.

## Validation

- `pnpm test src/lib/tweet-repository.test.ts src/lib/timeline-collections-live.test.ts src/lib/mention-threads-live.test.ts src/lib/timeline-live.test.ts` — 4 files / 58 tests passed
- `pnpm check`
- `pnpm test` — 142 files / 1,190 tests passed
- `pnpm build`
- `pnpm pack:smoke` — 98 packaged files; installed production server passed
- `pnpm e2e` — 12 Chromium tests passed
- structured autoreview — clean, no accepted/actionable findings

## Built behavior proof

Ran the built `bin/birdclaw.mjs` against a fresh isolated `BIRDCLAW_HOME` and a deterministic local Bird transport fixture. A likes sync stored the primary reply with `is_replied = 1` and the included quote-only reply with `is_replied = 0`, preserving both parent IDs. Repeating the sync kept the quote-only row at `0`.
