### PR TITLE
fix(init): select authenticated X account

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -555,7 +555,14 @@ describe("cli", () => {
 	it("prints init, auth status, archive results, and db stats as json", async () => {
 		const { runCli } = await loadCli();
 
-		await runCli(["node", "birdclaw", "--json", "init"]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"init",
+			"--account",
+			"ikuznetsov_com",
+		]);
 		await runCli(["node", "birdclaw", "--json", "auth", "status"]);
 		await runCli(["node", "birdclaw", "--json", "archive", "find"]);
 		await runCli(["node", "birdclaw", "--json", "db", "stats"]);
@@ -564,6 +571,11 @@ describe("cli", () => {
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"rootDir": "/tmp/.birdclaw"'),
 		);
+		expect(hydrateProfilesFromXMock).toHaveBeenCalledWith({
+			account: "ikuznetsov_com",
+			accountOnly: true,
+			seededAccountOnly: true,
+		});
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"statusText": "local"'),
 		);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -561,7 +561,7 @@ describe("cli", () => {
 			"--json",
 			"init",
 			"--account",
-			"ikuznetsov_com",
+			"steipete",
 		]);
 		await runCli(["node", "birdclaw", "--json", "auth", "status"]);
 		await runCli(["node", "birdclaw", "--json", "archive", "find"]);
@@ -572,7 +572,7 @@ describe("cli", () => {
 			expect.stringContaining('"rootDir": "/tmp/.birdclaw"'),
 		);
 		expect(hydrateProfilesFromXMock).toHaveBeenCalledWith({
-			account: "ikuznetsov_com",
+			account: "steipete",
 			accountOnly: true,
 			seededAccountOnly: true,
 		});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -552,17 +552,14 @@ describe("cli", () => {
 		vi.clearAllMocks();
 	});
 
-	it("prints init, auth status, archive results, and db stats as json", async () => {
+	it("keeps plain init local-only and prints core results as json", async () => {
 		const { runCli } = await loadCli();
 
-		await runCli([
-			"node",
-			"birdclaw",
-			"--json",
-			"init",
-			"--account",
-			"steipete",
-		]);
+		await runCli(["node", "birdclaw", "--json", "init"]);
+		const initResult = JSON.parse(
+			String(consoleLogMock.mock.calls[0]?.[0]),
+		) as Record<string, unknown>;
+		expect(initResult).not.toHaveProperty("account");
 		await runCli(["node", "birdclaw", "--json", "auth", "status"]);
 		await runCli(["node", "birdclaw", "--json", "archive", "find"]);
 		await runCli(["node", "birdclaw", "--json", "db", "stats"]);
@@ -571,11 +568,7 @@ describe("cli", () => {
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"rootDir": "/tmp/.birdclaw"'),
 		);
-		expect(hydrateProfilesFromXMock).toHaveBeenCalledWith({
-			account: "steipete",
-			accountOnly: true,
-			seededAccountOnly: true,
-		});
+		expect(hydrateProfilesFromXMock).not.toHaveBeenCalled();
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"statusText": "local"'),
 		);
@@ -591,6 +584,79 @@ describe("cli", () => {
 			port: 3000,
 			serverVersion: packageVersion,
 		});
+	});
+
+	it("selects an authenticated account during init when explicitly requested", async () => {
+		hydrateProfilesFromXMock.mockResolvedValue({
+			ok: true,
+			hydratedProfiles: 0,
+			hydratedAccount: true,
+			account: {
+				handle: "@steipete",
+				externalUserId: "25401953",
+			},
+		});
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"init",
+			"--account",
+			"steipete",
+		]);
+
+		expect(hydrateProfilesFromXMock).toHaveBeenCalledWith({
+			account: "steipete",
+			accountOnly: true,
+			seededAccountOnly: true,
+		});
+		expect(consoleLogMock).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(consoleLogMock.mock.calls[0]?.[0]))).toEqual({
+			ok: true,
+			account: {
+				handle: "@steipete",
+				externalUserId: "25401953",
+			},
+			rootDir: "/tmp/.birdclaw",
+			configPath: "/tmp/.birdclaw/config.json",
+			dbPath: "/tmp/.birdclaw/birdclaw.sqlite",
+			mediaOriginalsDir: "/tmp/.birdclaw/media/originals",
+			mediaThumbsDir: "/tmp/.birdclaw/media/thumbs",
+		});
+	});
+
+	it("fails init when the explicit account cannot be selected", async () => {
+		hydrateProfilesFromXMock.mockResolvedValue({
+			ok: true,
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "Selected xurl account is unavailable",
+		});
+		const { runCli } = await loadCli();
+
+		await expect(
+			runCli(["node", "birdclaw", "--json", "init", "--account", "missing"]),
+		).rejects.toThrow("Selected xurl account is unavailable");
+
+		expect(hydrateProfilesFromXMock).toHaveBeenCalledWith({
+			account: "missing",
+			accountOnly: true,
+			seededAccountOnly: true,
+		});
+		expect(consoleLogMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects an empty init account before provider lookup", async () => {
+		const { runCli } = await loadCli();
+
+		await expect(
+			runCli(["node", "birdclaw", "--json", "init", "--account", "  @  "]),
+		).rejects.toThrow("--account requires a non-empty username");
+
+		expect(hydrateProfilesFromXMock).not.toHaveBeenCalled();
+		expect(consoleLogMock).not.toHaveBeenCalled();
 	});
 
 	it("sets the preferred auth transport", async () => {

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -144,17 +144,30 @@ export function registerCoreCommands({
 			"Select an authenticated xurl account instead of its default",
 		)
 		.action(async (options: { account?: string }) => {
+			const selectedAccount = options.account?.trim().replace(/^@/, "");
+			if (options.account !== undefined && !selectedAccount) {
+				throw new Error("--account requires a non-empty username");
+			}
 			const paths = ensureBirdclawDirs();
 			await getQueryEnvelope();
-			const account = await hydrateProfilesFromX({
-				account: options.account,
-				accountOnly: true,
-				seededAccountOnly: true,
-			});
+			const account =
+				selectedAccount === undefined
+					? undefined
+					: await hydrateProfilesFromX({
+							account: selectedAccount,
+							accountOnly: true,
+							seededAccountOnly: true,
+						});
+			if (selectedAccount !== undefined && !account?.account) {
+				throw new Error(
+					account?.reason ??
+						`Could not select authenticated xurl account @${selectedAccount}`,
+				);
+			}
 			print(
 				{
 					ok: true,
-					account: account.account,
+					...(account?.account ? { account: account.account } : {}),
 					rootDir: paths.rootDir,
 					configPath: paths.configPath,
 					dbPath: paths.dbPath,

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -139,12 +139,22 @@ export function registerCoreCommands({
 	program
 		.command("init")
 		.description("Create local birdclaw root and seed the database")
-		.action(async () => {
+		.option(
+			"--account <username>",
+			"Select an authenticated xurl account instead of its default",
+		)
+		.action(async (options: { account?: string }) => {
 			const paths = ensureBirdclawDirs();
 			await getQueryEnvelope();
+			const account = await hydrateProfilesFromX({
+				account: options.account,
+				accountOnly: true,
+				seededAccountOnly: true,
+			});
 			print(
 				{
 					ok: true,
+					account: account.account,
 					rootDir: paths.rootDir,
 					configPath: paths.configPath,
 					dbPath: paths.dbPath,

--- a/src/lib/demo-account.ts
+++ b/src/lib/demo-account.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import type { Database } from "./sqlite";
+
+export const DEMO_PRIMARY_ACCOUNT = {
+	id: "acct_primary",
+	name: "Peter",
+	handle: "@steipete",
+	externalUserId: "25401953",
+	transport: "xurl",
+	isDefault: 1,
+	createdAt: "2026-03-08T12:00:00.000Z",
+} as const;
+
+export const DEMO_PRIMARY_ACCOUNT_MARKER_KEY =
+	"identity:demo-seed:acct_primary:v1";
+
+export type StoredPrimaryAccount = {
+	name: string;
+	handle: string;
+	external_user_id: string | null;
+	transport: string;
+	is_default: number;
+	created_at: string;
+};
+
+type DemoAccountMarker = {
+	version: 1;
+	tableCounts: Record<string, number>;
+	fingerprint: string;
+};
+
+function quoteIdentifier(value: string) {
+	return `"${value.replaceAll('"', '""')}"`;
+}
+
+function getTrackedTableNames(db: Database) {
+	return (
+		db
+			.prepare(
+				`select name
+				 from sqlite_master
+				 where type = 'table'
+				   and name not like 'sqlite_%'
+				   and name not like 'tweets_fts%'
+				   and name not like 'dm_fts%'
+				   and name <> 'sync_cache'
+				   and upper(coalesce(sql, '')) not like 'CREATE VIRTUAL TABLE%'
+				 order by name`,
+			)
+			.all() as Array<{ name: string }>
+	).map((row) => row.name);
+}
+
+function getTableCount(db: Database, table: string) {
+	return (
+		db
+			.prepare(`select count(*) as count from ${quoteIdentifier(table)}`)
+			.get() as { count: number }
+	).count;
+}
+
+function getTableRows(db: Database, table: string) {
+	const columns = db
+		.prepare(`pragma table_info(${quoteIdentifier(table)})`)
+		.all() as Array<{ name: string; pk: number }>;
+	const primaryKey = columns
+		.filter((column) => column.pk > 0)
+		.sort((left, right) => left.pk - right.pk);
+	const orderColumns = primaryKey.length > 0 ? primaryKey : columns;
+	const orderBy = orderColumns
+		.map((column) => quoteIdentifier(column.name))
+		.join(", ");
+	return db
+		.prepare(
+			`select * from ${quoteIdentifier(table)}${orderBy ? ` order by ${orderBy}` : ""}`,
+		)
+		.all();
+}
+
+function computeFingerprint(db: Database, tableNames: string[]) {
+	const hash = createHash("sha256");
+	for (const table of tableNames) {
+		hash.update(table);
+		hash.update("\0");
+		hash.update(JSON.stringify(getTableRows(db, table)));
+		hash.update("\0");
+	}
+	return hash.digest("hex");
+}
+
+export function createDemoPrimaryAccountMarkerValue(db: Database) {
+	const tableNames = getTrackedTableNames(db);
+	const tableCounts = Object.fromEntries(
+		tableNames.map((table) => [table, getTableCount(db, table)]),
+	);
+	return JSON.stringify({
+		version: 1,
+		tableCounts,
+		fingerprint: computeFingerprint(db, tableNames),
+	} satisfies DemoAccountMarker);
+}
+
+export function hasUntouchedDemoPrimaryAccountState(
+	db: Database,
+	account: StoredPrimaryAccount | undefined,
+) {
+	if (!isUntouchedDemoPrimaryAccount(account)) return false;
+	const row = db
+		.prepare("select value_json from sync_cache where cache_key = ?")
+		.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY) as { value_json: string } | undefined;
+	if (!row) return false;
+
+	let marker: DemoAccountMarker;
+	try {
+		marker = JSON.parse(row.value_json) as DemoAccountMarker;
+	} catch {
+		return false;
+	}
+	if (
+		marker.version !== 1 ||
+		!marker.tableCounts ||
+		typeof marker.tableCounts !== "object" ||
+		typeof marker.fingerprint !== "string"
+	) {
+		return false;
+	}
+
+	const tableNames = getTrackedTableNames(db);
+	const markedTableNames = Object.keys(marker.tableCounts).sort();
+	if (
+		tableNames.length !== markedTableNames.length ||
+		tableNames.some((table, index) => table !== markedTableNames[index])
+	) {
+		return false;
+	}
+	for (const table of tableNames) {
+		if (getTableCount(db, table) !== marker.tableCounts[table]) return false;
+	}
+	return computeFingerprint(db, tableNames) === marker.fingerprint;
+}
+
+export function isUntouchedDemoPrimaryAccount(
+	account: StoredPrimaryAccount | undefined,
+) {
+	return (
+		account?.name === DEMO_PRIMARY_ACCOUNT.name &&
+		account.handle === DEMO_PRIMARY_ACCOUNT.handle &&
+		account.external_user_id === DEMO_PRIMARY_ACCOUNT.externalUserId &&
+		account.transport === DEMO_PRIMARY_ACCOUNT.transport &&
+		account.is_default === DEMO_PRIMARY_ACCOUNT.isDefault
+	);
+}

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
+import { DEMO_PRIMARY_ACCOUNT_MARKER_KEY } from "./demo-account";
 
 const mocks = vi.hoisted(() => ({
 	getTransportStatus: vi.fn(),
@@ -20,7 +21,7 @@ vi.mock("./xurl", async () => {
 	return {
 		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
-		lookupAuthenticatedOAuth2UserEffect: fromMock(
+		lookupSelectedAuthenticatedOAuth2UserEffect: fromMock(
 			mocks.lookupAuthenticatedOAuth2User,
 		),
 		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
@@ -78,6 +79,86 @@ describe("profile hydration", () => {
 			reason: "xurl missing",
 		});
 		expect(mocks.lookupUsersByIds).not.toHaveBeenCalled();
+	});
+
+	it("does not fall back to Bird for explicit xurl account selection", async () => {
+		const db = getNativeDb();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "local",
+			installed: false,
+			statusText: "xurl missing",
+		});
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			id: "999",
+			username: "wrong_bird_account",
+			name: "Wrong Bird Account",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "selected_xurl_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toEqual({
+			ok: true,
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "Cannot select xurl account @selected_xurl_account: xurl missing",
+		});
+
+		expect(mocks.getAuthenticatedBirdAccount).not.toHaveBeenCalled();
+		expect(mocks.lookupAuthenticatedOAuth2User).not.toHaveBeenCalled();
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+		}).toEqual(before);
+	});
+
+	it("propagates explicit OAuth2 account lookup failures", async () => {
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockRejectedValue(
+			new Error("selected account is not authenticated"),
+		);
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "missing",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).rejects.toThrow("selected account is not authenticated");
+		expect(mocks.getAuthenticatedBirdAccount).not.toHaveBeenCalled();
+	});
+
+	it("rejects an empty explicit account before provider lookup", async () => {
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+
+		await expect(
+			hydrateProfilesFromX({
+				account: "  @  ",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).rejects.toThrow("requires a non-empty username");
+		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
+		expect(mocks.lookupAuthenticatedOAuth2User).not.toHaveBeenCalled();
 	});
 
 	it("hydrates imported placeholder profiles from xurl", async () => {
@@ -194,7 +275,11 @@ describe("profile hydration", () => {
 
 		const { hydrateProfilesFromX } = await import("./profile-hydration");
 		await expect(
-			hydrateProfilesFromX({ account: "steipete" }),
+			hydrateProfilesFromX({
+				account: "steipete",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
 		).resolves.toMatchObject({
 			hydratedAccount: true,
 			account: {
@@ -218,19 +303,150 @@ describe("profile hydration", () => {
 			external_user_id: "25401953",
 			transport: "xurl",
 		});
+		expect(
+			db
+				.prepare("select 1 from sync_cache where cache_key = ?")
+				.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		).toBeUndefined();
+
+		await expect(
+			hydrateProfilesFromX({
+				account: "steipete",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedAccount: true,
+			account: {
+				handle: "@steipete",
+				externalUserId: "25401953",
+			},
+		});
+
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "999",
+			username: "other_account",
+			name: "Other Account",
+		});
+		await expect(
+			hydrateProfilesFromX({
+				account: "other_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedAccount: false,
+			reason: "Primary account is not the untouched demo seed",
+		});
 	});
+
+	it.each([
+		{
+			username: "sam",
+			conflictQuery: "select handle from profiles where id = 'profile_sam'",
+			renamedHandle: "seeded_profile_sam",
+		},
+		{
+			username: "birdclaw_lab",
+			conflictQuery: "select handle from accounts where id = 'acct_studio'",
+			renamedHandle: "@seeded_acct_studio",
+		},
+	])(
+		"selects a different account when @$username collides with demo data",
+		async ({ username, conflictQuery, renamedHandle }) => {
+			const db = getNativeDb();
+			mocks.getTransportStatus.mockResolvedValue({
+				availableTransport: "xurl",
+				installed: true,
+				statusText: "xurl available",
+			});
+			mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+				id: "999",
+				username,
+				name: "Selected Account",
+			});
+
+			const { hydrateProfilesFromX } = await import("./profile-hydration");
+			await expect(
+				hydrateProfilesFromX({
+					account: username,
+					accountOnly: true,
+					seededAccountOnly: true,
+				}),
+			).resolves.toMatchObject({
+				hydratedAccount: true,
+				account: { handle: `@${username}`, externalUserId: "999" },
+			});
+
+			expect(
+				db
+					.prepare(
+						"select handle, external_user_id from accounts where id = 'acct_primary'",
+					)
+					.get(),
+			).toEqual({ handle: `@${username}`, external_user_id: "999" });
+			expect(db.prepare(conflictQuery).get()).toEqual({
+				handle: renamedHandle,
+			});
+		},
+	);
 
 	it("does not replace an imported primary account during init", async () => {
 		const db = getNativeDb();
 		db.prepare(
-			"update accounts set name = ?, handle = ?, external_user_id = ? where id = 'acct_primary'",
-		).run("Archive Owner", "@archive_owner", "42");
+			"update accounts set name = ?, handle = ?, external_user_id = ?, transport = ? where id = 'acct_primary'",
+		).run("Archive Owner", "@archive_owner", "42", "archive");
+		db.prepare(
+			"update profiles set handle = ?, display_name = ?, bio = ?, avatar_url = ? where id = 'profile_me'",
+		).run(
+			"archive_owner",
+			"Archive Owner",
+			"Imported archive owner",
+			"https://example.com/archive-owner.png",
+		);
+		db.prepare(
+			"update tweet_account_edges set source = 'archive' where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		).run();
+
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const ownershipQuery = db.prepare(
+			"select * from tweet_account_edges where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		};
+		expect(before).toMatchObject({
+			account: {
+				name: "Archive Owner",
+				handle: "@archive_owner",
+				external_user_id: "42",
+				transport: "archive",
+			},
+			profile: {
+				handle: "archive_owner",
+				display_name: "Archive Owner",
+				bio: "Imported archive owner",
+				avatar_url: "https://example.com/archive-owner.png",
+			},
+			ownership: {
+				account_id: "acct_primary",
+				tweet_id: "tweet_001",
+				kind: "home",
+				source: "archive",
+			},
+		});
 		mocks.getTransportStatus.mockResolvedValue({
 			availableTransport: "xurl",
 			installed: true,
 			statusText: "xurl available",
 		});
-		mocks.lookupUsersByIds.mockResolvedValue([]);
 		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
 			id: "25401953",
 			username: "steipete",
@@ -241,6 +457,280 @@ describe("profile hydration", () => {
 		await expect(
 			hydrateProfilesFromX({
 				account: "steipete",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "Primary account is not the untouched demo seed",
+		});
+
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		}).toEqual(before);
+		expect(mocks.lookupAuthenticatedOAuth2User).toHaveBeenCalledWith(
+			"steipete",
+		);
+		expect(mocks.lookupUsersByIds).not.toHaveBeenCalled();
+	});
+
+	it("preserves legacy selective-import ownership without a seed marker", async () => {
+		const db = getNativeDb();
+		db.prepare("delete from sync_cache where cache_key = ?").run(
+			DEMO_PRIMARY_ACCOUNT_MARKER_KEY,
+		);
+		db.prepare(
+			"update tweet_account_edges set source = 'archive' where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		).run();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const ownershipQuery = db.prepare(
+			"select * from tweet_account_edges where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "999",
+			username: "other_account",
+			name: "Other Account",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "other_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "Primary account is not the untouched demo seed",
+		});
+
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		}).toEqual(before);
+	});
+
+	it("preserves seed-shaped ownership after account data changes", async () => {
+		const db = getNativeDb();
+		expect(
+			db
+				.prepare("select 1 from sync_cache where cache_key = ?")
+				.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		).toEqual({ 1: 1 });
+		db.prepare(
+			"update tweet_account_edges set source = 'xurl' where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		).run();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const ownershipQuery = db.prepare(
+			"select * from tweet_account_edges where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "999",
+			username: "other_account",
+			name: "Other Account",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "other_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedProfiles: 0,
+			hydratedAccount: false,
+			reason: "Primary account is not the untouched demo seed",
+		});
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			ownership: ownershipQuery.get(),
+		}).toEqual(before);
+	});
+
+	it("rejects a null explicit OAuth2 account result", async () => {
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue(null);
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "missing",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).rejects.toThrow("Could not resolve authenticated xurl account @missing");
+	});
+
+	it("rejects a provider identity that does not match the selected account", async () => {
+		const db = getNativeDb();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const markerQuery = db.prepare(
+			"select * from sync_cache where cache_key = ?",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			marker: markerQuery.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "999",
+			username: "unexpected_account",
+			name: "Unexpected Account",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "selected_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).rejects.toThrow(
+			"Authenticated xurl identity does not match requested account @selected_account",
+		);
+
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			marker: markerQuery.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		}).toEqual(before);
+	});
+
+	it("rejects an explicit provider response without a user ID", async () => {
+		const db = getNativeDb();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const markerQuery = db.prepare(
+			"select * from sync_cache where cache_key = ?",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			marker: markerQuery.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			username: "selected_account",
+			name: "Selected Account",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "selected_account",
+				accountOnly: true,
+				seededAccountOnly: true,
+			}),
+		).rejects.toThrow("did not include a user ID");
+
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+			marker: markerQuery.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		}).toEqual(before);
+	});
+
+	it("rechecks demo ownership inside the account update transaction", async () => {
+		const db = getNativeDb();
+		const accountQuery = db.prepare(
+			"select * from accounts where id = 'acct_primary'",
+		);
+		const profileQuery = db.prepare(
+			"select * from profiles where id = 'profile_me'",
+		);
+		const before = {
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+		};
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "999",
+			username: "other_account",
+			name: "Other Account",
+		});
+
+		const originalTransaction = db.transaction.bind(db);
+		let injectedOwnership = false;
+		vi.spyOn(db, "transaction").mockImplementation((callback) =>
+			originalTransaction((...args: unknown[]) => {
+				if (!injectedOwnership) {
+					injectedOwnership = true;
+					db.prepare(
+						"update tweet_account_edges set source = 'archive' where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
+					).run();
+				}
+				return callback(...args);
+			}),
+		);
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "other_account",
+				accountOnly: true,
 				seededAccountOnly: true,
 			}),
 		).resolves.toMatchObject({
@@ -248,17 +738,23 @@ describe("profile hydration", () => {
 			reason: "Primary account is not the untouched demo seed",
 		});
 
+		expect(injectedOwnership).toBe(true);
+		expect({
+			account: accountQuery.get(),
+			profile: profileQuery.get(),
+		}).toEqual(before);
 		expect(
 			db
 				.prepare(
-					"select name, handle, external_user_id from accounts where id = 'acct_primary'",
+					"select source from tweet_account_edges where account_id = 'acct_primary' and tweet_id = 'tweet_001' and kind = 'home'",
 				)
 				.get(),
-		).toEqual({
-			name: "Archive Owner",
-			handle: "@archive_owner",
-			external_user_id: "42",
-		});
+		).toEqual({ source: "archive" });
+		expect(
+			db
+				.prepare("select 1 from sync_cache where cache_key = ?")
+				.get(DEMO_PRIMARY_ACCOUNT_MARKER_KEY),
+		).toEqual({ 1: 1 });
 	});
 
 	it("skips non-numeric archive placeholder ids before calling X", async () => {
@@ -614,7 +1110,7 @@ describe("profile hydration", () => {
 			.get() as Record<string, unknown>;
 		const account = db
 			.prepare(
-				"select name, handle, transport from accounts where id = 'acct_primary'",
+				"select name, handle, external_user_id, transport from accounts where id = 'acct_primary'",
 			)
 			.get() as Record<string, unknown>;
 
@@ -631,6 +1127,7 @@ describe("profile hydration", () => {
 		expect(account).toEqual({
 			name: "Peter Steinberger",
 			handle: "@steipete",
+			external_user_id: "25401953",
 			transport: "xurl",
 		});
 	});

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -10,6 +10,7 @@ import { getNativeDb, resetDatabaseForTests } from "./db";
 const mocks = vi.hoisted(() => ({
 	getTransportStatus: vi.fn(),
 	lookupAuthenticatedUser: vi.fn(),
+	lookupAuthenticatedOAuth2User: vi.fn(),
 	lookupUsersByIds: vi.fn(),
 	getAuthenticatedBirdAccount: vi.fn(),
 }));
@@ -19,6 +20,9 @@ vi.mock("./xurl", async () => {
 	return {
 		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupAuthenticatedOAuth2UserEffect: fromMock(
+			mocks.lookupAuthenticatedOAuth2User,
+		),
 		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
 	};
 });
@@ -42,6 +46,7 @@ describe("profile hydration", () => {
 		resetDatabaseForTests();
 		mocks.getTransportStatus.mockReset();
 		mocks.lookupAuthenticatedUser.mockReset();
+		mocks.lookupAuthenticatedOAuth2User.mockReset();
 		mocks.lookupUsersByIds.mockReset();
 		mocks.getAuthenticatedBirdAccount.mockReset();
 		mocks.getAuthenticatedBirdAccount.mockRejectedValue(
@@ -119,6 +124,7 @@ describe("profile hydration", () => {
 			},
 		]);
 		mocks.lookupAuthenticatedUser.mockResolvedValue({
+			id: "25401953",
 			username: "steipete",
 			name: "Peter Steinberger",
 			description: "Bio",
@@ -161,6 +167,98 @@ describe("profile hydration", () => {
 			avatar_url: "https://pbs.twimg.com/profile_images/42/avatar.jpg",
 		});
 		expect(title.title).toBe("Sam Altman");
+		expect(
+			db
+				.prepare(
+					"select handle, external_user_id from accounts where id = 'acct_primary'",
+				)
+				.get(),
+		).toEqual({ handle: "@steipete", external_user_id: "25401953" });
+	});
+
+	it("selects an explicit authenticated xurl account", async () => {
+		const db = getNativeDb();
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupUsersByIds.mockResolvedValue([]);
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "1493511301808721921",
+			username: "ikuznetsov_com",
+			name: "Ivan Kuznetsov",
+			description: "Builder",
+			public_metrics: { followers_count: 218, following_count: 299 },
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({ account: "ikuznetsov_com" }),
+		).resolves.toMatchObject({
+			hydratedAccount: true,
+			account: {
+				handle: "@ikuznetsov_com",
+				externalUserId: "1493511301808721921",
+			},
+		});
+
+		expect(mocks.lookupAuthenticatedOAuth2User).toHaveBeenCalledWith(
+			"ikuznetsov_com",
+		);
+		expect(
+			db
+				.prepare(
+					"select name, handle, external_user_id, transport from accounts where id = 'acct_primary'",
+				)
+				.get(),
+		).toEqual({
+			name: "Ivan Kuznetsov",
+			handle: "@ikuznetsov_com",
+			external_user_id: "1493511301808721921",
+			transport: "xurl",
+		});
+	});
+
+	it("does not replace an imported primary account during init", async () => {
+		const db = getNativeDb();
+		db.prepare(
+			"update accounts set name = ?, handle = ?, external_user_id = ? where id = 'acct_primary'",
+		).run("Archive Owner", "@archive_owner", "42");
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupUsersByIds.mockResolvedValue([]);
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "1493511301808721921",
+			username: "ikuznetsov_com",
+			name: "Ivan Kuznetsov",
+		});
+
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+		await expect(
+			hydrateProfilesFromX({
+				account: "ikuznetsov_com",
+				seededAccountOnly: true,
+			}),
+		).resolves.toMatchObject({
+			hydratedAccount: false,
+			reason: "Primary account is not the untouched demo seed",
+		});
+
+		expect(
+			db
+				.prepare(
+					"select name, handle, external_user_id from accounts where id = 'acct_primary'",
+				)
+				.get(),
+		).toEqual({
+			name: "Archive Owner",
+			handle: "@archive_owner",
+			external_user_id: "42",
+		});
 	});
 
 	it("skips non-numeric archive placeholder ids before calling X", async () => {

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -185,26 +185,26 @@ describe("profile hydration", () => {
 		});
 		mocks.lookupUsersByIds.mockResolvedValue([]);
 		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
-			id: "1493511301808721921",
-			username: "ikuznetsov_com",
-			name: "Ivan Kuznetsov",
+			id: "25401953",
+			username: "steipete",
+			name: "Peter Steinberger",
 			description: "Builder",
 			public_metrics: { followers_count: 218, following_count: 299 },
 		});
 
 		const { hydrateProfilesFromX } = await import("./profile-hydration");
 		await expect(
-			hydrateProfilesFromX({ account: "ikuznetsov_com" }),
+			hydrateProfilesFromX({ account: "steipete" }),
 		).resolves.toMatchObject({
 			hydratedAccount: true,
 			account: {
-				handle: "@ikuznetsov_com",
-				externalUserId: "1493511301808721921",
+				handle: "@steipete",
+				externalUserId: "25401953",
 			},
 		});
 
 		expect(mocks.lookupAuthenticatedOAuth2User).toHaveBeenCalledWith(
-			"ikuznetsov_com",
+			"steipete",
 		);
 		expect(
 			db
@@ -213,9 +213,9 @@ describe("profile hydration", () => {
 				)
 				.get(),
 		).toEqual({
-			name: "Ivan Kuznetsov",
-			handle: "@ikuznetsov_com",
-			external_user_id: "1493511301808721921",
+			name: "Peter Steinberger",
+			handle: "@steipete",
+			external_user_id: "25401953",
 			transport: "xurl",
 		});
 	});
@@ -232,15 +232,15 @@ describe("profile hydration", () => {
 		});
 		mocks.lookupUsersByIds.mockResolvedValue([]);
 		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
-			id: "1493511301808721921",
-			username: "ikuznetsov_com",
-			name: "Ivan Kuznetsov",
+			id: "25401953",
+			username: "steipete",
+			name: "Peter Steinberger",
 		});
 
 		const { hydrateProfilesFromX } = await import("./profile-hydration");
 		await expect(
 			hydrateProfilesFromX({
-				account: "ikuznetsov_com",
+				account: "steipete",
 				seededAccountOnly: true,
 			}),
 		).resolves.toMatchObject({

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -6,6 +6,7 @@ import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import {
 	getTransportStatusEffect,
+	lookupAuthenticatedOAuth2UserEffect,
 	lookupAuthenticatedUserEffect,
 	lookupUsersByIdsEffect,
 } from "./xurl";
@@ -15,7 +16,17 @@ export type HydrateProfilesResult = {
 	ok: true;
 	hydratedProfiles: number;
 	hydratedAccount: boolean;
+	account?: {
+		handle: string;
+		externalUserId: string | null;
+	};
 	reason?: string;
+};
+
+export type HydrateProfilesOptions = {
+	account?: string;
+	accountOnly?: boolean;
+	seededAccountOnly?: boolean;
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -131,10 +142,9 @@ function hydrateAccountFromBirdEffect(): Effect.Effect<boolean, unknown> {
 	});
 }
 
-export function hydrateProfilesFromXEffect(): Effect.Effect<
-	HydrateProfilesResult,
-	unknown
-> {
+export function hydrateProfilesFromXEffect(
+	options: HydrateProfilesOptions = {},
+): Effect.Effect<HydrateProfilesResult, unknown> {
 	return Effect.gen(function* () {
 		const transport = yield* getTransportStatusEffect();
 		if (transport.availableTransport !== "xurl") {
@@ -158,17 +168,19 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 			updateLocalProfile,
 		} = yield* trySync(() => {
 			const db = getNativeDb();
-			const candidateRows = db
-				.prepare(
-					`
+			const candidateRows = options.accountOnly
+				? []
+				: (db
+						.prepare(
+							`
       select id
       from profiles
       where id like 'profile_user_%'
         and (followers_count = 0 or bio like 'Imported from archive user %' or handle like 'id%')
       order by id asc
       `,
-				)
-				.all() as Array<{ id: string }>;
+						)
+						.all() as Array<{ id: string }>);
 
 			const candidateIds = candidateRows
 				.map((row) => row.id.replace(/^profile_user_/, ""))
@@ -194,6 +206,7 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
     update accounts
     set name = ?,
         handle = ?,
+		external_user_id = ?,
         transport = 'xurl'
     where id = 'acct_primary'
   `);
@@ -231,15 +244,47 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 		}
 
 		let hydratedAccount = false;
-		const me = yield* lookupAuthenticatedUserEffect().pipe(
-			Effect.catchAll(() => Effect.succeed(null)),
-		);
+		let account: HydrateProfilesResult["account"];
+		const me = yield* (
+			options.account
+				? lookupAuthenticatedOAuth2UserEffect(options.account)
+				: lookupAuthenticatedUserEffect()
+		).pipe(Effect.catchAll(() => Effect.succeed(null)));
 		if (me) {
+			const username = String(me.username ?? "").replace(/^@/, "");
+			const externalUserId =
+				typeof me.id === "string" && me.id.length > 0 ? me.id : null;
+			const currentAccount = (yield* trySync(() =>
+				db
+					.prepare(
+						"select handle, external_user_id, transport from accounts where id = 'acct_primary'",
+					)
+					.get(),
+			)) as
+				| {
+						handle: string;
+						external_user_id: string | null;
+						transport: string;
+				  }
+				| undefined;
+			const isSeededPlaceholder =
+				currentAccount?.handle.replace(/^@/, "").toLowerCase() ===
+					SEEDED_ACCOUNT_HANDLE &&
+				currentAccount.external_user_id === SEEDED_ACCOUNT_EXTERNAL_USER_ID &&
+				currentAccount.transport === "xurl";
+			if (options.seededAccountOnly && !isSeededPlaceholder) {
+				return {
+					ok: true,
+					hydratedProfiles,
+					hydratedAccount: false,
+					reason: "Primary account is not the untouched demo seed",
+				};
+			}
 			const metrics = asRecord(me.public_metrics);
 			yield* trySync(() => {
 				db.transaction(() => {
 					updateLocalProfile.run(
-						String(me.username ?? "steipete").replace(/^@/, ""),
+						username || SEEDED_ACCOUNT_HANDLE,
 						String(me.name ?? "Peter Steinberger"),
 						String(me.description ?? ""),
 						toInt(metrics?.followers_count),
@@ -251,23 +296,31 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 					);
 					updateAccount.run(
 						String(me.name ?? "Peter Steinberger"),
-						`@${String(me.username ?? "steipete").replace(/^@/, "")}`,
+						`@${username || SEEDED_ACCOUNT_HANDLE}`,
+						externalUserId,
 					);
 				})();
 			});
 			hydratedAccount = true;
+			account = {
+				handle: `@${username || SEEDED_ACCOUNT_HANDLE}`,
+				externalUserId,
+			};
 		}
 
 		return {
 			ok: true,
 			hydratedProfiles,
 			hydratedAccount,
+			account,
 		};
 	});
 }
 
-export function hydrateProfilesFromX(): Promise<HydrateProfilesResult> {
-	return runEffectPromise(hydrateProfilesFromXEffect());
+export function hydrateProfilesFromX(
+	options?: HydrateProfilesOptions,
+): Promise<HydrateProfilesResult> {
+	return runEffectPromise(hydrateProfilesFromXEffect(options));
 }
 
 export const __test__ = {

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -3,10 +3,15 @@ import { Effect } from "effect";
 import { normalizeAvatarUrl } from "./avatar-cache";
 import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { getNativeDb } from "./db";
+import {
+	DEMO_PRIMARY_ACCOUNT_MARKER_KEY,
+	hasUntouchedDemoPrimaryAccountState,
+	type StoredPrimaryAccount,
+} from "./demo-account";
 import { runEffectPromise } from "./effect-runtime";
 import {
 	getTransportStatusEffect,
-	lookupAuthenticatedOAuth2UserEffect,
+	lookupSelectedAuthenticatedOAuth2UserEffect,
 	lookupAuthenticatedUserEffect,
 	lookupUsersByIdsEffect,
 } from "./xurl";
@@ -49,6 +54,11 @@ function trySync<T>(try_: () => T) {
 		try: try_,
 		catch: toError,
 	});
+}
+
+function normalizeSelectedAccount(value: string) {
+	const username = value.trim().replace(/^@/, "");
+	return username.length > 0 ? username : null;
 }
 
 const SEEDED_ACCOUNT_HANDLE = "steipete";
@@ -146,8 +156,25 @@ export function hydrateProfilesFromXEffect(
 	options: HydrateProfilesOptions = {},
 ): Effect.Effect<HydrateProfilesResult, unknown> {
 	return Effect.gen(function* () {
+		const selectedAccount =
+			options.account === undefined
+				? undefined
+				: normalizeSelectedAccount(options.account);
+		if (selectedAccount === null) {
+			return yield* Effect.fail(
+				new Error("Explicit account selection requires a non-empty username"),
+			);
+		}
 		const transport = yield* getTransportStatusEffect();
 		if (transport.availableTransport !== "xurl") {
+			if (selectedAccount !== undefined) {
+				return {
+					ok: true,
+					hydratedProfiles: 0,
+					hydratedAccount: false,
+					reason: `Cannot select xurl account @${selectedAccount}: ${transport.statusText}`,
+				};
+			}
 			// xurl is unavailable, so the live profile backfill can't run. When the
 			// bird transport is authenticated we can still correct the seeded
 			// account handle (e.g. the placeholder @steipete) from `bird whoami`.
@@ -163,6 +190,9 @@ export function hydrateProfilesFromXEffect(
 		const {
 			candidateIds,
 			db,
+			deleteDemoPrimaryAccountMarker,
+			renameSeedAccountHandle,
+			renameSeedProfileHandle,
 			updateAccount,
 			updateConversationTitle,
 			updateLocalProfile,
@@ -206,14 +236,33 @@ export function hydrateProfilesFromXEffect(
     update accounts
     set name = ?,
         handle = ?,
-		external_user_id = ?,
+		external_user_id = coalesce(?, external_user_id),
         transport = 'xurl'
     where id = 'acct_primary'
+  `);
+			const renameSeedProfileHandle = db.prepare(`
+    update profiles
+    set handle = 'seeded_' || id
+    where id <> 'profile_me'
+      and lower(handle) = lower(?)
+  `);
+			const renameSeedAccountHandle = db.prepare(`
+    update accounts
+    set handle = '@seeded_' || id
+    where id <> 'acct_primary'
+      and lower(ltrim(handle, '@')) = lower(?)
+  `);
+			const deleteDemoPrimaryAccountMarker = db.prepare(`
+    delete from sync_cache
+    where cache_key = ?
   `);
 
 			return {
 				candidateIds,
 				db,
+				deleteDemoPrimaryAccountMarker,
+				renameSeedAccountHandle,
+				renameSeedProfileHandle,
 				updateAccount,
 				updateConversationTitle,
 				updateLocalProfile,
@@ -245,44 +294,77 @@ export function hydrateProfilesFromXEffect(
 
 		let hydratedAccount = false;
 		let account: HydrateProfilesResult["account"];
-		const me = yield* (
-			options.account
-				? lookupAuthenticatedOAuth2UserEffect(options.account)
-				: lookupAuthenticatedUserEffect()
-		).pipe(Effect.catchAll(() => Effect.succeed(null)));
+		const me =
+			selectedAccount !== undefined
+				? yield* lookupSelectedAuthenticatedOAuth2UserEffect(selectedAccount)
+				: yield* lookupAuthenticatedUserEffect().pipe(
+						Effect.catchAll(() => Effect.succeed(null)),
+					);
+		if (selectedAccount !== undefined && !me) {
+			return yield* Effect.fail(
+				new Error(
+					`Could not resolve authenticated xurl account @${selectedAccount}`,
+				),
+			);
+		}
 		if (me) {
-			const username = String(me.username ?? "").replace(/^@/, "");
+			const username = String(me.username ?? "")
+				.trim()
+				.replace(/^@/, "");
+			if (
+				selectedAccount !== undefined &&
+				(username.length === 0 ||
+					username.toLowerCase() !== selectedAccount.toLowerCase())
+			) {
+				return yield* Effect.fail(
+					new Error(
+						`Authenticated xurl identity does not match requested account @${selectedAccount}`,
+					),
+				);
+			}
 			const externalUserId =
-				typeof me.id === "string" && me.id.length > 0 ? me.id : null;
-			const currentAccount = (yield* trySync(() =>
-				db
-					.prepare(
-						"select handle, external_user_id, transport from accounts where id = 'acct_primary'",
-					)
-					.get(),
-			)) as
-				| {
-						handle: string;
-						external_user_id: string | null;
-						transport: string;
-				  }
-				| undefined;
-			const isSeededPlaceholder =
-				currentAccount?.handle.replace(/^@/, "").toLowerCase() ===
-					SEEDED_ACCOUNT_HANDLE &&
-				currentAccount.external_user_id === SEEDED_ACCOUNT_EXTERNAL_USER_ID &&
-				currentAccount.transport === "xurl";
-			if (options.seededAccountOnly && !isSeededPlaceholder) {
-				return {
-					ok: true,
-					hydratedProfiles,
-					hydratedAccount: false,
-					reason: "Primary account is not the untouched demo seed",
-				};
+				typeof me.id === "string" && me.id.trim().length > 0
+					? me.id.trim()
+					: null;
+			if (selectedAccount !== undefined && externalUserId === null) {
+				return yield* Effect.fail(
+					new Error(
+						`Authenticated xurl response for @${selectedAccount} did not include a user ID`,
+					),
+				);
 			}
 			const metrics = asRecord(me.public_metrics);
-			yield* trySync(() => {
+			const selected = yield* trySync(() =>
 				db.transaction(() => {
+					const currentAccount = db
+						.prepare(
+							"select name, handle, external_user_id, transport, is_default, created_at from accounts where id = 'acct_primary'",
+						)
+						.get() as StoredPrimaryAccount | undefined;
+					const currentHandle = currentAccount?.handle
+						.replace(/^@/, "")
+						.toLowerCase();
+					const identityMatches =
+						currentAccount !== undefined &&
+						externalUserId !== null &&
+						currentAccount.external_user_id !== null
+							? externalUserId === currentAccount.external_user_id
+							: username.length > 0 && currentHandle === username.toLowerCase();
+					const isSeededPlaceholder =
+						options.seededAccountOnly && !identityMatches
+							? hasUntouchedDemoPrimaryAccountState(db, currentAccount)
+							: false;
+					if (
+						options.seededAccountOnly &&
+						!identityMatches &&
+						!isSeededPlaceholder
+					) {
+						return false;
+					}
+					if (isSeededPlaceholder) {
+						renameSeedProfileHandle.run(username);
+						renameSeedAccountHandle.run(username);
+					}
 					updateLocalProfile.run(
 						username || SEEDED_ACCOUNT_HANDLE,
 						String(me.name ?? "Peter Steinberger"),
@@ -299,8 +381,18 @@ export function hydrateProfilesFromXEffect(
 						`@${username || SEEDED_ACCOUNT_HANDLE}`,
 						externalUserId,
 					);
-				})();
-			});
+					deleteDemoPrimaryAccountMarker.run(DEMO_PRIMARY_ACCOUNT_MARKER_KEY);
+					return true;
+				})(),
+			);
+			if (!selected) {
+				return {
+					ok: true,
+					hydratedProfiles,
+					hydratedAccount: false,
+					reason: "Primary account is not the untouched demo seed",
+				};
+			}
 			hydratedAccount = true;
 			account = {
 				handle: `@${username || SEEDED_ACCOUNT_HANDLE}`,

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,6 +1,11 @@
 import type { Database } from "./sqlite";
+import {
+	createDemoPrimaryAccountMarkerValue,
+	DEMO_PRIMARY_ACCOUNT,
+	DEMO_PRIMARY_ACCOUNT_MARKER_KEY,
+} from "./demo-account";
 
-const now = new Date("2026-03-08T12:00:00.000Z");
+const now = new Date(DEMO_PRIMARY_ACCOUNT.createdAt);
 
 function isoMinutesAgo(minutes: number) {
 	return new Date(now.getTime() - minutes * 60_000).toISOString();
@@ -61,6 +66,10 @@ export function seedDemoData(db: Database) {
 	    source, raw_json, updated_at
 	  ) values (?, ?, ?, ?, ?, 1, 'demo', '{}', ?)
 	`);
+	const insertDemoAccountMarker = db.prepare(`
+		insert or replace into sync_cache (cache_key, value_json, updated_at)
+		values (?, ?, ?)
+	`);
 	const insertTweetCollection = db.prepare(`
 	  insert into tweet_collections (
 	    account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
@@ -110,13 +119,7 @@ export function seedDemoData(db: Database) {
 
 	const accounts = [
 		{
-			id: "acct_primary",
-			name: "Peter",
-			handle: "@steipete",
-			externalUserId: "25401953",
-			transport: "xurl",
-			isDefault: 1,
-			createdAt: now.toISOString(),
+			...DEMO_PRIMARY_ACCOUNT,
 		},
 		{
 			id: "acct_studio",
@@ -656,6 +659,12 @@ export function seedDemoData(db: Database) {
 		for (const occurrence of linkOccurrences) {
 			insertLinkOccurrence.run(occurrence);
 		}
+
+		insertDemoAccountMarker.run(
+			DEMO_PRIMARY_ACCOUNT_MARKER_KEY,
+			createDemoPrimaryAccountMarkerValue(db),
+			DEMO_PRIMARY_ACCOUNT.createdAt,
+		);
 	});
 
 	transaction();

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -790,6 +790,40 @@ describe("xurl transport wrapper", () => {
 		]);
 	});
 
+	it("ignores configured OAuth2 overrides for explicit account selection", async () => {
+		process.env.BIRDCLAW_XURL_OAUTH2_APP = "configured-app";
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME = "configured-account";
+		execFileAsyncMock
+			.mockResolvedValueOnce({
+				stdout: AUTH_STATUS_STEIPETE,
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				stdout: JSON.stringify({
+					data: { id: "1", username: "steipete" },
+				}),
+				stderr: "",
+			});
+		const { lookupSelectedAuthenticatedOAuth2UserEffect } =
+			await import("./xurl");
+
+		await expect(
+			Effect.runPromise(
+				lookupSelectedAuthenticatedOAuth2UserEffect("@steipete"),
+			),
+		).resolves.toEqual({
+			id: "1",
+			username: "steipete",
+		});
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, "xurl", [
+			"--auth",
+			"oauth2",
+			"--username",
+			"steipete",
+			"whoami",
+		]);
+	});
+
 	it("caches authenticated user lookups for repeated callers", async () => {
 		execFileAsyncMock.mockResolvedValueOnce({
 			stdout: JSON.stringify({ data: { id: "1", username: "steipete" } }),

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -893,6 +893,16 @@ export const lookupAuthenticatedOAuth2UserEffect = Effect.fn(
 	}).pipe(Effect.map(authenticatedUserFromPayload)),
 );
 
+export const lookupSelectedAuthenticatedOAuth2UserEffect = Effect.fn(
+	"xurl.lookupSelectedAuthenticatedOAuth2User",
+)((username: string) =>
+	runOAuth2JsonCommandEffect({
+		args: ["whoami"],
+		username,
+		useConfiguredCandidate: false,
+	}).pipe(Effect.map(authenticatedUserFromPayload)),
+);
+
 export function lookupAuthenticatedUserEffect() {
 	// Failures are not cached: invalidate so the next caller retries fresh.
 	return cachedAuthenticatedUser.pipe(


### PR DESCRIPTION
Fresh BirdClaw databases start with demo identity data. This change keeps plain `birdclaw init` local and deterministic, and adds explicit authenticated identity selection through `birdclaw init --account <username>`.

The explicit path resolves the exact requested OAuth2 account, rejects configured-account overrides, mismatched or incomplete provider identities, and persists the selected handle and X user ID. Replacement is allowed only while the database still matches its recorded demo-seed state; imported, synced, restored, or otherwise modified ownership fails closed instead of being relabeled. Repeating selection for the already-persisted identity remains idempotent.

Demo profile/account handle collisions are resolved transactionally before the primary identity is updated. The ownership guard, identity writes, and one-use seed-marker deletion share one immediate SQLite transaction. Archive import behavior and the existing Bird fallback are unchanged.

## Test plan

- Targeted regression suite: 5 files, 204 tests passed (`cli`, profile hydration, xurl, archive import, database)
- Full suite: 145 files, 1,292 tests passed
- `pnpm run format:check` passed
- `pnpm run lint` passed with warnings denied
- `pnpm run typecheck` passed

Coverage includes plain-init gating, strict explicit OAuth2 selection, conflicting configured credentials, empty/mismatched/incomplete identities, handle collisions, external user ID persistence, idempotent reselection, legacy/imported ownership preservation, same-row-count ownership mutations, and the atomic guard/write boundary.

## Redacted real authenticated proof

Run on July 14, 2026 against a real authenticated OAuth2 setup using fresh temporary `BIRDCLAW_HOME` databases. Provider output, auth status, credentials, handles, and user IDs were kept private.

- Plain init ran behind a provider-access tripwire: local xurl status checks were allowed, but provider access would fail the run. Provider lookup count was zero and init returned no account.
- Explicit init selected the real requested OAuth2 identity. Its returned handle/user ID matched the authenticated response and the persisted `acct_primary` row; the one-use demo marker was consumed.
- A second temporary database was given an archive-owned account/profile/edge fixture. Explicit selection was refused, the command exited non-zero, and an exact before/after comparison confirmed the established owner and ownership edge were unchanged; the marker was not consumed.

```text
plain_init_provider_calls=0
explicit_oauth2_selection=PASS
persisted_handle_and_user_id=PASS
established_imported_owner_preserved=PASS
redacted_real_proof=PASS
```

## Post-Deploy Monitoring & Validation

No deployment-specific monitoring is needed. On a fresh temporary database, plain `birdclaw init` should return no account and perform no provider lookup; `birdclaw init --account <username>` should return and persist only that authenticated OAuth2 identity.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-111827?logo=openai&logoColor=white)
