### PR TITLE
fix: bookmarks sync in web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Restore web Likes and Bookmarks sync when automatic transport selection falls back to Bird without all-pages mode. (#87 - thanks @zuyu)
 - Bundle the TanStack Start H3 runtime into production server artifacts so installed npm packages can start without undeclared transitive dependencies.
 - Add completed Today digest PDF export with route-scoped print styling, while excluding partial failed streams. (#77 - thanks @Gatsby1s)
 - Make the Today digest's selected period visually distinct and expose its pressed state to assistive technology. (#72 - thanks @Gatsby1s)

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -595,6 +595,21 @@ describe("bird transport wrapper", () => {
 		]);
 	});
 
+	it("omits max-pages for single-page bird saved collections", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdStdoutOnce("[]");
+		mockBirdStdoutOnce("[]");
+		const { listBookmarkedTweetsViaBird, listLikedTweetsViaBird } =
+			await import("./bird");
+
+		await listLikedTweetsViaBird({ maxResults: 5, maxPages: 2 });
+		await listBookmarkedTweetsViaBird({ maxResults: 7, maxPages: 3 });
+
+		expect(execFileAsyncMock).toHaveBeenCalledTimes(2);
+		expectBirdCommandCall(1, ["likes", "-n", "5", "--json-full"]);
+		expectBirdCommandCall(2, ["bookmarks", "-n", "7", "--json-full"]);
+	});
+
 	it("maps bird home timeline json into xurl-compatible payloads", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce(

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -641,9 +641,9 @@ function listTweetsViaBirdCommandEffect({
 		const args = [command, "-n", String(maxResults)];
 		if (all) {
 			args.push("--all");
-		}
-		if (maxPages !== undefined) {
-			args.push("--max-pages", String(maxPages));
+			if (maxPages !== undefined) {
+				args.push("--max-pages", String(maxPages));
+			}
 		}
 		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);


### PR DESCRIPTION
## Summary
Fix bookmarks sync in web UI, w/o `xurl` installed, given `--max-pages` argument, but no `--all`

## Root cause

listTweetsViaBirdCommandEffect (shared by bookmarks and likes) sent --max-pages to the bird CLI without --all, which the CLI rejects (--max-pages requires --all or --cursor).

The web UI's bookmarks sync always requests maxPages: 5 without all: true, https://github.com/steipete/birdclaw/blob/207017d64cd374ee4c60f7d60f08b4c975c39149/src/lib/web-sync.ts#L255-L259

and since xurl isn't installed on your machine, it fell through to the bird transport and hit this.

Fixed by only emitting --max-pages when --all is also set, matching the gating pattern already used elsewhere in the file.

Refresh http://127.0.0.1:3000/bookmarks — sync should now work. This also fixes the same latent issue for likes sync, which shares the buggy function.

## Validation

* `pnpm test src/lib/bird.test.ts` -- 1 file / 27 tests passed
* `pnpm check`
* `pnpm test` -- 142 files / 1,190 tests passed
* `pnpm build`
* `pnpm pack:smoke` -- 98 packaged files; installed production server passed
* `pnpm e2e` — 12 Chromium tests passed

## Manual Test
Bookmark sync in Web UI works locally.