### PR TITLE
perf: make timeline FTS search sub-second on large archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.4 - Unreleased
 
+### Fixed
+
+- `search tweets` now returns in well under a second on large archives (previously ~60s, minutes for common terms): the FTS5 match set is materialized once instead of SQLite re-running the MATCH scan per timeline edge row, the join order adapts to term frequency, the LIMIT is resolved on an id-only inner query, and snippets are computed only for returned rows.
+
 ## 0.9.3 - 2026-07-04
 
 ### Changed

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -9,6 +9,7 @@ import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listInboxItems } from "./inbox";
 import {
 	applyDmRequestMutationToLocalStore,
+	buildTimelineItemsQuery,
 	createDmReply,
 	createDmReplyEffect,
 	createPost,
@@ -564,6 +565,76 @@ describe("birdclaw queries", () => {
 		expect(items.map((item) => item.id)).toEqual(["tweet_006"]);
 		expect(items[0]?.accountId).toBe("acct_studio");
 		expect(items[0]?.searchSnippet).toContain("<mark>Agents</mark>");
+	});
+
+	// Perf regression guard: with bound parameters SQLite used to pick a plan
+	// that re-ran the whole tweets_fts MATCH scan for every timeline edge row,
+	// turning limited searches into minutes on large archives. Every tweets_fts
+	// access must stay inside the materialized fts_matches CTE so the match
+	// scan runs exactly once.
+	it("keeps timeline search FTS scans inside the materialized match CTE", () => {
+		setupTempHome();
+		const db = getNativeDb();
+
+		// Both drive strategies: selective terms iterate the match set, dense
+		// terms walk the created_at index (hint above the crossover threshold).
+		for (const ftsMatchCountHint of [0, 1_000_000]) {
+			const plan = buildTimelineItemsQuery(
+				{ resource: "home", search: "Agents", limit: 5 },
+				ftsMatchCountHint,
+			);
+			const planRows = db
+				.prepare(`explain query plan ${plan.sql}`)
+				.all(...plan.params) as Array<{
+				id: number;
+				parent: number;
+				detail: string;
+			}>;
+			const parentById = new Map(planRows.map((row) => [row.id, row.parent]));
+			const materializeIds = new Set(
+				planRows
+					.filter((row) => row.detail.startsWith("MATERIALIZE fts_matches"))
+					.map((row) => row.id),
+			);
+			expect(materializeIds.size).toBe(1);
+
+			const ftsAccesses = planRows.filter(
+				(row) =>
+					row.detail.includes("tweets_fts") &&
+					!row.detail.startsWith("MATERIALIZE"),
+			);
+			expect(ftsAccesses.length).toBeGreaterThan(0);
+			for (const access of ftsAccesses) {
+				let ancestor: number | undefined = access.parent;
+				let insideMaterialize = false;
+				while (ancestor !== undefined && ancestor !== 0) {
+					if (materializeIds.has(ancestor)) {
+						insideMaterialize = true;
+						break;
+					}
+					ancestor = parentById.get(ancestor);
+				}
+				expect(insideMaterialize).toBe(true);
+			}
+		}
+	});
+
+	it("returns identical timeline search results for both FTS drive strategies", () => {
+		setupTempHome();
+		const db = getNativeDb();
+
+		const results = [0, 1_000_000].map((ftsMatchCountHint) => {
+			const plan = buildTimelineItemsQuery(
+				{ resource: "home", search: "Agents", limit: 5 },
+				ftsMatchCountHint,
+			);
+			return (
+				db.prepare(plan.sql).all(...plan.params) as Array<{ id: string }>
+			).map((row) => row.id);
+		});
+
+		expect(results[0]?.length).toBeGreaterThan(0);
+		expect(results[0]).toEqual(results[1]);
 	});
 
 	it("keeps timeline membership account-scoped for the same canonical tweet", () => {

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -487,26 +487,44 @@ function getTimelineQualityReason(
 
 const RECENT_TIMELINE_EDGE_CANDIDATES = 5000;
 
-export function listTimelineItems({
-	resource,
-	account,
-	listAccountId,
-	listId,
-	search,
-	replyFilter = "all",
-	since,
-	until,
-	untilId,
-	includeReplies = true,
-	qualityFilter = "all",
-	lowQualityThreshold,
-	includeQualityReason = false,
-	likedOnly = false,
-	bookmarkedOnly = false,
-	limit = 18,
-}: TimelineQuery): TimelineItem[] {
-	const db = getReadDb();
+export interface TimelineItemsQueryPlan {
+	sql: string;
+	params: Array<string | number>;
+	fallbackSql: string;
+	fallbackParams: Array<string | number>;
+	usedRecentEdgeWindow: boolean;
+	ftsSearch: string;
+}
+
+// Above this many FTS matches, iterating the match set (with the per-row
+// dedupe subquery) costs more than walking the created_at index newest-first
+// and probing the match set until the limit fills.
+const FTS_DRIVE_FROM_MATCHES_MAX = 10_000;
+
+// Exported so tests can EXPLAIN the generated SQL with bound parameters and
+// guard the query plan (see the fts_matches comment below).
+export function buildTimelineItemsQuery(
+	{
+		resource,
+		account,
+		listAccountId,
+		listId,
+		search,
+		replyFilter = "all",
+		since,
+		until,
+		untilId,
+		includeReplies = true,
+		qualityFilter = "all",
+		lowQualityThreshold,
+		likedOnly = false,
+		bookmarkedOnly = false,
+		limit = 18,
+	}: TimelineQuery,
+	ftsMatchCountHint = 0,
+): TimelineItemsQueryPlan {
 	const kind = resource === "mentions" ? "mention" : resource;
+	const cteParams: Array<string | number> = [];
 	const params: Array<string | number> = [];
 	const normalizedLowQualityThreshold =
 		normalizeLowQualityThreshold(lowQualityThreshold);
@@ -520,9 +538,8 @@ export function listTimelineItems({
 	    `;
 	const unwindowedTimelineEdgesCte = timelineEdgesCte;
 	let usedRecentEdgeWindow = false;
-	let join = "";
 	let where = "where e.kind = ?";
-	let searchSnippetSelect = "";
+	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
 
 	const canUseRecentEdgeWindow =
 		!likedOnly &&
@@ -560,7 +577,7 @@ export function listTimelineItems({
 	          where kind = ?
 	        )
 				`;
-			params.push(collectionKind);
+			cteParams.push(collectionKind);
 		}
 		where = "where 1 = 1";
 	} else if (canUseRecentEdgeWindow) {
@@ -582,11 +599,11 @@ export function listTimelineItems({
 			RECENT_TIMELINE_EDGE_CANDIDATES,
 			limit * 50,
 		);
-		params.push(kind, candidateLimit);
+		cteParams.push(kind, candidateLimit);
 		where = "where e.kind = ?";
 		params.push(kind);
 	} else {
-		params.push(kind);
+		cteParams.push(kind);
 		where = "where e.kind = ?";
 		params.push(kind);
 	}
@@ -661,19 +678,53 @@ export function listTimelineItems({
 		params.push(listAccountId, listId);
 	}
 
-	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
+	// Materialize the FTS match set once. Joining tweets_fts directly looks
+	// equivalent, but with bound parameters SQLite picks a plan that re-runs
+	// the whole MATCH scan for every timeline edge row (minutes on large
+	// archives). The cross joins pin the join order: selective terms iterate
+	// the match set, ultra-common terms walk the created_at index newest-first
+	// and probe the match set so the limit fills after a few rows. Snippets
+	// are computed in a separate pass for only the returned rows.
+	const ftsMatchesCte = ftsSearch
+		? `, fts_matches as materialized (
+        select tweet_id
+        from tweets_fts
+        where tweets_fts.text match ?
+      )`
+		: "";
 	if (ftsSearch) {
-		join += " join tweets_fts on tweets_fts.tweet_id = t.id ";
-		where += " and tweets_fts.text match ?";
-		searchSnippetSelect =
-			", snippet(tweets_fts, 1, '<mark>', '</mark>', '...', 16) as search_snippet";
-		params.push(ftsSearch);
+		cteParams.push(ftsSearch);
 	}
+	const searchDrivenFrom =
+		ftsMatchCountHint > FTS_DRIVE_FROM_MATCHES_MAX
+			? `tweets t
+        cross join fts_matches on fts_matches.tweet_id = t.id
+        cross join timeline_edges e on e.tweet_id = t.id`
+			: `fts_matches
+        cross join tweets t on t.id = fts_matches.tweet_id
+        cross join timeline_edges e on e.tweet_id = t.id`;
 
 	params.push(limit);
+	if (ftsSearch) {
+		// Outer limit; the inner search CTE consumes the first one.
+		params.push(limit);
+	}
+
+	// For searches, resolve the limited id set first so the wide column list
+	// (embedded tweets, bookmark/like probes) is only evaluated for returned
+	// rows instead of every match.
+	const searchSelectionCte = ftsSearch
+		? `, search_selection as materialized (
+        select t.id as tweet_id, e.account_id, e.kind, e.raw_json
+        from ${searchDrivenFrom}
+        ${where}
+        order by t.created_at desc, t.id desc
+        limit ?
+      )`
+		: "";
 
 	const buildTimelineSelectSql = (timelineEdgesSql: string) => `
-      ${timelineEdgesSql}
+      ${timelineEdgesSql}${ftsMatchesCte}${searchSelectionCte}
       select
         t.id,
         e.account_id,
@@ -750,8 +801,7 @@ export function listTimelineItems({
         qp.avatar_hue as quoted_avatar_hue,
         qp.avatar_url as quoted_avatar_url,
         qp.created_at as quoted_profile_created_at
-        ${searchSnippetSelect}
-      from timeline_edges e
+      from ${ftsSearch ? "search_selection e" : "timeline_edges e"}
       join tweets t on t.id = e.tweet_id
       join accounts a on a.id = e.account_id
       join profiles p on p.id = t.author_profile_id
@@ -759,20 +809,74 @@ export function listTimelineItems({
       left join profiles rp on rp.id = rt.author_profile_id
       left join tweets qt on qt.id = t.quoted_tweet_id
       left join profiles qp on qp.id = qt.author_profile_id
-      ${join}
-      ${where}
+      ${ftsSearch ? "" : where}
       order by t.created_at desc, t.id desc
       limit ?
       `;
 
-	let rows = db
-		.prepare(buildTimelineSelectSql(timelineEdgesCte))
-		.all(...params) as Array<Record<string, unknown>>;
+	return {
+		sql: buildTimelineSelectSql(timelineEdgesCte),
+		params: [...cteParams, ...params],
+		fallbackSql: buildTimelineSelectSql(unwindowedTimelineEdgesCte),
+		fallbackParams: [kind, kind, limit],
+		usedRecentEdgeWindow,
+		ftsSearch,
+	};
+}
 
-	if (usedRecentEdgeWindow && rows.length < limit) {
-		rows = db
-			.prepare(buildTimelineSelectSql(unwindowedTimelineEdgesCte))
-			.all(kind, kind, limit) as Array<Record<string, unknown>>;
+const SEARCH_SNIPPET_SQL =
+	"snippet(tweets_fts, 1, '<mark>', '</mark>', '...', 16)";
+
+export function listTimelineItems(query: TimelineQuery): TimelineItem[] {
+	const db = getReadDb();
+	const {
+		includeQualityReason = false,
+		lowQualityThreshold,
+		limit = 18,
+	} = query;
+	const normalizedLowQualityThreshold =
+		normalizeLowQualityThreshold(lowQualityThreshold);
+	const ftsSearch = query.search?.trim() ? toFtsSearchQuery(query.search) : "";
+	const ftsMatchCount = ftsSearch
+		? Number(
+				(
+					db
+						.prepare(
+							"select count(*) as match_count from tweets_fts where tweets_fts.text match ?",
+						)
+						.get(ftsSearch) as { match_count: number }
+				).match_count,
+			)
+		: 0;
+	const plan = buildTimelineItemsQuery(query, ftsMatchCount);
+
+	let rows = db.prepare(plan.sql).all(...plan.params) as Array<
+		Record<string, unknown>
+	>;
+
+	if (plan.usedRecentEdgeWindow && rows.length < limit) {
+		rows = db.prepare(plan.fallbackSql).all(...plan.fallbackParams) as Array<
+			Record<string, unknown>
+		>;
+	}
+
+	if (plan.ftsSearch && rows.length > 0) {
+		const snippetRows = db
+			.prepare(
+				`select tweet_id, ${SEARCH_SNIPPET_SQL} as search_snippet
+         from tweets_fts
+         where tweets_fts.text match ?
+           and tweet_id in (${rows.map(() => "?").join(",")})`,
+			)
+			.all(plan.ftsSearch, ...rows.map((row) => String(row.id))) as Array<
+			Record<string, unknown>
+		>;
+		const snippetByTweetId = new Map(
+			snippetRows.map((row) => [String(row.tweet_id), row.search_snippet]),
+		);
+		for (const row of rows) {
+			row.search_snippet = snippetByTweetId.get(String(row.id));
+		}
 	}
 
 	const urlExpansionCache: UrlExpansionCache = new Map();


### PR DESCRIPTION
## Summary

`birdclaw search tweets` took ~60-70s on a 924MB real archive (272k home edges) and minutes at 100% CPU for common terms. Root cause: with bound parameters SQLite planned the FTS join as the innermost loop, re-running the entire `tweets_fts` MATCH scan once per timeline edge row (confirmed via CPU profile and `EXPLAIN QUERY PLAN`; the same SQL with literal values planned FTS-first and ran in 83ms).

## Fix

- Materialize the FTS match set once in a `fts_matches as materialized` CTE so the MATCH scan can only run once.
- Pick the join drive order from a cheap `count(*)` on the match set: selective terms iterate the match set; dense terms (>10k matches) walk the `created_at` index newest-first and probe the match set until the limit fills.
- Resolve the LIMIT on an id-only inner selection so the wide column list (embedded tweets, bookmark/like probes) is only evaluated for returned rows.
- Compute snippets in a post-pass for only the returned rows.
- Extract query construction into an exported `buildTimelineItemsQuery()` so tests can EXPLAIN the real parameterized SQL.

The DM search path already had an equivalent materialized-CTE structure; only the timeline path was affected.

## Results (real 924MB archive, end-to-end incl. node startup)

| Query | Before | After |
|---|---|---|
| `search tweets "typescript" --limit 2` | 2m 54s | 0.34s |
| `"effect"` | minutes | 0.29s |
| `"the"` (139k matches, worst case) | minutes | 0.66s |
| `"quaternion"` (rare) | — | 0.24s |

## Verification

- Output byte-identical to installed birdclaw 0.9.3 for the same search on the real archive.
- Both hybrid drive orders return identical rows for dense and sparse terms.
- Mentions, liked-only, and account-filter branches verified against the real archive.
- Regression guard: plan-shape tests assert every `tweets_fts` access stays inside the materialized CTE, plus a parity test across both drive strategies.
- Full suite green (1209 tests), format/lint/typecheck clean.
