### PR TITLE
feat: add per-operation account selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.10.1 - Unreleased
 
+### Added
+
+- Select existing accounts per live operation with `--account <username>` or `accounts.default`, including sync, profile hydration, DMs, compose, moderation, and scheduled jobs, without changing persistent database identity. (idea from #97 - thanks @ivankuznetsov)
+
 ## 0.10.0 - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -239,8 +239,10 @@ Don't have an archive yet? Request it from <https://x.com/settings/download_your
 Optional profile hydration through xurl can improve bios, follower counts, and avatars, but it performs live X profile reads and can spend API credits on large archives. With an existing private bird installation, the command can instead correct the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
 
 ```bash
-birdclaw import hydrate-profiles --json
+birdclaw import hydrate-profiles --account steipete --json
 ```
+
+Every command that touches live account auth accepts `--account <username>` (stored IDs also work). To reuse one selection without changing the database identity, set `{"accounts":{"default":"steipete"}}` in `~/.birdclaw/config.json`; an explicit flag overrides it for one operation.
 
 `import archive` is idempotent. Re-running parses follower/following edges into the local follow graph, streams bundled media files under `data/tweets_media/`, `data/direct_messages_media/`, and the other archive media folders into `~/.birdclaw/media/originals/archive/<kind>/<id>/`, and pulls `video_info.variants[]` so archive video and animated-GIF rows carry mp4 URLs for the live media fetcher. Already-extracted files are skipped when size matches.
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -143,10 +143,10 @@ A fresh install with just an archive and no live transport still gets a usable [
 The archive ships with stale profile metadata (bios, follower counts, avatars from years ago). Hydrate from live Twitter when you can:
 
 ```bash
-birdclaw import hydrate-profiles --json
+birdclaw import hydrate-profiles --account steipete --json
 ```
 
-With xurl available, this walks the imported profiles table and refreshes each entry. On large archives, that can mean hundreds or thousands of live X profile reads and may spend API credits. In Bird-only mode, the command uses `bird whoami` to correct the seeded local account identity but does not bulk-hydrate imported profiles. Without a live transport, hydration is a no-op and the archive's snapshot stays.
+With xurl available, this walks the imported profiles table and refreshes each entry. On large archives, that can mean hundreds or thousands of live X profile reads and may spend API credits. `--account` accepts a username or stored account ID and routes the operation through that account. In Bird-only mode, the command verifies `bird whoami`; without an explicit selection it retains the legacy seeded-account correction, while explicit selection never relabels another stored identity. Without a live transport, hydration is a no-op and the archive's snapshot stays.
 
 Avatars are written to `~/.birdclaw/media/thumbs/avatars/` so the web UI does not re-fetch them on every render.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -76,6 +76,16 @@ birdclaw sync mentions --mode bird
 birdclaw sync likes --mode xurl
 ```
 
+Select an existing Birdclaw account per operation with its username or stored ID:
+
+```text
+birdclaw sync timeline --account steipete --mode xurl
+birdclaw import hydrate-profiles --account @steipete
+birdclaw profiles replies @someone --account steipete
+```
+
+With xurl, Birdclaw routes that invocation to the matching named OAuth2 account. With Bird, Birdclaw cannot switch cookie jars itself and instead refuses the operation when `bird whoami` does not match. Put `{"accounts":{"default":"steipete"}}` in `config.json` to omit the repeated flag. This selects an existing row only; it does not change the database default or persist credential identity.
+
 Supported modes differ by command; use `birdclaw sync <command> --help`.
 
 ## Security
@@ -85,4 +95,4 @@ Supported modes differ by command; use `birdclaw sync <command> --help`.
 - Use archive-only mode when live access is unnecessary.
 - Set `BIRDCLAW_DISABLE_LIVE_WRITES=1` for development or dry runs.
 
-For multiple Birdclaw accounts, use `--account <id>` on commands that support it. See [Configuration](configuration.md#multi-account).
+For multiple Birdclaw accounts, use `--account <username>` or a stored account ID on commands that support it. See [Configuration](configuration.md#multi-account).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,8 @@ birdclaw debug transport
 - write default config if absent
 - optionally detect `xurl` and `bird`
 
+Account-capable commands accept `--account <username>` or a stored account ID. Set `accounts.default` in `config.json` for a reversible default; an explicit flag wins.
+
 ### `import tweet <tweet-id-or-url...>`
 
 - disabled unless `--fxtwitter` is passed on the same invocation
@@ -610,6 +612,7 @@ birdclaw media fetch --no-include-video --parallel 3 --pacing-ms 250 --json
 
 Flags:
 
+- `--account <username>` — account username or stored ID
 - `--limit <n>`
 
 Examples:

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -26,7 +26,7 @@ birdclaw compose post --account acct_primary "Multi-account post."
 
 Flags:
 
-- `--account <id>`
+- `--account <username>` — account username or stored ID
 - `--reply-to <tweet-id>` — equivalent to `compose reply`
 - `--quote <tweet-id>` — quote-tweet
 - `--media <path>` — attach a local file (planned)
@@ -57,6 +57,8 @@ birdclaw compose dm dm_004 --account acct_primary "Sounds good."
 ```
 
 `compose dm` resolves the conversation, picks the right transport (`bird` is preferred for DM writes because OAuth2 DM scopes are flaky), and merges the sent message back into the local DM tables.
+
+All compose commands accept `--account`. For DMs, the selected account must own the local conversation. Set `accounts.default` in `config.json` for a recurring choice.
 
 ## Disabling live writes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,9 @@ The Playwright test home is `.playwright-home` in the repo, which is why CI neve
 
 ```json
 {
+	"accounts": {
+		"default": "steipete"
+	},
 	"actions": {
 		"transport": "auto"
 	},
@@ -55,6 +58,12 @@ The Playwright test home is `.playwright-home` in the repo, which is why CI neve
 	}
 }
 ```
+
+### `accounts.default`
+
+Set a Birdclaw account username (with or without `@`) or stored account ID. Commands with an `--account` option use this value when the flag is omitted. An explicit `--account` always wins.
+
+Selection is per operation. Birdclaw resolves the existing account row, routes xurl through that username for the command, then restores the process environment. It never creates an account, changes the database default, or binds a live credential to stored data.
 
 ### `actions.transport`
 
@@ -105,7 +114,15 @@ See [Backup](backup.md). When `autoSync` is enabled, read commands pull + merge 
 
 ## Multi-account
 
-birdclaw was built around multiple accounts in a single shared database from day one. Pass `--account <id>` on commands that support account selection, including moderation, mentions, DMs, and live sync commands.
+birdclaw was built around multiple accounts in a single shared database from day one. Pass `--account <username>` (or a stored account ID) on commands that support account selection, including moderation, profile hydration, profile reply inspection, mentions, DMs, live sync, and scheduled jobs.
+
+```bash
+birdclaw sync timeline --account steipete --mode xurl
+birdclaw import hydrate-profiles --account @steipete
+birdclaw compose post --account acct_primary "Ship it."
+```
+
+For a recurring choice, set `accounts.default` in `config.json`. Explicit flags remain reversible one-command overrides. xurl can select a named OAuth2 account; Bird has one active cookie identity, so Bird-backed operations verify that identity matches the selected Birdclaw account before reading or writing.
 
 Per-account state — cursors, transport preferences, last-sync watermarks, OpenAI score caches — lives inside the same `birdclaw.sqlite`. There is no per-account directory tree.
 

--- a/src/cli-moderation.ts
+++ b/src/cli-moderation.ts
@@ -31,7 +31,7 @@ export function registerModerationCommands({
 
 	blocksCommand
 		.command("list")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--search <query>", "Filter blocked profiles")
 		.option("--limit <n>", "Limit results", "50")
 		.action((options) => {
@@ -45,7 +45,7 @@ export function registerModerationCommands({
 
 	blocksCommand
 		.command("add <query>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await addBlock(
@@ -58,7 +58,7 @@ export function registerModerationCommands({
 
 	blocksCommand
 		.command("remove <query>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await removeBlock(
@@ -71,7 +71,7 @@ export function registerModerationCommands({
 
 	blocksCommand
 		.command("sync")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (options) => {
 			const result = await syncBlocks(options.account);
 			print(result, asJson());
@@ -80,7 +80,7 @@ export function registerModerationCommands({
 	blocksCommand
 		.command("import <path>")
 		.description("Import a newline-delimited blocklist file")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (filePath, options) => {
 			const result = await importBlocklist(options.account, filePath);
 			print(result, asJson());
@@ -91,7 +91,7 @@ export function registerModerationCommands({
 		.description(
 			"Record a known-good remote block locally without another live write",
 		)
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (query, options) => {
 			const result = await recordBlock(options.account, query);
 			print(result, asJson());
@@ -103,7 +103,7 @@ export function registerModerationCommands({
 
 	mutesCommand
 		.command("list")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--search <query>", "Filter muted profiles")
 		.option("--limit <n>", "Limit results", "50")
 		.action((options) => {
@@ -117,7 +117,7 @@ export function registerModerationCommands({
 
 	mutesCommand
 		.command("add <query>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await addMute(
@@ -130,7 +130,7 @@ export function registerModerationCommands({
 
 	mutesCommand
 		.command("remove <query>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await removeMute(
@@ -146,7 +146,7 @@ export function registerModerationCommands({
 		.description(
 			"Record a known-good remote mute locally without another live write",
 		)
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (query, options) => {
 			const result = await recordMute(options.account, query);
 			print(result, asJson());
@@ -155,7 +155,7 @@ export function registerModerationCommands({
 	program
 		.command("ban <query>")
 		.description("Alias for blocks add")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await addBlock(
@@ -169,7 +169,7 @@ export function registerModerationCommands({
 	program
 		.command("unban <query>")
 		.description("Alias for blocks remove")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await removeBlock(
@@ -183,7 +183,7 @@ export function registerModerationCommands({
 	program
 		.command("mute <query>")
 		.description("Mute a user for one account")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await addMute(
@@ -197,7 +197,7 @@ export function registerModerationCommands({
 	program
 		.command("unmute <query>")
 		.description("Unmute a user for one account")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.option("--transport <mode>", "auto, bird, or xurl")
 		.action(async (query, options) => {
 			const result = await removeMute(

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureBirdclawDirsMock = vi.fn();
 const getBirdclawPathsMock = vi.fn();
+const getDefaultAccountSelectorMock = vi.fn();
+const resolveOperationAccountMock = vi.fn();
 const resolveMentionsDataSourceMock = vi.fn();
 const setActionsTransportMock = vi.fn();
 const getQueryEnvelopeMock = vi.fn();
@@ -46,6 +48,8 @@ const listTimelineItemsMock = vi.fn();
 const listDmConversationsMock = vi.fn();
 const applyDmRequestMutationToLocalStoreMock = vi.fn();
 const runDirectMessageRequestMutationViaBirdMock = vi.fn();
+const getAuthenticatedBirdAccountMock = vi.fn();
+const getConversationThreadMock = vi.fn();
 const hydrateProfilesFromXMock = vi.fn();
 const inspectProfileRepliesMock = vi.fn();
 const runResearchModeMock = vi.fn();
@@ -84,11 +88,22 @@ Object.defineProperty(
 
 vi.mock("#/lib/config", () => ({
 	ensureBirdclawDirs: () => ensureBirdclawDirsMock(),
+	getDefaultAccountSelector: () => getDefaultAccountSelectorMock(),
 	getBirdclawConfig: () => ({}),
 	getBirdclawPaths: () => getBirdclawPathsMock(),
 	resolveMentionsDataSource: (...args: unknown[]) =>
 		resolveMentionsDataSourceMock(...args),
 	setActionsTransport: (...args: unknown[]) => setActionsTransportMock(...args),
+}));
+
+vi.mock("#/lib/account-selection", () => ({
+	resolveOperationAccount: (...args: unknown[]) =>
+		resolveOperationAccountMock(...args),
+}));
+
+vi.mock("#/lib/dm-read-model", () => ({
+	getConversationThread: (...args: unknown[]) =>
+		getConversationThreadMock(...args),
 }));
 
 vi.mock("#/lib/archive-finder", () => ({
@@ -260,6 +275,8 @@ vi.mock("#/lib/production-server", () => ({
 }));
 
 vi.mock("#/lib/bird", () => ({
+	getAuthenticatedBirdAccount: (...args: unknown[]) =>
+		getAuthenticatedBirdAccountMock(...args),
 	runDirectMessageRequestMutationViaBird: (...args: unknown[]) =>
 		runDirectMessageRequestMutationViaBirdMock(...args),
 }));
@@ -293,6 +310,8 @@ describe("cli", () => {
 		consoleLogMock.mockClear();
 		ensureBirdclawDirsMock.mockReset();
 		getBirdclawPathsMock.mockReset();
+		getDefaultAccountSelectorMock.mockReset();
+		resolveOperationAccountMock.mockReset();
 		resolveMentionsDataSourceMock.mockReset();
 		setActionsTransportMock.mockReset();
 		getQueryEnvelopeMock.mockReset();
@@ -335,6 +354,8 @@ describe("cli", () => {
 		listDmConversationsMock.mockReset();
 		applyDmRequestMutationToLocalStoreMock.mockReset();
 		runDirectMessageRequestMutationViaBirdMock.mockReset();
+		getAuthenticatedBirdAccountMock.mockReset();
+		getConversationThreadMock.mockReset();
 		hydrateProfilesFromXMock.mockReset();
 		inspectProfileRepliesMock.mockReset();
 		runResearchModeMock.mockReset();
@@ -366,6 +387,22 @@ describe("cli", () => {
 		getBirdclawPathsMock.mockReturnValue({
 			rootDir: "/tmp/.birdclaw",
 			dbPath: "/tmp/.birdclaw/birdclaw.sqlite",
+		});
+		getDefaultAccountSelectorMock.mockReturnValue(undefined);
+		resolveOperationAccountMock.mockImplementation((selector?: string) => ({
+			id:
+				selector === "steipete" || selector === "@steipete"
+					? "acct_primary"
+					: (selector ?? "acct_primary"),
+			username: selector?.replace(/^@/, "") ?? "steipete",
+			externalUserId: "25401953",
+		}));
+		getConversationThreadMock.mockReturnValue({
+			conversation: { accountId: "acct_primary" },
+		});
+		getAuthenticatedBirdAccountMock.mockResolvedValue({
+			id: "25401953",
+			username: "steipete",
 		});
 		resolveMentionsDataSourceMock.mockImplementation(
 			(mode?: string) => mode ?? "birdclaw",
@@ -2906,8 +2943,54 @@ describe("cli", () => {
 		]);
 
 		expect(inspectProfileRepliesMock).toHaveBeenCalledWith("@sam", {
+			account: undefined,
 			limit: 7,
 		});
+	});
+
+	it("applies the config account default and restores xurl selection", async () => {
+		getDefaultAccountSelectorMock.mockReturnValue("@steipete");
+		delete process.env.BIRDCLAW_XURL_OAUTH2_USERNAME;
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "mentions", "export", "--limit", "2"]);
+
+		expect(resolveOperationAccountMock).toHaveBeenCalledWith("@steipete");
+		expect(exportMentionItemsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ account: "acct_primary" }),
+		);
+		expect(process.env.BIRDCLAW_XURL_OAUTH2_USERNAME).toBeUndefined();
+	});
+
+	it("lets an explicit account override the config default", async () => {
+		getDefaultAccountSelectorMock.mockReturnValue("other_user");
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"mentions",
+			"export",
+			"--account",
+			"@steipete",
+		]);
+
+		expect(resolveOperationAccountMock).toHaveBeenCalledWith("@steipete");
+		expect(resolveOperationAccountMock).not.toHaveBeenCalledWith("other_user");
+		expect(exportMentionItemsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ account: "acct_primary" }),
+		);
+	});
+
+	it("preserves legacy command defaults without forcing named xurl auth", async () => {
+		delete process.env.BIRDCLAW_XURL_OAUTH2_USERNAME;
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "compose", "post", "Ship it"]);
+
+		expect(createPostMock).toHaveBeenCalledWith("acct_primary", "Ship it");
+		expect(resolveOperationAccountMock).not.toHaveBeenCalled();
+		expect(process.env.BIRDCLAW_XURL_OAUTH2_USERNAME).toBeUndefined();
 	});
 
 	it("dispatches compose and inbox commands", async () => {
@@ -2943,7 +3026,11 @@ describe("cli", () => {
 			"tweet_1",
 			"Strong point",
 		);
-		expect(createDmReplyMock).toHaveBeenCalledWith("dm_1", "Looks good");
+		expect(createDmReplyMock).toHaveBeenCalledWith(
+			"dm_1",
+			"Looks good",
+			undefined,
+		);
 		expect(scoreInboxMock).toHaveBeenCalledWith({ kind: "dms", limit: 3 });
 		expect(listInboxItemsMock).toHaveBeenCalledWith({
 			kind: "dms",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,11 @@ import { dirname, join } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
-import { createCommandContext } from "#/cli/command-context";
+import {
+	configureOperationAccountSelection,
+	createCommandContext,
+	resetOperationAccountSelection,
+} from "#/cli/command-context";
 import { registerAnalysisCommands } from "#/cli/register-analysis";
 import { registerComposeCommands } from "#/cli/register-compose";
 import { registerCoreCommands } from "#/cli/register-core";
@@ -43,6 +47,7 @@ const program = new Command()
 	.version(packageVersion.version ?? "0.0.0")
 	.option("--json", "Emit JSON output");
 const commandContext = createCommandContext(program);
+configureOperationAccountSelection(program);
 
 registerCoreCommands(commandContext);
 registerSearchCommands(commandContext);
@@ -67,6 +72,7 @@ export async function runCli(argv = process.argv) {
 	try {
 		await program.parseAsync(argv);
 	} finally {
+		resetOperationAccountSelection();
 		await closeDatabase();
 	}
 }

--- a/src/cli/command-context.ts
+++ b/src/cli/command-context.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
+import {
+	resolveOperationAccount,
+	type OperationAccount,
+} from "#/lib/account-selection";
 import { maybeAutoSyncBackup, maybeAutoUpdateBackup } from "#/lib/backup";
+import { getDefaultAccountSelector } from "#/lib/config";
 
 export interface CliCommandContext {
 	program: Command;
@@ -15,6 +20,59 @@ export interface CliCommandContext {
 		value: string | undefined,
 		option: string,
 	) => number | undefined;
+}
+
+let previousXurlUsername:
+	| { existed: boolean; value: string | undefined }
+	| undefined;
+
+function commandHasAccountOption(command: Command) {
+	return command.options.some((option) => option.attributeName() === "account");
+}
+
+function selectOperationAccount(
+	command: Command,
+): OperationAccount | undefined {
+	if (!commandHasAccountOption(command)) return undefined;
+
+	const source = command.getOptionValueSource("account");
+	const current = command.getOptionValue("account");
+	const explicit =
+		source === "cli" && typeof current === "string" ? current : undefined;
+	const configSelector = getDefaultAccountSelector();
+	const selector = explicit || configSelector;
+	if (!selector) return undefined;
+
+	const account = resolveOperationAccount(selector);
+	command.setOptionValueWithSource(
+		"account",
+		account.id,
+		explicit ? "cli" : "config",
+	);
+	return account;
+}
+
+export function resetOperationAccountSelection() {
+	if (!previousXurlUsername) return;
+	if (previousXurlUsername.existed) {
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME = previousXurlUsername.value;
+	} else {
+		delete process.env.BIRDCLAW_XURL_OAUTH2_USERNAME;
+	}
+	previousXurlUsername = undefined;
+}
+
+export function configureOperationAccountSelection(program: Command) {
+	program.hook("preAction", (_root, actionCommand) => {
+		const account = selectOperationAccount(actionCommand);
+		if (!account) return;
+		previousXurlUsername ??= {
+			existed: Object.hasOwn(process.env, "BIRDCLAW_XURL_OAUTH2_USERNAME"),
+			value: process.env.BIRDCLAW_XURL_OAUTH2_USERNAME,
+		};
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME = account.username;
+	});
+	program.hook("postAction", resetOperationAccountSelection);
 }
 
 export function print(data: unknown, asJson: boolean) {

--- a/src/cli/register-analysis.ts
+++ b/src/cli/register-analysis.ts
@@ -360,7 +360,7 @@ export function registerAnalysisCommands({
 	program
 		.command("research [query]")
 		.description("Build a markdown research brief from bookmarked threads")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--limit <n>", "Seed bookmark limit", "20")
 		.option("--thread-depth <n>", "Maximum ancestor walk depth", "10")
 		.option("--out <path>", "Write the markdown brief to a file")
@@ -382,7 +382,7 @@ export function registerAnalysisCommands({
 	program
 		.command("discuss <query>")
 		.description("Search live/local tweets and summarize the results with AI")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option(
 			"--source <source>",
 			"all, search, home, mentions, authored, likes, or bookmarks",
@@ -413,7 +413,7 @@ export function registerAnalysisCommands({
 		.command("profile-analyze <handle>")
 		.alias("profile-analyse")
 		.description("Backfill a profile with xurl and summarize it with AI")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--model <model>", "OpenAI model id")
 		.option("--refresh", "Bypass profile fetch and analysis caches")
 		.option("--max-tweets <n>", "Maximum profile tweets", "10000")
@@ -447,7 +447,7 @@ export function registerAnalysisCommands({
 	program
 		.command("today")
 		.description("Stream an AI digest of what happened today")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--include-dms", "Include private DM context")
 		.option("--model <model>", "OpenAI model id")
 		.option(
@@ -473,7 +473,7 @@ export function registerAnalysisCommands({
 	program
 		.command("digest [period]")
 		.description("Stream an AI digest for today, 24h, yesterday, or week")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--include-dms", "Include private DM context")
 		.option("--since <isoDate>", "Start of explicit window")
 		.option("--until <isoDate>", "End of explicit window")

--- a/src/cli/register-compose.ts
+++ b/src/cli/register-compose.ts
@@ -13,7 +13,7 @@ export function registerComposeCommands({
 
 	composeCommand
 		.command("post <text>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (text, options) => {
 			const result = await createPost(options.account, text);
 			await autoSyncAfterWrite();
@@ -22,7 +22,7 @@ export function registerComposeCommands({
 
 	composeCommand
 		.command("reply <tweetId> <text>")
-		.option("--account <accountId>", "Account id", "acct_primary")
+		.option("--account <username>", "Account username or id", "acct_primary")
 		.action(async (tweetId, text, options) => {
 			const result = await createTweetReply(options.account, tweetId, text);
 			await autoSyncAfterWrite();
@@ -32,8 +32,9 @@ export function registerComposeCommands({
 	composeCommand
 		.command("dm <conversationId> <text>")
 		.description("Reply inside an existing DM conversation")
-		.action(async (conversationId, text) => {
-			const result = await createDmReply(conversationId, text);
+		.option("--account <username>", "Account username or id")
+		.action(async (conversationId, text, options) => {
+			const result = await createDmReply(conversationId, text, options.account);
 			await autoSyncAfterWrite();
 			print(result, asJson());
 		});

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -236,8 +236,9 @@ export function registerCoreCommands({
 		.description(
 			"Backfill archive-imported profiles from live Twitter metadata",
 		)
-		.action(async () => {
-			const result = await hydrateProfilesFromX();
+		.option("--account <username>", "Account username or id")
+		.action(async (options) => {
+			const result = await hydrateProfilesFromX({ account: options.account });
 			await autoSyncAfterWrite();
 			print(result, asJson());
 		});

--- a/src/cli/register-dms.ts
+++ b/src/cli/register-dms.ts
@@ -1,5 +1,11 @@
-import { runDirectMessageRequestMutationViaBird } from "#/lib/bird";
+import {
+	getAuthenticatedBirdAccount,
+	runDirectMessageRequestMutationViaBird,
+} from "#/lib/bird";
+import { resolveOperationAccount } from "#/lib/account-selection";
+import { getConversationThread } from "#/lib/dm-read-model";
 import { syncDirectMessagesViaCachedBird } from "#/lib/dms-live";
+import { assertLiveAccountMatches } from "#/lib/live-sync-engine";
 import { applyDmRequestMutationToLocalStore } from "#/lib/queries";
 import type { CliCommandContext } from "./command-context";
 import {
@@ -19,7 +25,7 @@ export function registerDirectMessageCommands({
 
 	dmsCommand
 		.command("list")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, bird, or xurl", "bird")
 		.option("--refresh", "Refresh live DMs before listing")
 		.option("--cache-ttl <seconds>", "Live-cache freshness window", "120")
@@ -124,7 +130,7 @@ export function registerDirectMessageCommands({
 	dmsCommand
 		.command("sync")
 		.description("Refresh live direct messages into the local store")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, bird, or xurl", "bird")
 		.option("--limit <n>", "Limit messages", "20")
 		.option("--inbox <kind>", "all, accepted, or requests", "all")
@@ -169,13 +175,38 @@ export function registerDirectMessageCommands({
 	for (const action of ["accept", "reject", "block"] as const) {
 		const command = dmsCommand
 			.command(`${action} <conversationId>`)
-			.description(`${action} a live DM message request through bird`);
+			.description(`${action} a live DM message request through bird`)
+			.option("--account <username>", "Account username or id");
 		if (action === "block") {
 			command
 				.option("--max-pages <n>", "Additional timeline pages to search", "3")
 				.option("--all-pages", "Search all accepted/request timeline pages");
 		}
 		command.action(async (conversationId, options) => {
+			const conversation = getConversationThread(conversationId);
+			if (!conversation) throw new Error("Conversation not found");
+			const selected = resolveOperationAccount(
+				options.account ?? conversation.conversation.accountId,
+			);
+			if (selected.id !== conversation.conversation.accountId) {
+				throw new Error(
+					`Conversation belongs to ${conversation.conversation.accountId}, not ${selected.id}`,
+				);
+			}
+			if (process.env.BIRDCLAW_DISABLE_LIVE_WRITES !== "1") {
+				const authenticated = await getAuthenticatedBirdAccount();
+				assertLiveAccountMatches({
+					source: "bird",
+					account: {
+						accountId: selected.id,
+						username: selected.username,
+						externalUserId: selected.externalUserId,
+						isDefault: false,
+					},
+					liveUsername: authenticated.username,
+					liveExternalUserId: authenticated.id,
+				});
+			}
 			const maxPages =
 				action === "block"
 					? parseNonNegativeIntegerOption(options.maxPages, "--max-pages")

--- a/src/cli/register-graph.ts
+++ b/src/cli/register-graph.ts
@@ -22,7 +22,7 @@ export function registerGraphCommands({
 		.description(
 			"Summarize cached followers, following, mutuals, and snapshots",
 		)
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.action(async (options) => {
 			await autoUpdateBeforeRead();
 			print(getFollowGraphSummary({ account: options.account }), true);
@@ -31,7 +31,7 @@ export function registerGraphCommands({
 	graphCommand
 		.command("top-followers")
 		.description("List current followers sorted by their follower count")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--limit <n>", "Limit results", "20")
 		.action(async (options) => {
 			await autoUpdateBeforeRead();
@@ -48,7 +48,7 @@ export function registerGraphCommands({
 		.command("unfollowed")
 		.description("List cached ended follow edges since a date")
 		.requiredOption("--date <date>", "YYYY-MM-DD or ISO timestamp")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--direction <direction>", "followers or following", "followers")
 		.option("--limit <n>", "Limit results", "100")
 		.action(async (options) => {
@@ -68,7 +68,7 @@ export function registerGraphCommands({
 	graphCommand
 		.command("events")
 		.description("List cached append-only follow graph events")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--direction <direction>", "followers or following")
 		.option("--kind <kind>", "started or ended")
 		.option("--since <date>", "YYYY-MM-DD or ISO timestamp")
@@ -99,7 +99,7 @@ export function registerGraphCommands({
 	graphCommand
 		.command("non-mutual-following")
 		.description("List current following who are not current followers")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--sort <mode>", "followers or handle", "followers")
 		.option("--limit <n>", "Limit results", "100")
 		.action(async (options) => {
@@ -117,7 +117,7 @@ export function registerGraphCommands({
 	graphCommand
 		.command("mutuals")
 		.description("List profiles that are both followers and following")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--limit <n>", "Limit results", "100")
 		.action(async (options) => {
 			await autoUpdateBeforeRead();

--- a/src/cli/register-jobs.ts
+++ b/src/cli/register-jobs.ts
@@ -20,7 +20,7 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 		.description(
 			"Refresh live account timelines and append a JSONL audit entry",
 		)
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option(
 			"--steps <steps>",
 			"Comma list: timeline,mentions,mention-threads,likes,bookmarks,dms",
@@ -57,7 +57,7 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 		.option("--label <label>", "LaunchAgent label")
 		.option("--interval-seconds <seconds>", "Launch interval", "1800")
 		.option("--program <path>", "birdclaw executable or command", "birdclaw")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option(
 			"--steps <steps>",
 			"Comma list: timeline,mentions,mention-threads,likes,bookmarks,dms",
@@ -104,7 +104,7 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 	jobsCommand
 		.command("sync-bookmarks")
 		.description("Refresh live bookmarks and append a JSONL audit entry")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, xurl, or bird", "auto")
 		.option("--limit <n>", "Per-page/result limit", "100")
 		.option("--all", "Fetch every retrievable page")
@@ -130,6 +130,7 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 	jobsCommand
 		.command("install-bookmarks-launchd")
 		.description("Install a LaunchAgent that runs bookmark sync every 3 hours")
+		.option("--account <username>", "Account username or id")
 		.option("--label <label>", "LaunchAgent label")
 		.option("--interval-seconds <seconds>", "Launch interval", "10800")
 		.option("--program <path>", "birdclaw executable or command", "birdclaw")
@@ -148,6 +149,7 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 		.option("--no-load", "Write plist without loading it")
 		.action(async (options) => {
 			const result = await installBookmarkSyncLaunchAgent({
+				account: options.account,
 				label: options.label,
 				intervalSeconds: Number(options.intervalSeconds),
 				program: options.program,

--- a/src/cli/register-lists.ts
+++ b/src/cli/register-lists.ts
@@ -14,7 +14,7 @@ export function registerListCommands({
 	listsCommand
 		.command("list")
 		.description("List cached owned X Lists")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.action(async (options) => {
 			await autoUpdateBeforeRead();
 			const items = listStoredXLists({ account: options.account });
@@ -36,7 +36,7 @@ export function registerListCommands({
 		.command("members [name]")
 		.description("List cached members for one X List")
 		.option("--list-id <id>", "Select by List id")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--include-ended", "Include members absent from a complete sync")
 		.option("--limit <n>", "Limit results", "100")
 		.action(async (name, options) => {

--- a/src/cli/register-mentions.ts
+++ b/src/cli/register-mentions.ts
@@ -23,7 +23,7 @@ export function registerMentionCommands({
 		.description(
 			"Return mention tweets with plain-text and markdown renderings",
 		)
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "birdclaw, auto, xurl, or bird")
 		.option("--replied", "Only replied items")
 		.option("--unreplied", "Only unreplied items")
@@ -80,9 +80,11 @@ export function registerMentionCommands({
 	profilesCommand
 		.command("replies <query>")
 		.description("Inspect recent authored replies for one profile")
+		.option("--account <username>", "Account username or id")
 		.option("--limit <n>", "Limit replies", "12")
 		.action(async (query, options) => {
 			const result = await inspectProfileReplies(query, {
+				account: options.account,
 				limit: Number(options.limit),
 			});
 			print(result, asJson());

--- a/src/cli/register-search.ts
+++ b/src/cli/register-search.ts
@@ -40,7 +40,7 @@ export function registerSearchCommands({
 	searchCommand
 		.command("tweets [query]")
 		.option("--resource <resource>", "home, mentions, or authored", "home")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--list <name>", "Only authors in a cached X List")
 		.option("--list-id <id>", "Only authors in a cached X List id")
 		.option("--replied", "Only replied items")
@@ -185,7 +185,7 @@ export function registerSearchCommands({
 	searchCommand
 		.command("links <query>")
 		.description("Search indexed short links, expansions, and linked tweets")
-		.option("--account <accountIdOrHandle>", "Account id or handle")
+		.option("--account <username>", "Account username or id")
 		.option("--since <date>", "Include links created at or after this date")
 		.option("--until <date>", "Include links created before this date")
 		.option("--source <kind>", "dm or tweet")
@@ -274,7 +274,7 @@ export function registerSearchCommands({
 		.description(
 			"Fetch missing pbs.twimg.com image media already stored in tweets",
 		)
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--limit <n>", "Stop after N tweets processed")
 		.option(
 			"--kind <kind>",
@@ -330,7 +330,7 @@ export function registerSearchCommands({
 	program
 		.command("whois <query>")
 		.description("Identify likely people or orgs from local DMs and tweets")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--no-dms", "Do not search DMs")
 		.option("--tweets", "Include local tweet search evidence")
 		.option("--no-resolve-profiles", "Do not resolve placeholder profiles")

--- a/src/cli/register-sync.ts
+++ b/src/cli/register-sync.ts
@@ -26,7 +26,7 @@ export function registerSyncCommands({
 	syncCommand
 		.command("lists")
 		.description("Sync owned X Lists and rate-limited membership pages")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, bird, or xurl", "auto")
 		.option("--max-lists <n>", "Maximum owned Lists to inspect", "20")
 		.option("--member-limit <n>", "Members per transport page", "20")
@@ -62,7 +62,7 @@ export function registerSyncCommands({
 	syncCommand
 		.command("timeline")
 		.description("Refresh live home timeline through xurl or bird")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, xurl, or bird", "auto")
 		.option("--limit <n>", "Result limit", "100")
 		.option("--max-pages <n>", "Stop after N xurl pages", "3")
@@ -86,7 +86,7 @@ export function registerSyncCommands({
 	syncCommand
 		.command("mentions")
 		.description("Refresh live mentions through xurl or bird")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "auto, bird, or xurl", "auto")
 		.option("--limit <n>", "Result limit per page", "20")
 		.option("--max-pages <n>", "Stop after N pages")
@@ -129,7 +129,7 @@ export function registerSyncCommands({
 	syncCommand
 		.command("authored")
 		.description("Refresh authenticated authored tweets through xurl")
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "xurl", "xurl")
 		.option("--limit <n>", "X API page size", "100")
 		.option("--max-pages <n>", "Stop after N pages and resume later")
@@ -171,7 +171,7 @@ export function registerSyncCommands({
 		.description(
 			"Fetch tweet conversation context for recent mentions through bird or xurl",
 		)
-		.option("--account <accountId>", "Account id")
+		.option("--account <username>", "Account username or id")
 		.option("--mode <mode>", "bird or xurl", "bird")
 		.option("--limit <n>", "Recent mentions to inspect", "30")
 		.option("--delay-ms <n>", "Delay between thread fetches", "1500")
@@ -210,7 +210,7 @@ export function registerSyncCommands({
 		syncCommand
 			.command(kind)
 			.description(`Refresh live ${kind} through xurl or bird`)
-			.option("--account <accountId>", "Account id")
+			.option("--account <username>", "Account username or id")
 			.option("--mode <mode>", "auto, xurl, or bird", "auto")
 			.option("--limit <n>", "Per-page/result limit", "20")
 			.option("--all", "Fetch every retrievable page")
@@ -244,7 +244,7 @@ export function registerSyncCommands({
 			.description(
 				`Dry-run or refresh live ${direction} into the local follow graph`,
 			)
-			.option("--account <accountId>", "Account id")
+			.option("--account <username>", "Account username or id")
 			.option("--mode <mode>", "auto, bird, or xurl", "auto")
 			.option("--limit <n>", "X API users per page", "1000")
 			.option("--max-pages <n>", "Stop after N pages")

--- a/src/lib/account-selection.test.ts
+++ b/src/lib/account-selection.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetBirdclawPathsForTests } from "./config";
+import { getNativeDb, resetDatabaseForTests } from "./db";
+import {
+	findOperationAccount,
+	resolveOperationAccount,
+} from "./account-selection";
+
+describe("operation account selection", () => {
+	let homeDir = "";
+
+	beforeEach(() => {
+		homeDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-account-"));
+		process.env.BIRDCLAW_HOME = homeDir;
+		resetBirdclawPathsForTests();
+		resetDatabaseForTests();
+		const db = getNativeDb({ seedDemoData: false });
+		db.prepare(
+			`insert into accounts
+			 (id, name, handle, external_user_id, transport, is_default, created_at)
+			 values (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"acct_first",
+			"First",
+			"@first_user",
+			"100",
+			"archive",
+			0,
+			"2026-01-01T00:00:00.000Z",
+		);
+		db.prepare(
+			`insert into accounts
+			 (id, name, handle, external_user_id, transport, is_default, created_at)
+			 values (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"acct_default",
+			"Default",
+			"@Default_User",
+			"200",
+			"xurl",
+			1,
+			"2026-01-02T00:00:00.000Z",
+		);
+	});
+
+	afterEach(() => {
+		resetDatabaseForTests();
+		resetBirdclawPathsForTests();
+		delete process.env.BIRDCLAW_HOME;
+		rmSync(homeDir, { recursive: true, force: true });
+	});
+
+	it("accepts ids, usernames, and @usernames without changing storage", () => {
+		const db = getNativeDb({ seedDemoData: false });
+		expect(findOperationAccount(db, "acct_first")).toEqual({
+			id: "acct_first",
+			username: "first_user",
+			externalUserId: "100",
+		});
+		expect(findOperationAccount(db, "default_user")).toEqual({
+			id: "acct_default",
+			username: "Default_User",
+			externalUserId: "200",
+		});
+		expect(findOperationAccount(db, "@DEFAULT_USER")).toEqual({
+			id: "acct_default",
+			username: "Default_User",
+			externalUserId: "200",
+		});
+		expect(
+			db.prepare("select id, is_default from accounts order by id asc").all(),
+		).toEqual([
+			{ id: "acct_default", is_default: 1 },
+			{ id: "acct_first", is_default: 0 },
+		]);
+	});
+
+	it("uses the database default only when no selector is supplied", () => {
+		const db = getNativeDb({ seedDemoData: false });
+		expect(findOperationAccount(db)).toMatchObject({ id: "acct_default" });
+		expect(findOperationAccount(db, "@")).toBeUndefined();
+		expect(findOperationAccount(db, "   ")).toBeUndefined();
+		expect(() => resolveOperationAccount("@")).toThrow("Unknown account: @");
+		expect(() => resolveOperationAccount("missing")).toThrow(
+			"Unknown account: missing",
+		);
+	});
+});

--- a/src/lib/account-selection.ts
+++ b/src/lib/account-selection.ts
@@ -1,0 +1,66 @@
+import type { Database } from "./sqlite";
+import { getNativeDb } from "./db";
+
+export interface OperationAccount {
+	id: string;
+	username: string;
+	externalUserId?: string;
+}
+
+function normalizedAccountSelector(selector: string) {
+	return selector.trim().replace(/^@/, "");
+}
+
+export function findOperationAccount(
+	db: Database,
+	selector?: string,
+): OperationAccount | undefined {
+	const hasSelector = selector !== undefined;
+	const normalized = hasSelector
+		? normalizedAccountSelector(selector)
+		: undefined;
+	if (hasSelector && !normalized) return undefined;
+	const row = hasSelector
+		? (db
+				.prepare(
+					`select id, handle, external_user_id
+					 from accounts
+					 where id = ?
+					    or lower(replace(handle, '@', '')) = lower(?)
+					 order by case when id = ? then 0 else 1 end,
+					          is_default desc,
+					          created_at asc
+					 limit 1`,
+				)
+				.get(selector.trim(), normalized, selector.trim()) as
+				| { id: string; handle: string; external_user_id: string | null }
+				| undefined)
+		: (db
+				.prepare(
+					`select id, handle, external_user_id
+					 from accounts
+					 order by is_default desc, created_at asc
+					 limit 1`,
+				)
+				.get() as
+				| { id: string; handle: string; external_user_id: string | null }
+				| undefined);
+
+	return row
+		? {
+				id: row.id,
+				username: row.handle.replace(/^@/, ""),
+				...(row.external_user_id
+					? { externalUserId: row.external_user_id }
+					: {}),
+			}
+		: undefined;
+}
+
+export function resolveOperationAccount(selector?: string): OperationAccount {
+	const account = findOperationAccount(getNativeDb(), selector);
+	if (!account) {
+		throw new Error(`Unknown account: ${selector?.trim() || "default"}`);
+	}
+	return account;
+}

--- a/src/lib/actions-transport.test.ts
+++ b/src/lib/actions-transport.test.ts
@@ -16,7 +16,17 @@ const mocks = vi.hoisted(() => ({
 	muteUserViaXurl: vi.fn(),
 	unmuteUserViaXurl: vi.fn(),
 	lookupAuthenticatedUser: vi.fn(),
+	getAuthenticatedBirdAccount: vi.fn(),
 }));
+
+vi.mock("./bird", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
+	return {
+		getAuthenticatedBirdAccountEffect: fromMock(
+			mocks.getAuthenticatedBirdAccount,
+		),
+	};
+});
 
 vi.mock("./bird-actions", async () => {
 	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
@@ -63,7 +73,12 @@ describe("actions transport", () => {
 		mocks.muteUserViaXurl.mockReset();
 		mocks.unmuteUserViaXurl.mockReset();
 		mocks.lookupAuthenticatedUser.mockReset();
+		mocks.getAuthenticatedBirdAccount.mockReset();
 		mocks.lookupAuthenticatedUser.mockResolvedValue({ id: "1" });
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			id: "1",
+			username: "steipete",
+		});
 		mocks.blockUserViaBird.mockResolvedValue({
 			ok: true,
 			output: "bird block ok",
@@ -148,10 +163,14 @@ describe("actions transport", () => {
 		expect(mocks.blockUserViaXurl).not.toHaveBeenCalled();
 	});
 
-	it("does not require xurl account verification before bird actions", async () => {
+	it("verifies the selected bird account without consulting xurl", async () => {
 		mocks.lookupAuthenticatedUser.mockResolvedValue({
 			id: "2",
 			username: "other",
+		});
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			id: "25401953",
+			username: "steipete",
 		});
 		const { runModerationAction } = await import("./actions-transport");
 		const result = await runModerationAction({
@@ -171,6 +190,7 @@ describe("actions transport", () => {
 			transport: "bird",
 		});
 		expect(mocks.blockUserViaBird).toHaveBeenCalledWith("7");
+		expect(mocks.getAuthenticatedBirdAccount).toHaveBeenCalledTimes(1);
 		expect(mocks.lookupAuthenticatedUser).not.toHaveBeenCalled();
 		expect(mocks.blockUserViaXurl).not.toHaveBeenCalled();
 	});

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -5,9 +5,11 @@ import {
 	unblockUserViaBirdEffect,
 	unmuteUserViaBirdEffect,
 } from "./bird-actions";
+import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { type ActionsTransport, resolveActionsTransport } from "./config";
 import { Effect } from "effect";
 import { runEffectPromise } from "./effect-runtime";
+import { assertLiveAccountMatches } from "./live-sync-engine";
 import { profileHandleKey } from "./profile-row";
 import type {
 	ModerationAction,
@@ -98,8 +100,25 @@ function verifyExpectedAccountEffect(
 function runBirdActionEffect(
 	action: ModerationAction,
 	query: string,
+	expectedAccount?: ExpectedActionAccount,
 ): Effect.Effect<ActionTransportResult, unknown> {
 	return Effect.gen(function* () {
+		if (expectedAccount && !liveWritesDisabled()) {
+			const authenticated = yield* getAuthenticatedBirdAccountEffect();
+			yield* trySync(() =>
+				assertLiveAccountMatches({
+					source: "bird",
+					account: {
+						accountId: expectedAccount.id,
+						username: profileHandleKey(expectedAccount.handle),
+						externalUserId: expectedAccount.externalUserId ?? undefined,
+						isDefault: false,
+					},
+					liveUsername: authenticated.username,
+					liveExternalUserId: authenticated.id,
+				}),
+			);
+		}
 		const result = yield* action === "block"
 			? blockUserViaBirdEffect(query)
 			: action === "unblock"
@@ -227,7 +246,7 @@ export function runModerationActionEffect({
 			);
 
 		if (requestedTransport === "bird") {
-			return yield* runBirdActionEffect(action, query);
+			return yield* runBirdActionEffect(action, query, expectedAccount);
 		}
 		if (requestedTransport === "xurl") {
 			const accountCheck = yield* verifyXurlAccount();
@@ -242,7 +261,19 @@ export function runModerationActionEffect({
 			);
 		}
 
-		const birdResult = yield* runBirdActionEffect(action, query);
+		const birdResult = yield* runBirdActionEffect(
+			action,
+			query,
+			expectedAccount,
+		).pipe(
+			Effect.catchAll((error) =>
+				Effect.succeed({
+					ok: false as const,
+					output: error instanceof Error ? error.message : String(error),
+					transport: "bird" as const,
+				}),
+			),
+		);
 		if (birdResult.ok) {
 			return birdResult;
 		}

--- a/src/lib/blocks.test.ts
+++ b/src/lib/blocks.test.ts
@@ -18,7 +18,17 @@ const mocks = vi.hoisted(() => ({
 	lookupUsersByIds: vi.fn(),
 	unblockUserViaBird: vi.fn(),
 	unblockUserViaXurl: vi.fn(),
+	getAuthenticatedBirdAccount: vi.fn(),
 }));
+
+vi.mock("./bird", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
+	return {
+		getAuthenticatedBirdAccountEffect: fromMock(
+			mocks.getAuthenticatedBirdAccount,
+		),
+	};
+});
 
 vi.mock("./bird-actions", async () => {
 	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
@@ -68,6 +78,7 @@ afterEach(() => {
 	mocks.lookupUsersByIds.mockReset();
 	mocks.unblockUserViaBird.mockReset();
 	mocks.unblockUserViaXurl.mockReset();
+	mocks.getAuthenticatedBirdAccount.mockReset();
 
 	for (const tempRoot of tempRoots.splice(0)) {
 		rmSync(tempRoot, { recursive: true, force: true });
@@ -79,6 +90,10 @@ describe("blocklist", () => {
 		delete process.env.BIRDCLAW_DISABLE_LIVE_WRITES;
 		mocks.lookupProfileViaBird.mockResolvedValue(null);
 		mocks.lookupAuthenticatedUser.mockResolvedValue({
+			id: "25401953",
+			username: "steipete",
+		});
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
 			id: "25401953",
 			username: "steipete",
 		});

--- a/src/lib/bookmark-sync-job.test.ts
+++ b/src/lib/bookmark-sync-job.test.ts
@@ -207,6 +207,7 @@ describe("bookmark sync job", () => {
 		resetBirdclawPathsForTests();
 		const launchAgentsDir = makeTempDir("birdclaw-launchagents-");
 		const agent = buildBookmarkSyncLaunchAgentPlist({
+			account: "acct_work",
 			program: "/opt/homebrew/bin/birdclaw",
 			intervalSeconds: 10_800,
 			maxPages: 5,
@@ -215,6 +216,7 @@ describe("bookmark sync job", () => {
 		expect(agent.plist).toContain("<key>StartInterval</key>");
 		expect(agent.plist).toContain("<integer>10800</integer>");
 		expect(agent.programArguments).toContain("sync-bookmarks");
+		expect(agent.programArguments).toContain("acct_work");
 		expect(agent.programArguments).toContain("--all");
 		expect(agent.programArguments).toContain("--max-pages");
 		expect(agent.programArguments).toContain("5");

--- a/src/lib/bookmark-sync-job.ts
+++ b/src/lib/bookmark-sync-job.ts
@@ -79,6 +79,7 @@ export interface BookmarkSyncAuditEntry {
 }
 
 export interface BookmarkSyncLaunchAgentOptions {
+	account?: string;
 	label?: string;
 	intervalSeconds?: number;
 	program?: string;
@@ -251,6 +252,7 @@ export function runBookmarkSyncJob(
 
 function buildProgramArguments({
 	program = "birdclaw",
+	account,
 	mode = "auto",
 	limit = DEFAULT_BOOKMARK_SYNC_LIMIT,
 	all = false,
@@ -271,6 +273,9 @@ function buildProgramArguments({
 		"--log",
 		resolveUserPath(logPath ?? getDefaultBookmarkSyncAuditLogPath()),
 	];
+	if (account) {
+		args.push("--account", account);
+	}
 	if (all || maxPages !== undefined) {
 		args.push("--all");
 	}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -8,6 +8,7 @@ import {
 	getBirdCommand,
 	getBirdclawConfig,
 	getBirdclawPaths,
+	getDefaultAccountSelector,
 	resetBirdclawPathsForTests,
 	resolveActionsTransport,
 	resolveMentionsDataSource,
@@ -62,6 +63,9 @@ describe("config", () => {
 		writeFileSync(
 			path.join(tempRoot, "config.json"),
 			JSON.stringify({
+				accounts: {
+					default: "  @steipete  ",
+				},
 				actions: {
 					transport: "xurl",
 				},
@@ -73,6 +77,9 @@ describe("config", () => {
 		);
 
 		expect(getBirdclawConfig()).toEqual({
+			accounts: {
+				default: "  @steipete  ",
+			},
 			actions: {
 				transport: "xurl",
 			},
@@ -81,6 +88,7 @@ describe("config", () => {
 				birdCommand: "/tmp/custom-bird",
 			},
 		});
+		expect(getDefaultAccountSelector()).toBe("@steipete");
 		expect(resolveMentionsDataSource()).toBe("bird");
 		expect(resolveActionsTransport()).toBe("xurl");
 		expect(getBirdCommand()).toBe("/tmp/custom-bird");

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,6 +21,9 @@ export type MentionsDataSource = "birdclaw" | "auto" | "xurl" | "bird";
 export type ActionsTransport = "auto" | "bird" | "xurl";
 
 export interface BirdclawConfig {
+	accounts?: {
+		default?: string;
+	};
 	mentions?: {
 		dataSource?: MentionsDataSource;
 		birdCommand?: string;
@@ -34,6 +37,11 @@ export interface BirdclawConfig {
 		autoSync?: boolean;
 		staleAfterSeconds?: number;
 	};
+}
+
+export function getDefaultAccountSelector() {
+	const selector = getBirdclawConfig().accounts?.default?.trim();
+	return selector || undefined;
 }
 
 let cachedPaths: BirdclawPaths | undefined;

--- a/src/lib/live-sync-engine.test.ts
+++ b/src/lib/live-sync-engine.test.ts
@@ -52,6 +52,12 @@ describe("live sync engine", () => {
 			externalUserId: "222",
 			isDefault: false,
 		});
+		expect(resolveLiveSyncAccount(db, "@SECONDARY")).toEqual({
+			accountId: "secondary",
+			username: "secondary",
+			externalUserId: "222",
+			isDefault: false,
+		});
 	});
 
 	it("normalizes adapter errors and rejects account mismatches", async () => {

--- a/src/lib/live-sync-engine.ts
+++ b/src/lib/live-sync-engine.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { findOperationAccount } from "./account-selection";
 import { databaseWriteEffect } from "./database-writer";
 import { toError } from "./effect-runtime";
 import type { Database } from "./sqlite";
@@ -40,12 +41,13 @@ export function resolveLiveSyncAccount(
 	db: Database,
 	accountId?: string,
 ): LiveSyncAccount {
-	const row = accountId
+	const selected = findOperationAccount(db, accountId);
+	const row = selected
 		? (db
 				.prepare(
 					"select id, handle, external_user_id, is_default from accounts where id = ?",
 				)
-				.get(accountId) as
+				.get(selected.id) as
 				| {
 						id: string;
 						handle: string;
@@ -53,23 +55,7 @@ export function resolveLiveSyncAccount(
 						is_default: number;
 				  }
 				| undefined)
-		: (db
-				.prepare(
-					`
-          select id, handle, external_user_id, is_default
-          from accounts
-          order by is_default desc, created_at asc
-          limit 1
-          `,
-				)
-				.get() as
-				| {
-						id: string;
-						handle: string;
-						external_user_id: string | null;
-						is_default: number;
-				  }
-				| undefined);
+		: undefined;
 
 	if (!row) {
 		throw new Error(`Unknown account: ${accountId ?? "default"}`);

--- a/src/lib/mutes.test.ts
+++ b/src/lib/mutes.test.ts
@@ -17,7 +17,17 @@ const mocks = vi.hoisted(() => ({
 	muteUserViaXurl: vi.fn(),
 	unmuteUserViaBird: vi.fn(),
 	unmuteUserViaXurl: vi.fn(),
+	getAuthenticatedBirdAccount: vi.fn(),
 }));
+
+vi.mock("./bird", async () => {
+	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
+	return {
+		getAuthenticatedBirdAccountEffect: fromMock(
+			mocks.getAuthenticatedBirdAccount,
+		),
+	};
+});
 
 vi.mock("./bird-actions", async () => {
 	const { effectFromMock: fromMock } = await import("../test/effect-mocks");
@@ -61,7 +71,12 @@ describe("mutes", () => {
 		mocks.muteUserViaXurl.mockReset();
 		mocks.unmuteUserViaBird.mockReset();
 		mocks.unmuteUserViaXurl.mockReset();
+		mocks.getAuthenticatedBirdAccount.mockReset();
 		mocks.lookupAuthenticatedUser.mockResolvedValue({
+			id: "25401953",
+			username: "steipete",
+		});
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
 			id: "25401953",
 			username: "steipete",
 		});

--- a/src/lib/profile-hydration.test.ts
+++ b/src/lib/profile-hydration.test.ts
@@ -19,6 +19,12 @@ vi.mock("./xurl", async () => {
 	return {
 		getTransportStatusEffect: fromMock(mocks.getTransportStatus),
 		lookupAuthenticatedUserEffect: fromMock(mocks.lookupAuthenticatedUser),
+		lookupAuthenticatedUserUnscopedEffect: fromMock(
+			mocks.lookupAuthenticatedUser,
+		),
+		lookupAuthenticatedOAuth2UserEffect: fromMock(
+			mocks.lookupAuthenticatedUser,
+		),
 		lookupUsersByIdsEffect: fromMock(mocks.lookupUsersByIds),
 	};
 });
@@ -129,7 +135,7 @@ describe("profile hydration", () => {
 		});
 
 		const { hydrateProfilesFromX } = await import("./profile-hydration");
-		const result = await hydrateProfilesFromX();
+		const result = await hydrateProfilesFromX({ account: "steipete" });
 		const hydrated = db
 			.prepare(
 				"select handle, display_name, bio, followers_count, following_count, avatar_url from profiles where id = 'profile_user_42'",
@@ -161,6 +167,66 @@ describe("profile hydration", () => {
 			avatar_url: "https://pbs.twimg.com/profile_images/42/avatar.jpg",
 		});
 		expect(title.title).toBe("Sam Altman");
+		expect(mocks.lookupAuthenticatedUser).toHaveBeenCalledWith("steipete");
+		expect(mocks.lookupUsersByIds).toHaveBeenCalledWith(["42"], {
+			username: "steipete",
+		});
+	});
+
+	it("verifies a selected credential before bulk profile writes", async () => {
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedUser.mockResolvedValue({
+			id: "999",
+			username: "different_user",
+		});
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+
+		await expect(hydrateProfilesFromX({ account: "steipete" })).rejects.toThrow(
+			"refusing to sync",
+		);
+		expect(mocks.lookupUsersByIds).not.toHaveBeenCalled();
+	});
+
+	it("does not overwrite the primary profile for a selected secondary account", async () => {
+		const db = getNativeDb();
+		db.prepare(
+			`insert into accounts
+			 (id, name, handle, external_user_id, transport, is_default, created_at)
+			 values ('acct_secondary', 'Secondary', '@secondary', '999', 'xurl', 0, '2026-01-01T00:00:00.000Z')`,
+		).run();
+		const before = db
+			.prepare(
+				"select handle, display_name, avatar_url from profiles where id = 'profile_me'",
+			)
+			.get();
+		mocks.getTransportStatus.mockResolvedValue({
+			availableTransport: "xurl",
+			installed: true,
+			statusText: "xurl available",
+		});
+		mocks.lookupAuthenticatedUser.mockResolvedValue({
+			id: "999",
+			username: "secondary",
+			name: "Secondary Updated",
+			public_metrics: { followers_count: 10 },
+		});
+		mocks.lookupUsersByIds.mockResolvedValue([]);
+		const { hydrateProfilesFromX } = await import("./profile-hydration");
+
+		await expect(
+			hydrateProfilesFromX({ account: "acct_secondary" }),
+		).resolves.toMatchObject({ hydratedAccount: true });
+		expect(
+			db
+				.prepare(
+					"select handle, display_name, avatar_url from profiles where id = 'profile_me'",
+				)
+				.get(),
+		).toEqual(before);
 	});
 
 	it("skips non-numeric archive placeholder ids before calling X", async () => {

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -5,8 +5,13 @@ import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import {
+	assertLiveAccountMatches,
+	resolveLiveSyncAccount,
+} from "./live-sync-engine";
+import {
 	getTransportStatusEffect,
-	lookupAuthenticatedUserEffect,
+	lookupAuthenticatedOAuth2UserEffect,
+	lookupAuthenticatedUserUnscopedEffect,
 	lookupUsersByIdsEffect,
 } from "./xurl";
 import { upsertProfileFromXUser } from "./x-profile";
@@ -43,7 +48,9 @@ function trySync<T>(try_: () => T) {
 const SEEDED_ACCOUNT_HANDLE = "steipete";
 const SEEDED_ACCOUNT_EXTERNAL_USER_ID = "25401953";
 
-function hydrateAccountFromBirdEffect(): Effect.Effect<boolean, unknown> {
+function hydrateAccountFromBirdEffect(
+	selector?: string,
+): Effect.Effect<boolean, unknown> {
 	return Effect.gen(function* () {
 		const account = yield* getAuthenticatedBirdAccountEffect().pipe(
 			Effect.catchAll(() => Effect.succeed(null)),
@@ -53,6 +60,33 @@ function hydrateAccountFromBirdEffect(): Effect.Effect<boolean, unknown> {
 		const handle = account.username.replace(/^@/, "");
 		const name = account.name?.trim() || null;
 		const externalUserId = account.id ?? null;
+		if (selector) {
+			return yield* trySync(() => {
+				const db = getNativeDb();
+				const selected = resolveLiveSyncAccount(db, selector);
+				assertLiveAccountMatches({
+					source: "bird",
+					account: selected,
+					liveUsername: handle,
+					liveExternalUserId: externalUserId ?? undefined,
+				});
+				return db.transaction(() => {
+					db.prepare(
+						`update accounts
+						 set name = coalesce(?, name),
+						     transport = 'bird',
+						     external_user_id = coalesce(?, external_user_id)
+						 where id = ?`,
+					).run(name, externalUserId, selected.accountId);
+					db.prepare(
+						`update profiles
+						 set display_name = coalesce(?, display_name)
+						 where lower(handle) = lower(?)`,
+					).run(name, selected.username);
+					return true;
+				})();
+			});
+		}
 		const hydrated = yield* trySync(() => {
 			const db = getNativeDb();
 			return db.transaction(() => {
@@ -131,17 +165,16 @@ function hydrateAccountFromBirdEffect(): Effect.Effect<boolean, unknown> {
 	});
 }
 
-export function hydrateProfilesFromXEffect(): Effect.Effect<
-	HydrateProfilesResult,
-	unknown
-> {
+export function hydrateProfilesFromXEffect({
+	account,
+}: { account?: string } = {}): Effect.Effect<HydrateProfilesResult, unknown> {
 	return Effect.gen(function* () {
 		const transport = yield* getTransportStatusEffect();
 		if (transport.availableTransport !== "xurl") {
 			// xurl is unavailable, so the live profile backfill can't run. When the
 			// bird transport is authenticated we can still correct the seeded
 			// account handle (e.g. the placeholder @steipete) from `bird whoami`.
-			const hydratedAccount = yield* hydrateAccountFromBirdEffect();
+			const hydratedAccount = yield* hydrateAccountFromBirdEffect(account);
 			return {
 				ok: true,
 				hydratedProfiles: 0,
@@ -153,11 +186,15 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 		const {
 			candidateIds,
 			db,
+			selectedAccount,
 			updateAccount,
 			updateConversationTitle,
 			updateLocalProfile,
 		} = yield* trySync(() => {
 			const db = getNativeDb();
+			const selectedAccount = account
+				? resolveLiveSyncAccount(db, account)
+				: undefined;
 			const candidateRows = db
 				.prepare(
 					`
@@ -188,30 +225,52 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
         following_count = coalesce(?, following_count),
         avatar_url = coalesce(?, avatar_url),
         created_at = coalesce(?, created_at)
-    where id = 'profile_me'
+    where id = ?
   `);
 			const updateAccount = db.prepare(`
     update accounts
     set name = ?,
         handle = ?,
-        transport = 'xurl'
-    where id = 'acct_primary'
+		transport = 'xurl',
+		external_user_id = coalesce(?, external_user_id)
+	where id = ?
   `);
 
 			return {
 				candidateIds,
 				db,
+				selectedAccount,
 				updateAccount,
 				updateConversationTitle,
 				updateLocalProfile,
 			};
 		});
+		const selectedAuthenticatedUser = selectedAccount
+			? yield* lookupAuthenticatedOAuth2UserEffect(selectedAccount.username)
+			: undefined;
+		if (selectedAccount) {
+			yield* trySync(() =>
+				assertLiveAccountMatches({
+					source: "xurl",
+					account: selectedAccount,
+					liveUsername: String(selectedAuthenticatedUser?.username ?? ""),
+					liveExternalUserId:
+						typeof selectedAuthenticatedUser?.id === "string"
+							? selectedAuthenticatedUser.id
+							: undefined,
+				}),
+			);
+		}
 
 		let hydratedProfiles = 0;
 
 		for (let index = 0; index < candidateIds.length; index += 100) {
 			const batch = candidateIds.slice(index, index + 100);
-			const users = yield* lookupUsersByIdsEffect(batch);
+			const users = yield* selectedAccount
+				? lookupUsersByIdsEffect(batch, {
+						username: selectedAccount.username,
+					})
+				: lookupUsersByIdsEffect(batch);
 
 			yield* trySync(() => {
 				db.transaction(() => {
@@ -231,27 +290,45 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 		}
 
 		let hydratedAccount = false;
-		const me = yield* lookupAuthenticatedUserEffect().pipe(
-			Effect.catchAll(() => Effect.succeed(null)),
-		);
+		const me = selectedAccount
+			? selectedAuthenticatedUser
+			: yield* lookupAuthenticatedUserUnscopedEffect().pipe(
+					Effect.catchAll(() => Effect.succeed(null)),
+				);
 		if (me) {
 			const metrics = asRecord(me.public_metrics);
 			yield* trySync(() => {
 				db.transaction(() => {
-					updateLocalProfile.run(
-						String(me.username ?? "steipete").replace(/^@/, ""),
-						String(me.name ?? "Peter Steinberger"),
-						String(me.description ?? ""),
-						toInt(metrics?.followers_count),
-						metrics && "following_count" in metrics
-							? toInt(metrics.following_count)
-							: null,
-						normalizeAvatarUrl(me.profile_image_url),
-						typeof me.created_at === "string" ? me.created_at : null,
-					);
+					const accountId = selectedAccount?.accountId ?? "acct_primary";
+					const localProfile = db
+						.prepare(
+							"select id from profiles where lower(handle) = lower(?) limit 1",
+						)
+						.get(selectedAccount?.username ?? "steipete") as
+						| { id: string }
+						| undefined;
+					const localProfileId = selectedAccount
+						? localProfile?.id
+						: "profile_me";
+					if (localProfileId) {
+						updateLocalProfile.run(
+							String(me.username ?? "steipete").replace(/^@/, ""),
+							String(me.name ?? "Peter Steinberger"),
+							String(me.description ?? ""),
+							toInt(metrics?.followers_count),
+							metrics && "following_count" in metrics
+								? toInt(metrics.following_count)
+								: null,
+							normalizeAvatarUrl(me.profile_image_url),
+							typeof me.created_at === "string" ? me.created_at : null,
+							localProfileId,
+						);
+					}
 					updateAccount.run(
 						String(me.name ?? "Peter Steinberger"),
 						`@${String(me.username ?? "steipete").replace(/^@/, "")}`,
+						typeof me.id === "string" ? me.id : null,
+						accountId,
 					);
 				})();
 			});
@@ -266,8 +343,10 @@ export function hydrateProfilesFromXEffect(): Effect.Effect<
 	});
 }
 
-export function hydrateProfilesFromX(): Promise<HydrateProfilesResult> {
-	return runEffectPromise(hydrateProfilesFromXEffect());
+export function hydrateProfilesFromX(
+	options: { account?: string } = {},
+): Promise<HydrateProfilesResult> {
+	return runEffectPromise(hydrateProfilesFromXEffect(options));
 }
 
 export const __test__ = {

--- a/src/lib/profile-replies.test.ts
+++ b/src/lib/profile-replies.test.ts
@@ -3,7 +3,13 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveProfileMock = vi.fn();
+const resolveOperationAccountMock = vi.fn();
 const listUserTweetsMock = vi.fn();
+
+vi.mock("./account-selection", () => ({
+	resolveOperationAccount: (...args: unknown[]) =>
+		resolveOperationAccountMock(...args),
+}));
 
 vi.mock("./moderation-target", () => ({
 	resolveProfile: (...args: unknown[]) => resolveProfileMock(...args),
@@ -17,7 +23,12 @@ describe("profile reply inspection", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		resolveProfileMock.mockReset();
+		resolveOperationAccountMock.mockReset();
 		listUserTweetsMock.mockReset();
+		resolveOperationAccountMock.mockReturnValue({
+			id: "acct_primary",
+			username: "selected_user",
+		});
 	});
 
 	it("builds profile reply inspection effects lazily", async () => {
@@ -171,6 +182,35 @@ describe("profile reply inspection", () => {
 		expect(listUserTweetsMock).toHaveBeenCalledWith("42", {
 			maxResults: 20,
 			excludeRetweets: true,
+		});
+	});
+
+	it("routes live reply inspection through the selected username", async () => {
+		resolveProfileMock.mockResolvedValue({
+			profile: {
+				id: "profile_user_42",
+				handle: "jpctan",
+				displayName: "Jason Tan",
+				bio: "",
+				followersCount: 268,
+				avatarHue: 18,
+				createdAt: "2015-05-20T09:27:37.000Z",
+			},
+			externalUserId: "42",
+		});
+		listUserTweetsMock.mockResolvedValue({ items: [] });
+		const { inspectProfileReplies } = await import("./profile-replies");
+
+		await inspectProfileReplies("@jpctan", {
+			account: "acct_primary",
+			limit: 2,
+		});
+
+		expect(resolveOperationAccountMock).toHaveBeenCalledWith("acct_primary");
+		expect(listUserTweetsMock).toHaveBeenCalledWith("42", {
+			maxResults: 20,
+			excludeRetweets: true,
+			username: "selected_user",
 		});
 	});
 

--- a/src/lib/profile-replies.ts
+++ b/src/lib/profile-replies.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 
+import { resolveOperationAccount } from "./account-selection";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { resolveProfile } from "./moderation-target";
 import type { ProfileRepliesResponse, XurlReferencedTweet } from "./types";
@@ -15,16 +16,24 @@ function getScanSize(limit: number) {
 
 export function inspectProfileReplies(
 	query: string,
-	{ limit = 12 }: { limit?: number } = {},
+	{ account, limit = 12 }: { account?: string; limit?: number } = {},
 ): Promise<ProfileRepliesResponse> {
-	return runEffectPromise(inspectProfileRepliesEffect(query, { limit }));
+	return runEffectPromise(
+		inspectProfileRepliesEffect(query, { account, limit }),
+	);
 }
 
 export function inspectProfileRepliesEffect(
 	query: string,
-	{ limit = 12 }: { limit?: number } = {},
+	{ account, limit = 12 }: { account?: string; limit?: number } = {},
 ): Effect.Effect<ProfileRepliesResponse, unknown> {
 	return Effect.gen(function* () {
+		const operationAccount = account
+			? yield* Effect.try({
+					try: () => resolveOperationAccount(account),
+					catch: (error) => error,
+				})
+			: undefined;
 		const resolved = yield* tryPromise(() => resolveProfile(query));
 		const externalUserId = resolved.externalUserId;
 		if (!externalUserId) {
@@ -37,6 +46,7 @@ export function inspectProfileRepliesEffect(
 			listUserTweets(externalUserId, {
 				maxResults: getScanSize(limit),
 				excludeRetweets: true,
+				...(operationAccount ? { username: operationAccount.username } : {}),
 			}),
 		);
 		const items = timeline.items

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -2349,4 +2349,13 @@ describe("birdclaw queries", () => {
 			"Conversation not found",
 		);
 	});
+
+	it("rejects dm replies selected for a different account", async () => {
+		setupTempHome();
+
+		await expect(
+			createDmReply("dm_003", "wrong account", "acct_other"),
+		).rejects.toThrow("Conversation belongs to acct_primary, not acct_other");
+		expect(mocks.dmViaXurl).not.toHaveBeenCalled();
+	});
 });

--- a/src/lib/query-actions.ts
+++ b/src/lib/query-actions.ts
@@ -300,12 +300,21 @@ export function createTweetReply(
 	return runEffectPromise(createTweetReplyEffect(accountId, tweetId, text));
 }
 
-export function createDmReplyEffect(conversationId: string, text: string) {
+export function createDmReplyEffect(
+	conversationId: string,
+	text: string,
+	accountId?: string,
+) {
 	return Effect.gen(function* () {
 		const draft = yield* trySync(() => {
 			const conversation = getConversationThread(conversationId);
 			if (!conversation) {
 				throw new Error("Conversation not found");
+			}
+			if (accountId && conversation.conversation.accountId !== accountId) {
+				throw new Error(
+					`Conversation belongs to ${conversation.conversation.accountId}, not ${accountId}`,
+				);
 			}
 			const authorProfileId = getLocalAuthorProfileId(
 				conversation.conversation.accountId,
@@ -390,8 +399,12 @@ export function createDmReplyEffect(conversationId: string, text: string) {
 	});
 }
 
-export function createDmReply(conversationId: string, text: string) {
-	return runEffectPromise(createDmReplyEffect(conversationId, text));
+export function createDmReply(
+	conversationId: string,
+	text: string,
+	accountId?: string,
+) {
+	return runEffectPromise(createDmReplyEffect(conversationId, text, accountId));
 }
 
 export type DmRequestMutationAction = "accept" | "reject" | "block";

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -199,6 +199,19 @@ describe("xurl transport wrapper", () => {
 		});
 	});
 
+	it("keeps the unscoped authenticated lookup independent of ambient selection", async () => {
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME = "secondary";
+		execFileAsyncMock.mockResolvedValueOnce({
+			stdout: JSON.stringify({ data: { id: "1", username: "primary" } }),
+			stderr: "",
+		});
+		const { lookupAuthenticatedUserUnscopedEffect } = await import("./xurl");
+
+		await Effect.runPromise(lookupAuthenticatedUserUnscopedEffect());
+
+		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", ["whoami"]);
+	});
+
 	it("exposes xurl lookup helpers as lazy Effect programs", async () => {
 		execFileAsyncMock
 			.mockResolvedValueOnce({
@@ -1673,6 +1686,52 @@ describe("xurl transport wrapper", () => {
 			"hello",
 		]);
 		expect(result).toEqual({ ok: true, output: "sent" });
+	});
+
+	it("routes reads and writes through the configured operation account", async () => {
+		process.env.BIRDCLAW_XURL_OAUTH2_APP = "personal";
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME = "selected_user";
+		execFileAsyncMock
+			.mockResolvedValueOnce({ stdout: '{"data":{"id":"1"}}', stderr: "" })
+			.mockResolvedValueOnce({ stdout: "posted", stderr: "" })
+			.mockResolvedValueOnce({ stdout: "blocked", stderr: "" });
+		const { blockUserViaXurl, lookupAuthenticatedUserFresh, postViaXurl } =
+			await import("./xurl");
+
+		await lookupAuthenticatedUserFresh();
+		await postViaXurl("ship");
+		await blockUserViaXurl("1", "2");
+
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, "xurl", [
+			"--app",
+			"personal",
+			"--auth",
+			"oauth2",
+			"--username",
+			"selected_user",
+			"whoami",
+		]);
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, "xurl", [
+			"--app",
+			"personal",
+			"--username",
+			"selected_user",
+			"post",
+			"ship",
+		]);
+		expect(execFileAsyncMock).toHaveBeenNthCalledWith(3, "xurl", [
+			"--app",
+			"personal",
+			"--auth",
+			"oauth2",
+			"--username",
+			"selected_user",
+			"-X",
+			"POST",
+			"/2/users/1/blocking",
+			"-d",
+			'{"target_user_id":"2"}',
+		]);
 	});
 
 	it("passes through existing @ handles and reports shortcut failures", async () => {

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -62,7 +62,7 @@ const cachedTransportStatus = Effect.runSync(
 );
 const [cachedAuthenticatedUser, invalidateAuthenticatedUser] = Effect.runSync(
 	Effect.cachedInvalidateWithTTL(
-		Effect.suspend(() => lookupAuthenticatedUserFreshEffect()),
+		Effect.suspend(() => lookupAuthenticatedUserUnscopedFreshEffect()),
 		Duration.millis(AUTHENTICATED_USER_TTL_MS),
 	),
 );
@@ -278,7 +278,10 @@ const runShortcutEffect = Effect.fn("xurl.runShortcut")(function* (
 		return { ok: false, output: "live writes disabled" };
 	}
 
-	return yield* runSubprocessEffect({ command: "xurl", args }).pipe(
+	return yield* runSubprocessEffect({
+		command: "xurl",
+		args: [...configuredAccountGlobalArgs(), ...args],
+	}).pipe(
 		Effect.map(({ stdout, stderr }) => ({
 			ok: true,
 			output: stdout || stderr,
@@ -528,6 +531,14 @@ function configuredOAuth2Candidate(primaryUsername: string | undefined) {
 	};
 }
 
+function configuredAccountGlobalArgs() {
+	const candidate = configuredOAuth2Candidate(undefined);
+	return [
+		...(candidate?.app ? ["--app", candidate.app] : []),
+		...(candidate?.username ? ["--username", candidate.username] : []),
+	];
+}
+
 const runOAuth2JsonCommandEffect = Effect.fn("xurl.runOAuth2JsonCommand")(
 	function* ({
 		args,
@@ -659,7 +670,14 @@ const runMutationCommandEffect = Effect.fn("xurl.runMutationCommand")(
 			return { ok: false, output: "live writes disabled" };
 		}
 
-		return yield* runSubprocessEffect({ command: "xurl", args }).pipe(
+		const candidate = configuredOAuth2Candidate(undefined);
+		const commandArgs = candidate
+			? oauth2ArgsForCandidate(candidate, args)
+			: args;
+		return yield* runSubprocessEffect({
+			command: "xurl",
+			args: commandArgs,
+		}).pipe(
 			Effect.map(({ stdout, stderr }) => ({
 				ok: true,
 				output: stdout || stderr || "ok",
@@ -676,6 +694,7 @@ const runMutationCommandEffect = Effect.fn("xurl.runMutationCommand")(
 
 export const lookupUsersByIdsEffect = Effect.fn("xurl.lookupUsersByIds")((
 	ids: string[],
+	options: { username?: string } = {},
 ): Effect.Effect<XurlMentionUser[], XurlCommandError> => {
 	if (ids.length === 0) {
 		return Effect.succeed([]);
@@ -686,15 +705,22 @@ export const lookupUsersByIdsEffect = Effect.fn("xurl.lookupUsersByIds")((
 		"user.fields":
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
 	});
-	return runJsonCommandEffect([`/2/users?${query.toString()}`]).pipe(
+	const args = [`/2/users?${query.toString()}`];
+	const command = options.username
+		? runOAuth2JsonCommandEffect({ args, username: options.username })
+		: runJsonCommandEffect(args);
+	return command.pipe(
 		Effect.map((payload) =>
 			Array.isArray(payload.data) ? (payload.data as XurlMentionUser[]) : [],
 		),
 	);
 });
 
-export function lookupUsersByIds(ids: string[]) {
-	return runEffectPromise(lookupUsersByIdsEffect(ids));
+export function lookupUsersByIds(
+	ids: string[],
+	options: { username?: string } = {},
+) {
+	return runEffectPromise(lookupUsersByIdsEffect(ids, options));
 }
 
 function normalizeXListPage(payload: Record<string, unknown>): XListPage {
@@ -876,13 +902,23 @@ function authenticatedUserFromPayload(payload: Record<string, unknown>) {
 		: null;
 }
 
+function lookupAuthenticatedUserUnscopedFreshEffect() {
+	return runJsonCommandEffect(["whoami"]).pipe(
+		Effect.map(authenticatedUserFromPayload),
+	);
+}
+
 export const lookupAuthenticatedUserFreshEffect = Effect.fn(
 	"xurl.lookupAuthenticatedUserFresh",
-)(() =>
-	runJsonCommandEffect(["whoami"]).pipe(
+)(() => {
+	const username = cleanXurlUsernameLabel(
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME,
+	);
+	if (!username) return lookupAuthenticatedUserUnscopedFreshEffect();
+	return runOAuth2JsonCommandEffect({ args: ["whoami"], username }).pipe(
 		Effect.map(authenticatedUserFromPayload),
-	),
-);
+	);
+});
 
 export const lookupAuthenticatedOAuth2UserEffect = Effect.fn(
 	"xurl.lookupAuthenticatedOAuth2User",
@@ -893,11 +929,19 @@ export const lookupAuthenticatedOAuth2UserEffect = Effect.fn(
 	}).pipe(Effect.map(authenticatedUserFromPayload)),
 );
 
-export function lookupAuthenticatedUserEffect() {
+export function lookupAuthenticatedUserUnscopedEffect() {
 	// Failures are not cached: invalidate so the next caller retries fresh.
 	return cachedAuthenticatedUser.pipe(
 		Effect.tapError(() => invalidateAuthenticatedUser),
 	);
+}
+
+export function lookupAuthenticatedUserEffect() {
+	const username = cleanXurlUsernameLabel(
+		process.env.BIRDCLAW_XURL_OAUTH2_USERNAME,
+	);
+	if (username) return lookupAuthenticatedOAuth2UserEffect(username);
+	return lookupAuthenticatedUserUnscopedEffect();
 }
 
 export function lookupAuthenticatedUser() {


### PR DESCRIPTION
## Summary

- add explicit `--account <username>` routing to every command that touches authentication
- add `accounts.default` as a reversible config-file default; an explicit flag always wins
- resolve accounts without persisting or changing database identity, and verify selected identities before mutations
- preserve the existing unselected OAuth1/default-account path

This implements the account-selection value proposed by @ivankuznetsov in #97, while keeping `init` offline and local-only.

## Proof

- `pnpm install --frozen-lockfile` — lockfile current
- `pnpm check` — formatting, lint, and typecheck passed
- `pnpm coverage` — 1,293 tests passed; 90.68% line coverage
- `pnpm build` — client, SSR, and CLI builds passed
- `pnpm docs:site` — documentation site built
- `pnpm pack:smoke` — packed CLI smoke passed (126 files)
- `pnpm e2e` — 12 Chromium tests passed
- `pnpm audit --audit-level high` — no known vulnerabilities
- AutoReview branch mode against `origin/main` — clean

## Packaged CLI proof

Under Node 26.5.0, the packed tarball was installed into a clean temporary prefix. Both `search tweets --account @steipete --limit 1` and config-only `accounts.default: steipete` selected the expected stored account. A read-only SQLite check confirmed the database default and identity were unchanged.

The available local xurl installation has no registered apps (`xurl auth status`), so a non-interactive live API request could not be completed. The packaged CLI did route `sync timeline --account steipete --mode xurl` to exact named OAuth2 (`--username steipete`) before xurl stopped at its missing local authentication setup. No successful external API call is claimed.
