### PR TITLE
fix: clarify optional bird transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Recommend xurl for new live-transport setups, remove deprecated public bird package and repository instructions while preserving compatibility with existing private bird installs, and report unavailable xurl states as local/archive mode. (#93 - thanks @TheAngryPit)
 - Run Bird subprocesses through Git Bash on Windows instead of assuming `/bin/bash`, with a documented override for portable Git installations. (#94 - thanks @kristofer-atlas)
 
 ## 0.9.5 - 2026-07-06

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Notes:
 - Node `25.8.1` or Node 26.x
 - `pnpm`
 - macOS recommended for Spotlight archive discovery
-- `xurl` optional for live reads / writes
-- `bird` optional for cookie-backed likes, bookmarks, mentions, DMs, and write fallback
+- `xurl` recommended for live reads / writes
+- an existing private `bird` installation is optional for cookie-backed likes, bookmarks, mentions, DMs, and write fallback
 - OpenAI API key optional for inbox scoring
 
 ## Install
@@ -222,7 +222,7 @@ birdclaw auth status --json
 birdclaw db stats --json
 ```
 
-`auth status` reports Birdclaw's coarse xurl status. Verify xurl with `xurl whoami` and bird with `bird whoami`. For setup and transport selection, see [Sign in](docs/auth.md).
+`auth status` reports Birdclaw's coarse xurl status. Verify xurl with `xurl whoami`. If you already have a private bird installation, verify it with `bird whoami`. For setup and transport selection, see [Sign in](docs/auth.md).
 
 Find and import an archive:
 
@@ -234,7 +234,7 @@ birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 
 Don't have an archive yet? Request it from <https://x.com/settings/download_your_data>; X emails a download link when it is ready, which may take a few days. A fresh Birdclaw database needs the archive import to establish account identity before live sync. See [Archive Import → Get an archive](docs/archive.md#get-an-archive).
 
-Optional profile hydration through xurl can improve bios, follower counts, and avatars, but it performs live X profile reads and can spend API credits on large archives. In Bird-only mode, the command corrects the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
+Optional profile hydration through xurl can improve bios, follower counts, and avatars, but it performs live X profile reads and can spend API credits on large archives. With an existing private bird installation, the command can instead correct the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
 
 ```bash
 birdclaw import hydrate-profiles --json
@@ -700,7 +700,7 @@ tail -n 1 ~/.birdclaw/audit/bookmarks-sync.jsonl | jq .
 Current preference:
 
 - `xurl` first
-- `bird` fallback for surfaces where cookie-backed reads work better
+- existing private `bird` installations as a compatibility fallback for surfaces where cookie-backed reads work better
 
 Without `xurl` or `bird`, `birdclaw` still works in local/archive mode.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -7,10 +7,10 @@ description: "Connect birdclaw to X through xurl or bird, verify each tool, and 
 
 birdclaw keeps its database local. Archive import needs no X credentials. Live reads and writes are delegated to external CLIs:
 
-- [`xurl`](https://github.com/xdevplatform/xurl) uses the official X API and your own developer app.
-- [`bird`](https://github.com/steipete/bird) uses the active browser session through X's web API.
+- [`xurl`](https://github.com/xdevplatform/xurl) is the recommended setup for new users and uses the official X API with your own developer app.
+- Existing private `bird` installations remain supported for cookie-backed workflows and compatibility fallback.
 
-Install either tool or both. Transport selection is workflow-specific: sync commands expose `--mode`, while `auth use` only controls moderation writes such as block, unblock, mute, and unmute.
+Install xurl for a new live-transport setup. Transport selection is workflow-specific: sync commands expose `--mode`, while `auth use` only controls moderation writes such as block, unblock, mute, and unmute.
 
 On a fresh Birdclaw database, import your X archive before the first live sync. Archive import replaces the bundled demo identity with your account identity. The current auth commands verify transports but do not bind a new database to the authenticated X account.
 
@@ -31,16 +31,15 @@ xurl whoami
 
 Alternatively, use xurl's [no-sudo install script](https://github.com/xdevplatform/xurl#installation). Register `my-app` first by following the [xurl authentication guide](https://github.com/xdevplatform/xurl#authentication). The redirect URI configured in the X developer portal must match xurl's configured URI. Treat the client secret as a secret; avoid entering it in shared shell history or exposing it in process listings.
 
-## Set up bird
+## Existing bird installations
 
-Install bird, sign in to x.com in Safari, Chrome, or Firefox, then verify the detected account:
+Birdclaw preserves compatibility with existing private bird installations, but bird is not a public setup path for new users. If bird is already installed and authenticated, verify the detected account:
 
 ```text
-npm install -g @steipete/bird
 bird whoami
 ```
 
-bird reads `auth_token` and `ct0` cookies from the selected browser profile. If autodetection misses the right profile, see [bird authentication](https://github.com/steipete/bird#authentication-graphql) for cookie-source and profile flags.
+Existing bird configurations continue to provide cookie-backed fallback for supported reads and writes.
 
 ## Verify xurl in birdclaw
 
@@ -55,7 +54,7 @@ birdclaw auth status --json
 - `statusText` explains the detected state.
 - `rawStatus` contains xurl's status output when available.
 
-Use `xurl whoami` as the end-to-end authentication check. Run `xurl auth status` for detailed app/token state and `bird whoami` to verify bird independently.
+Use `xurl whoami` as the end-to-end authentication check. Run `xurl auth status` for detailed app/token state. Existing private bird users can run `bird whoami` to verify bird independently.
 
 ## Choose moderation transport
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Stable `--json` envelopes go to stdout, progress and warnings to stderr — pipe
 
 - **One local SQLite database** for tweets, DMs, likes, bookmarks, mentions, follows, blocks, and mutes — multi-account, FTS5-indexed.
 - **Archive-first, live-aware.** Import a Twitter archive to establish account identity, then selectively re-import stale slices with `--select` or refresh through live transports.
-- **Cached live reads** through [`xurl`](https://github.com/xdevplatform/xurl) and [`bird`](https://github.com/steipete/bird), so repeated reads do not keep spending the API budget.
+- **Cached live reads** through recommended [`xurl`](https://github.com/xdevplatform/xurl) setups or existing private `bird` installations, so repeated reads do not keep spending the API budget.
 - **Local web app** for `What happened`, `Home`, `Mentions`, `Likes`, `Bookmarks`, `DMs`, `Inbox`, and `Blocks` — light/dark/system theme, focused timeline lane, no dashboard chrome.
 - **AI-ranked inbox** (OpenAI) for low-signal filtering on mentions and DMs.
 - **Streaming AI digest** (OpenAI Responses API) for today, 24h, yesterday, or week, with DMs excluded unless explicitly enabled.

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,8 +16,8 @@ description: "Install birdclaw via Homebrew, npm, or from source. Optional xurl 
 
 Optional but encouraged:
 
-- [`xurl`](https://github.com/xdevplatform/xurl) — official-API live reads/writes (likes, bookmarks, blocks, mutes, posting)
-- [`bird`](https://github.com/steipete/bird) — browser-cookie-backed reads/writes for surfaces where `xurl` is rate-limited or unavailable
+- [`xurl`](https://github.com/xdevplatform/xurl) — recommended official-API live reads/writes (likes, bookmarks, blocks, mutes, posting)
+- an existing private `bird` installation — optional browser-cookie-backed compatibility fallback
 - `OPENAI_API_KEY` — inbox scoring and low-signal filtering
 
 birdclaw still works in pure local/archive mode without any of the above.
@@ -64,7 +64,7 @@ birdclaw auth status --json
 birdclaw db stats --json
 ```
 
-`auth status` runs Birdclaw's coarse xurl status probe. Verify xurl with `xurl whoami` and bird with `bird whoami`. See [Sign in](auth.md) for the complete setup and transport-selection model.
+`auth status` runs Birdclaw's coarse xurl status probe. Verify xurl with `xurl whoami`. Existing private bird users can verify bird with `bird whoami`. See [Sign in](auth.md) for the complete setup and transport-selection model.
 
 ## Optional: xurl
 
@@ -81,14 +81,11 @@ xurl whoami
 
 Alternatively, use xurl's [no-sudo install script](https://github.com/xdevplatform/xurl#installation). Register `my-app` through the [xurl authentication guide](https://github.com/xdevplatform/xurl#authentication), keeping the client secret out of shared shell history and process listings. The redirect URI configured in the X developer portal must match xurl's configured URI. Birdclaw shells out to xurl and does not own `~/.xurl`.
 
-## Optional: bird
+## Existing bird installations
 
-```text
-npm install -g @steipete/bird
-bird whoami
-```
+Birdclaw preserves compatibility with existing private bird installations, but bird is not a public setup path for new users. If bird is already installed, verify it with `bird whoami`.
 
-bird reads cookies from a logged-in Safari, Chrome, or Firefox profile. This matters most for DMs, mentions, timeline reads, and moderation flows where X rejects OAuth2 writes.
+This compatibility path matters most for DMs, mentions, timeline reads, and moderation flows where X rejects OAuth2 writes.
 
 If you only run birdclaw via `launchd` (`jobs install-bookmarks-launchd`), `bird` may need its `AUTH_TOKEN`/`CT0` exported via an env file because launchd does not see your interactive browser session. See [Jobs](jobs.md#env-files-for-launchd).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ birdclaw db stats --json
 
 `init` creates `~/.birdclaw/`, opens the shared SQLite database, writes a default config when none exists, and probes for `xurl` and `bird` on `PATH`.
 
-`auth status` runs Birdclaw's coarse xurl status probe. Verify xurl with `xurl whoami` and bird with `bird whoami`. If you want live sync, follow [Sign in](auth.md); skip it if you only need archive import.
+`auth status` runs Birdclaw's coarse xurl status probe. Verify xurl with `xurl whoami`. Existing private bird users can verify bird with `bird whoami`. If you want live sync, follow [Sign in](auth.md); skip it if you only need archive import.
 
 ## 3. Find and import an archive
 
@@ -39,7 +39,7 @@ birdclaw import archive --json
 birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 ```
 
-Optional profile hydration through xurl fills bios, follower counts, and avatars from live Twitter metadata. It can perform hundreds or thousands of live profile reads on large archives, so run it only when you are ready to spend those X API reads. In Bird-only mode, the command corrects the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
+Optional profile hydration through xurl fills bios, follower counts, and avatars from live Twitter metadata. It can perform hundreds or thousands of live profile reads on large archives, so run it only when you are ready to spend those X API reads. With an existing private bird installation, the command can instead correct the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
 
 ```bash
 birdclaw import hydrate-profiles --json

--- a/src/docs-site.test.ts
+++ b/src/docs-site.test.ts
@@ -39,7 +39,9 @@ describe("docs site", () => {
 		expect(auth).not.toContain("BIRDCLAW_PROFILE");
 		expect(auth).toContain("import your X archive before the first live sync");
 		expect(auth).toContain("npm install -g @xdevplatform/xurl");
-		expect(auth).toContain("npm install -g @steipete/bird");
+		expect(auth).toContain("Existing bird installations");
+		expect(auth).not.toContain("npm install -g @steipete/bird");
+		expect(auth).not.toContain('href="https://github.com/steipete/bird"');
 		expect(auth).not.toContain("brew install steipete/tap/bird");
 
 		const quickstart = fs.readFileSync(

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -261,7 +261,7 @@ describe("profile hydration", () => {
 			availableTransport: "local",
 			installed: true,
 			statusText:
-				"xurl installed but not authenticated. local (bird) mode active.",
+				"xurl installed but not authenticated. local/archive mode active.",
 		});
 		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
 			username: "realuser",
@@ -321,7 +321,7 @@ describe("profile hydration", () => {
 			availableTransport: "local",
 			installed: true,
 			statusText:
-				"xurl installed but not authenticated. local (bird) mode active.",
+				"xurl installed but not authenticated. local/archive mode active.",
 		});
 		// bird whoami reports a different handle but no numeric id.
 		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
@@ -374,7 +374,7 @@ describe("profile hydration", () => {
 			availableTransport: "local",
 			installed: true,
 			statusText:
-				"xurl installed but not authenticated. local (bird) mode active.",
+				"xurl installed but not authenticated. local/archive mode active.",
 		});
 		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
 			username: "differentuser",
@@ -428,7 +428,7 @@ describe("profile hydration", () => {
 			availableTransport: "local",
 			installed: true,
 			statusText:
-				"xurl installed but not authenticated. local (bird) mode active.",
+				"xurl installed but not authenticated. local/archive mode active.",
 		});
 		// Same handle, no id this run: existing id and avatar should survive.
 		mocks.getAuthenticatedBirdAccount.mockResolvedValue({

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -62,6 +62,9 @@ describe("xurl transport wrapper", () => {
 
 		expect(result.availableTransport).toBe("local");
 		expect(result.installed).toBe(false);
+		expect(result.statusText).toBe(
+			"xurl not installed. local/archive mode active.",
+		);
 	});
 
 	it("reports xurl auth state when available", async () => {
@@ -109,7 +112,9 @@ describe("xurl transport wrapper", () => {
 
 		expect(result.installed).toBe(true);
 		expect(result.availableTransport).toBe("local");
-		expect(result.statusText).toContain("not authenticated");
+		expect(result.statusText).toBe(
+			"xurl installed but not authenticated. local/archive mode active.",
+		);
 		expect(result.rawStatus).toContain("No apps registered");
 	});
 
@@ -126,7 +131,9 @@ describe("xurl transport wrapper", () => {
 
 		expect(result.installed).toBe(true);
 		expect(result.availableTransport).toBe("local");
-		expect(result.statusText).toContain("not authenticated");
+		expect(result.statusText).toBe(
+			"xurl installed but not authenticated. local/archive mode active.",
+		);
 		expect(result.rawStatus).toContain("No authenticated user");
 	});
 
@@ -154,6 +161,7 @@ describe("xurl transport wrapper", () => {
 		expect(result.installed).toBe(true);
 		expect(result.availableTransport).toBe("local");
 		expect(result.statusText).toContain("auth unavailable");
+		expect(result.statusText).toContain("local/archive mode active");
 	});
 
 	it("uses an unknown-error fallback for non-Error auth failures", async () => {
@@ -166,6 +174,7 @@ describe("xurl transport wrapper", () => {
 
 		expect(result.availableTransport).toBe("local");
 		expect(result.statusText).toContain("unknown error");
+		expect(result.statusText).toContain("local/archive mode active");
 	});
 
 	it("looks up users and the authenticated account via raw json endpoints", async () => {

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -213,7 +213,7 @@ const readTransportStatusEffect = Effect.fn("xurl.readTransportStatus")(
 			return {
 				installed: false,
 				availableTransport: "local" as const,
-				statusText: "xurl not installed. local mode active.",
+				statusText: "xurl not installed. local/archive mode active.",
 			};
 		}
 
@@ -229,7 +229,7 @@ const readTransportStatusEffect = Effect.fn("xurl.readTransportStatus")(
 						installed: true,
 						availableTransport: "local" as const,
 						statusText:
-							"xurl installed but not authenticated. local (bird) mode active.",
+							"xurl installed but not authenticated. local/archive mode active.",
 						rawStatus,
 					};
 				}
@@ -250,7 +250,7 @@ const readTransportStatusEffect = Effect.fn("xurl.readTransportStatus")(
 						!(error instanceof SubprocessError && !error.causeWasError)
 							? error.message
 							: "unknown error"
-					}`,
+					}. local/archive mode active.`,
 				}),
 			),
 		);


### PR DESCRIPTION
## Summary

- recommend xurl for new live-transport setups
- preserve compatibility guidance for existing private bird installations without publishing deprecated install or repository paths
- report missing, unauthenticated, and unavailable xurl states as local/archive mode instead of implying bird is active
- add exact runtime and generated-doc regressions, plus an Unreleased changelog entry thanking the reporter

Addresses #93.

## Proof

- `pnpm run docs:site`
- `pnpm exec vitest run src/lib/xurl.test.ts src/lib/profile-hydration.test.ts src/docs-site.test.ts` — 3 files, 85 tests passed
- `pnpm run check`
- `pnpm test` — 145 files, 1,275 tests passed
- `pnpm build`
- `pnpm run pack:smoke` — 126 files; packaged `--version` passed
- built CLI behavior contract: missing xurl, unauthenticated xurl, and authenticated xurl fixtures all returned the expected distinct transport/status envelopes
- generated docs contract: xurl recommendation and private bird compatibility present; deprecated `@steipete/bird` install command and dead public repository link absent
- `~/.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings

## Risk

Low. Compatibility code remains unchanged. The runtime change is limited to status text; documentation removes broken public onboarding while retaining existing-install behavior.
