### PR TITLE
refactor: modernize Effect usage (typed errors, Schedule retries, TTL caches, Effect.fn spans)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.3 - Unreleased
 
+### Changed
+
+- Modernize Effect usage across the transports: hidden 429 retries now run through a composed `Schedule` (capped exponential backoff, deadline- and abort-aware), transport/auth lookups are memoized with `Effect.cachedWithTTL`, xurl failures carry a typed `XurlCommandError` with structured rate-limit classification, link-preview DNS resolution uses `Effect.timeoutFail`, xurl/bird operations are traced `Effect.fn` spans, and live read paths call Effect transports directly instead of round-tripping through Promise wrappers.
+
 ## 0.9.2 - 2026-07-04
 
 ### Fixed

--- a/src/lib/actions-transport.test.ts
+++ b/src/lib/actions-transport.test.ts
@@ -18,22 +18,40 @@ const mocks = vi.hoisted(() => ({
 	lookupAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => ({
-	blockUserViaBird: mocks.blockUserViaBird,
-	unblockUserViaBird: mocks.unblockUserViaBird,
-	muteUserViaBird: mocks.muteUserViaBird,
-	readBirdStatusViaBird: mocks.readBirdStatusViaBird,
-	unmuteUserViaBird: mocks.unmuteUserViaBird,
-}));
+vi.mock("./bird-actions", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		blockUserViaBirdEffect: fromMock(mocks.blockUserViaBird),
+		unblockUserViaBirdEffect: fromMock(mocks.unblockUserViaBird),
+		muteUserViaBirdEffect: fromMock(mocks.muteUserViaBird),
+		readBirdStatusViaBirdEffect: fromMock(mocks.readBirdStatusViaBird),
+		unmuteUserViaBirdEffect: fromMock(mocks.unmuteUserViaBird),
+	};
+});
 
-vi.mock("./xurl", () => ({
-	blockUserViaXurl: mocks.blockUserViaXurl,
-	unblockUserViaXurl: mocks.unblockUserViaXurl,
-	muteUserViaXurl: mocks.muteUserViaXurl,
-	unmuteUserViaXurl: mocks.unmuteUserViaXurl,
-	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
-	lookupAuthenticatedUserFresh: mocks.lookupAuthenticatedUser,
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		blockUserViaXurlEffect: fromMock(mocks.blockUserViaXurl),
+		unblockUserViaXurlEffect: fromMock(mocks.unblockUserViaXurl),
+		muteUserViaXurlEffect: fromMock(mocks.muteUserViaXurl),
+		unmuteUserViaXurlEffect: fromMock(mocks.unmuteUserViaXurl),
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupAuthenticatedUserFreshEffect: fromMock(mocks.lookupAuthenticatedUser),
+	};
+});
 
 describe("actions transport", () => {
 	let birdclawHome: string | undefined;

--- a/src/lib/actions-transport.test.ts
+++ b/src/lib/actions-transport.test.ts
@@ -18,14 +18,8 @@ const mocks = vi.hoisted(() => ({
 	lookupAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./bird-actions", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		blockUserViaBirdEffect: fromMock(mocks.blockUserViaBird),
 		unblockUserViaBirdEffect: fromMock(mocks.unblockUserViaBird),
@@ -35,14 +29,8 @@ vi.mock("./bird-actions", () => {
 	};
 });
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		blockUserViaXurlEffect: fromMock(mocks.blockUserViaXurl),
 		unblockUserViaXurlEffect: fromMock(mocks.unblockUserViaXurl),

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -1,13 +1,13 @@
 import {
-	blockUserViaBird,
-	muteUserViaBird,
-	readBirdStatusViaBird,
-	unblockUserViaBird,
-	unmuteUserViaBird,
+	blockUserViaBirdEffect,
+	muteUserViaBirdEffect,
+	readBirdStatusViaBirdEffect,
+	unblockUserViaBirdEffect,
+	unmuteUserViaBirdEffect,
 } from "./bird-actions";
 import { type ActionsTransport, resolveActionsTransport } from "./config";
 import { Effect } from "effect";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise } from "./effect-runtime";
 import { profileHandleKey } from "./profile-row";
 import type {
 	ModerationAction,
@@ -15,11 +15,11 @@ import type {
 	ModerationTransportKind,
 } from "./types";
 import {
-	blockUserViaXurl,
-	lookupAuthenticatedUserFresh,
-	muteUserViaXurl,
-	unblockUserViaXurl,
-	unmuteUserViaXurl,
+	blockUserViaXurlEffect,
+	lookupAuthenticatedUserFreshEffect,
+	muteUserViaXurlEffect,
+	unblockUserViaXurlEffect,
+	unmuteUserViaXurlEffect,
 } from "./xurl";
 
 export type ActionTransportResult = ModerationActionTransportResult;
@@ -64,7 +64,7 @@ function verifyExpectedAccountEffect(
 		if (!expectedAccount) return null;
 		if (liveWritesDisabled()) return null;
 
-		const sourceUser = yield* tryPromise(() => lookupAuthenticatedUserFresh());
+		const sourceUser = yield* lookupAuthenticatedUserFreshEffect();
 		const sourceUserId =
 			sourceUser && typeof sourceUser.id === "string" ? sourceUser.id : "";
 		const sourceUsername =
@@ -100,15 +100,13 @@ function runBirdActionEffect(
 	query: string,
 ): Effect.Effect<ActionTransportResult, unknown> {
 	return Effect.gen(function* () {
-		const result = yield* tryPromise(() =>
-			action === "block"
-				? blockUserViaBird(query)
-				: action === "unblock"
-					? unblockUserViaBird(query)
-					: action === "mute"
-						? muteUserViaBird(query)
-						: unmuteUserViaBird(query),
-		);
+		const result = yield* action === "block"
+			? blockUserViaBirdEffect(query)
+			: action === "unblock"
+				? unblockUserViaBirdEffect(query)
+				: action === "mute"
+					? muteUserViaBirdEffect(query)
+					: unmuteUserViaBirdEffect(query);
 
 		return {
 			...result,
@@ -146,9 +144,7 @@ function runXurlActionEffect(
 
 		let sourceUserId = verifiedSourceUserId ?? "";
 		if (!sourceUserId) {
-			const sourceUser = yield* tryPromise(() =>
-				lookupAuthenticatedUserFresh(),
-			);
+			const sourceUser = yield* lookupAuthenticatedUserFreshEffect();
 			sourceUserId =
 				sourceUser && typeof sourceUser.id === "string" ? sourceUser.id : "";
 		}
@@ -160,15 +156,13 @@ function runXurlActionEffect(
 			};
 		}
 
-		const result = yield* tryPromise(() =>
-			action === "block"
-				? blockUserViaXurl(sourceUserId, targetUserId)
-				: action === "unblock"
-					? unblockUserViaXurl(sourceUserId, targetUserId)
-					: action === "mute"
-						? muteUserViaXurl(sourceUserId, targetUserId)
-						: unmuteUserViaXurl(sourceUserId, targetUserId),
-		);
+		const result = yield* action === "block"
+			? blockUserViaXurlEffect(sourceUserId, targetUserId)
+			: action === "unblock"
+				? unblockUserViaXurlEffect(sourceUserId, targetUserId)
+				: action === "mute"
+					? muteUserViaXurlEffect(sourceUserId, targetUserId)
+					: unmuteUserViaXurlEffect(sourceUserId, targetUserId);
 
 		if (!result.ok) {
 			return {
@@ -177,7 +171,7 @@ function runXurlActionEffect(
 			};
 		}
 
-		const status = yield* tryPromise(() => readBirdStatusViaBird(query));
+		const status = yield* readBirdStatusViaBirdEffect(query);
 		const { field: verifyField, expected: expectedValue } =
 			getVerifyExpectation(action);
 		const actualValue =

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -17,10 +17,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./xurl", () => {
 	const fromMock =
-		(mock: (...args: unknown[]) => unknown) =>
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
 		(...args: unknown[]) =>
 			Effect.tryPromise({
-				try: () => Promise.resolve(mock(...args)),
+				try: () => mock(...args),
 				catch: (error) => error,
 			});
 	return {

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -15,12 +15,20 @@ const mocks = vi.hoisted(() => ({
 	lookupAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock("./xurl", () => ({
-	getTransportStatus: (...args: unknown[]) => mocks.getTransportStatus(...args),
-	listUserTweets: (...args: unknown[]) => mocks.listUserTweets(...args),
-	lookupAuthenticatedUser: (...args: unknown[]) =>
-		mocks.lookupAuthenticatedUser(...args),
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => unknown) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => Promise.resolve(mock(...args)),
+				catch: (error) => error,
+			});
+	return {
+		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
+		listUserTweetsEffect: fromMock(mocks.listUserTweets),
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+	};
+});
 
 const tempDirs: string[] = [];
 

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -15,14 +15,8 @@ const mocks = vi.hoisted(() => ({
 	lookupAuthenticatedUser: vi.fn(),
 }));
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
 		listUserTweetsEffect: fromMock(mocks.listUserTweets),

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -291,44 +291,44 @@ function makeBirdStdoutTempEffect() {
 	);
 }
 
-export function runBirdJsonCommandEffect(args: string[], timeoutMs?: number) {
-	return Effect.scoped(
-		Effect.gen(function* () {
-			const birdCommand = yield* Effect.try({
-				try: () => getBirdCommand(),
-				catch: (error) =>
-					error instanceof Error ? error : new Error(String(error)),
-			});
-			const { stdoutPath } = yield* makeBirdStdoutTempEffect();
-			yield* Effect.tryPromise({
-				try: () =>
-					execFileAsync(
-						"/bin/bash",
-						[
-							"-c",
-							BIRD_STDOUT_REDIRECT_SCRIPT,
-							"birdclaw-bird",
-							stdoutPath,
-							birdCommand,
-							...args,
-						],
-						{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
-					),
-				catch: (error) => formatBirdCommandError(error, birdCommand),
-			});
-			return yield* Effect.try({
-				try: () => readFileSync(stdoutPath, "utf8"),
-				catch: (error) => error,
-			});
-		}),
-	);
-}
+export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
+	(args: string[], timeoutMs?: number) =>
+		Effect.scoped(
+			Effect.gen(function* () {
+				const birdCommand = yield* Effect.try({
+					try: () => getBirdCommand(),
+					catch: (error) =>
+						error instanceof Error ? error : new Error(String(error)),
+				});
+				const { stdoutPath } = yield* makeBirdStdoutTempEffect();
+				yield* Effect.tryPromise({
+					try: () =>
+						execFileAsync(
+							"/bin/bash",
+							[
+								"-c",
+								BIRD_STDOUT_REDIRECT_SCRIPT,
+								"birdclaw-bird",
+								stdoutPath,
+								birdCommand,
+								...args,
+							],
+							{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
+						),
+					catch: (error) => formatBirdCommandError(error, birdCommand),
+				});
+				return yield* Effect.try({
+					try: () => readFileSync(stdoutPath, "utf8"),
+					catch: (error) => error,
+				});
+			}),
+		),
+);
 
-function runBirdJsonCommandAllowFailureEffect(
-	args: string[],
-	timeoutMs?: number,
-) {
-	return Effect.scoped(
+const runBirdJsonCommandAllowFailureEffect = Effect.fn(
+	"bird.runJsonCommandAllowFailure",
+)((args: string[], timeoutMs?: number) =>
+	Effect.scoped(
 		Effect.gen(function* () {
 			const birdCommand = yield* Effect.try({
 				try: () => getBirdCommand(),
@@ -363,8 +363,8 @@ function runBirdJsonCommandAllowFailureEffect(
 				catch: (error) => error,
 			});
 		}),
-	);
-}
+	),
+);
 
 function runBirdTweetJsonCommandEffect(args: string[], timeoutMs?: number) {
 	return runBirdJsonCommandEffect([...args, "--json-full"], timeoutMs).pipe(
@@ -622,12 +622,8 @@ function normalizeBirdTweetItemEffect(payload: unknown, command: string) {
 	});
 }
 
-export function listMentionsViaBirdEffect({
-	maxResults,
-}: {
-	maxResults: number;
-}): Effect.Effect<XurlMentionsResponse, unknown> {
-	return Effect.gen(function* () {
+export const listMentionsViaBirdEffect = Effect.fn("bird.listMentions")(
+	function* ({ maxResults }: { maxResults: number }) {
 		const stdout = yield* runBirdTweetJsonCommandEffect([
 			"mentions",
 			"-n",
@@ -635,8 +631,8 @@ export function listMentionsViaBirdEffect({
 		]);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "mentions");
-	});
-}
+	},
+);
 
 export function listMentionsViaBird(options: {
 	maxResults: number;
@@ -644,7 +640,7 @@ export function listMentionsViaBird(options: {
 	return runEffectPromise(listMentionsViaBirdEffect(options));
 }
 
-function listTweetsViaBirdCommandEffect({
+const listTweetsViaBirdCommandEffect = Effect.fn("bird.listTweets")(function* ({
 	command,
 	maxResults,
 	all,
@@ -654,20 +650,18 @@ function listTweetsViaBirdCommandEffect({
 	maxResults: number;
 	all?: boolean;
 	maxPages?: number;
-}): Effect.Effect<XurlMentionsResponse, unknown> {
-	return Effect.gen(function* () {
-		const args = [command, "-n", String(maxResults)];
-		if (all) {
-			args.push("--all");
-			if (maxPages !== undefined) {
-				args.push("--max-pages", String(maxPages));
-			}
+}) {
+	const args = [command, "-n", String(maxResults)];
+	if (all) {
+		args.push("--all");
+		if (maxPages !== undefined) {
+			args.push("--max-pages", String(maxPages));
 		}
-		const stdout = yield* runBirdTweetJsonCommandEffect(args);
-		const payload = yield* parseBirdJsonEffect(stdout);
-		return yield* normalizeBirdTweetsPayloadEffect(payload, command);
-	});
-}
+	}
+	const stdout = yield* runBirdTweetJsonCommandEffect(args);
+	const payload = yield* parseBirdJsonEffect(stdout);
+	return yield* normalizeBirdTweetsPayloadEffect(payload, command);
+});
 
 export function listLikedTweetsViaBirdEffect(options: {
 	maxResults: number;
@@ -707,15 +701,15 @@ export function listBookmarkedTweetsViaBird(options: {
 	return runEffectPromise(listBookmarkedTweetsViaBirdEffect(options));
 }
 
-export function searchTweetsViaBirdEffect(
-	query: string,
-	options: {
-		maxResults: number;
-		all?: boolean;
-		maxPages?: number;
-	},
-): Effect.Effect<XurlMentionsResponse, unknown> {
-	return Effect.gen(function* () {
+export const searchTweetsViaBirdEffect = Effect.fn("bird.searchTweets")(
+	function* (
+		query: string,
+		options: {
+			maxResults: number;
+			all?: boolean;
+			maxPages?: number;
+		},
+	) {
 		const args = ["search", query, "-n", String(options.maxResults)];
 		if (options.all) {
 			args.push("--all");
@@ -726,8 +720,8 @@ export function searchTweetsViaBirdEffect(
 		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "search");
-	});
-}
+	},
+);
 
 export function searchTweetsViaBird(
 	query: string,
@@ -740,27 +734,24 @@ export function searchTweetsViaBird(
 	return runEffectPromise(searchTweetsViaBirdEffect(query, options));
 }
 
-export function lookupTweetsByIdsViaBirdEffect(
-	ids: string[],
-): Effect.Effect<XurlTweetsResponse, unknown> {
+export const lookupTweetsByIdsViaBirdEffect = Effect.fn(
+	"bird.lookupTweetsByIds",
+)(function* (ids: string[]): Effect.fn.Return<XurlTweetsResponse, unknown> {
 	if (ids.length === 0) {
-		return Effect.succeed({ data: [] });
+		return { data: [] };
 	}
 
-	return Effect.gen(function* () {
-		const tweets = yield* Effect.forEach(
-			ids,
-			(id) =>
-				Effect.gen(function* () {
-					const stdout = yield* runBirdTweetJsonCommandEffect(["read", id]);
-					const payload = yield* parseBirdJsonEffect(stdout);
-					return yield* normalizeBirdTweetItemEffect(payload, "read");
-				}),
-			{ concurrency: "unbounded" },
-		);
-		return normalizeBirdTweets(tweets);
-	});
-}
+	const tweets = yield* Effect.forEach(
+		ids,
+		Effect.fn("bird.readTweet")(function* (id: string) {
+			const stdout = yield* runBirdTweetJsonCommandEffect(["read", id]);
+			const payload = yield* parseBirdJsonEffect(stdout);
+			return yield* normalizeBirdTweetItemEffect(payload, "read");
+		}),
+		{ concurrency: "unbounded" },
+	);
+	return normalizeBirdTweets(tweets);
+});
 
 export function lookupTweetsByIdsViaBird(
 	ids: string[],
@@ -768,14 +759,14 @@ export function lookupTweetsByIdsViaBird(
 	return runEffectPromise(lookupTweetsByIdsViaBirdEffect(ids));
 }
 
-export function listHomeTimelineViaBirdEffect({
-	maxResults,
-	following = true,
-}: {
-	maxResults: number;
-	following?: boolean;
-}): Effect.Effect<XurlMentionsResponse, unknown> {
-	return Effect.gen(function* () {
+export const listHomeTimelineViaBirdEffect = Effect.fn("bird.listHomeTimeline")(
+	function* ({
+		maxResults,
+		following = true,
+	}: {
+		maxResults: number;
+		following?: boolean;
+	}) {
 		const args = ["home", "-n", String(maxResults)];
 		if (following) {
 			args.push("--following");
@@ -783,8 +774,8 @@ export function listHomeTimelineViaBirdEffect({
 		const stdout = yield* runBirdTweetJsonCommandEffect(args);
 		const payload = yield* parseBirdJsonEffect(stdout);
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "home");
-	});
-}
+	},
+);
 
 export function listHomeTimelineViaBird(options: {
 	maxResults: number;
@@ -838,20 +829,20 @@ function normalizeBirdFollowUsersEffect(
 	});
 }
 
-export function listFollowUsersViaBirdEffect({
-	direction,
-	userId,
-	maxResults,
-	all,
-	maxPages,
-}: {
-	direction: "followers" | "following";
-	userId?: string;
-	maxResults: number;
-	all?: boolean;
-	maxPages?: number;
-}): Effect.Effect<XurlFollowUsersResponse, unknown> {
-	return Effect.gen(function* () {
+export const listFollowUsersViaBirdEffect = Effect.fn("bird.listFollowUsers")(
+	function* ({
+		direction,
+		userId,
+		maxResults,
+		all,
+		maxPages,
+	}: {
+		direction: "followers" | "following";
+		userId?: string;
+		maxResults: number;
+		all?: boolean;
+		maxPages?: number;
+	}) {
 		const args = [direction, "-n", String(maxResults), "--json"];
 		if (userId) {
 			args.push("--user", userId);
@@ -869,8 +860,8 @@ export function listFollowUsersViaBirdEffect({
 			direction,
 			maxResults,
 		);
-	});
-}
+	},
+);
 
 export function listFollowUsersViaBird(options: {
 	direction: "followers" | "following";
@@ -914,12 +905,8 @@ function normalizeBirdLists(payload: unknown): XListPage {
 	return { data, meta: { result_count: data.length, next_token: null } };
 }
 
-export function listOwnedXListsViaBirdEffect({
-	maxResults,
-}: {
-	maxResults: number;
-}) {
-	return Effect.gen(function* () {
+export const listOwnedXListsViaBirdEffect = Effect.fn("bird.listOwnedXLists")(
+	function* ({ maxResults }: { maxResults: number }) {
 		const stdout = yield* runBirdJsonCommandEffect([
 			"lists",
 			"-n",
@@ -931,23 +918,23 @@ export function listOwnedXListsViaBirdEffect({
 			try: () => normalizeBirdLists(payload),
 			catch: (error) => error,
 		});
-	});
-}
+	},
+);
 
 export function listOwnedXListsViaBird(options: { maxResults: number }) {
 	return runEffectPromise(listOwnedXListsViaBirdEffect(options));
 }
 
-export function listXListMembersViaBirdEffect({
-	listId,
-	maxResults,
-	maxPages = 1,
-}: {
-	listId: string;
-	maxResults: number;
-	maxPages?: number;
-}) {
-	return Effect.gen(function* () {
+export const listXListMembersViaBirdEffect = Effect.fn("bird.listXListMembers")(
+	function* ({
+		listId,
+		maxResults,
+		maxPages = 1,
+	}: {
+		listId: string;
+		maxResults: number;
+		maxPages?: number;
+	}) {
 		const args = ["list-members", listId, "-n", String(maxResults), "--json"];
 		if (maxPages > 1) {
 			args.push("--all", "--max-pages", String(maxPages));
@@ -967,8 +954,8 @@ export function listXListMembersViaBirdEffect({
 			};
 		}
 		return normalized;
-	});
-}
+	},
+);
 
 export function listXListMembersViaBird(options: {
 	listId: string;
@@ -978,7 +965,7 @@ export function listXListMembersViaBird(options: {
 	return runEffectPromise(listXListMembersViaBirdEffect(options));
 }
 
-export function listThreadViaBirdEffect({
+export const listThreadViaBirdEffect = Effect.fn("bird.listThread")(function* ({
 	tweetId,
 	all,
 	maxPages,
@@ -988,20 +975,18 @@ export function listThreadViaBirdEffect({
 	all?: boolean;
 	maxPages?: number;
 	timeoutMs?: number;
-}): Effect.Effect<XurlMentionsResponse, unknown> {
-	return Effect.gen(function* () {
-		const args = ["thread", tweetId];
-		if (all) {
-			args.push("--all");
-		}
-		if (maxPages !== undefined) {
-			args.push("--max-pages", String(maxPages));
-		}
-		const stdout = yield* runBirdTweetJsonCommandEffect(args, timeoutMs);
-		const payload = yield* parseBirdJsonEffect(stdout);
-		return yield* normalizeBirdTweetsPayloadEffect(payload, "thread");
-	});
-}
+}) {
+	const args = ["thread", tweetId];
+	if (all) {
+		args.push("--all");
+	}
+	if (maxPages !== undefined) {
+		args.push("--max-pages", String(maxPages));
+	}
+	const stdout = yield* runBirdTweetJsonCommandEffect(args, timeoutMs);
+	const payload = yield* parseBirdJsonEffect(stdout);
+	return yield* normalizeBirdTweetsPayloadEffect(payload, "thread");
+});
 
 export function listThreadViaBird(options: {
 	tweetId: string;
@@ -1062,24 +1047,23 @@ function parseBirdWhoami(stdout: string): BirdAuthenticatedAccount {
 	};
 }
 
-export function getAuthenticatedBirdAccountEffect(): Effect.Effect<
-	BirdAuthenticatedAccount,
-	unknown
-> {
-	return Effect.gen(function* () {
-		const stdout = yield* runBirdJsonCommandEffect(["whoami"]);
-		return yield* Effect.try({
-			try: () => parseBirdWhoami(stdout),
-			catch: (error) => error,
-		});
+export const getAuthenticatedBirdAccountEffect = Effect.fn(
+	"bird.getAuthenticatedAccount",
+)(function* () {
+	const stdout = yield* runBirdJsonCommandEffect(["whoami"]);
+	return yield* Effect.try({
+		try: () => parseBirdWhoami(stdout),
+		catch: (error) => error,
 	});
-}
+});
 
 export function getAuthenticatedBirdAccount(): Promise<BirdAuthenticatedAccount> {
 	return runEffectPromise(getAuthenticatedBirdAccountEffect());
 }
 
-export function listDirectMessagesViaBirdEffect({
+export const listDirectMessagesViaBirdEffect = Effect.fn(
+	"bird.listDirectMessages",
+)(function* ({
 	maxResults,
 	inbox = "all",
 	maxPages,
@@ -1091,25 +1075,23 @@ export function listDirectMessagesViaBirdEffect({
 	maxPages?: number;
 	allPages?: boolean;
 	pageDelayMs?: number;
-}): Effect.Effect<BirdDmsResponse, unknown> {
-	return Effect.gen(function* () {
-		const args = ["dms", "-n", String(maxResults), "--json"];
-		if (inbox !== "all") {
-			args.push("--inbox", inbox);
-		}
-		if (allPages) {
-			args.push("--all-pages");
-		} else if (typeof maxPages === "number") {
-			args.push("--max-pages", String(maxPages));
-		}
-		if (typeof pageDelayMs === "number" && pageDelayMs > 0) {
-			args.push("--page-delay-ms", String(pageDelayMs));
-		}
-		const stdout = yield* runBirdJsonCommandEffect(args);
-		const payload = yield* parseBirdJsonEffect(stdout);
-		return yield* normalizeBirdDmsPayloadEffect(payload);
-	});
-}
+}) {
+	const args = ["dms", "-n", String(maxResults), "--json"];
+	if (inbox !== "all") {
+		args.push("--inbox", inbox);
+	}
+	if (allPages) {
+		args.push("--all-pages");
+	} else if (typeof maxPages === "number") {
+		args.push("--max-pages", String(maxPages));
+	}
+	if (typeof pageDelayMs === "number" && pageDelayMs > 0) {
+		args.push("--page-delay-ms", String(pageDelayMs));
+	}
+	const stdout = yield* runBirdJsonCommandEffect(args);
+	const payload = yield* parseBirdJsonEffect(stdout);
+	return yield* normalizeBirdDmsPayloadEffect(payload);
+});
 
 export function listDirectMessagesViaBird(options: {
 	maxResults: number;
@@ -1121,7 +1103,9 @@ export function listDirectMessagesViaBird(options: {
 	return runEffectPromise(listDirectMessagesViaBirdEffect(options));
 }
 
-export function runDirectMessageRequestMutationViaBirdEffect({
+export const runDirectMessageRequestMutationViaBirdEffect = Effect.fn(
+	"bird.runDirectMessageRequestMutation",
+)(function* ({
 	action,
 	conversationId,
 	maxPages,
@@ -1131,34 +1115,32 @@ export function runDirectMessageRequestMutationViaBirdEffect({
 	conversationId: string;
 	maxPages?: number;
 	allPages?: boolean;
-}): Effect.Effect<BirdDmMutationResponse, unknown> {
-	return Effect.gen(function* () {
-		const command =
-			action === "accept"
-				? "dm-accept"
-				: action === "reject"
-					? "dm-reject"
-					: "dm-block";
-		const args = [command, conversationId, "--json"];
-		if (action === "block") {
-			if (allPages) {
-				args.push("--all-pages");
-			} else if (typeof maxPages === "number") {
-				args.push("--max-pages", String(maxPages));
-			}
+}): Effect.fn.Return<BirdDmMutationResponse, unknown> {
+	const command =
+		action === "accept"
+			? "dm-accept"
+			: action === "reject"
+				? "dm-reject"
+				: "dm-block";
+	const args = [command, conversationId, "--json"];
+	if (action === "block") {
+		if (allPages) {
+			args.push("--all-pages");
+		} else if (typeof maxPages === "number") {
+			args.push("--max-pages", String(maxPages));
 		}
-		const stdout = yield* runBirdJsonCommandAllowFailureEffect(args);
-		const payload = yield* parseBirdJsonEffect(stdout);
-		if (
-			payload &&
-			typeof payload === "object" &&
-			typeof (payload as { success?: unknown }).success === "boolean"
-		) {
-			return payload as BirdDmMutationResponse;
-		}
-		throw new Error(`bird ${command} returned unexpected JSON`);
-	});
-}
+	}
+	const stdout = yield* runBirdJsonCommandAllowFailureEffect(args);
+	const payload = yield* parseBirdJsonEffect(stdout);
+	if (
+		payload &&
+		typeof payload === "object" &&
+		typeof (payload as { success?: unknown }).success === "boolean"
+	) {
+		return payload as BirdDmMutationResponse;
+	}
+	throw new Error(`bird ${command} returned unexpected JSON`);
+});
 
 export function runDirectMessageRequestMutationViaBird(options: {
 	action: BirdDmRequestAction;
@@ -1171,10 +1153,8 @@ export function runDirectMessageRequestMutationViaBird(options: {
 	);
 }
 
-export function lookupProfileViaBirdEffect(
-	usernameOrId: string,
-): Effect.Effect<XurlMentionUser | null, unknown> {
-	return Effect.gen(function* () {
+export const lookupProfileViaBirdEffect = Effect.fn("bird.lookupProfile")(
+	function* (usernameOrId: string) {
 		const target = usernameOrId.trim().replace(/^@/, "");
 		if (!target) {
 			return null;
@@ -1203,8 +1183,8 @@ export function lookupProfileViaBirdEffect(
 			stdout,
 		)) as BirdUserOverviewPayload;
 		return toXurlMentionUser(payload.user);
-	});
-}
+	},
+);
 
 export function lookupProfileViaBird(
 	usernameOrId: string,
@@ -1254,12 +1234,12 @@ function toXurlMentionUser(
 	};
 }
 
-export function lookupProfilesViaBirdEffect(
+export const lookupProfilesViaBirdEffect = Effect.fn("bird.lookupProfiles")((
 	usernameOrIds: string[],
 ): Effect.Effect<
 	Array<{ target: string; user: XurlMentionUser | null; error?: string }>,
 	unknown
-> {
+> => {
 	const targets = Array.from(
 		new Set(
 			usernameOrIds
@@ -1326,7 +1306,7 @@ export function lookupProfilesViaBirdEffect(
 			);
 		}),
 	);
-}
+});
 
 export function lookupProfilesViaBird(
 	usernameOrIds: string[],

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -20,22 +20,40 @@ const mocks = vi.hoisted(() => ({
 	unblockUserViaXurl: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => ({
-	blockUserViaBird: mocks.blockUserViaBird,
-	lookupProfileViaBird: mocks.lookupProfileViaBird,
-	readBirdStatusViaBird: mocks.readBirdStatusViaBird,
-	unblockUserViaBird: mocks.unblockUserViaBird,
-}));
+vi.mock("./bird-actions", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		blockUserViaBirdEffect: fromMock(mocks.blockUserViaBird),
+		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
+		readBirdStatusViaBirdEffect: fromMock(mocks.readBirdStatusViaBird),
+		unblockUserViaBirdEffect: fromMock(mocks.unblockUserViaBird),
+	};
+});
 
-vi.mock("./xurl", () => ({
-	blockUserViaXurl: mocks.blockUserViaXurl,
-	listBlockedUsers: mocks.listBlockedUsers,
-	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
-	lookupAuthenticatedUserFresh: mocks.lookupAuthenticatedUser,
-	lookupUsersByHandles: mocks.lookupUsersByHandles,
-	lookupUsersByIds: mocks.lookupUsersByIds,
-	unblockUserViaXurl: mocks.unblockUserViaXurl,
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		blockUserViaXurlEffect: fromMock(mocks.blockUserViaXurl),
+		listBlockedUsersEffect: fromMock(mocks.listBlockedUsers),
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupAuthenticatedUserFreshEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupUsersByHandlesEffect: fromMock(mocks.lookupUsersByHandles),
+		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
+		unblockUserViaXurlEffect: fromMock(mocks.unblockUserViaXurl),
+	};
+});
 
 const tempRoots: string[] = [];
 

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -20,14 +20,8 @@ const mocks = vi.hoisted(() => ({
 	unblockUserViaXurl: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./bird-actions", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		blockUserViaBirdEffect: fromMock(mocks.blockUserViaBird),
 		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
@@ -36,14 +30,8 @@ vi.mock("./bird-actions", () => {
 	};
 });
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		blockUserViaXurlEffect: fromMock(mocks.blockUserViaXurl),
 		listBlockedUsersEffect: fromMock(mocks.listBlockedUsers),

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise } from "./effect-runtime";
 import { getAccountHandle, getDefaultAccountId } from "./moderation-target";
 import {
 	createModerationActions,
@@ -11,9 +11,12 @@ import {
 	searchModerationCandidates,
 } from "./moderation-state";
 import type { BlockListResponse } from "./api-contracts";
-import type { BlockItem, BlockSearchItem } from "./types";
+import type { BlockItem, BlockSearchItem, XurlMentionUser } from "./types";
 import { upsertProfileFromXUser } from "./x-profile";
-import { listBlockedUsers, lookupAuthenticatedUserFresh } from "./xurl";
+import {
+	listBlockedUsersEffect,
+	lookupAuthenticatedUserFreshEffect,
+} from "./xurl";
 
 const blockActions = createModerationActions("block");
 
@@ -138,9 +141,7 @@ export function syncBlocksEffect(accountId: string) {
 		}
 
 		return yield* Effect.gen(function* () {
-			const me = yield* tryPromise(() => lookupAuthenticatedUserFresh()).pipe(
-				Effect.mapError(toError),
-			);
+			const me = yield* lookupAuthenticatedUserFreshEffect();
 			const sourceUserId =
 				typeof me?.id === "string" && me.id.length > 0 ? me.id : null;
 			const sourceUsername =
@@ -196,9 +197,10 @@ export function syncBlocksEffect(accountId: string) {
 			let completed = false;
 
 			do {
-				const page = yield* tryPromise(() =>
-					listBlockedUsers(sourceUserId, nextToken ?? undefined),
-				).pipe(Effect.mapError(toError));
+				const page: {
+					items: XurlMentionUser[];
+					nextToken: string | null;
+				} = yield* listBlockedUsersEffect(sourceUserId, nextToken ?? undefined);
 				const pageProfileIds = yield* databaseWriteEffect((writeDb) => {
 					return page.items.map((user) => {
 						const resolved = upsertProfileFromXUser(writeDb, user);

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -23,7 +23,11 @@ vi.mock("./bird", () => ({
 }));
 
 vi.mock("./xurl", () => ({
-	listFollowUsersViaXurl: mocks.listFollowUsersViaXurl,
+	listFollowUsersViaXurlEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listFollowUsersViaXurl(options),
+			catch: (error) => error,
+		}),
 }));
 
 const tempRoots: string[] = [];

--- a/src/lib/link-preview-metadata.ts
+++ b/src/lib/link-preview-metadata.ts
@@ -155,19 +155,6 @@ function stripAddressBrackets(value: string) {
 	return value.replace(/^\[|\]$/g, "");
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number) {
-	let timer: NodeJS.Timeout | null = null;
-	const timeout = new Promise<never>((_resolve, reject) => {
-		timer = setTimeout(
-			() => reject(new Error("Link preview request timed out")),
-			ms,
-		);
-	});
-	return Promise.race([promise, timeout]).finally(() => {
-		if (timer) clearTimeout(timer);
-	});
-}
-
 export async function resolvePublicAddresses(
 	hostname: string,
 ): Promise<string[]> {
@@ -186,26 +173,39 @@ function validateResolvedAddresses(addresses: string[]) {
 	}
 }
 
-async function resolveSafeAddresses(
-	hostname: string,
-	resolveHost: (hostname: string) => Promise<string[]>,
-	timeoutMs: number,
-): Promise<ResolvedAddress[]> {
-	const normalizedHostname = stripAddressBrackets(hostname);
-	const addresses = await withTimeout(
-		resolveHost(normalizedHostname),
-		timeoutMs,
-	);
-	validateResolvedAddresses(addresses);
-	return addresses.map((address) => {
-		const normalized = stripAddressBrackets(address);
-		const family = net.isIP(normalized);
-		if (family !== 4 && family !== 6) {
-			throw new Error("Link preview host resolved to an invalid address");
-		}
-		return { address: normalized, family };
-	});
-}
+const resolveSafeAddressesEffect = Effect.fn(
+	"linkPreview.resolveSafeAddresses",
+)(
+	(
+		hostname: string,
+		resolveHost: (hostname: string) => Promise<string[]>,
+		timeoutMs: number,
+	) =>
+		tryPromise(() => resolveHost(stripAddressBrackets(hostname))).pipe(
+			Effect.timeoutFail({
+				duration: timeoutMs,
+				onTimeout: () => new Error("Link preview request timed out"),
+			}),
+			Effect.flatMap((addresses) =>
+				Effect.try({
+					try: (): ResolvedAddress[] => {
+						validateResolvedAddresses(addresses);
+						return addresses.map((address) => {
+							const normalized = stripAddressBrackets(address);
+							const family = net.isIP(normalized);
+							if (family !== 4 && family !== 6) {
+								throw new Error(
+									"Link preview host resolved to an invalid address",
+								);
+							}
+							return { address: normalized, family };
+						});
+					},
+					catch: (error) => error,
+				}),
+			),
+		),
+);
 
 function headersFromIncoming(headers: http.IncomingHttpHeaders): HeadersInit {
 	const result = new Headers();
@@ -370,31 +370,31 @@ function nodeSafeFetch(
 	);
 }
 
-export function safePreviewFetchEffect(
-	url: string,
-	options: Pick<
-		GetLinkPreviewOptions,
-		"fetchImpl" | "method" | "resolveHost" | "timeoutMs"
-	>,
-) {
-	const resolveHost =
-		options.resolveHost ??
-		(options.fetchImpl
-			? null
-			: (hostname: string) => resolvePublicAddresses(hostname));
-	const timeoutMs = options.timeoutMs ?? FETCH_TIMEOUT_MS;
-	const method = options.method ?? "GET";
-	const deadline = Date.now() + timeoutMs;
-	const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
-	const headers: Record<string, string> = {
-		"user-agent":
-			"Mozilla/5.0 (Macintosh; Intel Mac OS X 15_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36 birdclaw/0.4",
-		accept:
-			"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-		"accept-language": "en-US,en;q=0.9",
-	};
+export const safePreviewFetchEffect = Effect.fn("linkPreview.safePreviewFetch")(
+	function* (
+		url: string,
+		options: Pick<
+			GetLinkPreviewOptions,
+			"fetchImpl" | "method" | "resolveHost" | "timeoutMs"
+		>,
+	) {
+		const resolveHost =
+			options.resolveHost ??
+			(options.fetchImpl
+				? null
+				: (hostname: string) => resolvePublicAddresses(hostname));
+		const timeoutMs = options.timeoutMs ?? FETCH_TIMEOUT_MS;
+		const method = options.method ?? "GET";
+		const deadline = Date.now() + timeoutMs;
+		const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
+		const headers: Record<string, string> = {
+			"user-agent":
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 15_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36 birdclaw/0.4",
+			accept:
+				"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+			"accept-language": "en-US,en;q=0.9",
+		};
 
-	return Effect.gen(function* () {
 		if (options.fetchImpl && !isInjectedFetchAllowed()) {
 			return yield* Effect.fail(
 				new Error("Custom link preview fetch is only available in tests"),
@@ -406,20 +406,20 @@ export function safePreviewFetchEffect(
 			if (Date.now() >= deadline) {
 				return yield* Effect.fail(new Error("Link preview request timed out"));
 			}
-			let remainingMs = remainingTimeoutMs();
 			const parsed = yield* Effect.try({
 				try: () => assertSafePreviewUrl(currentUrl),
 				catch: (error) => error,
 			});
 			if (options.fetchImpl && resolveHost) {
-				yield* tryPromise(() =>
-					resolveSafeAddresses(parsed.hostname, resolveHost, remainingMs),
+				yield* resolveSafeAddressesEffect(
+					parsed.hostname,
+					resolveHost,
+					remainingTimeoutMs(),
 				);
 			}
 			if (Date.now() >= deadline) {
 				return yield* Effect.fail(new Error("Link preview request timed out"));
 			}
-			remainingMs = remainingTimeoutMs();
 
 			const response = options.fetchImpl
 				? yield* tryPromise(
@@ -428,23 +428,27 @@ export function safePreviewFetchEffect(
 								headers,
 								method,
 								redirect: "manual",
-								signal: AbortSignal.timeout(remainingMs),
+								signal: AbortSignal.timeout(remainingTimeoutMs()),
 							}) as Promise<Response>,
 					)
-				: yield* tryPromise(() =>
-						resolveSafeAddresses(
-							parsed.hostname,
-							options.resolveHost ?? resolvePublicAddresses,
-							remainingMs,
-						).then((addresses) =>
-							Date.now() >= deadline
-								? Promise.reject(new Error("Link preview request timed out"))
-								: nodeSafeFetch(parsed, {
-										addresses,
-										headers,
-										method,
-										timeoutMs: remainingTimeoutMs(),
-									}),
+				: yield* resolveSafeAddressesEffect(
+						parsed.hostname,
+						options.resolveHost ?? resolvePublicAddresses,
+						remainingTimeoutMs(),
+					).pipe(
+						Effect.filterOrFail(
+							() => Date.now() < deadline,
+							() => new Error("Link preview request timed out"),
+						),
+						Effect.flatMap((addresses) =>
+							tryPromise(() =>
+								nodeSafeFetch(parsed, {
+									addresses,
+									headers,
+									method,
+									timeoutMs: remainingTimeoutMs(),
+								}),
+							),
 						),
 					);
 			if (response.status < 300 || response.status >= 400) return response;
@@ -466,8 +470,8 @@ export function safePreviewFetchEffect(
 		return yield* Effect.fail(
 			new Error("Link preview redirected too many times"),
 		);
-	});
-}
+	},
+);
 
 function readResponseTextEffect(response: Response) {
 	const contentLength = Number(response.headers.get("content-length") ?? 0);
@@ -568,15 +572,17 @@ export function extractLinkPreviewMetadata(
 	};
 }
 
-export function fetchLinkPreviewMetadataEffect(
-	url: string,
-	options: Pick<
-		GetLinkPreviewOptions,
-		"fetchImpl" | "resolveHost" | "timeoutMs"
-	> = {},
-): Effect.Effect<LinkPreviewMetadata> {
-	return Effect.gen(function* () {
-		const response = yield* safePreviewFetchEffect(url, options);
+export const fetchLinkPreviewMetadataEffect = Effect.fn(
+	"linkPreview.fetchMetadata",
+)(
+	function* (
+		url: string,
+		_options: Pick<
+			GetLinkPreviewOptions,
+			"fetchImpl" | "resolveHost" | "timeoutMs"
+		> = {},
+	): Effect.fn.Return<LinkPreviewMetadata, unknown> {
+		const response = yield* safePreviewFetchEffect(url, _options);
 		const finalUrl = response.url || url;
 		const contentType = response.headers.get("content-type") ?? "";
 		if (!response.ok) {
@@ -599,8 +605,10 @@ export function fetchLinkPreviewMetadataEffect(
 				extractLinkPreviewMetadata(content.slice(0, MAX_HTML_CHARS), finalUrl),
 			catch: (error) => error,
 		});
-	}).pipe(
-		Effect.catchAll((error) =>
+	},
+	// Any failure degrades to a host-label preview carrying the error message.
+	(effect, url) =>
+		Effect.catchAll(effect, (error) =>
 			Effect.succeed({
 				url,
 				title: hostLabel(url),
@@ -608,10 +616,9 @@ export function fetchLinkPreviewMetadataEffect(
 				imageUrl: youtubeThumbnail(url),
 				siteName: hostLabel(url),
 				error: error instanceof Error ? error.message : String(error),
-			}),
+			} satisfies LinkPreviewMetadata),
 		),
-	);
-}
+);
 
 export function fetchLinkPreviewMetadata(
 	url: string,
@@ -713,11 +720,8 @@ function persistPreview(
 	);
 }
 
-export function getOrFetchLinkPreviewEffect(
-	url: string,
-	options: GetLinkPreviewOptions = {},
-): Effect.Effect<LinkPreviewMetadata> {
-	return Effect.gen(function* () {
+export const getOrFetchLinkPreviewEffect = Effect.fn("linkPreview.getOrFetch")(
+	function* (url: string, options: GetLinkPreviewOptions = {}) {
 		const db = getNativeDb({ seedDemoData: false });
 		const cached = readCachedPreview(db, url, options.shortUrl);
 		if (cached && hasUsefulPreview(cached) && !options.refresh) {
@@ -730,8 +734,8 @@ export function getOrFetchLinkPreviewEffect(
 		);
 		persistPreview(db, url, options.shortUrl, cached, preview);
 		return preview;
-	});
-}
+	},
+);
 
 export function getOrFetchLinkPreview(
 	url: string,

--- a/src/lib/live-transport-gateway.ts
+++ b/src/lib/live-transport-gateway.ts
@@ -1,4 +1,3 @@
-import { Effect } from "effect";
 import {
 	getAuthenticatedBirdAccountEffect,
 	listBookmarkedTweetsViaBirdEffect,
@@ -11,18 +10,18 @@ import {
 	searchTweetsViaBirdEffect,
 } from "./bird";
 import {
-	getTransportStatus,
+	getTransportStatusEffect,
 	getTweetByIdEffect,
-	listBookmarkedTweetsViaXurl,
+	listBookmarkedTweetsViaXurlEffect,
 	listDirectMessageEventsViaXurlEffect,
-	listFollowUsersViaXurl,
+	listFollowUsersViaXurlEffect,
 	listHomeTimelineViaXurlEffect,
-	listLikedTweetsViaXurl,
-	listMentionsViaXurl,
-	listUserTweets,
+	listLikedTweetsViaXurlEffect,
+	listMentionsViaXurlEffect,
+	listUserTweetsEffect,
 	lookupAuthenticatedOAuth2UserEffect,
-	lookupAuthenticatedUser,
-	lookupUsersByHandles,
+	lookupAuthenticatedUserEffect,
+	lookupUsersByHandlesEffect,
 	searchRecentByConversationIdEffect,
 	searchRecentTweetsEffect,
 } from "./xurl";
@@ -40,37 +39,18 @@ export interface BirdReadTransport {
 }
 
 export interface XurlReadTransport {
-	getTransportStatus(
-		...args: Parameters<typeof getTransportStatus>
-	): Effect.Effect<Awaited<ReturnType<typeof getTransportStatus>>, Error>;
+	getTransportStatus: typeof getTransportStatusEffect;
 	getTweetById: typeof getTweetByIdEffect;
-	listBookmarks(
-		...args: Parameters<typeof listBookmarkedTweetsViaXurl>
-	): Effect.Effect<
-		Awaited<ReturnType<typeof listBookmarkedTweetsViaXurl>>,
-		Error
-	>;
+	listBookmarks: typeof listBookmarkedTweetsViaXurlEffect;
 	listDirectMessages: typeof listDirectMessageEventsViaXurlEffect;
-	listFollowUsers(
-		...args: Parameters<typeof listFollowUsersViaXurl>
-	): Effect.Effect<Awaited<ReturnType<typeof listFollowUsersViaXurl>>, Error>;
+	listFollowUsers: typeof listFollowUsersViaXurlEffect;
 	listHomeTimeline: typeof listHomeTimelineViaXurlEffect;
-	listLikes(
-		...args: Parameters<typeof listLikedTweetsViaXurl>
-	): Effect.Effect<Awaited<ReturnType<typeof listLikedTweetsViaXurl>>, Error>;
-	listMentions(
-		...args: Parameters<typeof listMentionsViaXurl>
-	): Effect.Effect<Awaited<ReturnType<typeof listMentionsViaXurl>>, Error>;
-	listUserTweets(
-		...args: Parameters<typeof listUserTweets>
-	): Effect.Effect<Awaited<ReturnType<typeof listUserTweets>>, Error>;
+	listLikes: typeof listLikedTweetsViaXurlEffect;
+	listMentions: typeof listMentionsViaXurlEffect;
+	listUserTweets: typeof listUserTweetsEffect;
 	lookupAuthenticatedOAuth2User: typeof lookupAuthenticatedOAuth2UserEffect;
-	lookupAuthenticatedUser(
-		...args: Parameters<typeof lookupAuthenticatedUser>
-	): Effect.Effect<Awaited<ReturnType<typeof lookupAuthenticatedUser>>, Error>;
-	lookupUsersByHandles(
-		...args: Parameters<typeof lookupUsersByHandles>
-	): Effect.Effect<Awaited<ReturnType<typeof lookupUsersByHandles>>, Error>;
+	lookupAuthenticatedUser: typeof lookupAuthenticatedUserEffect;
+	lookupUsersByHandles: typeof lookupUsersByHandlesEffect;
 	searchConversation: typeof searchRecentByConversationIdEffect;
 	searchRecentTweets: typeof searchRecentTweetsEffect;
 }
@@ -80,49 +60,40 @@ export interface LiveTransportGateway {
 	xurl: XurlReadTransport;
 }
 
-function fromPromise<T>(run: () => PromiseLike<T>): Effect.Effect<T, Error> {
-	return Effect.tryPromise({
-		try: run,
-		catch: (error) =>
-			error instanceof Error ? error : new Error(String(error)),
-	});
-}
-
+// Every entry delegates to the Effect-native transport function directly;
+// nothing round-trips through a Promise boundary. Spread forwarding keeps
+// call arity identical to a direct call, which mocked transports assert on.
 export const liveTransportGateway: LiveTransportGateway = {
 	bird: {
-		getAuthenticatedAccount: () => getAuthenticatedBirdAccountEffect(),
-		listBookmarks: (options) => listBookmarkedTweetsViaBirdEffect(options),
-		listDirectMessages: (options) => listDirectMessagesViaBirdEffect(options),
-		listFollowUsers: (options) => listFollowUsersViaBirdEffect(options),
-		listHomeTimeline: (options) => listHomeTimelineViaBirdEffect(options),
-		listLikes: (options) => listLikedTweetsViaBirdEffect(options),
-		listMentions: (options) => listMentionsViaBirdEffect(options),
-		listThread: (options) => listThreadViaBirdEffect(options),
-		searchTweets: (query, options) => searchTweetsViaBirdEffect(query, options),
+		getAuthenticatedAccount: (...args) =>
+			getAuthenticatedBirdAccountEffect(...args),
+		listBookmarks: (...args) => listBookmarkedTweetsViaBirdEffect(...args),
+		listDirectMessages: (...args) => listDirectMessagesViaBirdEffect(...args),
+		listFollowUsers: (...args) => listFollowUsersViaBirdEffect(...args),
+		listHomeTimeline: (...args) => listHomeTimelineViaBirdEffect(...args),
+		listLikes: (...args) => listLikedTweetsViaBirdEffect(...args),
+		listMentions: (...args) => listMentionsViaBirdEffect(...args),
+		listThread: (...args) => listThreadViaBirdEffect(...args),
+		searchTweets: (...args) => searchTweetsViaBirdEffect(...args),
 	},
 	xurl: {
-		getTransportStatus: (...args) =>
-			fromPromise(() => getTransportStatus(...args)),
-		getTweetById: (id, options) => getTweetByIdEffect(id, options),
-		listBookmarks: (...args) =>
-			fromPromise(() => listBookmarkedTweetsViaXurl(...args)),
-		listDirectMessages: (options) =>
-			listDirectMessageEventsViaXurlEffect(options),
-		listFollowUsers: (...args) =>
-			fromPromise(() => listFollowUsersViaXurl(...args)),
-		listHomeTimeline: (options) => listHomeTimelineViaXurlEffect(options),
-		listLikes: (...args) => fromPromise(() => listLikedTweetsViaXurl(...args)),
-		listMentions: (...args) => fromPromise(() => listMentionsViaXurl(...args)),
-		listUserTweets: (...args) => fromPromise(() => listUserTweets(...args)),
-		lookupAuthenticatedOAuth2User: (username) =>
-			lookupAuthenticatedOAuth2UserEffect(username),
+		getTransportStatus: (...args) => getTransportStatusEffect(...args),
+		getTweetById: (...args) => getTweetByIdEffect(...args),
+		listBookmarks: (...args) => listBookmarkedTweetsViaXurlEffect(...args),
+		listDirectMessages: (...args) =>
+			listDirectMessageEventsViaXurlEffect(...args),
+		listFollowUsers: (...args) => listFollowUsersViaXurlEffect(...args),
+		listHomeTimeline: (...args) => listHomeTimelineViaXurlEffect(...args),
+		listLikes: (...args) => listLikedTweetsViaXurlEffect(...args),
+		listMentions: (...args) => listMentionsViaXurlEffect(...args),
+		listUserTweets: (...args) => listUserTweetsEffect(...args),
+		lookupAuthenticatedOAuth2User: (...args) =>
+			lookupAuthenticatedOAuth2UserEffect(...args),
 		lookupAuthenticatedUser: (...args) =>
-			fromPromise(() => lookupAuthenticatedUser(...args)),
-		lookupUsersByHandles: (...args) =>
-			fromPromise(() => lookupUsersByHandles(...args)),
-		searchConversation: (conversationId, options) =>
-			searchRecentByConversationIdEffect(conversationId, options),
-		searchRecentTweets: (query, options) =>
-			searchRecentTweetsEffect(query, options),
+			lookupAuthenticatedUserEffect(...args),
+		lookupUsersByHandles: (...args) => lookupUsersByHandlesEffect(...args),
+		searchConversation: (...args) =>
+			searchRecentByConversationIdEffect(...args),
+		searchRecentTweets: (...args) => searchRecentTweetsEffect(...args),
 	},
 };

--- a/src/lib/mentions-live.test.ts
+++ b/src/lib/mentions-live.test.ts
@@ -32,9 +32,16 @@ vi.mock("./bird", async () => {
 });
 
 vi.mock("./xurl", () => ({
-	listMentionsViaXurl: (...args: unknown[]) => listMentionsViaXurlMock(...args),
-	lookupUsersByHandles: (...args: unknown[]) =>
-		lookupUsersByHandlesMock(...args),
+	listMentionsViaXurlEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => listMentionsViaXurlMock(...args),
+			catch: (error) => error,
+		}),
+	lookupUsersByHandlesEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => lookupUsersByHandlesMock(...args),
+			catch: (error) => error,
+		}),
 }));
 
 const tempDirs: string[] = [];

--- a/src/lib/moderation-target.test.ts
+++ b/src/lib/moderation-target.test.ts
@@ -14,15 +14,33 @@ const mocks = vi.hoisted(() => ({
 	lookupUsersByIds: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => ({
-	lookupProfileViaBird: mocks.lookupProfileViaBird,
-}));
+vi.mock("./bird-actions", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
+	};
+});
 
-vi.mock("./xurl", () => ({
-	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
-	lookupUsersByHandles: mocks.lookupUsersByHandles,
-	lookupUsersByIds: mocks.lookupUsersByIds,
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupUsersByHandlesEffect: fromMock(mocks.lookupUsersByHandles),
+		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
+	};
+});
 
 const tempDirs: string[] = [];
 

--- a/src/lib/moderation-target.test.ts
+++ b/src/lib/moderation-target.test.ts
@@ -14,27 +14,15 @@ const mocks = vi.hoisted(() => ({
 	lookupUsersByIds: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./bird-actions", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
 	};
 });
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
 		lookupUsersByHandlesEffect: fromMock(mocks.lookupUsersByHandles),

--- a/src/lib/moderation-target.ts
+++ b/src/lib/moderation-target.ts
@@ -1,16 +1,16 @@
 import type { Database } from "./sqlite";
 import { Effect } from "effect";
-import { lookupProfileViaBird } from "./bird-actions";
+import { lookupProfileViaBirdEffect } from "./bird-actions";
 import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise } from "./effect-runtime";
 import { normalizeProfileHandle, profileFromDbRow } from "./profile-row";
 import type { ProfileRecord, XurlMentionUser } from "./types";
 import { getExternalUserId, upsertProfileFromXUser } from "./x-profile";
 import {
-	lookupAuthenticatedUser,
-	lookupUsersByHandles,
-	lookupUsersByIds,
+	lookupAuthenticatedUserEffect,
+	lookupUsersByHandlesEffect,
+	lookupUsersByIdsEffect,
 } from "./xurl";
 
 export interface ResolvedModerationProfile {
@@ -122,8 +122,8 @@ export function resolveProfileEffect(
 		let user: XurlMentionUser | undefined;
 		let lastError: unknown;
 
-		const birdResult = yield* tryPromise(() =>
-			lookupProfileViaBird(local?.profile.handle ?? normalizedQuery),
+		const birdResult = yield* lookupProfileViaBirdEffect(
+			local?.profile.handle ?? normalizedQuery,
 		).pipe(
 			Effect.map((value) => ({ ok: true as const, value })),
 			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
@@ -135,10 +135,12 @@ export function resolveProfileEffect(
 		}
 
 		if (!user) {
-			const xurlResult = yield* tryPromise(() =>
+			const xurlResult = yield* (
 				/^\d+$/.test(normalizedQuery)
-					? lookupUsersByIds([normalizedQuery])
-					: lookupUsersByHandles([local?.profile.handle ?? normalizedQuery]),
+					? lookupUsersByIdsEffect([normalizedQuery])
+					: lookupUsersByHandlesEffect([
+							local?.profile.handle ?? normalizedQuery,
+						])
 			).pipe(
 				Effect.map((value) => ({ ok: true as const, value })),
 				Effect.catchAll((error) =>
@@ -201,7 +203,7 @@ export function resolveProfile(
 
 export function getAuthenticatedUserIdEffect() {
 	return Effect.gen(function* () {
-		const me = yield* tryPromise(() => lookupAuthenticatedUser());
+		const me = yield* lookupAuthenticatedUserEffect();
 		const id = me?.id;
 		return typeof id === "string" && id.length > 0 ? id : null;
 	}).pipe(Effect.catchAll(() => Effect.succeed(null)));

--- a/src/lib/mutes.test.ts
+++ b/src/lib/mutes.test.ts
@@ -19,21 +19,39 @@ const mocks = vi.hoisted(() => ({
 	unmuteUserViaXurl: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => ({
-	lookupProfileViaBird: mocks.lookupProfileViaBird,
-	muteUserViaBird: mocks.muteUserViaBird,
-	readBirdStatusViaBird: mocks.readBirdStatusViaBird,
-	unmuteUserViaBird: mocks.unmuteUserViaBird,
-}));
+vi.mock("./bird-actions", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
+		muteUserViaBirdEffect: fromMock(mocks.muteUserViaBird),
+		readBirdStatusViaBirdEffect: fromMock(mocks.readBirdStatusViaBird),
+		unmuteUserViaBirdEffect: fromMock(mocks.unmuteUserViaBird),
+	};
+});
 
-vi.mock("./xurl", () => ({
-	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
-	lookupAuthenticatedUserFresh: mocks.lookupAuthenticatedUser,
-	lookupUsersByHandles: mocks.lookupUsersByHandles,
-	lookupUsersByIds: mocks.lookupUsersByIds,
-	muteUserViaXurl: mocks.muteUserViaXurl,
-	unmuteUserViaXurl: mocks.unmuteUserViaXurl,
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupAuthenticatedUserFreshEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupUsersByHandlesEffect: fromMock(mocks.lookupUsersByHandles),
+		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
+		muteUserViaXurlEffect: fromMock(mocks.muteUserViaXurl),
+		unmuteUserViaXurlEffect: fromMock(mocks.unmuteUserViaXurl),
+	};
+});
 
 const tempDirs: string[] = [];
 

--- a/src/lib/mutes.test.ts
+++ b/src/lib/mutes.test.ts
@@ -19,14 +19,8 @@ const mocks = vi.hoisted(() => ({
 	unmuteUserViaXurl: vi.fn(),
 }));
 
-vi.mock("./bird-actions", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./bird-actions", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		lookupProfileViaBirdEffect: fromMock(mocks.lookupProfileViaBird),
 		muteUserViaBirdEffect: fromMock(mocks.muteUserViaBird),
@@ -35,14 +29,8 @@ vi.mock("./bird-actions", () => {
 	};
 });
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
 		lookupAuthenticatedUserFreshEffect: fromMock(mocks.lookupAuthenticatedUser),

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -162,6 +162,13 @@ function toError(error: unknown) {
 }
 
 function isXurlRateLimitError(error: Error) {
+	// Structured classification from the transport (tag check, so it also works
+	// across module instances); message heuristics stay as a fallback for 429s
+	// that surface without a parseable payload.
+	const tagged = error as { _tag?: unknown; rateLimited?: unknown };
+	if (tagged._tag === "XurlCommandError" && tagged.rateLimited === true) {
+		return true;
+	}
 	return (
 		error.message.includes("Too Many Requests") ||
 		error.message.includes('"status":429') ||

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -14,15 +14,35 @@ const mocks = vi.hoisted(() => ({
 	getAuthenticatedBirdAccount: vi.fn(),
 }));
 
-vi.mock("./xurl", () => ({
-	getTransportStatus: mocks.getTransportStatus,
-	lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
-	lookupUsersByIds: mocks.lookupUsersByIds,
-}));
+vi.mock("./xurl", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
+		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
+	};
+});
 
-vi.mock("./bird", () => ({
-	getAuthenticatedBirdAccount: mocks.getAuthenticatedBirdAccount,
-}));
+vi.mock("./bird", () => {
+	const fromMock =
+		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
+		(...args: unknown[]) =>
+			Effect.tryPromise({
+				try: () => mock(...args),
+				catch: (error) => error,
+			});
+	return {
+		getAuthenticatedBirdAccountEffect: fromMock(
+			mocks.getAuthenticatedBirdAccount,
+		),
+	};
+});
 
 describe("profile hydration", () => {
 	let homeDir = "";

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -14,14 +14,8 @@ const mocks = vi.hoisted(() => ({
 	getAuthenticatedBirdAccount: vi.fn(),
 }));
 
-vi.mock("./xurl", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./xurl", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
@@ -29,14 +23,8 @@ vi.mock("./xurl", () => {
 	};
 });
 
-vi.mock("./bird", () => {
-	const fromMock =
-		(mock: (...args: unknown[]) => PromiseLike<unknown>) =>
-		(...args: unknown[]) =>
-			Effect.tryPromise({
-				try: () => mock(...args),
-				catch: (error) => error,
-			});
+vi.mock("./bird", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
 	return {
 		getAuthenticatedBirdAccountEffect: fromMock(
 			mocks.getAuthenticatedBirdAccount,

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -1,13 +1,13 @@
 import { Effect } from "effect";
 
 import { normalizeAvatarUrl } from "./avatar-cache";
-import { getAuthenticatedBirdAccount } from "./bird";
+import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { getNativeDb } from "./db";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise } from "./effect-runtime";
 import {
-	getTransportStatus,
-	lookupAuthenticatedUser,
-	lookupUsersByIds,
+	getTransportStatusEffect,
+	lookupAuthenticatedUserEffect,
+	lookupUsersByIdsEffect,
 } from "./xurl";
 import { upsertProfileFromXUser } from "./x-profile";
 
@@ -45,7 +45,7 @@ const SEEDED_ACCOUNT_EXTERNAL_USER_ID = "25401953";
 
 function hydrateAccountFromBirdEffect(): Effect.Effect<boolean, unknown> {
 	return Effect.gen(function* () {
-		const account = yield* tryPromise(() => getAuthenticatedBirdAccount()).pipe(
+		const account = yield* getAuthenticatedBirdAccountEffect().pipe(
 			Effect.catchAll(() => Effect.succeed(null)),
 		);
 		if (!account?.username) return false;
@@ -136,7 +136,7 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 	unknown
 > {
 	return Effect.gen(function* () {
-		const transport = yield* tryPromise(() => getTransportStatus());
+		const transport = yield* getTransportStatusEffect();
 		if (transport.availableTransport !== "xurl") {
 			// xurl is unavailable, so the live profile backfill can't run. When the
 			// bird transport is authenticated we can still correct the seeded
@@ -211,7 +211,7 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 
 		for (let index = 0; index < candidateIds.length; index += 100) {
 			const batch = candidateIds.slice(index, index + 100);
-			const users = yield* tryPromise(() => lookupUsersByIds(batch));
+			const users = yield* lookupUsersByIdsEffect(batch);
 
 			yield* trySync(() => {
 				db.transaction(() => {
@@ -231,7 +231,7 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 		}
 
 		let hydratedAccount = false;
-		const me = yield* tryPromise(() => lookupAuthenticatedUser()).pipe(
+		const me = yield* lookupAuthenticatedUserEffect().pipe(
 			Effect.catchAll(() => Effect.succeed(null)),
 		);
 		if (me) {

--- a/src/lib/profile-resolver.test.ts
+++ b/src/lib/profile-resolver.test.ts
@@ -30,8 +30,16 @@ vi.mock("./bird", () => ({
 }));
 
 vi.mock("./xurl", () => ({
-	lookupUsersByHandles: mocks.lookupUsersByHandles,
-	lookupUsersByIds: mocks.lookupUsersByIds,
+	lookupUsersByHandlesEffect: (handles: string[]) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupUsersByHandles(handles),
+			catch: (error) => error,
+		}),
+	lookupUsersByIdsEffect: (ids: string[]) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupUsersByIds(ids),
+			catch: (error) => error,
+		}),
 }));
 
 let homeDir = "";

--- a/src/lib/profile-resolver.ts
+++ b/src/lib/profile-resolver.ts
@@ -5,7 +5,7 @@ import {
 	lookupProfileViaBirdEffect,
 	lookupProfilesViaBirdEffect,
 } from "./bird";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import {
 	hydrateProfileAffiliationOrganizationsEffect,
@@ -14,7 +14,7 @@ import {
 import { profileFromDbRow, profileHandleKey } from "./profile-row";
 import type { ProfileRecord, XurlMentionUser } from "./types";
 import { getExternalUserId, upsertProfileFromXUser } from "./x-profile";
-import { lookupUsersByHandles, lookupUsersByIds } from "./xurl";
+import { lookupUsersByHandlesEffect, lookupUsersByIdsEffect } from "./xurl";
 
 const PROFILE_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const PROFILE_NEGATIVE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -122,10 +122,9 @@ function updateConversationTitles(profile: ProfileRecord, db = getNativeDb()) {
 }
 
 function lookupViaXurlEffect(externalUserId: string) {
-	return Effect.gen(function* () {
-		const [user] = yield* tryPromise(() => lookupUsersByIds([externalUserId]));
-		return user ?? null;
-	});
+	return lookupUsersByIdsEffect([externalUserId]).pipe(
+		Effect.map(([user]) => user ?? null),
+	);
 }
 
 function fetchProfileUserEffect(
@@ -234,9 +233,7 @@ function fetchProfileUsersEffect(
 			return results;
 		}
 
-		const xurlResult = yield* tryPromise(() =>
-			lookupUsersByIds(unresolved),
-		).pipe(
+		const xurlResult = yield* lookupUsersByIdsEffect(unresolved).pipe(
 			Effect.map((users) => ({ ok: true as const, users })),
 			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
 		);
@@ -487,9 +484,7 @@ export function resolveProfilesForHandlesEffect(
 		}
 
 		if (unresolved.length > 0 && xurlFallback) {
-			const xurlResult = yield* tryPromise(() =>
-				lookupUsersByHandles(unresolved),
-			).pipe(
+			const xurlResult = yield* lookupUsersByHandlesEffect(unresolved).pipe(
 				Effect.map((users) => ({ ok: true as const, users })),
 				Effect.catchAll((error) =>
 					Effect.succeed({ ok: false as const, error }),

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -39,9 +39,21 @@ vi.mock("./bird", () => ({
 }));
 
 vi.mock("./xurl", () => ({
-	listBookmarkedTweetsViaXurl: mocks.listBookmarkedTweetsViaXurl,
-	listLikedTweetsViaXurl: mocks.listLikedTweetsViaXurl,
-	lookupUsersByHandles: mocks.lookupUsersByHandles,
+	listBookmarkedTweetsViaXurlEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listBookmarkedTweetsViaXurl(options),
+			catch: (error) => error,
+		}),
+	listLikedTweetsViaXurlEffect: (options: unknown) =>
+		Effect.tryPromise({
+			try: () => mocks.listLikedTweetsViaXurl(options),
+			catch: (error) => error,
+		}),
+	lookupUsersByHandlesEffect: (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => mocks.lookupUsersByHandles(...args),
+			catch: (error) => error,
+		}),
 }));
 
 const tempRoots: string[] = [];

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -1242,7 +1242,10 @@ export function listFollowUsersViaXurl(options: {
 export const listBlockedUsersEffect = Effect.fn("xurl.listBlockedUsers")((
 	userId: string,
 	paginationToken?: string,
-) => {
+): Effect.Effect<
+	{ items: XurlMentionUser[]; nextToken: string | null },
+	XurlCommandError
+> => {
 	const query = new URLSearchParams({
 		max_results: "100",
 		"user.fields":

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Duration, Effect, Schedule } from "effect";
 import { runEffectPromise } from "./effect-runtime";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 import type {
@@ -51,20 +51,21 @@ type OAuth2UsernameCandidate = {
 	username?: string;
 };
 
-let transportStatusCache:
-	| {
-			expiresAt: number;
-			pending?: Promise<TransportStatus>;
-			value?: TransportStatus;
-	  }
-	| undefined;
-let authenticatedUserCache:
-	| {
-			expiresAt: number;
-			pending?: Promise<Record<string, unknown> | null>;
-			value?: Record<string, unknown> | null;
-	  }
-	| undefined;
+// Module-level memoized effects: concurrent callers share one in-flight
+// computation and successes are cached for the TTL. `Effect.suspend` defers
+// the lookups so these consts can be built before the functions they call.
+const cachedTransportStatus = Effect.runSync(
+	Effect.cachedWithTTL(
+		Effect.suspend(() => readTransportStatusEffect()),
+		Duration.millis(TRANSPORT_STATUS_TTL_MS),
+	),
+);
+const [cachedAuthenticatedUser, invalidateAuthenticatedUser] = Effect.runSync(
+	Effect.cachedInvalidateWithTTL(
+		Effect.suspend(() => lookupAuthenticatedUserFreshEffect()),
+		Duration.millis(AUTHENTICATED_USER_TTL_MS),
+	),
+);
 const oauth2CandidateCache = new Map<
 	string,
 	{ expiresAt: number; value: OAuth2UsernameCandidate }
@@ -115,8 +116,21 @@ function formatExecError(error: unknown, fallback: string) {
 	return parts.join("\n");
 }
 
-function formatXurlCommandError(error: unknown, args: string[]) {
-	return new Error(formatExecError(error, `xurl ${args.join(" ")} failed`));
+export class XurlCommandError extends Data.TaggedError("XurlCommandError")<{
+	readonly message: string;
+	readonly commandArgs: readonly string[];
+	readonly rateLimited: boolean;
+	readonly cause: unknown;
+}> {}
+
+function toXurlCommandError(cause: unknown, args: string[]) {
+	if (cause instanceof XurlCommandError) return cause;
+	return new XurlCommandError({
+		message: formatExecError(cause, `xurl ${args.join(" ")} failed`),
+		commandArgs: args,
+		rateLimited: isRateLimitedFailure(cause),
+		cause,
+	});
 }
 
 function normalizeError(error: unknown) {
@@ -145,15 +159,12 @@ function parseErrorPayload(error: unknown) {
 	}
 }
 
-function getRetryDelayMs(error: unknown, attempt: number) {
-	const payload = parseErrorPayload(error);
-	const status = Number(payload?.status ?? 0);
-	if (status !== 429) {
-		return null;
-	}
+function isRateLimitedFailure(error: unknown) {
+	return Number(parseErrorPayload(error)?.status ?? 0) === 429;
+}
 
-	const baseDelay = getJsonRetryBaseDelayMs();
-	return Math.min(baseDelay * 2 ** attempt, 30_000);
+function jsonRetryDelayMs(retries: number) {
+	return Math.min(getJsonRetryBaseDelayMs() * 2 ** retries, 30_000);
 }
 
 function emitJsonCommandAttempt(
@@ -178,7 +189,7 @@ function capTimelineCollectionMaxResults(
 }
 
 export function resetAuthenticatedUserCache() {
-	authenticatedUserCache = undefined;
+	Effect.runSync(invalidateAuthenticatedUser);
 	oauth2CandidateCache.clear();
 }
 
@@ -195,8 +206,8 @@ function isUnauthenticatedXurlStatus(status: string) {
 	);
 }
 
-function readTransportStatusEffect(): Effect.Effect<TransportStatus, never> {
-	return Effect.gen(function* () {
+const readTransportStatusEffect = Effect.fn("xurl.readTransportStatus")(
+	function* () {
 		const installed = yield* hasXurlEffect();
 		if (!installed) {
 			return {
@@ -243,76 +254,43 @@ function readTransportStatusEffect(): Effect.Effect<TransportStatus, never> {
 				}),
 			),
 		);
-	});
-}
+	},
+);
 
-export function getTransportStatusEffect() {
-	return Effect.gen(function* () {
-		const now = Date.now();
-		if (transportStatusCache?.value && transportStatusCache.expiresAt > now) {
-			return transportStatusCache.value;
-		}
-
-		if (transportStatusCache?.pending) {
-			const status = yield* Effect.tryPromise({
-				try: () => transportStatusCache?.pending ?? Promise.resolve(undefined),
-				catch: normalizeError,
-			});
-			if (status) return status;
-		}
-
-		const pending = runEffectPromise(readTransportStatusEffect());
-
-		transportStatusCache = {
-			expiresAt: 0,
-			pending,
-		};
-
-		const status = yield* Effect.tryPromise({
-			try: () => pending,
-			catch: normalizeError,
-		}).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					transportStatusCache = undefined;
-				}).pipe(Effect.flatMap(() => Effect.fail(error))),
-			),
-		);
-		transportStatusCache = {
-			expiresAt: Date.now() + TRANSPORT_STATUS_TTL_MS,
-			value: status,
-		};
-		return status;
-	});
+export function getTransportStatusEffect(): Effect.Effect<
+	TransportStatus,
+	never
+> {
+	return cachedTransportStatus;
 }
 
 export function getTransportStatus(): Promise<TransportStatus> {
 	return runEffectPromise(getTransportStatusEffect());
 }
 
-function runShortcutEffect(args: string[]) {
-	return Effect.gen(function* () {
-		if (liveWritesDisabled()) {
-			if (e2eFakeLiveWritesEnabled()) {
-				return { ok: true, output: "e2e fake live write" };
-			}
-			return { ok: false, output: "live writes disabled" };
+const runShortcutEffect = Effect.fn("xurl.runShortcut")(function* (
+	args: string[],
+) {
+	if (liveWritesDisabled()) {
+		if (e2eFakeLiveWritesEnabled()) {
+			return { ok: true, output: "e2e fake live write" };
 		}
+		return { ok: false, output: "live writes disabled" };
+	}
 
-		return yield* runSubprocessEffect({ command: "xurl", args }).pipe(
-			Effect.map(({ stdout, stderr }) => ({
-				ok: true,
-				output: stdout || stderr,
-			})),
-			Effect.catchAll((error) =>
-				Effect.succeed({
-					ok: false,
-					output: formatExecError(error, "xurl execution failed"),
-				}),
-			),
-		);
-	});
-}
+	return yield* runSubprocessEffect({ command: "xurl", args }).pipe(
+		Effect.map(({ stdout, stderr }) => ({
+			ok: true,
+			output: stdout || stderr,
+		})),
+		Effect.catchAll((error) =>
+			Effect.succeed({
+				ok: false,
+				output: formatExecError(error, "xurl execution failed"),
+			}),
+		),
+	);
+});
 
 function execXurlJsonEffect(
 	args: string[],
@@ -356,66 +334,71 @@ function execXurlTextEffect(
 function parseJsonPayloadEffect(
 	stdout: string,
 	args: string[],
-): Effect.Effect<Record<string, unknown>, Error> {
+): Effect.Effect<Record<string, unknown>, XurlCommandError> {
 	return Effect.try({
 		try: () => JSON.parse(stdout) as Record<string, unknown>,
-		catch: (error) => formatXurlCommandError(error, args),
+		catch: (error) => toXurlCommandError(error, args),
 	});
 }
 
-function runJsonCommandEffect(
+const runJsonCommandEffect = Effect.fn("xurl.runJsonCommand")(function* (
 	args: string[],
 	options: JsonCommandOptions = {},
-	attempt = 0,
-): Effect.Effect<Record<string, unknown>, Error> {
-	return Effect.gen(function* () {
-		const deadlineMs =
-			options.deadlineMs ??
-			(typeof options.timeoutMs === "number" &&
-			Number.isFinite(options.timeoutMs) &&
-			options.timeoutMs > 0
-				? Date.now() + options.timeoutMs
-				: undefined);
-		const timeoutMs = deadlineMs
-			? Math.max(0, deadlineMs - Date.now())
-			: undefined;
-		return yield* execXurlJsonEffect(args, timeoutMs, options.signal).pipe(
-			Effect.flatMap(({ stdout }) => parseJsonPayloadEffect(stdout, args)),
-			Effect.tap(() =>
-				Effect.sync(() =>
-					emitJsonCommandAttempt(options, { args, attempt, status: "ok" }),
-				),
+) {
+	const deadlineMs =
+		options.deadlineMs ??
+		(typeof options.timeoutMs === "number" &&
+		Number.isFinite(options.timeoutMs) &&
+		options.timeoutMs > 0
+			? Date.now() + options.timeoutMs
+			: undefined);
+	let attempt = 0;
+
+	const attemptCommand = Effect.suspend(() =>
+		execXurlJsonEffect(
+			args,
+			deadlineMs === undefined
+				? undefined
+				: Math.max(0, deadlineMs - Date.now()),
+			options.signal,
+		),
+	).pipe(
+		Effect.flatMap(({ stdout }) => parseJsonPayloadEffect(stdout, args)),
+		Effect.mapError((error) => toXurlCommandError(error, args)),
+		Effect.tap(() =>
+			Effect.sync(() =>
+				emitJsonCommandAttempt(options, { args, attempt, status: "ok" }),
 			),
-			Effect.catchAll((error) => {
-				const retryDelayMs = getRetryDelayMs(error, attempt);
+		),
+		Effect.tapError((error) =>
+			Effect.sync(() => {
 				emitJsonCommandAttempt(options, {
 					args,
 					attempt,
-					status: retryDelayMs === null ? "error" : "rate_limited",
+					status: error.rateLimited ? "rate_limited" : "error",
 					error,
 				});
-				if (retryDelayMs === null || attempt >= JSON_RETRY_LIMIT - 1) {
-					return Effect.fail(formatXurlCommandError(error, args));
-				}
-				if (options.signal?.aborted) {
-					return Effect.fail(formatXurlCommandError(error, args));
-				}
-				const remainingMs = deadlineMs
-					? Math.max(0, deadlineMs - Date.now())
-					: undefined;
-				if (remainingMs !== undefined && retryDelayMs >= remainingMs) {
-					return Effect.fail(formatXurlCommandError(error, args));
-				}
-
-				return Effect.sleep(retryDelayMs).pipe(
-					Effect.flatMap(() =>
-						runJsonCommandEffect(args, { ...options, deadlineMs }, attempt + 1),
-					),
-				);
+				attempt += 1;
 			}),
-		);
-	});
-}
+		),
+	);
+
+	// Retry hidden 429s with capped exponential backoff, but never sleep past
+	// the caller's deadline or an external abort.
+	const rateLimitRetries = Schedule.recurs(JSON_RETRY_LIMIT - 1).pipe(
+		Schedule.whileInput(
+			(error: XurlCommandError) =>
+				error.rateLimited && options.signal?.aborted !== true,
+		),
+		Schedule.check((_error, retries) => {
+			if (deadlineMs === undefined) return true;
+			return jsonRetryDelayMs(retries) < Math.max(0, deadlineMs - Date.now());
+		}),
+		Schedule.addDelay((retries) => Duration.millis(jsonRetryDelayMs(retries))),
+	);
+
+	return yield* Effect.retry(attemptCommand, rateLimitRetries);
+});
 
 function cleanXurlUsernameLabel(username?: string) {
 	const label = username?.trim().replace(/^@/, "");
@@ -464,14 +447,15 @@ function parseOAuth2UsernamesFromStatus(rawStatus: string) {
 	return usernames;
 }
 
-function readOAuth2UsernameCandidatesEffect(
-	deadlineMs?: number,
-): Effect.Effect<OAuth2UsernameCandidate[], never> {
-	return execXurlTextEffect(["auth", "status"], deadlineMs).pipe(
-		Effect.map(({ stdout }) => parseOAuth2UsernamesFromStatus(stdout)),
-		Effect.catchAll(() => Effect.succeed([])),
-	);
-}
+const readOAuth2UsernameCandidatesEffect = Effect.fn(
+	"xurl.readOAuth2UsernameCandidates",
+)(
+	(deadlineMs?: number): Effect.Effect<OAuth2UsernameCandidate[], never> =>
+		execXurlTextEffect(["auth", "status"], deadlineMs).pipe(
+			Effect.map(({ stdout }) => parseOAuth2UsernamesFromStatus(stdout)),
+			Effect.catchAll(() => Effect.succeed([])),
+		),
+);
 
 export function readXurlOAuth2AccountsEffect(): Effect.Effect<
 	LiveDataSourceAccount[],
@@ -487,36 +471,35 @@ export function readXurlOAuth2AccountsEffect(): Effect.Effect<
 	);
 }
 
-function lookupOAuth2UsernameForAccountEffect(
+const lookupOAuth2UsernameForAccountEffect = Effect.fn(
+	"xurl.lookupOAuth2UsernameForAccount",
+)(function* (
 	expectedUsername: string,
 	attemptedUsernames: Set<string>,
 	deadlineMs?: number,
 	knownCandidates?: OAuth2UsernameCandidate[],
 ) {
-	return Effect.gen(function* () {
-		const expected = comparableXurlUsername(expectedUsername);
-		if (!expected) return undefined;
+	const expected = comparableXurlUsername(expectedUsername);
+	if (!expected) return undefined;
 
-		const candidates =
-			knownCandidates ??
-			(yield* readOAuth2UsernameCandidatesEffect(deadlineMs));
-		for (const candidate of candidates) {
-			const candidateKey = `${candidate.app ?? "default"}:${candidate.username}`;
-			if (attemptedUsernames.has(candidateKey)) continue;
-			const payload = yield* runJsonCommandEffect(
-				oauth2ArgsForCandidate(candidate, ["/2/users/me"]),
-				{ deadlineMs },
-			).pipe(Effect.catchAll(() => Effect.succeed(null)));
-			const user = payload ? authenticatedUserFromPayload(payload) : null;
-			const actual = comparableXurlUsername(String(user?.username ?? ""));
-			if (actual === expected) {
-				return candidate;
-			}
+	const candidates =
+		knownCandidates ?? (yield* readOAuth2UsernameCandidatesEffect(deadlineMs));
+	for (const candidate of candidates) {
+		const candidateKey = `${candidate.app ?? "default"}:${candidate.username}`;
+		if (attemptedUsernames.has(candidateKey)) continue;
+		const payload = yield* runJsonCommandEffect(
+			oauth2ArgsForCandidate(candidate, ["/2/users/me"]),
+			{ deadlineMs },
+		).pipe(Effect.catchAll(() => Effect.succeed(null)));
+		const user = payload ? authenticatedUserFromPayload(payload) : null;
+		const actual = comparableXurlUsername(String(user?.username ?? ""));
+		if (actual === expected) {
+			return candidate;
 		}
+	}
 
-		return undefined;
-	});
-}
+	return undefined;
+});
 
 function oauth2ArgsForCandidate(
 	candidate: OAuth2UsernameCandidate | undefined,
@@ -545,19 +528,19 @@ function configuredOAuth2Candidate(primaryUsername: string | undefined) {
 	};
 }
 
-function runOAuth2JsonCommandEffect({
-	args,
-	username,
-	options,
-	useConfiguredCandidate = true,
-}: {
-	args: string[];
-	username?: string;
-	options?: JsonCommandOptions;
-	useConfiguredCandidate?: boolean;
-}) {
-	const primaryUsername = cleanXurlUsernameLabel(username);
-	return Effect.gen(function* () {
+const runOAuth2JsonCommandEffect = Effect.fn("xurl.runOAuth2JsonCommand")(
+	function* ({
+		args,
+		username,
+		options,
+		useConfiguredCandidate = true,
+	}: {
+		args: string[];
+		username?: string;
+		options?: JsonCommandOptions;
+		useConfiguredCandidate?: boolean;
+	}) {
+		const primaryUsername = cleanXurlUsernameLabel(username);
 		const deadlineMs =
 			options?.deadlineMs ??
 			(typeof options?.timeoutMs === "number" &&
@@ -617,7 +600,12 @@ function runOAuth2JsonCommandEffect({
 		}
 
 		if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
-			return yield* Effect.fail(new Error("xurl OAuth2 fallback timed out"));
+			return yield* new XurlCommandError({
+				message: "xurl OAuth2 fallback timed out",
+				commandArgs: args,
+				rateLimited: false,
+				cause: undefined,
+			});
 		}
 
 		return yield* runJsonCommandEffect(
@@ -659,11 +647,11 @@ function runOAuth2JsonCommandEffect({
 				);
 			}),
 		);
-	});
-}
+	},
+);
 
-function runMutationCommandEffect(args: string[]) {
-	return Effect.gen(function* () {
+const runMutationCommandEffect = Effect.fn("xurl.runMutationCommand")(
+	function* (args: string[]) {
 		if (liveWritesDisabled()) {
 			if (e2eFakeLiveWritesEnabled()) {
 				return { ok: true, output: "e2e fake live write" };
@@ -683,10 +671,12 @@ function runMutationCommandEffect(args: string[]) {
 				}),
 			),
 		);
-	});
-}
+	},
+);
 
-export function lookupUsersByIdsEffect(ids: string[]) {
+export const lookupUsersByIdsEffect = Effect.fn("xurl.lookupUsersByIds")((
+	ids: string[],
+): Effect.Effect<XurlMentionUser[], XurlCommandError> => {
 	if (ids.length === 0) {
 		return Effect.succeed([]);
 	}
@@ -701,7 +691,7 @@ export function lookupUsersByIdsEffect(ids: string[]) {
 			Array.isArray(payload.data) ? (payload.data as XurlMentionUser[]) : [],
 		),
 	);
-}
+});
 
 export function lookupUsersByIds(ids: string[]) {
 	return runEffectPromise(lookupUsersByIdsEffect(ids));
@@ -755,7 +745,7 @@ function normalizeXListPage(payload: Record<string, unknown>): XListPage {
 	};
 }
 
-export function listOwnedXListsViaXurlEffect({
+export const listOwnedXListsViaXurlEffect = Effect.fn("xurl.listOwnedXLists")(({
 	userId,
 	username,
 	maxResults,
@@ -765,7 +755,7 @@ export function listOwnedXListsViaXurlEffect({
 	username?: string;
 	maxResults: number;
 	paginationToken?: string;
-}) {
+}) => {
 	const query = new URLSearchParams({
 		max_results: String(maxResults),
 		"list.fields":
@@ -776,7 +766,7 @@ export function listOwnedXListsViaXurlEffect({
 		args: [`/2/users/${userId}/owned_lists?${query.toString()}`],
 		username,
 	}).pipe(Effect.map(normalizeXListPage));
-}
+});
 
 export function listOwnedXListsViaXurl(options: {
 	userId: string;
@@ -787,37 +777,39 @@ export function listOwnedXListsViaXurl(options: {
 	return runEffectPromise(listOwnedXListsViaXurlEffect(options));
 }
 
-export function listXListMembersViaXurlEffect({
-	listId,
-	username,
-	maxResults,
-	paginationToken,
-}: {
-	listId: string;
-	username?: string;
-	maxResults: number;
-	paginationToken?: string;
-}) {
-	const query = new URLSearchParams({
-		max_results: String(maxResults),
-		"user.fields": RICH_USER_FIELDS,
-	});
-	if (paginationToken) query.set("pagination_token", paginationToken);
-	return runOAuth2JsonCommandEffect({
-		args: [`/2/lists/${listId}/members?${query.toString()}`],
+export const listXListMembersViaXurlEffect = Effect.fn("xurl.listXListMembers")(
+	({
+		listId,
 		username,
-	}).pipe(
-		Effect.map((payload) => ({
-			data: Array.isArray(payload.data)
-				? (payload.data as XurlMentionUser[])
-				: [],
-			meta:
-				payload.meta && typeof payload.meta === "object"
-					? (payload.meta as Record<string, unknown>)
-					: {},
-		})),
-	);
-}
+		maxResults,
+		paginationToken,
+	}: {
+		listId: string;
+		username?: string;
+		maxResults: number;
+		paginationToken?: string;
+	}) => {
+		const query = new URLSearchParams({
+			max_results: String(maxResults),
+			"user.fields": RICH_USER_FIELDS,
+		});
+		if (paginationToken) query.set("pagination_token", paginationToken);
+		return runOAuth2JsonCommandEffect({
+			args: [`/2/lists/${listId}/members?${query.toString()}`],
+			username,
+		}).pipe(
+			Effect.map((payload) => ({
+				data: Array.isArray(payload.data)
+					? (payload.data as XurlMentionUser[])
+					: [],
+				meta:
+					payload.meta && typeof payload.meta === "object"
+						? (payload.meta as Record<string, unknown>)
+						: {},
+			})),
+		);
+	},
+);
 
 export function listXListMembersViaXurl(options: {
 	listId: string;
@@ -828,7 +820,9 @@ export function listXListMembersViaXurl(options: {
 	return runEffectPromise(listXListMembersViaXurlEffect(options));
 }
 
-export function lookupUsersByHandlesEffect(
+export const lookupUsersByHandlesEffect = Effect.fn(
+	"xurl.lookupUsersByHandles",
+)((
 	handles: string[],
 	options: {
 		auth?: "oauth2";
@@ -836,7 +830,7 @@ export function lookupUsersByHandlesEffect(
 		signal?: AbortSignal;
 		useConfiguredCandidate?: boolean;
 	} = {},
-) {
+): Effect.Effect<XurlMentionUser[], XurlCommandError> => {
 	if (handles.length === 0) {
 		return Effect.succeed([]);
 	}
@@ -861,7 +855,7 @@ export function lookupUsersByHandlesEffect(
 			Array.isArray(payload.data) ? (payload.data as XurlMentionUser[]) : [],
 		),
 	);
-}
+});
 
 export function lookupUsersByHandles(
 	handles: string[],
@@ -882,60 +876,28 @@ function authenticatedUserFromPayload(payload: Record<string, unknown>) {
 		: null;
 }
 
-export function lookupAuthenticatedUserFreshEffect() {
-	return runJsonCommandEffect(["whoami"]).pipe(
+export const lookupAuthenticatedUserFreshEffect = Effect.fn(
+	"xurl.lookupAuthenticatedUserFresh",
+)(() =>
+	runJsonCommandEffect(["whoami"]).pipe(
 		Effect.map(authenticatedUserFromPayload),
-	);
-}
+	),
+);
 
-export function lookupAuthenticatedOAuth2UserEffect(username?: string) {
-	return runOAuth2JsonCommandEffect({
+export const lookupAuthenticatedOAuth2UserEffect = Effect.fn(
+	"xurl.lookupAuthenticatedOAuth2User",
+)((username?: string) =>
+	runOAuth2JsonCommandEffect({
 		args: ["whoami"],
 		username,
-	}).pipe(Effect.map(authenticatedUserFromPayload));
-}
+	}).pipe(Effect.map(authenticatedUserFromPayload)),
+);
 
 export function lookupAuthenticatedUserEffect() {
-	return Effect.gen(function* () {
-		const now = Date.now();
-		if (
-			authenticatedUserCache &&
-			"value" in authenticatedUserCache &&
-			authenticatedUserCache.expiresAt > now
-		) {
-			return authenticatedUserCache.value ?? null;
-		}
-
-		if (authenticatedUserCache?.pending) {
-			return yield* Effect.tryPromise({
-				try: () => authenticatedUserCache?.pending ?? Promise.resolve(null),
-				catch: normalizeError,
-			});
-		}
-
-		const pending = runEffectPromise(lookupAuthenticatedUserFreshEffect());
-
-		authenticatedUserCache = {
-			expiresAt: 0,
-			pending,
-		};
-
-		const value = yield* Effect.tryPromise({
-			try: () => pending,
-			catch: normalizeError,
-		}).pipe(
-			Effect.catchAll((error) =>
-				Effect.sync(() => {
-					authenticatedUserCache = undefined;
-				}).pipe(Effect.flatMap(() => Effect.fail(error))),
-			),
-		);
-		authenticatedUserCache = {
-			expiresAt: Date.now() + AUTHENTICATED_USER_TTL_MS,
-			value,
-		};
-		return value;
-	});
+	// Failures are not cached: invalidate so the next caller retries fresh.
+	return cachedAuthenticatedUser.pipe(
+		Effect.tapError(() => invalidateAuthenticatedUser),
+	);
 }
 
 export function lookupAuthenticatedUser() {
@@ -946,50 +908,48 @@ export function lookupAuthenticatedUserFresh() {
 	return runEffectPromise(lookupAuthenticatedUserFreshEffect());
 }
 
-function resolveUserIdEffect({
+const resolveUserIdEffect = Effect.fn("xurl.resolveUserId")(function* ({
 	username,
 	userId,
 }: {
 	username?: string;
 	userId?: string;
 }) {
-	return Effect.gen(function* () {
-		if (userId) return userId;
-		if (username) {
-			const [user] = yield* lookupUsersByHandlesEffect([username]);
-			if (!user?.id) {
-				return yield* Effect.fail(
-					new Error(`Could not resolve Twitter user id for @${username}`),
-				);
-			}
-			return String(user.id);
-		}
-		const user = yield* lookupAuthenticatedUserEffect();
+	if (userId) return userId;
+	if (username) {
+		const [user] = yield* lookupUsersByHandlesEffect([username]);
 		if (!user?.id) {
 			return yield* Effect.fail(
-				new Error("Could not resolve authenticated Twitter user id"),
+				new Error(`Could not resolve Twitter user id for @${username}`),
 			);
 		}
 		return String(user.id);
-	});
-}
+	}
+	const user = yield* lookupAuthenticatedUserEffect();
+	if (!user?.id) {
+		return yield* Effect.fail(
+			new Error("Could not resolve authenticated Twitter user id"),
+		);
+	}
+	return String(user.id);
+});
 
-export function listMentionsViaXurlEffect({
-	maxResults,
-	username,
-	userId,
-	paginationToken,
-	sinceId,
-	startTime,
-}: {
-	maxResults: number;
-	username?: string;
-	userId?: string;
-	paginationToken?: string;
-	sinceId?: string;
-	startTime?: string;
-}): Effect.Effect<XurlMentionsResponse, Error> {
-	return Effect.gen(function* () {
+export const listMentionsViaXurlEffect = Effect.fn("xurl.listMentions")(
+	function* ({
+		maxResults,
+		username,
+		userId,
+		paginationToken,
+		sinceId,
+		startTime,
+	}: {
+		maxResults: number;
+		username?: string;
+		userId?: string;
+		paginationToken?: string;
+		sinceId?: string;
+		startTime?: string;
+	}) {
 		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
 		const query = new URLSearchParams({
 			max_results: String(maxResults),
@@ -1014,8 +974,8 @@ export function listMentionsViaXurlEffect({
 			username,
 		});
 		return toXurlMentionsResponse(payload);
-	});
-}
+	},
+);
 
 export function listMentionsViaXurl(options: {
 	maxResults: number;
@@ -1028,20 +988,20 @@ export function listMentionsViaXurl(options: {
 	return runEffectPromise(listMentionsViaXurlEffect(options));
 }
 
-export function listHomeTimelineViaXurlEffect({
-	maxResults,
-	username,
-	userId,
-	paginationToken,
-	timeoutMs,
-}: {
-	maxResults: number;
-	username?: string;
-	userId?: string;
-	paginationToken?: string;
-	timeoutMs?: number;
-}): Effect.Effect<XurlMentionsResponse, Error> {
-	return Effect.gen(function* () {
+export const listHomeTimelineViaXurlEffect = Effect.fn("xurl.listHomeTimeline")(
+	function* ({
+		maxResults,
+		username,
+		userId,
+		paginationToken,
+		timeoutMs,
+	}: {
+		maxResults: number;
+		username?: string;
+		userId?: string;
+		paginationToken?: string;
+		timeoutMs?: number;
+	}) {
 		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
 		const query = new URLSearchParams({
 			max_results: String(maxResults),
@@ -1063,8 +1023,8 @@ export function listHomeTimelineViaXurlEffect({
 			options: { timeoutMs },
 		});
 		return toXurlMentionsResponse(payload);
-	});
-}
+	},
+);
 
 export function listHomeTimelineViaXurl(options: {
 	maxResults: number;
@@ -1094,7 +1054,9 @@ function toXurlMentionsResponse(
 	};
 }
 
-function listTimelineCollectionViaXurlEffect({
+const listTimelineCollectionViaXurlEffect = Effect.fn(
+	"xurl.listTimelineCollection",
+)(function* ({
 	collection,
 	maxResults,
 	username,
@@ -1108,34 +1070,32 @@ function listTimelineCollectionViaXurlEffect({
 	userId?: string;
 	isPaginatedWalk?: boolean;
 	paginationToken?: string;
-}): Effect.Effect<XurlMentionsResponse, Error> {
-	return Effect.gen(function* () {
-		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
-		const requestMaxResults = capTimelineCollectionMaxResults(
-			collection,
-			maxResults,
-			isPaginatedWalk,
-		);
-		const query = new URLSearchParams({
-			max_results: String(requestMaxResults),
-			expansions: AUTHOR_MEDIA_EXPANSIONS,
-			"tweet.fields":
-				"created_at,conversation_id,entities,public_metrics,referenced_tweets",
-			"media.fields": MEDIA_FIELDS,
-			"user.fields":
-				"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
-		});
-		if (paginationToken) {
-			query.set("pagination_token", paginationToken);
-		}
-
-		const payload = yield* runOAuth2JsonCommandEffect({
-			args: [`/2/users/${resolvedUserId}/${collection}?${query.toString()}`],
-			username,
-		});
-		return toXurlMentionsResponse(payload);
+}) {
+	const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
+	const requestMaxResults = capTimelineCollectionMaxResults(
+		collection,
+		maxResults,
+		isPaginatedWalk,
+	);
+	const query = new URLSearchParams({
+		max_results: String(requestMaxResults),
+		expansions: AUTHOR_MEDIA_EXPANSIONS,
+		"tweet.fields":
+			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+		"media.fields": MEDIA_FIELDS,
+		"user.fields":
+			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
 	});
-}
+	if (paginationToken) {
+		query.set("pagination_token", paginationToken);
+	}
+
+	const payload = yield* runOAuth2JsonCommandEffect({
+		args: [`/2/users/${resolvedUserId}/${collection}?${query.toString()}`],
+		username,
+	});
+	return toXurlMentionsResponse(payload);
+});
 
 export function listLikedTweetsViaXurlEffect(options: {
 	maxResults: number;
@@ -1229,20 +1189,20 @@ export function listDirectMessageEventsViaXurl(options: {
 	return runEffectPromise(listDirectMessageEventsViaXurlEffect(options));
 }
 
-export function listFollowUsersViaXurlEffect({
-	direction,
-	maxResults,
-	username,
-	userId,
-	paginationToken,
-}: {
-	direction: FollowDirection;
-	maxResults: number;
-	username?: string;
-	userId?: string;
-	paginationToken?: string;
-}): Effect.Effect<XurlFollowUsersResponse, Error> {
-	return Effect.gen(function* () {
+export const listFollowUsersViaXurlEffect = Effect.fn("xurl.listFollowUsers")(
+	function* ({
+		direction,
+		maxResults,
+		username,
+		userId,
+		paginationToken,
+	}: {
+		direction: FollowDirection;
+		maxResults: number;
+		username?: string;
+		userId?: string;
+		paginationToken?: string;
+	}) {
 		const resolvedUserId = yield* resolveUserIdEffect({ username, userId });
 		const query = new URLSearchParams({
 			max_results: String(maxResults),
@@ -1266,8 +1226,8 @@ export function listFollowUsersViaXurlEffect({
 					? (payload.meta as Record<string, unknown>)
 					: undefined,
 		};
-	});
-}
+	},
+);
 
 export function listFollowUsersViaXurl(options: {
 	direction: FollowDirection;
@@ -1279,10 +1239,10 @@ export function listFollowUsersViaXurl(options: {
 	return runEffectPromise(listFollowUsersViaXurlEffect(options));
 }
 
-export function listBlockedUsersEffect(
+export const listBlockedUsersEffect = Effect.fn("xurl.listBlockedUsers")((
 	userId: string,
 	paginationToken?: string,
-) {
+) => {
 	const query = new URLSearchParams({
 		max_results: "100",
 		"user.fields":
@@ -1309,13 +1269,13 @@ export function listBlockedUsersEffect(
 			};
 		}),
 	);
-}
+});
 
 export function listBlockedUsers(userId: string, paginationToken?: string) {
 	return runEffectPromise(listBlockedUsersEffect(userId, paginationToken));
 }
 
-export function listUserTweetsEffect(
+export const listUserTweetsEffect = Effect.fn("xurl.listUserTweets")((
 	userId: string,
 	{
 		maxResults,
@@ -1348,7 +1308,7 @@ export function listUserTweetsEffect(
 		onAttempt?: JsonCommandOptions["onAttempt"];
 		useConfiguredCandidate?: boolean;
 	},
-): Effect.Effect<XurlUserTweetsResponse, Error> {
+): Effect.Effect<XurlUserTweetsResponse, Error> => {
 	const query = new URLSearchParams({
 		max_results: String(maxResults),
 		expansions: MEDIA_EXPANSION,
@@ -1411,7 +1371,7 @@ export function listUserTweetsEffect(
 			};
 		}),
 	);
-}
+});
 
 export function listUserTweets(
 	userId: string,
@@ -1453,9 +1413,9 @@ function toXurlTweetsResponse(
 	};
 }
 
-export function lookupTweetsByIdsEffect(
+export const lookupTweetsByIdsEffect = Effect.fn("xurl.lookupTweetsByIds")((
 	ids: string[],
-): Effect.Effect<XurlTweetsResponse, Error> {
+): Effect.Effect<XurlTweetsResponse, XurlCommandError> => {
 	if (ids.length === 0) {
 		return Effect.succeed({ data: [] });
 	}
@@ -1473,13 +1433,15 @@ export function lookupTweetsByIdsEffect(
 	return runJsonCommandEffect([`/2/tweets?${query.toString()}`]).pipe(
 		Effect.map(toXurlTweetsResponse),
 	);
-}
+});
 
 export function lookupTweetsByIds(ids: string[]): Promise<XurlTweetsResponse> {
 	return runEffectPromise(lookupTweetsByIdsEffect(ids));
 }
 
-export function searchRecentByConversationIdEffect(
+export const searchRecentByConversationIdEffect = Effect.fn(
+	"xurl.searchRecentByConversationId",
+)((
 	conversationId: string,
 	{
 		maxResults,
@@ -1498,7 +1460,7 @@ export function searchRecentByConversationIdEffect(
 		signal?: AbortSignal;
 		onAttempt?: JsonCommandOptions["onAttempt"];
 	},
-): Effect.Effect<XurlTweetsResponse, Error> {
+): Effect.Effect<XurlTweetsResponse, Error> => {
 	const query = new URLSearchParams({
 		query: `conversation_id:${conversationId}`,
 		max_results: String(maxResults),
@@ -1522,7 +1484,7 @@ export function searchRecentByConversationIdEffect(
 				})
 			: runJsonCommandEffect(args, { timeoutMs, signal, onAttempt });
 	return command.pipe(Effect.map(toXurlTweetsResponse));
-}
+});
 
 export function searchRecentByConversationId(
 	conversationId: string,
@@ -1541,7 +1503,7 @@ export function searchRecentByConversationId(
 	);
 }
 
-export function searchRecentTweetsEffect(
+export const searchRecentTweetsEffect = Effect.fn("xurl.searchRecentTweets")((
 	searchQuery: string,
 	{
 		maxResults,
@@ -1558,7 +1520,7 @@ export function searchRecentTweetsEffect(
 		username?: string;
 		timeoutMs?: number;
 	},
-): Effect.Effect<XurlTweetsResponse, Error> {
+): Effect.Effect<XurlTweetsResponse, Error> => {
 	const query = new URLSearchParams({
 		query: searchQuery,
 		max_results: String(maxResults),
@@ -1583,7 +1545,7 @@ export function searchRecentTweetsEffect(
 		options: { timeoutMs },
 		useConfiguredCandidate: false,
 	}).pipe(Effect.map(toXurlTweetsResponse));
-}
+});
 
 export function searchRecentTweets(
 	searchQuery: string,
@@ -1599,10 +1561,10 @@ export function searchRecentTweets(
 	return runEffectPromise(searchRecentTweetsEffect(searchQuery, options));
 }
 
-export function getTweetByIdEffect(
+export const getTweetByIdEffect = Effect.fn("xurl.getTweetById")((
 	id: string,
 	{ timeoutMs }: { timeoutMs?: number } = {},
-): Effect.Effect<XurlTweetsResponse, Error> {
+): Effect.Effect<XurlTweetsResponse, XurlCommandError> => {
 	const query = new URLSearchParams({
 		expansions: AUTHOR_MEDIA_EXPANSIONS,
 		"tweet.fields": THREAD_TWEET_FIELDS,
@@ -1636,7 +1598,7 @@ export function getTweetByIdEffect(
 			};
 		}),
 	);
-}
+});
 
 export function getTweetById(
 	id: string,

--- a/src/test/effect-mocks.ts
+++ b/src/test/effect-mocks.ts
@@ -1,0 +1,12 @@
+import { Effect } from "effect";
+
+// Wraps a vi.fn() promise mock as an Effect-returning transport function for
+// vi.mock factories. Non-thenable returns (unconfigured mocks) fail the
+// effect, matching how Effect.tryPromise treated the old promise wrappers.
+export function effectFromMock(mock: (...args: unknown[]) => unknown) {
+	return (...args: unknown[]) =>
+		Effect.tryPromise({
+			try: () => mock(...args) as PromiseLike<unknown>,
+			catch: (error) => error,
+		});
+}


### PR DESCRIPTION
Modernizes the codebase to current Effect 3.21 idioms (verified against the installed package and effect.website docs). Focused on the places where Effect genuinely improves the code; DB singleton, media-fetch's injectable clock seams, and zod contracts were deliberately left alone.

## What changed

### xurl transport (the core of the PR)
- **Typed errors**: new `XurlCommandError` (`Data.TaggedError`) carries the command args, the original cause, and a structured `rateLimited` flag classified once from the 429 payload. Message text is unchanged, so everything that reports errors reads the same.
- **Schedule-based retry**: the recursive hidden-429 retry in `runJsonCommandEffect` is now `Effect.retry` with `Schedule.recurs(5)` + `whileInput` (rate-limited and not aborted) + `check` (never sleep past the caller's deadline) + `addDelay` (capped exponential backoff). Semantics verified attempt-for-attempt against the existing fake-timer tests, including per-attempt telemetry numbering.
- **TTL caches**: the hand-rolled transport-status and authenticated-user caches (mutable module state + Promise ping-pong through `runEffectPromise`/`tryPromise`) are now `Effect.cachedWithTTL` / `Effect.cachedInvalidateWithTTL`. Concurrent callers share one in-flight computation; failures invalidate so the next caller retries; `resetAuthenticatedUserCache` still works via the invalidate handle.
- **Traced functions**: endpoint and engine functions are `Effect.fn` with `xurl.*` spans.

### live-transport-gateway
Every xurl entry previously wrapped the *Promise* wrapper back into an Effect (`Effect -> Promise -> Effect` per live call). All entries now delegate to the Effect-native functions directly; `fromPromise` is deleted and the transport interfaces are `typeof` the Effect functions.

### bird transport
All command/endpoint functions converted to traced `Effect.fn` (`bird.*` spans); resource handling (`acquireRelease`/`scoped` temp dirs) untouched.

### link-preview-metadata
The `Promise.race` + `setTimeout` `withTimeout` helper is replaced by `Effect.timeoutFail` inside a new `resolveSafeAddressesEffect`, and the resolve-then-fetch promise chain is now effect composition (`filterOrFail` for the deadline gate). `fetchLinkPreviewMetadataEffect` uses the `Effect.fn` pipe-argument form for its degrade-to-host-label fallback. Timeout budgets now start when the effect runs rather than when it is built.

### rate-limit classification (profile-analysis)
`isXurlRateLimitError` checks the tagged `rateLimited` flag first (by `_tag`, so it also works across module instances/mocks) and keeps the message heuristics as fallback for 429s without a parseable payload.

### ping-pong sweep
`moderation-target`, `actions-transport`, `blocks`, `profile-hydration`, `profile-resolver` now call the Effect transports directly instead of `tryPromise(() => promiseWrapper(...))`. Test mock factories for the affected modules provide the Effect-shaped exports (unconfigured mocks still fail like before, preserving fallback-path coverage).

## Deliberately not done (follow-ups)
- DB layer stays a module singleton (cost > benefit for a Layer refactor; both would fight `vi.resetModules` test patterns).
- media-fetch keeps its injectable `sleep`/`now` seams: tests assert exact pacing sequences and Effect TestClock is not in the test stack.
- zod -> effect/Schema for the API contracts would touch the React client and is a separate project.

## Verification
- `pnpm check` (oxfmt, oxlint deny-warnings, tsgo) clean
- Full vitest suite: 143 files, 1207 tests green; coverage 89.0/80.1/89.8/90.6 vs 85/80/85/85 gates
- `pnpm build`, `pack:smoke`, and all 12 Playwright e2e tests green
- Live-tested on clawmac against the real archive: `db stats`, FTS tweet/DM search, `auth status` (real xurl, both OAuth2 apps detected through the new cached status), `/api/data-sources` with all three transports healthy, and a real xurl JSON call through the new retry engine (non-429 failure correctly not retried, error text identical to before).
