### PR TITLE
Fix bird subprocess shell on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add a disabled-by-default, bearer-authenticated read-only MCP endpoint for account-scoped cached tweet search and thread research, with startup configuration/schema validation, strict loopback/Host/Origin/path isolation, bounded stateless requests, and no DM, live X, OpenAI, filesystem, or write tools.
 
+### Fixed
+
+- Run Bird subprocesses through Git Bash on Windows instead of assuming `/bin/bash`, with a documented override for portable Git installations. (#94 - thanks @kristofer-atlas)
+
 ## 0.9.5 - 2026-07-06
 
 ### Fixed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,8 @@ User config:
 - `BIRDCLAW_HOME`
 - `BIRDCLAW_CONFIG`
 - `BIRDCLAW_ACTIONS_TRANSPORT`
+- `BIRDCLAW_BIRD_COMMAND`
+- `BIRDCLAW_BASH_COMMAND`
 - `BIRDCLAW_MCP_TOKEN`
 - `BIRDCLAW_MCP_PUBLIC_URL`
 - `BIRDCLAW_MCP_ACCOUNT`
@@ -205,6 +207,10 @@ by default. Override it with `BIRDCLAW_BIRD_COMMAND` or:
 	}
 }
 ```
+
+On Windows, Birdclaw runs the redirect wrapper through Git Bash. Common Git for
+Windows installations are detected automatically; set `BIRDCLAW_BASH_COMMAND`
+to the full path of `bash.exe` for a portable or non-standard installation.
 
 ### `backup import`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,8 @@ See [Backup](backup.md). When `autoSync` is enabled, read commands pull + merge 
 | `BIRDCLAW_HOME`                | Override the storage root (`~/.birdclaw` by default)                                                                                                 |
 | `BIRDCLAW_CONFIG`              | Read and write config at a non-default path                                                                                                          |
 | `BIRDCLAW_ACTIONS_TRANSPORT`   | Override moderation action transport with `auto`, `xurl`, or `bird` for one process                                                                  |
+| `BIRDCLAW_BIRD_COMMAND`        | Override the `bird` executable used by live Bird transports                                                                                          |
+| `BIRDCLAW_BASH_COMMAND`        | Override the Git Bash executable used for Bird subprocess redirection on Windows                                                                     |
 | `BIRDCLAW_HOST`                | Host interface for the production `birdclaw serve` listener; defaults to `127.0.0.1`                                                                 |
 | `BIRDCLAW_PORT`                | Port for the production `birdclaw serve` listener; defaults to `3000`                                                                                |
 | `BIRDCLAW_ALLOWED_HOSTS`       | Comma-separated extra hostnames accepted by the source `pnpm dev` server                                                                             |

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -107,7 +107,9 @@ describe("bird transport wrapper", () => {
 			__test__.getBirdStdoutShellCommand(
 				"win32",
 				{ Path: "D:\\PortableGit\\bin;." },
-				(candidate) => candidate === "D:\\PortableGit\\bin\\bash.exe",
+				(candidate) =>
+					candidate === "D:\\PortableGit\\bin\\bash.exe" ||
+					candidate === "D:\\PortableGit\\cmd\\git.exe",
 			),
 		).toBe("D:\\PortableGit\\bin\\bash.exe");
 		expect(
@@ -123,9 +125,18 @@ describe("bird transport wrapper", () => {
 			__test__.getBirdStdoutShellCommand(
 				"win32",
 				{ Path: "D:\\PortableGit\\cmd" },
-				(candidate) => candidate === "D:\\PortableGit\\bin\\bash.exe",
+				(candidate) =>
+					candidate === "D:\\PortableGit\\bin\\bash.exe" ||
+					candidate === "D:\\PortableGit\\cmd\\git.exe",
 			),
 		).toBe("D:\\PortableGit\\bin\\bash.exe");
+		expect(() =>
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{ Path: "C:\\Windows\\System32;D:\\PortableGit\\cmd" },
+				(candidate) => candidate === "C:\\Windows\\System32\\bash.exe",
+			),
+		).toThrow("Git Bash unavailable: no trusted bash.exe found");
 		expect(() =>
 			__test__.getBirdStdoutShellCommand(
 				"win32",

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -500,7 +500,7 @@ describe("bird transport wrapper", () => {
 		const { listMentionsViaBird } = await import("./bird");
 
 		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"Bash unavailable: /bin/bash",
+			"Bash unavailable:",
 		);
 	});
 
@@ -625,7 +625,7 @@ describe("bird transport wrapper", () => {
 				action: "accept",
 				conversationId: "111-333",
 			}),
-		).rejects.toThrow("Bash unavailable: /bin/bash");
+		).rejects.toThrow("Bash unavailable:");
 	});
 
 	it("passes pagination options to bird DM block mutations", async () => {

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -457,7 +457,7 @@ describe("bird transport wrapper", () => {
 		);
 	});
 
-	it("explains how to configure Git Bash when the wrapper shell is missing", async () => {
+	it("explains how to configure Bash when the wrapper shell is missing", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdRejectOnce(
 			Object.assign(new Error("spawn bash.exe ENOENT"), { code: "ENOENT" }),
@@ -466,7 +466,7 @@ describe("bird transport wrapper", () => {
 		const { listMentionsViaBird } = await import("./bird");
 
 		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"Git Bash unavailable: /bin/bash",
+			"Bash unavailable: /bin/bash",
 		);
 	});
 
@@ -576,6 +576,22 @@ describe("bird transport wrapper", () => {
 			}),
 		).resolves.toEqual(payload);
 		expectBirdCommandCall(1, ["dm-reject", "111-333", "--json"]);
+	});
+
+	it("preserves missing-shell errors from failed bird DM mutations", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdRejectOnce(
+			Object.assign(new Error("spawn bash ENOENT"), { code: "ENOENT" }),
+		);
+
+		const { runDirectMessageRequestMutationViaBird } = await import("./bird");
+
+		await expect(
+			runDirectMessageRequestMutationViaBird({
+				action: "accept",
+				conversationId: "111-333",
+			}),
+		).rejects.toThrow("Bash unavailable: /bin/bash");
 	});
 
 	it("passes pagination options to bird DM block mutations", async () => {
@@ -1136,6 +1152,18 @@ describe("bird transport wrapper", () => {
 		});
 		expect(
 			__test__.formatBirdCommandError(enoent, "/missing/bird", "bash.exe"),
+		).toEqual(
+			expect.objectContaining({
+				message: expect.stringContaining("Bash unavailable: bash.exe"),
+			}),
+		);
+		expect(
+			__test__.formatBirdCommandError(
+				enoent,
+				"C:\\bird.cmd",
+				"bash.exe",
+				"win32",
+			),
 		).toEqual(
 			expect.objectContaining({
 				message: expect.stringContaining("Git Bash unavailable: bash.exe"),

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -112,6 +112,19 @@ describe("bird transport wrapper", () => {
 		).toBe("bash.exe");
 	});
 
+	it("disables MSYS argument conversion for the Windows redirect wrapper", async () => {
+		const { __test__ } = await import("./bird");
+
+		expect(
+			__test__.getBirdStdoutShellEnv("win32", {
+				PATH: "C:\\Windows",
+				MSYS2_ARG_CONV_EXCL: "/legacy",
+			}),
+		).toEqual({ PATH: "C:\\Windows", MSYS2_ARG_CONV_EXCL: "*" });
+		const posixEnv = { PATH: "/usr/bin" };
+		expect(__test__.getBirdStdoutShellEnv("linux", posixEnv)).toBe(posixEnv);
+	});
+
 	it("maps bird mentions json into xurl-compatible payloads", async () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce(
@@ -441,6 +454,19 @@ describe("bird transport wrapper", () => {
 
 		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
 			"bird command unavailable: /missing/bird",
+		);
+	});
+
+	it("explains how to configure Git Bash when the wrapper shell is missing", async () => {
+		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
+		mockBirdRejectOnce(
+			Object.assign(new Error("spawn bash.exe ENOENT"), { code: "ENOENT" }),
+		);
+
+		const { listMentionsViaBird } = await import("./bird");
+
+		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
+			"Git Bash unavailable: /bin/bash",
 		);
 	});
 
@@ -1108,14 +1134,16 @@ describe("bird transport wrapper", () => {
 			text: "hello\nworld",
 			tab: "a\tb",
 		});
-		expect(__test__.formatBirdCommandError(enoent, "/missing/bird")).toEqual(
+		expect(
+			__test__.formatBirdCommandError(enoent, "/missing/bird", "bash.exe"),
+		).toEqual(
 			expect.objectContaining({
-				message: expect.stringContaining(
-					"bird command unavailable: /missing/bird",
-				),
+				message: expect.stringContaining("Git Bash unavailable: bash.exe"),
 			}),
 		);
-		expect(__test__.formatBirdCommandError("boom", "/tmp/bird")).toBe("boom");
+		expect(
+			__test__.formatBirdCommandError("boom", "/tmp/bird", "/bin/bash"),
+		).toBe("boom");
 		expect(
 			__test__.isUnsupportedBirdOptionError(
 				Object.assign(new Error("bad"), {

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -106,10 +106,17 @@ describe("bird transport wrapper", () => {
 		expect(
 			__test__.getBirdStdoutShellCommand(
 				"win32",
-				{} as NodeJS.ProcessEnv,
+				{ Path: "D:\\PortableGit\\bin;." },
+				(candidate) => candidate === "D:\\PortableGit\\bin\\bash.exe",
+			),
+		).toBe("D:\\PortableGit\\bin\\bash.exe");
+		expect(() =>
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{ PATH: ".;relative\\bin" },
 				() => false,
 			),
-		).toBe("bash.exe");
+		).toThrow("Git Bash unavailable: no trusted bash.exe found");
 	});
 
 	it("disables MSYS argument conversion for the Windows redirect wrapper", async () => {

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -110,6 +110,22 @@ describe("bird transport wrapper", () => {
 				(candidate) => candidate === "D:\\PortableGit\\bin\\bash.exe",
 			),
 		).toBe("D:\\PortableGit\\bin\\bash.exe");
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{ LOCALAPPDATA: "D:\\Users\\Sam\\AppData\\Local" },
+				(candidate) =>
+					candidate ===
+					"D:\\Users\\Sam\\AppData\\Local\\Programs\\Git\\bin\\bash.exe",
+			),
+		).toBe("D:\\Users\\Sam\\AppData\\Local\\Programs\\Git\\bin\\bash.exe");
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{ Path: "D:\\PortableGit\\cmd" },
+				(candidate) => candidate === "D:\\PortableGit\\bin\\bash.exe",
+			),
+		).toBe("D:\\PortableGit\\bin\\bash.exe");
 		expect(() =>
 			__test__.getBirdStdoutShellCommand(
 				"win32",

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -39,7 +39,7 @@ function mockBirdRejectWithStdoutOnce(
 function expectBirdCommandCall(callNumber: number, args: string[]) {
 	const call = execFileAsyncMock.mock.calls[callNumber - 1];
 	expect(call).toBeDefined();
-	expect(call[0]).toBe("/bin/bash");
+	expect(String(call[0])).toMatch(/(?:^\/bin\/bash$|bash\.exe$)/);
 	expect((call[1] as string[])[0]).toBe("-c");
 	expect((call[1] as string[]).slice(4)).toEqual(["/tmp/bird", ...args]);
 	expect(call[2]).toEqual(
@@ -72,6 +72,44 @@ describe("bird transport wrapper", () => {
 		expect(execFileAsyncMock).not.toHaveBeenCalled();
 
 		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("uses /bin/bash for the bird stdout redirect wrapper on POSIX systems", async () => {
+		const { __test__ } = await import("./bird");
+
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"linux",
+				{} as NodeJS.ProcessEnv,
+				() => false,
+			),
+		).toBe("/bin/bash");
+	});
+
+	it("uses Git Bash for the bird stdout redirect wrapper on Windows", async () => {
+		const { __test__ } = await import("./bird");
+
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{} as NodeJS.ProcessEnv,
+				(candidate) => candidate === "C:\\Program Files\\Git\\bin\\bash.exe",
+			),
+		).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{ BIRDCLAW_BASH_COMMAND: "D:\\Git\\bin\\bash.exe" },
+				() => false,
+			),
+		).toBe("D:\\Git\\bin\\bash.exe");
+		expect(
+			__test__.getBirdStdoutShellCommand(
+				"win32",
+				{} as NodeJS.ProcessEnv,
+				() => false,
+			),
+		).toBe("bash.exe");
 	});
 
 	it("maps bird mentions json into xurl-compatible payloads", async () => {

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -246,6 +246,7 @@ function formatBirdCommandError(
 	error: unknown,
 	birdCommand: string,
 	shellCommand: string,
+	platform: NodeJS.Platform = process.platform,
 ) {
 	const text = [
 		error instanceof Error ? error.message : "",
@@ -267,9 +268,13 @@ function formatBirdCommandError(
 		"code" in error &&
 		(error as { code?: unknown }).code === "ENOENT"
 	) {
-		return new Error(
-			`Git Bash unavailable: ${shellCommand}\nInstall Git for Windows, add bash.exe to PATH, or set BIRDCLAW_BASH_COMMAND to its full path.`,
-		);
+		return platform === "win32"
+			? new Error(
+					`Git Bash unavailable: ${shellCommand}\nInstall Git for Windows, add bash.exe to PATH, or set BIRDCLAW_BASH_COMMAND to its full path.`,
+				)
+			: new Error(
+					`Bash unavailable: ${shellCommand}\nInstall Bash or set BIRDCLAW_BASH_COMMAND to its full path.`,
+				);
 	}
 	if (
 		/No such file or directory|command not found|cannot execute/i.test(text) &&
@@ -403,7 +408,9 @@ const runBirdJsonCommandAllowFailureEffect = Effect.fn(
 							timeout: timeoutMs,
 						},
 					).catch((error: unknown) => {
-						const stdout = readFileSync(stdoutPath, "utf8");
+						const stdout = existsSync(stdoutPath)
+							? readFileSync(stdoutPath, "utf8")
+							: "";
 						if (stdout.trim().length > 0) {
 							return { stdout: "", stderr: "" };
 						}

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -337,15 +337,13 @@ function getBirdStdoutShellCommand(
 	for (const rawDirectory of pathValue?.split(";") ?? []) {
 		const directory = rawDirectory.trim().replace(/^"(.*)"$/, "$1");
 		if (!win32Path.isAbsolute(directory)) continue;
-		const pathCandidate = win32Path.join(directory, "bash.exe");
-		if (pathExists(pathCandidate)) return pathCandidate;
-		if (win32Path.basename(directory).toLowerCase() === "cmd") {
-			const siblingCandidate = win32Path.join(
-				win32Path.dirname(directory),
-				"bin",
-				"bash.exe",
-			);
-			if (pathExists(siblingCandidate)) return siblingCandidate;
+		const directoryName = win32Path.basename(directory).toLowerCase();
+		if (directoryName !== "bin" && directoryName !== "cmd") continue;
+		const gitRoot = win32Path.dirname(directory);
+		const bashCandidate = win32Path.join(gitRoot, "bin", "bash.exe");
+		const gitCandidate = win32Path.join(gitRoot, "cmd", "git.exe");
+		if (pathExists(bashCandidate) && pathExists(gitCandidate)) {
+			return bashCandidate;
 		}
 	}
 	throw new Error(

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, win32 as win32Path } from "node:path";
 import { promisify } from "node:util";
 import { Effect } from "effect";
 import { getBirdCommand } from "./config";
@@ -323,10 +323,21 @@ function getBirdStdoutShellCommand(
 	if (platform !== "win32") {
 		return "/bin/bash";
 	}
-	return (
-		WINDOWS_BASH_COMMAND_CANDIDATES.find((candidate) =>
-			pathExists(candidate),
-		) ?? "bash.exe"
+	const candidate = WINDOWS_BASH_COMMAND_CANDIDATES.find((candidate) =>
+		pathExists(candidate),
+	);
+	if (candidate) return candidate;
+	const pathValue = Object.entries(env).find(
+		([name]) => name.toLowerCase() === "path",
+	)?.[1];
+	for (const rawDirectory of pathValue?.split(";") ?? []) {
+		const directory = rawDirectory.trim().replace(/^"(.*)"$/, "$1");
+		if (!win32Path.isAbsolute(directory)) continue;
+		const pathCandidate = win32Path.join(directory, "bash.exe");
+		if (pathExists(pathCandidate)) return pathCandidate;
+	}
+	throw new Error(
+		"Git Bash unavailable: no trusted bash.exe found\nInstall Git for Windows, add its absolute bin directory to PATH, or set BIRDCLAW_BASH_COMMAND to its full path.",
 	);
 }
 

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -242,7 +242,11 @@ function parseBirdJson(stdout: string) {
 	}
 }
 
-function formatBirdCommandError(error: unknown, birdCommand: string) {
+function formatBirdCommandError(
+	error: unknown,
+	birdCommand: string,
+	shellCommand: string,
+) {
 	const text = [
 		error instanceof Error ? error.message : "",
 		error &&
@@ -259,11 +263,17 @@ function formatBirdCommandError(error: unknown, birdCommand: string) {
 			: "",
 	].join("\n");
 	if (
-		(error instanceof Error &&
-			"code" in error &&
-			(error as { code?: unknown }).code === "ENOENT") ||
-		(/No such file or directory|command not found|cannot execute/i.test(text) &&
-			text.includes(birdCommand))
+		error instanceof Error &&
+		"code" in error &&
+		(error as { code?: unknown }).code === "ENOENT"
+	) {
+		return new Error(
+			`Git Bash unavailable: ${shellCommand}\nInstall Git for Windows, add bash.exe to PATH, or set BIRDCLAW_BASH_COMMAND to its full path.`,
+		);
+	}
+	if (
+		/No such file or directory|command not found|cannot execute/i.test(text) &&
+		text.includes(birdCommand)
 	) {
 		return new Error(
 			`bird command unavailable: ${birdCommand}\nInstall bird on PATH, set BIRDCLAW_BIRD_COMMAND, or update ~/.birdclaw/config.json mentions.birdCommand.`,
@@ -315,6 +325,14 @@ function getBirdStdoutShellCommand(
 	);
 }
 
+function getBirdStdoutShellEnv(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+) {
+	if (platform !== "win32") return env;
+	return { ...env, MSYS2_ARG_CONV_EXCL: "*" };
+}
+
 export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 	(args: string[], timeoutMs?: number) =>
 		Effect.scoped(
@@ -325,10 +343,11 @@ export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 						error instanceof Error ? error : new Error(String(error)),
 				});
 				const { stdoutPath } = yield* makeBirdStdoutTempEffect();
+				const shellCommand = getBirdStdoutShellCommand();
 				yield* Effect.tryPromise({
 					try: () =>
 						execFileAsync(
-							getBirdStdoutShellCommand(),
+							shellCommand,
 							[
 								"-c",
 								BIRD_STDOUT_REDIRECT_SCRIPT,
@@ -337,9 +356,14 @@ export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 								birdCommand,
 								...args,
 							],
-							{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
+							{
+								env: getBirdStdoutShellEnv(),
+								maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES,
+								timeout: timeoutMs,
+							},
 						),
-					catch: (error) => formatBirdCommandError(error, birdCommand),
+					catch: (error) =>
+						formatBirdCommandError(error, birdCommand, shellCommand),
 				});
 				return yield* Effect.try({
 					try: () => readFileSync(stdoutPath, "utf8"),
@@ -360,10 +384,11 @@ const runBirdJsonCommandAllowFailureEffect = Effect.fn(
 					error instanceof Error ? error : new Error(String(error)),
 			});
 			const { stdoutPath } = yield* makeBirdStdoutTempEffect();
+			const shellCommand = getBirdStdoutShellCommand();
 			yield* Effect.tryPromise({
 				try: () =>
 					execFileAsync(
-						getBirdStdoutShellCommand(),
+						shellCommand,
 						[
 							"-c",
 							BIRD_STDOUT_REDIRECT_SCRIPT,
@@ -372,13 +397,17 @@ const runBirdJsonCommandAllowFailureEffect = Effect.fn(
 							birdCommand,
 							...args,
 						],
-						{ maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES, timeout: timeoutMs },
+						{
+							env: getBirdStdoutShellEnv(),
+							maxBuffer: BIRD_JSON_MAX_BUFFER_BYTES,
+							timeout: timeoutMs,
+						},
 					).catch((error: unknown) => {
 						const stdout = readFileSync(stdoutPath, "utf8");
 						if (stdout.trim().length > 0) {
 							return { stdout: "", stderr: "" };
 						}
-						throw formatBirdCommandError(error, birdCommand);
+						throw formatBirdCommandError(error, birdCommand, shellCommand);
 					}),
 				catch: (error) => error,
 			});
@@ -1346,6 +1375,7 @@ export const __test__ = {
 	parseBirdJson,
 	formatBirdCommandError,
 	isUnsupportedBirdOptionError,
+	getBirdStdoutShellEnv,
 	getBirdTweetItems,
 	getBirdTweetItem,
 	toMediaEntities,

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -323,9 +323,13 @@ function getBirdStdoutShellCommand(
 	if (platform !== "win32") {
 		return "/bin/bash";
 	}
-	const candidate = WINDOWS_BASH_COMMAND_CANDIDATES.find((candidate) =>
-		pathExists(candidate),
-	);
+	const candidates = [...WINDOWS_BASH_COMMAND_CANDIDATES];
+	if (env.LOCALAPPDATA && win32Path.isAbsolute(env.LOCALAPPDATA)) {
+		candidates.push(
+			win32Path.join(env.LOCALAPPDATA, "Programs", "Git", "bin", "bash.exe"),
+		);
+	}
+	const candidate = candidates.find((candidate) => pathExists(candidate));
 	if (candidate) return candidate;
 	const pathValue = Object.entries(env).find(
 		([name]) => name.toLowerCase() === "path",
@@ -335,6 +339,14 @@ function getBirdStdoutShellCommand(
 		if (!win32Path.isAbsolute(directory)) continue;
 		const pathCandidate = win32Path.join(directory, "bash.exe");
 		if (pathExists(pathCandidate)) return pathCandidate;
+		if (win32Path.basename(directory).toLowerCase() === "cmd") {
+			const siblingCandidate = win32Path.join(
+				win32Path.dirname(directory),
+				"bin",
+				"bash.exe",
+			);
+			if (pathExists(siblingCandidate)) return siblingCandidate;
+		}
 	}
 	throw new Error(
 		"Git Bash unavailable: no trusted bash.exe found\nInstall Git for Windows, add its absolute bin directory to PATH, or set BIRDCLAW_BASH_COMMAND to its full path.",
@@ -359,7 +371,11 @@ export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 						error instanceof Error ? error : new Error(String(error)),
 				});
 				const { stdoutPath } = yield* makeBirdStdoutTempEffect();
-				const shellCommand = getBirdStdoutShellCommand();
+				const shellCommand = yield* Effect.try({
+					try: () => getBirdStdoutShellCommand(),
+					catch: (error) =>
+						error instanceof Error ? error : new Error(String(error)),
+				});
 				yield* Effect.tryPromise({
 					try: () =>
 						execFileAsync(
@@ -400,7 +416,11 @@ const runBirdJsonCommandAllowFailureEffect = Effect.fn(
 					error instanceof Error ? error : new Error(String(error)),
 			});
 			const { stdoutPath } = yield* makeBirdStdoutTempEffect();
-			const shellCommand = getBirdStdoutShellCommand();
+			const shellCommand = yield* Effect.try({
+				try: () => getBirdStdoutShellCommand(),
+				catch: (error) =>
+					error instanceof Error ? error : new Error(String(error)),
+			});
 			yield* Effect.tryPromise({
 				try: () =>
 					execFileAsync(

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -20,6 +20,11 @@ import type {
 const execFileAsync = promisify(execFile);
 const BIRD_JSON_MAX_BUFFER_BYTES = 512 * 1024 * 1024;
 const BIRD_STDOUT_REDIRECT_SCRIPT = 'out="$1"; shift; exec "$@" > "$out"';
+const WINDOWS_BASH_COMMAND_CANDIDATES = [
+	"C:\\Program Files\\Git\\bin\\bash.exe",
+	"C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+	"C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+];
 
 interface BirdTweetMedia {
 	type?: string;
@@ -291,6 +296,25 @@ function makeBirdStdoutTempEffect() {
 	);
 }
 
+function getBirdStdoutShellCommand(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+	pathExists: (path: string) => boolean = existsSync,
+) {
+	if (env.BIRDCLAW_BASH_COMMAND) {
+		// Trust the explicit override for portable or non-standard Git installs.
+		return env.BIRDCLAW_BASH_COMMAND;
+	}
+	if (platform !== "win32") {
+		return "/bin/bash";
+	}
+	return (
+		WINDOWS_BASH_COMMAND_CANDIDATES.find((candidate) =>
+			pathExists(candidate),
+		) ?? "bash.exe"
+	);
+}
+
 export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 	(args: string[], timeoutMs?: number) =>
 		Effect.scoped(
@@ -304,7 +328,7 @@ export const runBirdJsonCommandEffect = Effect.fn("bird.runJsonCommand")(
 				yield* Effect.tryPromise({
 					try: () =>
 						execFileAsync(
-							"/bin/bash",
+							getBirdStdoutShellCommand(),
 							[
 								"-c",
 								BIRD_STDOUT_REDIRECT_SCRIPT,
@@ -339,7 +363,7 @@ const runBirdJsonCommandAllowFailureEffect = Effect.fn(
 			yield* Effect.tryPromise({
 				try: () =>
 					execFileAsync(
-						"/bin/bash",
+						getBirdStdoutShellCommand(),
 						[
 							"-c",
 							BIRD_STDOUT_REDIRECT_SCRIPT,
@@ -1327,5 +1351,6 @@ export const __test__ = {
 	toMediaEntities,
 	toTweetEntities,
 	toReferencedTweets,
+	getBirdStdoutShellCommand,
 	normalizeBirdTweets,
 };


### PR DESCRIPTION
## Summary

Use Git Bash for Bird subprocess stdout capture on Windows while preserving `/bin/bash` on POSIX systems.

The repaired branch:

- discovers Git Bash only from trusted standard install locations, the current user's Git install, or validated Git roots on `PATH`
- supports an explicit `BIRDCLAW_BASH_COMMAND` override for portable Git installations
- preserves slash-prefixed Bird arguments with `MSYS2_ARG_CONV_EXCL=*`
- keeps shell-discovery failures distinct from Bird command failures
- covers Windows discovery, overrides, unsafe-path rejection, argument preservation, and diagnostics
- documents the override and thanks @kristofer-atlas in the changelog

## Proof

- Native Windows 11 Home ARM64 on `STEIPETESURFACE`, Node 26.5.0, pnpm 10.34.3, Git for Windows 2.54.0
- Real subprocess through `C:\Program Files\Git\bin\bash.exe` at `cd6b378a47d274f75a2d4ab4577a3663d3222d9f`: stdout `[]`; captured Bird args `search /imagine`
- Windows focused suite: `src/lib/bird.test.ts`, 34/34 passed
- Full megaclaw gate: formatting, lint, typecheck; 145 files and 1,275 tests passed; production build; package smoke with 126 files
- `pnpm audit --prod`: zero known vulnerabilities
- Autoreview: clean, no accepted or actionable findings

