### PR TITLE
feat: add explicit offline demo initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.10.1 - Unreleased
 
+### Added
+
+- Add explicit `init --demo` sample data for zero-auth offline exploration while keeping normal initialization empty.
+
 ## 0.10.0 - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ birdclaw auth status --json
 birdclaw db stats --json
 ```
 
+Want to explore before importing an archive or signing in? `birdclaw init --demo` fills the local database with sample tweets, DMs, profiles, and links. It makes no network requests; run `birdclaw serve` afterward to browse the demo.
+
 `auth status` reports Birdclaw's coarse xurl status. Verify xurl with `xurl whoami`. If you already have a private bird installation, verify it with `bird whoami`. For setup and transport selection, see [Sign in](docs/auth.md).
 
 Find and import an archive:
@@ -234,7 +236,7 @@ birdclaw import archive --json
 birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 ```
 
-Don't have an archive yet? Request it from <https://x.com/settings/download_your_data>; X emails a download link when it is ready, which may take a few days. A fresh Birdclaw database needs the archive import to establish account identity before live sync. See [Archive Import → Get an archive](docs/archive.md#get-an-archive).
+Don't have an archive yet? Request it from <https://x.com/settings/download_your_data>; X emails a download link when it is ready, which may take a few days. A fresh or demo Birdclaw database needs the archive import to establish real account identity before live sync. See [Archive Import → Get an archive](docs/archive.md#get-an-archive).
 
 Optional profile hydration through xurl can improve bios, follower counts, and avatars, but it performs live X profile reads and can spend API credits on large archives. With an existing private bird installation, the command can instead correct the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -13,7 +13,7 @@ By default, archive import is a full archive replay. It refreshes archive-owned 
 
 ## Get an archive
 
-On a fresh Birdclaw database, archive import establishes the account identity required by live sync. Do not sync a newly initialized demo database before importing your archive. An archive is optional only when restoring an existing Birdclaw database or backup that already contains the correct account.
+On a fresh Birdclaw database, archive import establishes the account identity required by live sync. Do not sync an empty database or the synthetic `init --demo` workspace before importing your archive. An archive is optional only when restoring an existing Birdclaw database or backup that already contains the correct account.
 
 Request flow:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -12,7 +12,7 @@ birdclaw keeps its database local. Archive import needs no X credentials. Live r
 
 Install xurl for a new live-transport setup. Transport selection is workflow-specific: sync commands expose `--mode`, while `auth use` only controls moderation writes such as block, unblock, mute, and unmute.
 
-On a fresh Birdclaw database, import your X archive before the first live sync. Archive import replaces the bundled demo identity with your account identity. The current auth commands verify transports but do not bind a new database to the authenticated X account.
+On a fresh Birdclaw database, import your X archive before the first live sync. Archive import establishes your real account identity; `init --demo` creates only synthetic sample data. The current auth commands verify transports but do not bind a new database to the authenticated X account.
 
 ## Set up xurl
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,7 @@ User config:
 ## Command tree
 
 ```text
-birdclaw init
+birdclaw init [--demo]
 birdclaw auth status
 birdclaw auth use <transport>
 birdclaw import archive [path]
@@ -130,9 +130,10 @@ birdclaw debug transport
 ### `init`
 
 - create app dir
-- create DB
+- create an empty DB
 - write default config if absent
-- optionally detect `xurl` and `bird`
+- `--demo` seeds sample tweets, DMs, profiles, and links without authentication or network access
+- print useful next commands for the selected setup path
 
 ### `import tweet <tweet-id-or-url...>`
 
@@ -861,6 +862,7 @@ stderr:
 
 ```bash
 birdclaw init
+birdclaw init --demo
 birdclaw auth status
 birdclaw import archive ~/Downloads/twitter-archive.zip --select tweets,directMessages
 birdclaw sync all --transport xurl

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,7 +24,14 @@ birdclaw auth status --json
 birdclaw db stats --json
 ```
 
-`init` creates `~/.birdclaw/`, opens the shared SQLite database, writes a default config when none exists, and probes for `xurl` and `bird` on `PATH`.
+`init` creates `~/.birdclaw/`, opens an empty SQLite database, and writes a default config when none exists. To explore immediately with no archive, credentials, or network access, use the self-contained demo instead:
+
+```bash
+birdclaw init --demo
+birdclaw serve
+```
+
+The demo includes sample tweets, DMs, profiles, and links. Its output also suggests useful read-only commands to try next.
 
 `auth status` runs Birdclaw's coarse xurl status probe. Verify xurl with `xurl whoami`. Existing private bird users can verify bird with `bird whoami`. If you want live sync, follow [Sign in](auth.md); skip it if you only need archive import.
 
@@ -54,7 +61,7 @@ birdclaw import archive ~/Downloads/twitter-archive-2026.zip --select directMess
 
 Valid slices: `tweets`, `likes`, `bookmarks`, `profiles`, `directMessages`, `followers`, `following`. Use `dms` as a short alias for `directMessages`.
 
-No archive yet? Request one and wait for X to prepare it. Do not run live sync against a freshly initialized database: `auth status` and `auth use` do not replace the bundled demo account identity.
+No archive yet? Request one and wait for X to prepare it. Do not run live sync against an empty or demo database: `auth status` and `auth use` do not establish real account identity.
 
 ## 4. Sync live state
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -13,7 +13,7 @@ description: "Sync authored tweets, Lists, likes, bookmarks, home timeline, ment
 - saves cursors so the next run resumes where the last one stopped
 - caches results on cache-backed surfaces so repeat reads do not keep spending the API budget
 
-On a fresh database, import your X archive before the first live sync. The archive replaces Birdclaw's bundled demo identity with your account identity; transport authentication alone does not perform that binding.
+On a fresh database, import your X archive before the first live sync. The archive establishes real account identity; transport authentication alone does not perform that binding, and `init --demo` contains only synthetic sample data.
 
 ## Web auto-sync
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -164,6 +164,18 @@ try {
 	if (!helpOutput.includes("Run the local web app")) {
 		throw new Error("Installed CLI help is missing serve");
 	}
+	const { stdout: initOutput } = await run(bin, ["--json", "init", "--demo"], {
+		cwd: installDir,
+		env,
+	});
+	const init = JSON.parse(initOutput);
+	if (
+		init.demo?.seeded !== true ||
+		init.demo?.counts?.accounts !== 2 ||
+		!init.nextSteps?.includes("birdclaw serve")
+	) {
+		throw new Error(`Installed CLI demo init failed: ${initOutput}`);
+	}
 	const { stdout: statsOutput } = await run(bin, ["--json", "db", "stats"], {
 		cwd: installDir,
 		env,

--- a/scripts/start-test-server.mjs
+++ b/scripts/start-test-server.mjs
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { withSanitizedNodeOptions } from "./sanitize-node-options.mjs";
 
 const cwd = process.cwd();
@@ -18,6 +19,28 @@ if (
 }
 
 rmSync(resolvedHome, { recursive: true, force: true });
+
+const seedEnv = {
+	...withSanitizedNodeOptions(process.env),
+	BIRDCLAW_HOME: resolvedHome,
+	BIRDCLAW_E2E: "1",
+	BIRDCLAW_DISABLE_LIVE_WRITES: "1",
+};
+const require = createRequire(import.meta.url);
+const seed = spawnSync(
+	process.execPath,
+	[
+		require.resolve("tsx/cli"),
+		path.join(cwd, "src", "cli.ts"),
+		"--json",
+		"init",
+		"--demo",
+	],
+	{ cwd, env: seedEnv, stdio: "inherit" },
+);
+if (seed.status !== 0) {
+	throw new Error(`Could not seed Playwright demo (${String(seed.status)})`);
+}
 
 const child = spawn(
 	process.execPath,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -7,6 +7,8 @@ const getBirdclawPathsMock = vi.fn();
 const resolveMentionsDataSourceMock = vi.fn();
 const setActionsTransportMock = vi.fn();
 const getQueryEnvelopeMock = vi.fn();
+const getNativeDbMock = vi.fn();
+const seedDemoDataMock = vi.fn();
 const findArchivesMock = vi.fn();
 const importArchiveMock = vi.fn();
 const importTweetsViaFxTwitterMock = vi.fn();
@@ -89,6 +91,15 @@ vi.mock("#/lib/config", () => ({
 	resolveMentionsDataSource: (...args: unknown[]) =>
 		resolveMentionsDataSourceMock(...args),
 	setActionsTransport: (...args: unknown[]) => setActionsTransportMock(...args),
+}));
+
+vi.mock("#/lib/db", () => ({
+	closeDatabase: vi.fn(),
+	getNativeDb: (...args: unknown[]) => getNativeDbMock(...args),
+}));
+
+vi.mock("#/lib/seed", () => ({
+	seedDemoData: (...args: unknown[]) => seedDemoDataMock(...args),
 }));
 
 vi.mock("#/lib/archive-finder", () => ({
@@ -296,6 +307,8 @@ describe("cli", () => {
 		resolveMentionsDataSourceMock.mockReset();
 		setActionsTransportMock.mockReset();
 		getQueryEnvelopeMock.mockReset();
+		getNativeDbMock.mockReset();
+		seedDemoDataMock.mockReset();
 		findArchivesMock.mockReset();
 		importArchiveMock.mockReset();
 		importTweetsViaFxTwitterMock.mockReset();
@@ -379,6 +392,17 @@ describe("cli", () => {
 			transport: { statusText: "local", installed: false },
 			accounts: [],
 			archives: [],
+		});
+		getNativeDbMock.mockReturnValue({});
+		seedDemoDataMock.mockReturnValue({
+			seeded: true,
+			counts: {
+				accounts: 2,
+				profiles: 6,
+				tweets: 6,
+				conversations: 4,
+				messages: 8,
+			},
 		});
 		findArchivesMock.mockResolvedValue([{ name: "twitter.zip" }]);
 		importArchiveMock.mockResolvedValue({
@@ -601,6 +625,22 @@ describe("cli", () => {
 			port: 3000,
 			serverVersion: packageVersion,
 		});
+		expect(getNativeDbMock).toHaveBeenCalledWith({ seedDemoData: false });
+		expect(seedDemoDataMock).not.toHaveBeenCalled();
+	});
+
+	it("seeds and explains an offline demo only when requested", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "--json", "init", "--demo"]);
+
+		expect(seedDemoDataMock).toHaveBeenCalledWith({});
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"seeded": true'),
+		);
+		expect(consoleLogMock).toHaveBeenCalledWith(
+			expect.stringContaining('"birdclaw serve"'),
+		);
 	});
 
 	it("sets the preferred auth transport", async () => {

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -8,9 +8,11 @@ import {
 	importArchive,
 } from "#/lib/archive-import";
 import { ensureBirdclawDirs, setActionsTransport } from "#/lib/config";
+import { getNativeDb } from "#/lib/db";
 import { importTweetsViaFxTwitter } from "#/lib/fxtwitter";
 import { hydrateProfilesFromX } from "#/lib/profile-hydration";
 import { getQueryEnvelope } from "#/lib/queries";
+import { seedDemoData } from "#/lib/seed";
 import { printError, type CliCommandContext } from "./command-context";
 
 const IMPORT_SLICE_LABELS: Record<ImportProgressSlice, string> = {
@@ -139,18 +141,30 @@ export function registerCoreCommands({
 }: CliCommandContext) {
 	program
 		.command("init")
-		.description("Create local birdclaw root and seed the database")
-		.action(async () => {
+		.description("Create an empty local birdclaw workspace")
+		.option("--demo", "Seed sample tweets and DMs for offline exploration")
+		.action((options: { demo?: boolean }) => {
 			const paths = ensureBirdclawDirs();
-			await getQueryEnvelope();
+			const db = getNativeDb({ seedDemoData: false });
+			const demo = options.demo
+				? { requested: true, ...seedDemoData(db) }
+				: { requested: false };
 			print(
 				{
 					ok: true,
+					demo,
 					rootDir: paths.rootDir,
 					configPath: paths.configPath,
 					dbPath: paths.dbPath,
 					mediaOriginalsDir: paths.mediaOriginalsDir,
 					mediaThumbsDir: paths.mediaThumbsDir,
+					nextSteps: options.demo
+						? [
+								"birdclaw search tweets --limit 5",
+								"birdclaw dms list --limit 5",
+								"birdclaw serve",
+							]
+						: ["birdclaw import archive <path>", "birdclaw init --demo"],
 				},
 				asJson(),
 			);

--- a/src/docs-site.test.ts
+++ b/src/docs-site.test.ts
@@ -50,8 +50,12 @@ describe("docs site", () => {
 		);
 		expect(quickstart).not.toContain("fully usable in live-only mode");
 		expect(quickstart).toContain(
-			"Do not run live sync against a freshly initialized database",
+			"Do not run live sync against an empty or demo database",
 		);
+		expect(quickstart).toContain(
+			'birdclaw</span> init <span class="hl-f">--demo',
+		);
+		expect(quickstart).toContain("no archive, credentials, or network access");
 	});
 
 	it("keeps underscores inside autolink URLs literal", () => {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -11,6 +11,7 @@ import {
 	getStrictReadDb,
 	resetDatabaseForTests,
 } from "./db";
+import { seedDemoData } from "./seed";
 import NativeSqliteDatabase, { SQLITE_BUSY_TIMEOUT_MS } from "./sqlite";
 
 const tempDirs: string[] = [];
@@ -83,17 +84,24 @@ afterEach(() => {
 });
 
 describe("database init", () => {
-	it("seeds demo data after an initial unseeded open", () => {
+	it("seeds demo data only after an explicit request", () => {
 		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-"));
 		tempDirs.push(tempDir);
 		process.env.BIRDCLAW_HOME = tempDir;
 
-		const unseededDb = getNativeDb({ seedDemoData: false });
+		const testSeedFlag = process.env.BIRDCLAW_TEST_SEED_DEMO_DATA;
+		delete process.env.BIRDCLAW_TEST_SEED_DEMO_DATA;
+		const unseededDb = getNativeDb();
+		if (testSeedFlag === undefined) {
+			delete process.env.BIRDCLAW_TEST_SEED_DEMO_DATA;
+		} else {
+			process.env.BIRDCLAW_TEST_SEED_DEMO_DATA = testSeedFlag;
+		}
 		expect(
 			unseededDb.prepare("select count(*) as count from accounts").get(),
 		).toEqual({ count: 0 });
 
-		const seededDb = getNativeDb();
+		const seededDb = getNativeDb({ seedDemoData: true });
 
 		expect(
 			seededDb.prepare("select count(*) as count from accounts").get(),
@@ -105,6 +113,31 @@ describe("database init", () => {
 				)
 				.get(),
 		).toEqual({ count: 3 });
+	});
+
+	it("refuses to mix demo data into a partially populated database", () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const db = getNativeDb({ seedDemoData: false });
+		db.prepare(`
+			insert into profiles (
+				id, handle, display_name, bio, followers_count, following_count,
+				avatar_hue, created_at
+			) values (?, ?, ?, '', 0, 0, 0, ?)
+		`).run("profile_real", "real", "Real profile", "2026-07-17T00:00:00Z");
+
+		expect(seedDemoData(db)).toEqual({
+			seeded: false,
+			reason: "database-not-empty",
+		});
+		expect(db.prepare("select count(*) as count from accounts").get()).toEqual({
+			count: 0,
+		});
+		expect(db.prepare("select count(*) as count from profiles").get()).toEqual({
+			count: 1,
+		});
 	});
 
 	it("migrates legacy tweet tables before creating quoted tweet indexes", () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -939,8 +939,17 @@ function ensureDemoData(db: Database) {
 	demoSeedAttempted = true;
 }
 
+function shouldSeedDemoData(options: InitDatabaseOptions) {
+	return (
+		options.seedDemoData === true ||
+		(options.seedDemoData === undefined &&
+			process.env.BIRDCLAW_TEST_SEED_DEMO_DATA === "1")
+	);
+}
+
 function initDatabase(options: InitDatabaseOptions = {}) {
 	ensureBirdclawDirs();
+	const seedDemo = shouldSeedDemoData(options);
 
 	if (!nativeDb) {
 		const { dbPath } = getBirdclawPaths();
@@ -951,10 +960,10 @@ function initDatabase(options: InitDatabaseOptions = {}) {
 		  pragma foreign_keys = on;
 		`);
 		runDatabaseMigrations(nativeDb, DATABASE_MIGRATIONS);
-		if (options.seedDemoData !== false) {
+		if (seedDemo) {
 			ensureDemoData(nativeDb);
 		}
-	} else if (options.seedDemoData !== false) {
+	} else if (seedDemo) {
 		ensureDemoData(nativeDb);
 	}
 }

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -2,6 +2,19 @@ import type { Database } from "./sqlite";
 
 const now = new Date("2026-03-08T12:00:00.000Z");
 
+export type DemoSeedResult =
+	| {
+			seeded: true;
+			counts: {
+				accounts: number;
+				profiles: number;
+				tweets: number;
+				conversations: number;
+				messages: number;
+			};
+	  }
+	| { seeded: false; reason: "database-not-empty" };
+
 function isoMinutesAgo(minutes: number) {
 	return new Date(now.getTime() - minutes * 60_000).toISOString();
 }
@@ -22,16 +35,27 @@ function svgAvatarDataUrl(label: string, hue: number) {
 	return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
-export function seedDemoData(db: Database) {
-	const accountCount = db
-		.prepare("select count(*) as count from accounts")
-		.get() as {
-		count: number;
-	};
+function hasStoredContent(db: Database) {
+	const tables = db
+		.prepare(`
+			select name
+			from sqlite_master
+			where type = 'table'
+			  and name not like 'sqlite_%'
+			  and name not glob 'tweets_fts_*'
+			  and name not glob 'dm_fts_*'
+			order by name
+		`)
+		.all() as Array<{ name: string }>;
 
-	if (accountCount.count > 0) {
-		return;
+	for (const { name } of tables) {
+		if (!/^[a-z0-9_]+$/.test(name)) return true;
+		if (db.prepare(`select 1 from "${name}" limit 1`).get()) return true;
 	}
+	return false;
+}
+
+export function seedDemoData(db: Database): DemoSeedResult {
 	const linkNow = new Date();
 	const linkMinutesAgo = (minutes: number) =>
 		new Date(linkNow.getTime() - minutes * 60_000).toISOString();
@@ -588,7 +612,11 @@ export function seedDemoData(db: Database) {
 		},
 	];
 
-	const transaction = db.transaction(() => {
+	const transaction = db.transaction((): DemoSeedResult => {
+		if (hasStoredContent(db)) {
+			return { seeded: false, reason: "database-not-empty" };
+		}
+
 		for (const account of accounts) {
 			insertAccount.run(account);
 		}
@@ -656,7 +684,18 @@ export function seedDemoData(db: Database) {
 		for (const occurrence of linkOccurrences) {
 			insertLinkOccurrence.run(occurrence);
 		}
+
+		return {
+			seeded: true,
+			counts: {
+				accounts: accounts.length,
+				profiles: profiles.length,
+				tweets: tweets.length,
+				conversations: conversations.length,
+				messages: messages.length,
+			},
+		};
 	});
 
-	transaction();
+	return transaction();
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,6 @@
 process.env.BIRDCLAW_DISABLE_LIVE_WRITES ??= "1";
+// Existing integration fixtures opt into the same sample dataset as `init --demo`.
+process.env.BIRDCLAW_TEST_SEED_DEMO_DATA = "1";
 
 export {};
 


### PR DESCRIPTION
## Summary

- make normal `init` create an empty local workspace
- add explicit `init --demo` seeding for sample tweets, DMs, profiles, and links with no authentication or network access
- print useful next commands for both setup paths
- refuse demo seeding transactionally when any real application content already exists
- run package smoke and Playwright against the explicit demo path

## Proof

- `pnpm install --frozen-lockfile` — lockfile current
- `pnpm check` — formatting, lint, and typecheck passed
- `pnpm coverage` — 1,284 tests passed; 90.62% line coverage
- `pnpm build` — client, SSR, and CLI builds passed
- `pnpm docs:site` — documentation site built
- `pnpm pack:smoke` — packed CLI and production server smoke passed (126 files)
- `pnpm e2e` — 12 Chromium tests passed
- `pnpm audit --audit-level high` — no known vulnerabilities
- AutoReview branch mode against `origin/main` — clean

## Packaged CLI proof

Under Node 26.5.0, a freshly packed tarball was installed into a clean temporary prefix. Plain `init` produced an empty database (`0` accounts, `0` tweets, `0` DM messages). A separate `init --demo` produced `2` accounts, `6` tweets, and `8` DM messages; packaged `search tweets --limit 2` and `dms list --limit 1` returned sample rows successfully. Package smoke also launched and fetched the real production server from the installed tarball.
