### PR TITLE
fix: sidebar labels not appearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.5 - Unreleased
 
+### Fixed
+
+- Keep desktop sidebar labels visible by applying screen-reader-only styling only below the compact breakpoint. (#91 - thanks @MarkVillacampa)
+
 ## 0.9.4 - 2026-07-05
 
 ### Fixed

--- a/src/components/AppNav.test.tsx
+++ b/src/components/AppNav.test.tsx
@@ -86,6 +86,19 @@ describe("AppNav", () => {
 		expect(accountSwitcher).toContainElement(themeButton);
 	});
 
+	it("only visually hides standard labels below the wide-sidebar breakpoint", () => {
+		render(
+			<ThemeProvider>
+				<AppNav />
+			</ThemeProvider>,
+		);
+
+		const inboxLabel = screen.getByText("Inbox");
+		expect(inboxLabel).toHaveClass("max-[1100px]:sr-only");
+		expect(inboxLabel).not.toHaveClass("sr-only");
+		expect(inboxLabel).not.toHaveClass("min-[1100px]:not-sr-only");
+	});
+
 	it("uses icon-rail chrome when compact", () => {
 		routerState.path = "/dms";
 		render(

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -43,7 +43,7 @@ export const navLinkActiveClass = "nav-link-active font-bold";
 
 export const navLinkIconClass = "shrink-0";
 
-export const navLinkLabelClass = "sr-only min-[1100px]:not-sr-only";
+export const navLinkLabelClass = "max-[1100px]:sr-only";
 
 export const navLinkLabelCompactClass = "sr-only";
 


### PR DESCRIPTION
Now below the breakpoint the label is screen-reader-only (icon rail stays accessible) but at/above it the label is simply its default visible state. Applying sr-only one-directionally avoids relying on a not-sr-only override beating the base rule, which is order/cache fragile.

<img width="1767" height="989" alt="image" src="https://github.com/user-attachments/assets/4e3395c1-9074-47b6-ae02-89fd54f94810" />
