### PR TITLE
test: wait for filtered mention rendering

### DIFF
--- a/src/routes/mentions.test.tsx
+++ b/src/routes/mentions.test.tsx
@@ -128,7 +128,9 @@ describe("mentions route", () => {
 			expect(queryUrl?.searchParams.get("replyFilter")).toBe("all");
 		});
 
-		fireEvent.click(screen.getByRole("button", { name: "@steipete signal" }));
+		fireEvent.click(
+			await screen.findByRole("button", { name: "@steipete signal" }),
+		);
 		expect(fetchMock).not.toHaveBeenCalledWith(
 			"/api/action",
 			expect.anything(),


### PR DESCRIPTION
## Summary

Wait for the refetched filtered mention card to render before exercising its reply callback.

The test previously waited only until the request URL was observed. Under full-suite load, React Query could still be between the old and new result when the synchronous role query ran, producing a false missing-button failure.

## Reproduction

Exact-main full-suite run failed once at `src/routes/mentions.test.tsx:131` with no `@steipete signal` button visible while the refetch was pending. The same test had passed in earlier local and hosted runs, confirming timing sensitivity rather than a product regression.

## Proof

- focused test repeated 20 times — 20/20 passed
- `pnpm run check`
- `pnpm test` — 145 files, 1,275 tests passed
- `~/.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings

## Risk

Low. Test-only synchronization; production behavior is unchanged.
