### PR TITLE
feat: add opt-in FxTwitter tweet import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add explicit, read-only public-tweet import through the fixed FxTwitter endpoint, with durable row provenance and third-party disclosure documentation. (#99 - thanks @0xdevalias)
 - Add a disabled-by-default, bearer-authenticated read-only MCP endpoint for account-scoped cached tweet search and thread research, with startup configuration/schema validation, strict loopback/Host/Origin/path isolation, bounded stateless requests, and no DM, live X, OpenAI, filesystem, or write tools.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Status: WIP. Real and usable. Not done. Expect schema churn, transport gaps, and
 - archive import for tweets, likes, followers/following, profiles, and full DMs
 - selective archive re-imports for one stale slice without wiping the rest of the local store
 - archive import for bookmark exports when present
+- explicit, disabled-by-default import of named public tweets through the fixed read-only FxTwitter endpoint, with durable source provenance
 - archive import streams bundled media files into the local originals cache and extracts `video_info.variants[]` for video and animated-GIF rows
 - live authored sync through `xurl`, plus likes and bookmarks through `xurl` or `bird`
 - cache-first followers/following sync through `bird` or `xurl`
@@ -76,6 +77,7 @@ Status: WIP. Real and usable. Not done. Expect schema churn, transport gaps, and
 ### Safety
 
 - local-first by default
+- public FxTwitter import never runs automatically and requires a per-invocation flag that discloses the third-party request tradeoff
 - tests disable live writes
 - CI disables live writes
 - local web access has no default auth layer; the optional MCP endpoint uses a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,7 @@ birdclaw init
 birdclaw auth status
 birdclaw auth use <transport>
 birdclaw import archive [path]
+birdclaw import tweet <tweet-id-or-url...> --fxtwitter
 birdclaw sync all
 birdclaw sync tweets
 birdclaw sync authored
@@ -133,6 +134,16 @@ birdclaw debug transport
 - write default config if absent
 - optionally detect `xurl` and `bird`
 
+### `import tweet <tweet-id-or-url...>`
+
+- disabled unless `--fxtwitter` is passed on the same invocation
+- sends only requested public tweet IDs to the fixed read-only `https://api.fxtwitter.com` service
+- rejects custom origins, redirects, noncanonical URLs, and batches larger than 20 tweets
+- stores `fxtwitter` source markers in `tweet_sources` and `data/tweet_sources.jsonl` backups
+- discloses requested IDs plus ordinary network metadata such as IP address and request time to the third-party service
+
+See [Public tweet import](public-tweets.md) for the full privacy and capability boundary.
+
 ### `auth status`
 
 - show transport availability
@@ -171,6 +182,7 @@ birdclaw backup sync --repo ~/Projects/backup-birdclaw --remote https://github.c
 Shard contract:
 
 - tweets: `data/tweets/YYYY.jsonl`
+- tweet provenance: `data/tweet_sources.jsonl`
 - unknown tweet dates: `data/tweets/unknown.jsonl`
 - profiles: `data/profiles.jsonl` includes bio, follower/following counts, profile URL, location, verification type, structured URL entities, and raw profile JSON
 - affiliations: `data/profile_affiliations.jsonl` includes X badge/highlighted-label organization edges

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ birdclaw archive find --json
 birdclaw import archive --json
 birdclaw import archive ~/Downloads/twitter-archive.zip --select likes,bookmarks --json
 
+# Explicitly import named public tweets through the third-party FxTwitter service.
+birdclaw import tweet 20 --fxtwitter --json
+
 # Pull in mentions, likes, bookmarks, and the home timeline.
 birdclaw sync timeline --limit 100 --refresh --json
 birdclaw sync bookmarks --mode auto --all --json
@@ -50,6 +53,7 @@ Stable `--json` envelopes go to stdout, progress and warnings to stderr — pipe
 
 - **First time using birdclaw.** [Install](install.md) → [Quickstart](quickstart.md) covers archive-first account setup, live transports, and the local web app.
 - **Have a Twitter archive ZIP.** [Archive import](archive.md) walks through autodiscovery, selected re-imports, and idempotent re-runs.
+- **Need a few named public tweets without X credentials.** [Public tweet import](public-tweets.md) documents the explicit FxTwitter opt-in and third-party disclosure tradeoff.
 - **Already initialized, want fresh live data.** [Sync](sync.md) covers likes, bookmarks, timeline, mention threads, and rate-limit-aware resumable runs.
 - **Triaging mentions or DMs.** [Search](search.md), [Mentions](mentions.md), [DMs](dms.md), and [Inbox](inbox.md).
 - **Exploring your network.** [Network Map](network-map.md) plots current followers/following by profile location.

--- a/docs/public-tweets.md
+++ b/docs/public-tweets.md
@@ -1,0 +1,29 @@
+---
+title: Public Tweet Import
+description: "Explicitly import individual public tweets through the fixed, read-only FxTwitter endpoint, with durable source provenance and third-party disclosure guidance."
+---
+
+# Public tweet import
+
+Birdclaw can import individual public tweets through FxTwitter without X credentials. This transport is off by default and only runs when `--fxtwitter` is present on that invocation:
+
+```bash
+birdclaw import tweet 20 2030857479001960633 --fxtwitter --json
+birdclaw import tweet https://x.com/jack/status/20 --fxtwitter --json
+```
+
+The input must be a numeric tweet ID or a canonical HTTPS `x.com/<handle>/status/<id>` or `twitter.com/<handle>/status/<id>` URL. Birdclaw extracts the numeric ID and requests only the hardcoded `https://api.fxtwitter.com/2/status/<id>` endpoint. There is no configuration, environment variable, or flag for a custom or self-hosted origin, and redirects are rejected.
+
+## Privacy and disclosure
+
+FxTwitter is a third-party service. Passing `--fxtwitter` sends each requested public tweet ID to `api.fxtwitter.com`. The service and its hosting/network providers can also observe ordinary request metadata such as your IP address, request time, and Birdclaw user agent. Do not use this transport if that disclosure is unacceptable.
+
+Birdclaw does not send Twitter cookies, X API credentials, Birdclaw account data, DMs, local searches, or archive contents to FxTwitter. It does not automatically fall back to FxTwitter from another command. Every invocation requires the explicit flag.
+
+## Read-only boundary
+
+The FxTwitter transport exposes one capability: fetch a named public tweet by ID. It cannot search, enumerate timelines, fetch DMs or private account data, follow links returned by the service, or perform X writes. A single invocation accepts at most 20 tweet IDs and fetches them sequentially.
+
+Imported tweets use the same canonical `tweets`, `profiles`, media metadata, and FTS rows as archive and authenticated live imports. Provenance is stored separately in `tweet_sources` with `source = 'fxtwitter'`, the fixed request URL, and observation time. Git-friendly backups preserve those markers in `data/tweet_sources.jsonl`.
+
+Quoted public tweets included in the response are stored as reference context and receive their own FxTwitter provenance marker. Threads, conversations, profiles, timelines, search, follower lists, and arbitrary URLs are intentionally outside this transport.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -30,7 +30,14 @@ const sections = [
 	],
 	[
 		"Archive & Sync",
-		["archive.md", "sync.md", "media.md", "backup.md", "jobs.md"],
+		[
+			"archive.md",
+			"public-tweets.md",
+			"sync.md",
+			"media.md",
+			"backup.md",
+			"jobs.md",
+		],
 	],
 	[
 		"Reading & Triage",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,6 +9,7 @@ const setActionsTransportMock = vi.fn();
 const getQueryEnvelopeMock = vi.fn();
 const findArchivesMock = vi.fn();
 const importArchiveMock = vi.fn();
+const importTweetsViaFxTwitterMock = vi.fn();
 const importBlocklistMock = vi.fn();
 const addBlockMock = vi.fn();
 const recordBlockMock = vi.fn();
@@ -105,6 +106,11 @@ vi.mock("#/lib/archive-import", () => ({
 		"following",
 	],
 	importArchive: (...args: unknown[]) => importArchiveMock(...args),
+}));
+
+vi.mock("#/lib/fxtwitter", () => ({
+	importTweetsViaFxTwitter: (...args: unknown[]) =>
+		importTweetsViaFxTwitterMock(...args),
 }));
 
 vi.mock("#/lib/backup", async (importOriginal) => {
@@ -292,6 +298,7 @@ describe("cli", () => {
 		getQueryEnvelopeMock.mockReset();
 		findArchivesMock.mockReset();
 		importArchiveMock.mockReset();
+		importTweetsViaFxTwitterMock.mockReset();
 		importBlocklistMock.mockReset();
 		addBlockMock.mockReset();
 		recordBlockMock.mockReset();
@@ -377,6 +384,21 @@ describe("cli", () => {
 		importArchiveMock.mockResolvedValue({
 			ok: true,
 			archivePath: "/tmp/twitter.zip",
+		});
+		importTweetsViaFxTwitterMock.mockResolvedValue({
+			ok: true,
+			readOnlyTransport: true,
+			source: "fxtwitter",
+			endpoint: "https://api.fxtwitter.com",
+			requestedCount: 1,
+			importedCount: 1,
+			items: [
+				{
+					tweetId: "20",
+					source: "fxtwitter",
+					sourceUrl: "https://api.fxtwitter.com/2/status/20",
+				},
+			],
 		});
 		importBlocklistMock.mockResolvedValue({
 			ok: true,
@@ -1333,6 +1355,46 @@ describe("cli", () => {
 		expect(importArchiveMock).toHaveBeenCalledWith("/tmp/explicit.zip", {
 			select: ["tweets", "directMessages", "likes"],
 		});
+	});
+
+	it("requires explicit FxTwitter opt-in before public tweet import", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "import", "tweet", "20"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(importTweetsViaFxTwitterMock).not.toHaveBeenCalled();
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining("api.fxtwitter.com"),
+		);
+		consoleErrorMock.mockRestore();
+	});
+
+	it("imports public tweets through explicitly selected FxTwitter", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"tweet",
+			"20",
+			"https://x.com/example/status/30",
+			"--fxtwitter",
+		]);
+
+		expect(importTweetsViaFxTwitterMock).toHaveBeenCalledWith([
+			"20",
+			"https://x.com/example/status/30",
+		]);
+		expect(maybeAutoSyncBackupMock).toHaveBeenCalledOnce();
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"source": "fxtwitter"'),
+		);
 	});
 
 	it("rejects unknown archive import slices", async () => {

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -8,6 +8,7 @@ import {
 	importArchive,
 } from "#/lib/archive-import";
 import { ensureBirdclawDirs, setActionsTransport } from "#/lib/config";
+import { importTweetsViaFxTwitter } from "#/lib/fxtwitter";
 import { hydrateProfilesFromX } from "#/lib/profile-hydration";
 import { getQueryEnvelope } from "#/lib/queries";
 import { printError, type CliCommandContext } from "./command-context";
@@ -180,7 +181,7 @@ export function registerCoreCommands({
 
 	const importCommand = program
 		.command("import")
-		.description("Import local archive data");
+		.description("Import local or explicitly selected public data");
 	importCommand
 		.command("archive [archivePath]")
 		.description("Import a Twitter archive into the local SQLite store")
@@ -208,6 +209,27 @@ export function registerCoreCommands({
 			});
 			await autoSyncAfterWrite();
 			print(result, json);
+		});
+	importCommand
+		.command("tweet <tweets...>")
+		.description(
+			"Import public tweets through an explicitly selected read-only transport",
+		)
+		.option(
+			"--fxtwitter",
+			"Send tweet IDs to the fixed third-party api.fxtwitter.com endpoint",
+		)
+		.action(async (tweets: string[], options: { fxtwitter?: boolean }) => {
+			if (!options.fxtwitter) {
+				printError(
+					"Public tweet import is off by default. Pass --fxtwitter to disclose the requested tweet IDs and network metadata to api.fxtwitter.com.",
+				);
+				process.exitCode = 1;
+				return;
+			}
+			const result = await importTweetsViaFxTwitter(tweets);
+			await autoSyncAfterWrite();
+			print(result, asJson());
 		});
 	importCommand
 		.command("hydrate-profiles")

--- a/src/lib/backup-table-codecs.test.ts
+++ b/src/lib/backup-table-codecs.test.ts
@@ -13,7 +13,7 @@ import {
 describe("backup table codecs", () => {
 	it("owns every portable table and path exactly once", () => {
 		expect(assertBackupTableCodecRegistry()).toBe(true);
-		expect(BACKUP_TABLE_CODECS).toHaveLength(22);
+		expect(BACKUP_TABLE_CODECS).toHaveLength(23);
 		expect(BACKUP_TABLE_CODECS.map((codec) => codec.name)).toEqual([
 			"accounts",
 			"profiles",
@@ -23,6 +23,7 @@ describe("backup table codecs", () => {
 			"x_lists",
 			"x_list_members",
 			"tweets",
+			"tweet_sources",
 			"tweet_collections",
 			"tweet_account_edges",
 			"dm_conversations",
@@ -42,7 +43,7 @@ describe("backup table codecs", () => {
 			BACKUP_TABLE_CODECS.map((codec) => codec.merge.order).sort(
 				(left, right) => left - right,
 			),
-		).toEqual(Array.from({ length: 22 }, (_, index) => index));
+		).toEqual(Array.from({ length: 23 }, (_, index) => index));
 
 		const sample = { created_at: "2026-01-02T00:00:00.000Z", kind: "likes" };
 		for (const codec of BACKUP_TABLE_CODECS) {

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -522,6 +522,28 @@ const definitions = {
 			},
 		},
 	},
+	tweet_sources: {
+		exportSql: `
+      select tweet_id, source, source_url, observed_at
+      from tweet_sources
+      order by tweet_id, source
+    `,
+		...fixedShard("data/tweet_sources.jsonl", "tweet_sources"),
+		merge: {
+			order: 12,
+			sql: `
+      insert into tweet_sources (tweet_id, source, source_url, observed_at)
+      values (?, ?, ?, ?)
+      on conflict(tweet_id, source) do update set
+        source_url = case
+          when excluded.observed_at >= tweet_sources.observed_at then excluded.source_url
+          else tweet_sources.source_url
+        end,
+        observed_at = max(tweet_sources.observed_at, excluded.observed_at)
+      `,
+			columns: ["tweet_id", "source", "source_url", "observed_at"],
+		},
+	},
 	tweet_collections: {
 		exportSql: `
       select account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
@@ -537,7 +559,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`collections_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 12,
+			order: 13,
 			sql: `
       insert into tweet_collections (
         account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
@@ -583,7 +605,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`timeline_edges_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 13,
+			order: 14,
 			sql: `
       insert into tweet_account_edges (
         account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
@@ -622,7 +644,7 @@ const definitions = {
     `,
 		...fixedShard("data/dms/conversations.jsonl", "dm_conversations"),
 		merge: {
-			order: 14,
+			order: 15,
 			sql: `
       insert into dm_conversations (
         id, account_id, participant_profile_id, title, inbox_kind, last_message_at, unread_count, needs_reply
@@ -665,7 +687,7 @@ const definitions = {
 			candidate !== "data/dms/conversations.jsonl",
 		countKey: () => "dm_messages",
 		merge: {
-			order: 15,
+			order: 16,
 			sql: `
       insert into dm_messages (
         id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
@@ -706,7 +728,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/url_expansions.jsonl", "url_expansions"),
 		merge: {
-			order: 16,
+			order: 17,
 			transform: sanitizeImportedUrlExpansions,
 			sql: `
       insert into url_expansions (
@@ -754,7 +776,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/occurrences.jsonl", "link_occurrences"),
 		merge: {
-			order: 17,
+			order: 18,
 			sql: `
       insert into link_occurrences (
         source_kind, source_id, source_position, short_url, account_id,
@@ -786,7 +808,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/blocks.jsonl", "blocks"),
 		merge: {
-			order: 18,
+			order: 19,
 			sql: `
       insert into blocks (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -805,7 +827,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/mutes.jsonl", "mutes"),
 		merge: {
-			order: 19,
+			order: 20,
 			sql: `
       insert into mutes (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -824,7 +846,7 @@ const definitions = {
     `,
 		...fixedShard("data/actions/tweet_actions.jsonl", "tweet_actions"),
 		merge: {
-			order: 20,
+			order: 21,
 			sql: `
       insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at)
       values (?, ?, ?, ?, ?, ?)
@@ -846,7 +868,7 @@ const definitions = {
     `,
 		...fixedShard("data/ai_scores.jsonl", "ai_scores"),
 		merge: {
-			order: 21,
+			order: 22,
 			sql: `
       insert into ai_scores (
         entity_kind, entity_id, model, score, summary, reasoning, updated_at

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -56,6 +56,7 @@ function clearData() {
     delete from tweet_actions;
     delete from tweet_account_edges;
     delete from tweet_collections;
+		delete from tweet_sources;
     delete from link_occurrences;
     delete from url_expansions;
     delete from blocks;
@@ -163,6 +164,13 @@ function seedBackupFixture() {
       ('tweet_2024', 'Shipping text backups'),
       ('tweet_2025', 'Saved useful thing'),
       ('tweet_unknown_date', 'Unknown creation date like');
+
+    insert into tweet_sources (tweet_id, source, source_url, observed_at)
+    values (
+      'tweet_2024', 'fxtwitter',
+      'https://api.fxtwitter.com/2/status/tweet_2024',
+      '2025-01-03T00:00:00.000Z'
+    );
 
     insert into dm_conversations (
       id, account_id, participant_profile_id, title, inbox_kind, last_message_at, unread_count, needs_reply
@@ -409,6 +417,7 @@ describe("text backup", () => {
 			profile_snapshots: 1,
 			profile_bio_entities: 2,
 			tweets: 3,
+			tweet_sources: 1,
 			timeline_edges_home: 1,
 			timeline_edges_search: 1,
 			collections_bookmarks: 1,
@@ -433,6 +442,9 @@ describe("text backup", () => {
 			true,
 		);
 		expect(existsSync(path.join(repoPath, "data/tweets/unknown.jsonl"))).toBe(
+			true,
+		);
+		expect(existsSync(path.join(repoPath, "data/tweet_sources.jsonl"))).toBe(
 			true,
 		);
 		expect(existsSync(path.join(repoPath, "data/dms/2025.jsonl"))).toBe(true);
@@ -565,6 +577,16 @@ describe("text backup", () => {
 		expect(
 			getNativeDb({ seedDemoData: false })
 				.prepare(
+					"select source, source_url from tweet_sources where tweet_id = 'tweet_2024'",
+				)
+				.get(),
+		).toEqual({
+			source: "fxtwitter",
+			source_url: "https://api.fxtwitter.com/2/status/tweet_2024",
+		});
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare(
 					"select public_metrics_json from profiles where id = 'profile_friend'",
 				)
 				.get(),
@@ -584,7 +606,7 @@ describe("text backup", () => {
 		expect(validation.ok).toBe(true);
 	}, 20000);
 
-	it("emits byte-identical schema-v4 data and hashes for the same database", async () => {
+	it("emits byte-identical schema-v5 data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");
 		seedBackupFixture();
 		const firstRepoPath = makeTempDir("birdclaw-backup-stable-first-");
@@ -593,9 +615,9 @@ describe("text backup", () => {
 		const first = await exportBackup({ repoPath: firstRepoPath });
 		const second = await exportBackup({ repoPath: secondRepoPath });
 
-		expect(first.manifest.schemaVersion).toBe(4);
+		expect(first.manifest.schemaVersion).toBe(5);
 		expect(first.manifest.backupHash).toBe(
-			"bec137fa89f0f39cef137e8e74dfc59a7a892972189019c7d5e841f9c4c17895",
+			"43fd00e172a6a69a205eb13ecd3179ac0089a1ea252c3697dc3ab26d1a7dacb7",
 		);
 		expect(second.manifest.files).toEqual(first.manifest.files);
 		expect(second.manifest.counts).toEqual(first.manifest.counts);

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -27,7 +27,7 @@ import {
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 
-const BACKUP_SCHEMA_VERSION = 4;
+const BACKUP_SCHEMA_VERSION = 5;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_BACKUP_SHARD_BYTES = 48 * 1024 * 1024;
 const MANIFEST_PATH = "manifest.json";

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -354,13 +354,19 @@ describe("database init", () => {
 				)
 				.all(),
 		).toEqual([{ name: "x_list_members" }, { name: "x_lists" }]);
+		expect(
+			db
+				.prepare("pragma table_info(tweet_sources)")
+				.all()
+				.map((column) => (column as { name: string }).name),
+		).toEqual(["tweet_id", "source", "source_url", "observed_at"]);
 
 		const busyTimeout = db.pragma("busy_timeout", {
 			simple: true,
 		}) as number;
 		expect(busyTimeout).toBe(SQLITE_BUSY_TIMEOUT_MS);
 		expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
-		expect(db.pragma("user_version", { simple: true })).toBe(4);
+		expect(db.pragma("user_version", { simple: true })).toBe(5);
 	});
 
 	it("does not request a write lock for completed startup backfills", async () => {
@@ -444,8 +450,8 @@ describe("database init", () => {
 	});
 
 	it.each([
-		{ kind: "stale", version: 3 },
-		{ kind: "future", version: 5 },
+		{ kind: "stale", version: 4 },
+		{ kind: "future", version: 6 },
 	])(
 		"rejects a $kind schema and closes its provisional reader",
 		({ version }) => {
@@ -480,10 +486,10 @@ describe("database init", () => {
 
 		const writer = getNativeDb({ seedDemoData: false });
 		getReadDb({ seedDemoData: false });
-		writer.pragma("user_version = 5");
+		writer.pragma("user_version = 6");
 
 		expect(() => getStrictReadDb()).toThrow(
-			/schema 5 is not ready for version 4/,
+			/schema 6 is not ready for version 5/,
 		);
 	});
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -130,6 +130,14 @@ const BASE_SCHEMA_SQL = `
     quoted_tweet_id text
   );
 
+  create table if not exists tweet_sources (
+    tweet_id text not null,
+    source text not null,
+    source_url text not null,
+    observed_at text not null,
+    primary key (tweet_id, source)
+  );
+
   create table if not exists tweet_collections (
     account_id text not null,
     tweet_id text not null,
@@ -497,6 +505,18 @@ function ensureTweetCollectionsTable(db: Database) {
       raw_json text not null default '{}',
       updated_at text not null,
       primary key (account_id, tweet_id, kind)
+    );
+  `);
+}
+
+function ensureTweetSourcesTable(db: Database) {
+	db.exec(`
+    create table if not exists tweet_sources (
+      tweet_id text not null,
+      source text not null,
+      source_url text not null,
+      observed_at text not null,
+      primary key (tweet_id, source)
     );
   `);
 }
@@ -902,6 +922,11 @@ const DATABASE_MIGRATIONS: readonly DatabaseMigration[] = [
 				"create index if not exists idx_tweets_reply_to on tweets(reply_to_id)",
 			);
 		},
+	},
+	{
+		version: 5,
+		name: "add durable tweet source provenance",
+		up: ensureTweetSourcesTable,
 	},
 ];
 

--- a/src/lib/fxtwitter.test.ts
+++ b/src/lib/fxtwitter.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment node
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { useTestHome } from "../test/test-home";
+import { createRuntimeServices } from "./runtime-services";
+import {
+	FXTWITTER_ORIGIN,
+	getTweetByIdViaFxTwitterEffect,
+	importTweetsViaFxTwitterEffect,
+	parseFxTwitterTweetId,
+} from "./fxtwitter";
+
+const testHome = useTestHome({ prefix: "birdclaw-fxtwitter-" });
+
+function fxResponse(status: Record<string, unknown>, code = 200) {
+	return new Response(JSON.stringify({ status, code }), {
+		status: code,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function fixtureStatus(id = "20") {
+	return {
+		type: "status",
+		id,
+		text: "public tweet",
+		created_at: "Tue Mar 21 20:50:14 +0000 2006",
+		replies: 3,
+		reposts: 4,
+		likes: 5,
+		bookmarks: 6,
+		quotes: 7,
+		views: 8,
+		replying_to: { status: "10", user_id: "34" },
+		author: {
+			type: "profile",
+			id: "12",
+			screen_name: "jack",
+			name: "Jack",
+			description: "public profile",
+			location: "",
+			avatar_url: "https://pbs.twimg.com/profile_images/12/avatar_200x200.jpg",
+			followers: 100,
+			following: 2,
+			statuses: 50,
+			joined: "Tue Mar 21 20:50:14 +0000 2006",
+			verification: { verified: true, type: "individual" },
+		},
+		media: {
+			all: [
+				{
+					type: "photo",
+					id: "99",
+					url: "https://pbs.twimg.com/media/example.jpg?name=orig",
+					width: 1200,
+					height: 800,
+				},
+				{
+					type: "photo",
+					id: "100",
+					url: "https://attacker.example/private.jpg",
+				},
+			],
+		},
+		quote: {
+			type: "status",
+			id: "56",
+			text: "quoted public tweet",
+			created_at: "Wed Mar 22 20:50:14 +0000 2006",
+			author: {
+				type: "profile",
+				id: "34",
+				screen_name: "quoted",
+				name: "Quoted",
+			},
+			media: {},
+		},
+	};
+}
+
+describe("FxTwitter public tweet transport", () => {
+	it("accepts only numeric IDs and canonical public status URLs", () => {
+		expect(parseFxTwitterTweetId("20")).toBe("20");
+		expect(parseFxTwitterTweetId("https://x.com/jack/status/20")).toBe("20");
+		expect(
+			parseFxTwitterTweetId("https://www.twitter.com/jack/status/20/"),
+		).toBe("20");
+
+		for (const unsafe of [
+			"1",
+			"https://api.fxtwitter.com/2/status/20",
+			"http://x.com/jack/status/20",
+			"https://x.com@127.0.0.1/jack/status/20",
+			"https://x.com/jack/status/20?endpoint=http://127.0.0.1",
+			"https://x.com/i/web/status/20",
+		]) {
+			expect(() => parseFxTwitterTweetId(unsafe)).toThrow(
+				/canonical|only a tweet ID/,
+			);
+		}
+	});
+
+	it("uses the fixed endpoint, rejects redirects, and marks normalized rows", async () => {
+		const fetch = vi.fn().mockResolvedValue(fxResponse(fixtureStatus()));
+		const result = await Effect.runPromise(
+			getTweetByIdViaFxTwitterEffect(
+				"https://x.com/jack/status/20",
+				createRuntimeServices({ fetch }),
+			),
+		);
+
+		expect(fetch).toHaveBeenCalledOnce();
+		expect(fetch).toHaveBeenCalledWith(`${FXTWITTER_ORIGIN}/2/status/20`, {
+			method: "GET",
+			headers: {
+				Accept: "application/json",
+				"User-Agent": "birdclaw/fxtwitter-read-only",
+			},
+			redirect: "error",
+			signal: expect.any(AbortSignal),
+		});
+		expect(result.payload).toMatchObject({
+			data: [
+				{
+					id: "20",
+					author_id: "12",
+					text: "public tweet",
+					referenced_tweets: [
+						{ type: "replied_to", id: "10" },
+						{ type: "quoted", id: "56" },
+					],
+					public_metrics: { like_count: 5, impression_count: 8 },
+				},
+			],
+			includes: {
+				tweets: [{ id: "56", author_id: "34" }],
+				users: [{ id: "12", username: "jack" }, { id: "34" }],
+				media: [
+					{
+						media_key: "fxtwitter:20:99",
+						url: "https://pbs.twimg.com/media/example.jpg?name=orig",
+					},
+				],
+			},
+			meta: {
+				source: "fxtwitter",
+				endpoint: FXTWITTER_ORIGIN,
+				read_only: true,
+			},
+		});
+		expect([...result.provenance.entries()]).toEqual([
+			["56", `${FXTWITTER_ORIGIN}/2/status/20`],
+			["20", `${FXTWITTER_ORIGIN}/2/status/20`],
+		]);
+	});
+
+	it("validates all inputs before making any request", async () => {
+		const fetch = vi.fn();
+		await expect(
+			Effect.runPromise(
+				importTweetsViaFxTwitterEffect(
+					["20", "https://private.example/status/30"],
+					createRuntimeServices({ fetch }),
+				),
+			),
+		).rejects.toThrow(/only a tweet ID/);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("rejects unavailable, mismatched, and oversized responses", async () => {
+		const unavailable = createRuntimeServices({
+			fetch: vi
+				.fn()
+				.mockResolvedValue(
+					fxResponse(
+						{ type: "tombstone", id: "20", reason: "unavailable" },
+						404,
+					),
+				),
+		});
+		await expect(
+			Effect.runPromise(getTweetByIdViaFxTwitterEffect("20", unavailable)),
+		).rejects.toThrow(/status 404/);
+
+		const mismatched = createRuntimeServices({
+			fetch: vi.fn().mockResolvedValue(fxResponse(fixtureStatus("21"))),
+		});
+		await expect(
+			Effect.runPromise(getTweetByIdViaFxTwitterEffect("20", mismatched)),
+		).rejects.toThrow(/returned tweet 21/);
+
+		const oversized = createRuntimeServices({
+			fetch: vi.fn().mockResolvedValue(
+				new Response("{}", {
+					headers: { "content-length": String(2 * 1024 * 1024 + 1) },
+				}),
+			),
+		});
+		await expect(
+			Effect.runPromise(getTweetByIdViaFxTwitterEffect("20", oversized)),
+		).rejects.toThrow(/too large/);
+	});
+
+	it("persists canonical tweets with durable FxTwitter provenance", async () => {
+		const fetch = vi.fn().mockResolvedValue(fxResponse(fixtureStatus()));
+		const result = await Effect.runPromise(
+			importTweetsViaFxTwitterEffect(["20"], createRuntimeServices({ fetch })),
+		);
+
+		expect(result).toMatchObject({
+			ok: true,
+			readOnlyTransport: true,
+			source: "fxtwitter",
+			endpoint: FXTWITTER_ORIGIN,
+			requestedCount: 1,
+			importedCount: 1,
+			items: [
+				{
+					tweetId: "20",
+					source: "fxtwitter",
+					sourceUrl: `${FXTWITTER_ORIGIN}/2/status/20`,
+				},
+			],
+		});
+		expect(
+			testHome()
+				.db.prepare(
+					"select tweet_id, source, source_url from tweet_sources order by tweet_id",
+				)
+				.all(),
+		).toEqual([
+			{
+				tweet_id: "20",
+				source: "fxtwitter",
+				source_url: `${FXTWITTER_ORIGIN}/2/status/20`,
+			},
+			{
+				tweet_id: "56",
+				source: "fxtwitter",
+				source_url: `${FXTWITTER_ORIGIN}/2/status/20`,
+			},
+		]);
+		expect(
+			testHome().db.prepare("select id, text from tweets order by id").all(),
+		).toEqual([
+			{ id: "20", text: "public tweet" },
+			{ id: "56", text: "quoted public tweet" },
+		]);
+	});
+});

--- a/src/lib/fxtwitter.ts
+++ b/src/lib/fxtwitter.ts
@@ -1,0 +1,490 @@
+import { Buffer } from "node:buffer";
+import { Data, Effect } from "effect";
+import { getNativeDb } from "./db";
+import { runEffectPromise } from "./effect-runtime";
+import {
+	defaultRuntimeServices,
+	type RuntimeServices,
+} from "./runtime-services";
+import { ingestTweetPayload } from "./tweet-repository";
+import type {
+	XurlMediaItem,
+	XurlMentionUser,
+	XurlTweetData,
+	XurlTweetsResponse,
+} from "./types";
+
+export const FXTWITTER_ORIGIN = "https://api.fxtwitter.com";
+
+const FXTWITTER_TWEET_ID_PATTERN = /^\d{2,20}$/;
+const TWITTER_ENTITY_ID_PATTERN = /^\d{1,20}$/;
+const FXTWITTER_TIMEOUT_MS = 15_000;
+const FXTWITTER_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const FXTWITTER_MAX_TWEETS_PER_IMPORT = 20;
+const TWITTER_STATUS_HOSTS = new Set([
+	"twitter.com",
+	"www.twitter.com",
+	"x.com",
+	"www.x.com",
+]);
+const TWITTER_IMAGE_HOSTS = new Set(["pbs.twimg.com"]);
+const TWITTER_VIDEO_HOSTS = new Set(["video.twimg.com"]);
+
+type JsonRecord = Record<string, unknown>;
+
+export class FxTwitterError extends Data.TaggedError("FxTwitterError")<{
+	readonly message: string;
+	readonly status?: number;
+	readonly cause?: unknown;
+}> {}
+
+export interface FxTwitterTweet {
+	payload: XurlTweetsResponse;
+	provenance: ReadonlyMap<string, string>;
+}
+
+export interface FxTwitterImportResult {
+	ok: true;
+	readOnlyTransport: true;
+	source: "fxtwitter";
+	endpoint: typeof FXTWITTER_ORIGIN;
+	requestedCount: number;
+	importedCount: number;
+	items: Array<{
+		tweetId: string;
+		source: "fxtwitter";
+		sourceUrl: string;
+	}>;
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as JsonRecord)
+		: null;
+}
+
+function asArray(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function asString(value: unknown) {
+	return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown) {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
+}
+
+function asCount(value: unknown) {
+	return Math.max(0, Math.trunc(asNumber(value) ?? 0));
+}
+
+function toIsoDate(value: unknown, field: string) {
+	const raw = asString(value);
+	const timestamp = raw ? Date.parse(raw) : Number.NaN;
+	if (!Number.isFinite(timestamp)) {
+		throw new FxTwitterError({
+			message: `FxTwitter response has an invalid ${field}`,
+		});
+	}
+	return new Date(timestamp).toISOString();
+}
+
+function sourceUrlForTweet(tweetId: string) {
+	return `${FXTWITTER_ORIGIN}/2/status/${tweetId}`;
+}
+
+export function parseFxTwitterTweetId(value: string) {
+	const trimmed = value.trim();
+	if (FXTWITTER_TWEET_ID_PATTERN.test(trimmed)) return trimmed;
+
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		throw new FxTwitterError({
+			message: `Invalid public tweet ID or canonical x.com/Twitter status URL: ${trimmed}`,
+		});
+	}
+	if (
+		parsed.protocol !== "https:" ||
+		parsed.username ||
+		parsed.password ||
+		parsed.port ||
+		parsed.search ||
+		parsed.hash ||
+		!TWITTER_STATUS_HOSTS.has(parsed.hostname.toLowerCase())
+	) {
+		throw new FxTwitterError({
+			message:
+				"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
+		});
+	}
+	const match = /^\/[A-Za-z0-9_]{1,15}\/status\/(\d{2,20})\/?$/.exec(
+		parsed.pathname,
+	);
+	if (!match?.[1]) {
+		throw new FxTwitterError({
+			message:
+				"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
+		});
+	}
+	return match[1];
+}
+
+function safeUrlForHosts(value: unknown, hosts: ReadonlySet<string>) {
+	const raw = asString(value);
+	if (!raw) return undefined;
+	try {
+		const parsed = new URL(raw);
+		if (
+			parsed.protocol !== "https:" ||
+			parsed.username ||
+			parsed.password ||
+			parsed.port ||
+			!hosts.has(parsed.hostname.toLowerCase())
+		) {
+			return undefined;
+		}
+		return parsed.toString();
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeAuthor(value: unknown): XurlMentionUser {
+	const author = asRecord(value);
+	const id = asString(author?.id);
+	const username = asString(author?.screen_name);
+	if (!author || !id || !TWITTER_ENTITY_ID_PATTERN.test(id) || !username) {
+		throw new FxTwitterError({
+			message: "FxTwitter response is missing a valid tweet author",
+		});
+	}
+	const verification = asRecord(author.verification);
+	const website = asRecord(author.website);
+	const joined = asString(author.joined);
+	const joinedTimestamp = joined ? Date.parse(joined) : Number.NaN;
+	return {
+		id,
+		name: asString(author.name) ?? username,
+		username,
+		description: asString(author.description),
+		location: asString(author.location),
+		url: asString(website?.url),
+		verified: Boolean(verification?.verified),
+		verified_type: asString(verification?.type),
+		profile_image_url: safeUrlForHosts(author.avatar_url, TWITTER_IMAGE_HOSTS),
+		public_metrics: {
+			followers_count: asCount(author.followers),
+			following_count: asCount(author.following),
+			tweet_count: asCount(author.statuses),
+		},
+		created_at: Number.isFinite(joinedTimestamp)
+			? new Date(joinedTimestamp).toISOString()
+			: undefined,
+		protected: Boolean(author.protected),
+	};
+}
+
+function normalizeMedia(tweetId: string, value: unknown) {
+	const media = asRecord(value);
+	const items = asArray(media?.all);
+	const normalized: XurlMediaItem[] = [];
+	for (const [index, rawItem] of items.entries()) {
+		const item = asRecord(rawItem);
+		const type = asString(item?.type);
+		if (!item || !type) continue;
+		const providerId = asString(item.id) ?? String(index + 1);
+		const mediaKey = `fxtwitter:${tweetId}:${providerId}`;
+		if (type === "photo") {
+			const url = safeUrlForHosts(item.url, TWITTER_IMAGE_HOSTS);
+			if (!url) continue;
+			normalized.push({
+				media_key: mediaKey,
+				type: "photo",
+				url,
+				width: asNumber(item.width),
+				height: asNumber(item.height),
+				alt_text: asString(item.altText) ?? asString(item.alt_text),
+			});
+			continue;
+		}
+		if (type !== "video" && type !== "gif") continue;
+		const previewImageUrl = safeUrlForHosts(
+			item.thumbnail_url ?? item.thumbnailUrl ?? item.poster,
+			TWITTER_IMAGE_HOSTS,
+		);
+		const variantRows = [...asArray(item.variants), ...asArray(item.formats)];
+		const variants = variantRows.flatMap((rawVariant) => {
+			const variant = asRecord(rawVariant);
+			const url = safeUrlForHosts(variant?.url, TWITTER_VIDEO_HOSTS);
+			if (!variant || !url) return [];
+			return [
+				{
+					url,
+					content_type:
+						asString(variant.content_type) ??
+						asString(variant.contentType) ??
+						"video/mp4",
+					bit_rate: asNumber(variant.bit_rate) ?? asNumber(variant.bitrate),
+				},
+			];
+		});
+		if (!previewImageUrl && variants.length === 0) continue;
+		normalized.push({
+			media_key: mediaKey,
+			type: type === "gif" ? "animated_gif" : "video",
+			preview_image_url: previewImageUrl,
+			duration_ms: asNumber(item.duration_ms) ?? asNumber(item.durationMillis),
+			width: asNumber(item.width),
+			height: asNumber(item.height),
+			alt_text: asString(item.altText) ?? asString(item.alt_text),
+			variants,
+		});
+	}
+	return normalized;
+}
+
+function normalizeStatusTree(primaryValue: unknown, requestedId: string) {
+	const tweets = new Map<string, XurlTweetData>();
+	const users = new Map<string, XurlMentionUser>();
+	const media = new Map<string, XurlMediaItem>();
+	const provenance = new Map<string, string>();
+
+	const visit = (value: unknown, depth: number): XurlTweetData => {
+		const status = asRecord(value);
+		const id = asString(status?.id);
+		if (
+			!status ||
+			status.type !== "status" ||
+			!id ||
+			!FXTWITTER_TWEET_ID_PATTERN.test(id)
+		) {
+			throw new FxTwitterError({
+				message:
+					"FxTwitter response does not contain an available public tweet",
+			});
+		}
+		const author = normalizeAuthor(status.author);
+		users.set(author.id, author);
+		const tweetMedia = normalizeMedia(id, status.media);
+		for (const item of tweetMedia) media.set(item.media_key, item);
+
+		const referencedTweets: Array<{ type: string; id: string }> = [];
+		const replyingTo = asRecord(status.replying_to);
+		const repliedToId = asString(replyingTo?.status);
+		if (repliedToId && FXTWITTER_TWEET_ID_PATTERN.test(repliedToId)) {
+			referencedTweets.push({ type: "replied_to", id: repliedToId });
+		}
+		const quote = asRecord(status.quote);
+		if (quote?.type === "status" && depth < 2) {
+			const quotedTweet = visit(quote, depth + 1);
+			referencedTweets.push({ type: "quoted", id: quotedTweet.id });
+		}
+
+		const tweet: XurlTweetData = {
+			id,
+			author_id: author.id,
+			text: asString(status.text) ?? "",
+			created_at: toIsoDate(status.created_at, "tweet creation date"),
+			conversation_id: id,
+			in_reply_to_user_id: asString(replyingTo?.user_id),
+			attachments:
+				tweetMedia.length > 0
+					? { media_keys: tweetMedia.map((item) => item.media_key) }
+					: undefined,
+			referenced_tweets:
+				referencedTweets.length > 0 ? referencedTweets : undefined,
+			public_metrics: {
+				reply_count: asCount(status.replies),
+				retweet_count: asCount(status.reposts),
+				like_count: asCount(status.likes),
+				quote_count: asCount(status.quotes),
+				bookmark_count: asCount(status.bookmarks),
+				impression_count: asCount(status.views),
+			},
+		};
+		tweets.set(id, tweet);
+		provenance.set(id, sourceUrlForTweet(requestedId));
+		return tweet;
+	};
+
+	const primary = visit(primaryValue, 0);
+	if (primary.id !== requestedId) {
+		throw new FxTwitterError({
+			message: `FxTwitter returned tweet ${primary.id} for requested tweet ${requestedId}`,
+		});
+	}
+	return {
+		payload: {
+			data: [primary],
+			includes: {
+				users: [...users.values()],
+				tweets: [...tweets.values()].filter((tweet) => tweet.id !== primary.id),
+				media: [...media.values()],
+			},
+			meta: {
+				source: "fxtwitter",
+				endpoint: FXTWITTER_ORIGIN,
+				read_only: true,
+			},
+		},
+		provenance,
+	};
+}
+
+async function readBoundedJson(response: Response) {
+	const contentLength = Number(response.headers.get("content-length"));
+	if (
+		Number.isFinite(contentLength) &&
+		contentLength > FXTWITTER_MAX_RESPONSE_BYTES
+	) {
+		throw new FxTwitterError({ message: "FxTwitter response is too large" });
+	}
+	if (!response.body) return null;
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		total += value.byteLength;
+		if (total > FXTWITTER_MAX_RESPONSE_BYTES) {
+			await reader.cancel();
+			throw new FxTwitterError({ message: "FxTwitter response is too large" });
+		}
+		chunks.push(value);
+	}
+	try {
+		return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+	} catch (cause) {
+		throw new FxTwitterError({
+			message: "FxTwitter returned invalid JSON",
+			cause,
+		});
+	}
+}
+
+function toFxTwitterError(cause: unknown) {
+	if (cause instanceof FxTwitterError) return cause;
+	if (cause instanceof DOMException && cause.name === "AbortError") {
+		return new FxTwitterError({
+			message: "FxTwitter request timed out",
+			cause,
+		});
+	}
+	return new FxTwitterError({
+		message:
+			cause instanceof Error ? cause.message : "FxTwitter request failed",
+		cause,
+	});
+}
+
+export function getTweetByIdViaFxTwitterEffect(
+	input: string,
+	runtime: RuntimeServices = defaultRuntimeServices,
+): Effect.Effect<FxTwitterTweet, FxTwitterError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const tweetId = parseFxTwitterTweetId(input);
+			const controller = new AbortController();
+			const timeout = setTimeout(
+				() => controller.abort(),
+				FXTWITTER_TIMEOUT_MS,
+			);
+			try {
+				const response = await runtime.fetch(sourceUrlForTweet(tweetId), {
+					method: "GET",
+					headers: {
+						Accept: "application/json",
+						"User-Agent": "birdclaw/fxtwitter-read-only",
+					},
+					redirect: "error",
+					signal: controller.signal,
+				});
+				const body = await readBoundedJson(response);
+				const root = asRecord(body);
+				const providerCode = asNumber(root?.code);
+				if (!response.ok || providerCode !== 200) {
+					throw new FxTwitterError({
+						message: `FxTwitter lookup failed with status ${String(providerCode ?? response.status)}`,
+						status: response.status,
+					});
+				}
+				return normalizeStatusTree(root?.status, tweetId);
+			} finally {
+				clearTimeout(timeout);
+			}
+		},
+		catch: toFxTwitterError,
+	});
+}
+
+export function importTweetsViaFxTwitterEffect(
+	inputs: readonly string[],
+	runtime: RuntimeServices = defaultRuntimeServices,
+): Effect.Effect<FxTwitterImportResult, FxTwitterError> {
+	return Effect.gen(function* () {
+		const tweetIds = yield* Effect.try({
+			try: () => [...new Set(inputs.map(parseFxTwitterTweetId))],
+			catch: toFxTwitterError,
+		});
+		if (tweetIds.length === 0) {
+			return yield* Effect.fail(
+				new FxTwitterError({ message: "Pass at least one public tweet ID" }),
+			);
+		}
+		if (tweetIds.length > FXTWITTER_MAX_TWEETS_PER_IMPORT) {
+			return yield* Effect.fail(
+				new FxTwitterError({
+					message: `FxTwitter import accepts at most ${String(FXTWITTER_MAX_TWEETS_PER_IMPORT)} tweets per invocation`,
+				}),
+			);
+		}
+		const fetched = yield* Effect.forEach(
+			tweetIds,
+			(tweetId) => getTweetByIdViaFxTwitterEffect(tweetId, runtime),
+			{ concurrency: 1 },
+		);
+		return yield* Effect.try({
+			try: () => {
+				const db = getNativeDb({ seedDemoData: false });
+				const importedIds = new Set<string>();
+				for (const result of fetched) {
+					for (const tweetId of ingestTweetPayload(db, {
+						accountId: "public",
+						payload: result.payload,
+						source: "fxtwitter",
+						provenance: { sourceUrlByTweetId: result.provenance },
+					})) {
+						importedIds.add(tweetId);
+					}
+				}
+				return {
+					ok: true,
+					readOnlyTransport: true,
+					source: "fxtwitter",
+					endpoint: FXTWITTER_ORIGIN,
+					requestedCount: tweetIds.length,
+					importedCount: importedIds.size,
+					items: tweetIds.map((tweetId) => ({
+						tweetId,
+						source: "fxtwitter" as const,
+						sourceUrl: sourceUrlForTweet(tweetId),
+					})),
+				} satisfies FxTwitterImportResult;
+			},
+			catch: toFxTwitterError,
+		});
+	});
+}
+
+export function importTweetsViaFxTwitter(
+	inputs: readonly string[],
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return runEffectPromise(importTweetsViaFxTwitterEffect(inputs, runtime));
+}

--- a/src/lib/live-transport-gateway.ts
+++ b/src/lib/live-transport-gateway.ts
@@ -9,6 +9,7 @@ import {
 	listThreadViaBirdEffect,
 	searchTweetsViaBirdEffect,
 } from "./bird";
+import { getTweetByIdViaFxTwitterEffect } from "./fxtwitter";
 import {
 	getTransportStatusEffect,
 	getTweetByIdEffect,
@@ -55,8 +56,13 @@ export interface XurlReadTransport {
 	searchRecentTweets: typeof searchRecentTweetsEffect;
 }
 
+export interface FxTwitterReadTransport {
+	getTweetById: typeof getTweetByIdViaFxTwitterEffect;
+}
+
 export interface LiveTransportGateway {
 	bird: BirdReadTransport;
+	fxtwitter: FxTwitterReadTransport;
 	xurl: XurlReadTransport;
 }
 
@@ -75,6 +81,9 @@ export const liveTransportGateway: LiveTransportGateway = {
 		listMentions: (...args) => listMentionsViaBirdEffect(...args),
 		listThread: (...args) => listThreadViaBirdEffect(...args),
 		searchTweets: (...args) => searchTweetsViaBirdEffect(...args),
+	},
+	fxtwitter: {
+		getTweetById: (...args) => getTweetByIdViaFxTwitterEffect(...args),
 	},
 	xurl: {
 		getTransportStatus: (...args) => getTransportStatusEffect(...args),

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -15,6 +15,9 @@ export interface IngestTweetPayloadOptions {
 	edgeKind?: TweetAccountEdgeKind;
 	collectionKind?: "likes" | "bookmarks";
 	markRepliesAsReplied?: boolean;
+	provenance?: {
+		sourceUrlByTweetId: ReadonlyMap<string, string>;
+	};
 }
 
 function getReferencedTweetId(tweet: XurlMentionData, type: string) {
@@ -51,6 +54,7 @@ export function ingestTweetPayload(
 		edgeKind,
 		collectionKind,
 		markRepliesAsReplied = false,
+		provenance,
 	}: IngestTweetPayloadOptions,
 ) {
 	const usersById = new Map(
@@ -88,6 +92,15 @@ export function ingestTweetPayload(
       `)
 		: undefined;
 	const tweetIds: string[] = [];
+	const upsertSource = provenance
+		? db.prepare(`
+        insert into tweet_sources (tweet_id, source, source_url, observed_at)
+        values (?, ?, ?, ?)
+        on conflict(tweet_id, source) do update set
+          source_url = excluded.source_url,
+          observed_at = excluded.observed_at
+      `)
+		: undefined;
 
 	db.transaction(() => {
 		const observedAt = new Date().toISOString();
@@ -119,6 +132,10 @@ export function ingestTweetPayload(
 					? 1
 					: 0,
 			);
+			const sourceUrl = provenance?.sourceUrlByTweetId.get(tweet.id);
+			if (sourceUrl) {
+				upsertSource?.run(tweet.id, source, sourceUrl, observedAt);
+			}
 			if (edgeKind && isPrimaryTweet) {
 				upsertTweetAccountEdge(db, {
 					accountId,

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -257,7 +257,7 @@ describe("X List sync and local filtering", () => {
 		]);
 	});
 
-	it("round-trips List metadata and membership through schema v4 backup", async () => {
+	it("round-trips List metadata and membership through current-schema backup", async () => {
 		setupAccount();
 		mocks.listOwnedXListsViaBird.mockResolvedValue(ownedList(1));
 		mocks.listXListMembersViaBird.mockResolvedValue({
@@ -273,7 +273,7 @@ describe("X List sync and local filtering", () => {
 		tempRoots.push(backupRoot);
 		const exported = await exportBackup({ repoPath: backupRoot });
 		expect(exported.manifest).toMatchObject({
-			schemaVersion: 4,
+			schemaVersion: 5,
 			counts: { x_lists: 1, x_list_members: 1 },
 		});
 


### PR DESCRIPTION
## Summary

- add an explicit `birdclaw import tweet <ids-or-urls...> --fxtwitter` command, disabled unless the flag is present
- fetch only numeric tweet IDs from the hardcoded `https://api.fxtwitter.com/2/status/<id>` endpoint, with redirects rejected and no custom/self-hosted origin surface
- expose only a read-only single-tweet FxTwitter capability; no search, enumeration, private data, authentication, or X writes
- store canonical tweets plus queryable `fxtwitter` provenance in `tweet_sources`, including backup schema v5 support
- document the third-party disclosure of requested tweet IDs and ordinary network metadata

This is the narrow scope accepted in #99. Thanks @0xdevalias for proposing the FxTwitter transport.

## Live proof

Packed artifact, fresh isolated `BIRDCLAW_HOME`, Node `v26.5.0`, real public endpoint:

```text
birdclaw --json import tweet 20 896523232098078720 2030857479001960633 --fxtwitter
=> exit 0; source=fxtwitter; readOnlyTransport=true; requestedCount=3; importedCount=3

sqlite3 birdclaw.sqlite "select id from tweets ..."
=> 20, 896523232098078720, 2030857479001960633

sqlite3 birdclaw.sqlite "select tweet_id, source, source_url from tweet_sources ..."
=> all three source=fxtwitter; all URLs under https://api.fxtwitter.com/2/status/

birdclaw --json import tweet https://127.0.0.1/status/20 --fxtwitter
=> exit 1; canonical x.com/Twitter status URL required; provenance row count unchanged

birdclaw --json import tweet 20 --fxtwitter
=> exit 0; one canonical tweet row and one fxtwitter provenance row remain
```

Without `--fxtwitter`, the command exits 1 with the disclosure notice and creates no database. Packaged help identifies the fixed third-party endpoint. Source-blind behavior contract C1-C5 passed.

## Verification

```text
pnpm install --frozen-lockfile
=> lockfile current

pnpm run check
=> format, lint, and typecheck passed

pnpm test
=> 146 files passed; 1282 tests passed

pnpm run docs:site
=> docs site built; link validation passed

pnpm run build
=> client, server, and CLI built

pnpm run pack:smoke
=> 126 files; packaged --version passed in 308ms

pnpm audit --prod --audit-level=low
=> no known vulnerabilities

autoreview --mode local
autoreview --mode branch --base origin/main
=> clean
```

Refs #99
