### PR TITLE
fix: retain archive tweet tombstones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.11.1 - Unreleased
 
+### Added
+
+- Preserve explicit X archive deletions as source-attributed tweet, media, and quote tombstones, and retain observable X edit chains as portable revision records while hiding superseded bodies from active views.
+
+### Changed
+
+- Merge archive and backup imports by default so incomplete snapshots never delete destination-only rows; use explicit `--restore` for exact replacement.
+
 ## 0.11.0 - 2026-07-18
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Status: WIP. Real and usable. Not done. Expect schema churn, transport gaps, and
 - FTS5 search over tweets and DMs
 - archive autodiscovery on macOS
 - archive import for tweets, likes, followers/following, profiles, and full DMs
-- selective archive re-imports for one stale slice without wiping the rest of the local store
+- merge-safe archive re-imports that preserve destination-only rows, with `--restore` for deliberate exact replacement
+- source-attributed tombstones for explicit deleted-tweet records, including subordinate media/quote tombstones and observable edit-chain revisions
 - archive import for bookmark exports when present
 - explicit, disabled-by-default import of named public tweets through the fixed read-only FxTwitter endpoint, with durable source provenance
 - archive import streams bundled media files into the local originals cache and extracts `video_info.variants[]` for video and animated-GIF rows
@@ -236,7 +237,7 @@ birdclaw import archive --json
 birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 ```
 
-Don't have an archive yet? Request it from <https://x.com/settings/download_your_data>; X emails a download link when it is ready, which may take a few days. A fresh or demo Birdclaw database needs the archive import to establish real account identity before live sync. See [Archive Import → Get an archive](docs/archive.md#get-an-archive).
+Don't have an archive yet? Request it from <https://x.com/settings/download_your_data>; X emails a download link when it is ready, which may take a few days. A fresh Birdclaw database needs the archive import to establish real account identity before live sync; replace an `init --demo` identity with `import archive --restore`. See [Archive Import → Get an archive](docs/archive.md#get-an-archive).
 
 Optional profile hydration through xurl can improve bios, follower counts, and avatars, but it performs live X profile reads and can spend API credits on large archives. With an existing private bird installation, the command can instead correct the seeded local account identity from `bird whoami` without bulk-hydrating imported profiles:
 
@@ -246,7 +247,7 @@ birdclaw import hydrate-profiles --account steipete --json
 
 Every command that touches live account auth accepts `--account <username>` (stored IDs also work). To reuse one selection without changing the database identity, set `{"accounts":{"default":"steipete"}}` in `~/.birdclaw/config.json`; an explicit flag overrides it for one operation.
 
-`import archive` is idempotent. Re-running parses follower/following edges into the local follow graph, streams bundled media files under `data/tweets_media/`, `data/direct_messages_media/`, and the other archive media folders into `~/.birdclaw/media/originals/archive/<kind>/<id>/`, and pulls `video_info.variants[]` so archive video and animated-GIF rows carry mp4 URLs for the live media fetcher. Already-extracted files are skipped when size matches.
+`import archive` is idempotent and merge-safe. Re-running preserves destination-only rows, so a tweet that is simply absent from a newer timeline snapshot is not treated as deleted. Only an explicit deleted-tweet record creates a source-attributed tombstone; use `--restore` when you deliberately want the selected archive slices to replace local state exactly. Import also parses follower/following edges into the local follow graph, streams bundled media files under `data/tweets_media/`, `data/direct_messages_media/`, and the other archive media folders into `~/.birdclaw/media/originals/archive/<kind>/<id>/`, and pulls `video_info.variants[]` so archive video and animated-GIF rows carry mp4 URLs for the live media fetcher. Already-extracted files are skipped when size matches.
 
 Re-import only one part of a newer archive when you already have live or local data you want to keep:
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -7,23 +7,23 @@ description: "Import a Twitter/X archive into local SQLite — autodiscovery, se
 
 `birdclaw import archive` parses a Twitter/X archive ZIP and writes everything into the canonical SQLite tables: tweets, likes, bookmarks, profiles, followers/following edges, DMs, bundled media files, and (when present) blocklists.
 
-It is **idempotent**. Re-running on the same archive replays the import without producing duplicates, so you can import, then re-import after a fresh archive download to top up.
+It is **idempotent and merge-safe**. Re-running on the same archive does not produce duplicates, and importing a newer or incomplete archive preserves destination-only rows by default.
 
-By default, archive import is a full archive replay. It refreshes archive-owned data from the ZIP and rebuilds the local rows for all supported archive slices. Use `--select` when you want to refresh only one or two slices from a newer archive while preserving the rest of your local store.
+By default, archive import merges all supported slices from the ZIP. Use `--select` to merge only one or two slices, or add `--restore` when you deliberately want the imported slices to replace local state exactly.
 
 ## Get an archive
 
-On a fresh Birdclaw database, archive import establishes the account identity required by live sync. Do not sync an empty database or the synthetic `init --demo` workspace before importing your archive. An archive is optional only when restoring an existing Birdclaw database or backup that already contains the correct account.
+On a fresh Birdclaw database, archive import establishes the account identity required by live sync. Do not sync an empty database before importing your archive. To replace the synthetic identity created by `init --demo`, use `import archive --restore`. An archive is optional only when restoring an existing Birdclaw database or backup that already contains the correct account.
 
 Request flow:
 
-1. Sign in to x.com and go to <https://x.com/settings/download_your_data> (also reachable via *Settings and privacy → Your account → Download an archive of your data*).
+1. Sign in to x.com and go to <https://x.com/settings/download_your_data> (also reachable via _Settings and privacy → Your account → Download an archive of your data_).
 2. Re-enter your password and complete 2FA if prompted.
-3. Click *Request archive*. X queues the export and emails a download link when it is ready. [X Help](https://help.x.com/en/managing-your-account/how-to-download-your-x-archive) says preparation may take a few days.
-4. When the email arrives (subject: *Your X data is ready to download*), open the link, sign in again, and download the ZIP. Typical filename: `twitter-YYYY-MM-DD-<hash>.zip`.
+3. Click _Request archive_. X queues the export and emails a download link when it is ready. [X Help](https://help.x.com/en/managing-your-account/how-to-download-your-x-archive) says preparation may take a few days.
+4. When the email arrives (subject: _Your X data is ready to download_), open the link, sign in again, and download the ZIP. Typical filename: `twitter-YYYY-MM-DD-<hash>.zip`.
 5. Save the ZIP into `~/Downloads` so autodiscovery picks it up, or note its path and pass it explicitly to `import archive`.
 
-The archive is a point-in-time snapshot. You can request a fresh one later and use `--select` (see below) to refresh a single slice without wiping the rest of your local store.
+The archive is a point-in-time snapshot. You can request a fresh one later and use `--select` (see below) to merge a single slice without wiping the rest of your local store.
 
 ## Autodiscovery
 
@@ -47,8 +47,9 @@ birdclaw import archive ~/Downloads/twitter-archive-2025.zip --json
 Flags:
 
 - `--select <kinds>` — comma-separated subset of `tweets,likes,bookmarks,profiles,directMessages,followers,following`
+- `--restore` — exactly replace the imported slices instead of merging them
 
-`--select` is for targeted re-imports. It clears and replays only the selected archive slices for `acct_primary`, then leaves unselected local data alone. This matters when you have live-synced likes/bookmarks, local replies, another account in the same DB, or a fresh archive that only needs one stale surface refreshed.
+`--select` is for targeted re-imports. It merges only the selected archive slices for `acct_primary`, then leaves unselected local data alone. This matters when you have live-synced likes/bookmarks, local replies, another account in the same DB, or a fresh archive that only needs one stale surface refreshed.
 
 Accepted DM aliases:
 
@@ -63,25 +64,32 @@ Examples:
 birdclaw import archive ~/Downloads/twitter-archive.zip --select tweets,directMessages
 birdclaw import archive ~/Downloads/twitter-archive.zip --select likes,bookmarks --json
 birdclaw import archive ~/Downloads/twitter-archive.zip --select dms --json
+birdclaw import archive ~/Downloads/twitter-archive.zip --restore --json
 ```
 
 Use `--select profiles` when you want archive profile metadata refreshed. When selecting only tweets, likes, bookmarks, DMs, followers, or following, birdclaw preserves compatible existing profile rows and only inserts missing stubs needed for references.
 
-Selected imports validate the existing `acct_primary` account before writing. If the local default account does not match the archive account ID or handle, the command fails instead of merging two identities into one account.
+Every merge import validates the existing `acct_primary` account before writing. If the local default account does not match the archive account ID or handle, the command fails instead of merging two identities into one account. An explicit full `--restore` is the only mode that may replace that identity.
 
 ## Full import vs selected import
 
 Full import:
 
 - reads every supported archive file
-- refreshes archive-owned tweets, collections, profiles, DMs, and follow edges together
-- best for a clean first import or a deliberate full archive refresh
+- merges archive-owned tweets, collections, profiles, DMs, and follow edges together
+- best for a clean first import or topping up from a newer archive
 
 Selected import:
 
 - reads only the selected archive data plus the small account/profile baseline needed to validate identity and resolve references
-- clears only rows owned by the selected slice
-- preserves unselected tweets, DMs, likes/bookmarks, live collection rows, profile metadata, and other accounts
+- merges only rows owned by the selected slice
+- preserves destination-only and unselected tweets, DMs, likes/bookmarks, live collection rows, profile metadata, and other accounts
+
+Explicit restore:
+
+- clears portable rows owned by the imported full or selected slices before replaying the archive
+- removes destination-only rows in those slices, so use it only when exact replacement is intended
+- remains identity-scoped for selected imports and preserves unselected slices
 
 Typical targeted re-imports:
 
@@ -97,7 +105,18 @@ birdclaw import archive ~/Downloads/twitter-archive.zip --select directMessages 
 
 # Refresh archive follow graph only.
 birdclaw import archive ~/Downloads/twitter-archive.zip --select followers,following --json
+
+# Deliberately replace only the archive-owned tweet slice.
+birdclaw import archive ~/Downloads/twitter-archive.zip --select tweets --restore --json
 ```
+
+## Deletions and edit history
+
+Archive absence is not deletion. A tweet that disappears from a home or authored timeline may still exist on X, so a later snapshot that simply does not contain a stored tweet leaves that tweet active locally.
+
+Birdclaw creates a tombstone only from an explicit archive deleted-tweet record. The canonical tweet row retains `deleted_at`, a deletion source, and a reason; active search and timeline reads exclude it. Media identifiers and quoted-tweet relationships belonging to that parent receive subordinate tombstones so deleted content does not leak through media fetching or relationship views.
+
+When X exposes an edit-history ID chain, Birdclaw records the ordered revision identities. The raw body is attached only to a revision actually observed in the archive or a live payload; unobserved earlier IDs remain lossless identity stubs rather than invented content. Superseded bodies stay retained but disappear from active timelines, search, links, and media fetching. If the terminal revision is explicitly deleted, the whole chain stays inactive. Tombstones and revisions are included in portable backups.
 
 ## Bundled media files
 
@@ -134,7 +153,7 @@ When the archive ships with `data/follower.js` and `data/following.js`, `import 
 
 - each entry becomes a stub `profiles` row plus a current `follow_edges` row
 - counts land in the archive-import result envelope under `counts.followers` and `counts.following`
-- re-importing the same archive is a no-op; switching to a fresher archive tops up new edges
+- re-importing the same archive is a no-op; switching to a fresher archive tops up new edges without treating missing relationships as ended unless `--restore` is used
 
 A fresh install with just an archive and no live transport still gets a usable [follow graph](follow-graph.md). `birdclaw graph summary`, `graph mutuals`, and `graph top-followers` all work against archive-imported edges. Live `sync followers --yes` can layer churn on top later.
 
@@ -155,6 +174,8 @@ Avatars are written to `~/.birdclaw/media/thumbs/avatars/` so the web UI does no
 After import, archive data and live data live in the same canonical tables. There is no `archive_*` shadow universe.
 
 - **Tweets** → `tweets` table, indexed by FTS5 — searchable via `birdclaw search tweets`
+- **Explicit deletions** → retained tweet metadata plus `tweet_subordinate_tombstones`; excluded from active timelines, search, links, and media fetches
+- **Edit history** → ordered `tweet_revisions` rows, with raw payloads only for observed revision bodies and superseded canonical rows retained outside active views
 - **Likes** → `tweets` table + a `likes` collection edge — searchable via `--liked`
 - **Bookmarks** → `tweets` table + a `bookmarks` collection edge — searchable via `--bookmarked`
 - **DMs** → `dm_conversations` and `dm_events` tables, indexed by FTS5 — searchable via `birdclaw search dms`

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -116,7 +116,7 @@ Archive absence is not deletion. A tweet that disappears from a home or authored
 
 Birdclaw creates a tombstone only from an explicit archive deleted-tweet record. The canonical tweet row retains `deleted_at`, a deletion source, and a reason; active search and timeline reads exclude it. Media identifiers and quoted-tweet relationships belonging to that parent receive subordinate tombstones so deleted content does not leak through media fetching or relationship views.
 
-When X exposes an edit-history ID chain, Birdclaw records the ordered revision identities. The raw body is attached only to a revision actually observed in the archive or a live payload; unobserved earlier IDs remain lossless identity stubs rather than invented content. Superseded bodies stay retained but disappear from active timelines, search, links, and media fetching. If the terminal revision is explicitly deleted, the whole chain stays inactive. Tombstones and revisions are included in portable backups.
+When X exposes an edit-history ID chain, Birdclaw records the ordered revision identities. The raw body is attached only to a revision actually observed in the archive or a live payload; unobserved earlier IDs remain lossless identity stubs rather than invented content. Superseded bodies stay retained but disappear from active timelines, search, links, and media fetching. An explicit deletion of any observed revision tombstones the whole edit chain. Tombstones and revisions are included in portable backups.
 
 ## Bundled media files
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -19,6 +19,8 @@ data/profile_snapshots.jsonl
 data/profile_bio_entities.jsonl
 data/tweets/YYYY.jsonl
 data/tweets/unknown.jsonl
+data/tweet_revisions.jsonl
+data/tweet_subordinate_tombstones.jsonl
 data/collections/likes.jsonl
 data/collections/bookmarks.jsonl
 data/dms/conversations.jsonl
@@ -39,6 +41,7 @@ Design rules:
 - **tweets** are sharded by year for human browsing, partial loads, and yearly analysis
 - **DMs** are sharded by year with `conversation_id` in each row, so Git stays fast while preserving conversation membership
 - **collection-only tweets** with unknown timestamps go to `data/tweets/unknown.jsonl` instead of pretending they belong to 1970
+- **tweet tombstones and revisions** preserve explicit deletions, subordinate media/quote deletion state, and observable edit chains without re-exposing deleted or superseded rows through search
 - **likes** and **bookmarks** are stored as collection edges and mirrored into the timeline rows so existing queries keep working
 - **profiles** include bio, follower/following counts, profile URL, location, verification type, structured URL entities, and raw profile JSON so the snapshot is meaningful on its own
 - **profile affiliations** preserve X badge/highlighted-label organization edges separately from profile rows
@@ -102,7 +105,7 @@ birdclaw backup import ~/Projects/birdclaw-store --json
 
 Validates the backup first (unless `--no-validate`), then merge-imports rows into local SQLite. Local-only rows are preserved by default.
 
-`--replace` restores exactly from backup and **deletes local portable rows first**. Use it when you want a known-clean state from the backup, e.g. on a new machine.
+`--restore` restores exactly from backup and **deletes local portable rows first**. Use it when you want a known-clean state from the backup, e.g. on a new machine. The older `--replace` spelling remains as a deprecated alias.
 
 The FTS5 shadow tables for tweets and DMs are rebuilt from the JSONL text after import, so search is immediately available.
 
@@ -127,12 +130,12 @@ Exits non-zero on validation failure. Run it in CI before publishing a backup, o
 
 ```json
 {
-  "backup": {
-    "repoPath": "/Users/steipete/Projects/backup-birdclaw",
-    "remote": "https://github.com/steipete/backup-birdclaw.git",
-    "autoSync": true,
-    "staleAfterSeconds": 900
-  }
+	"backup": {
+		"repoPath": "/Users/steipete/Projects/backup-birdclaw",
+		"remote": "https://github.com/steipete/backup-birdclaw.git",
+		"autoSync": true,
+		"staleAfterSeconds": 900
+	}
 }
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,6 +187,8 @@ Shard contract:
 - tweets: `data/tweets/YYYY.jsonl`
 - tweet provenance: `data/tweet_sources.jsonl`
 - unknown tweet dates: `data/tweets/unknown.jsonl`
+- tweet revisions: `data/tweet_revisions.jsonl`
+- subordinate tweet tombstones: `data/tweet_subordinate_tombstones.jsonl`
 - profiles: `data/profiles.jsonl` includes bio, follower/following counts, profile URL, location, verification type, structured URL entities, and raw profile JSON
 - affiliations: `data/profile_affiliations.jsonl` includes X badge/highlighted-label organization edges
 - identity history: `data/profile_snapshots.jsonl` and `data/profile_bio_entities.jsonl` preserve profile-change states and extracted bio identity hints
@@ -231,7 +233,7 @@ to the full path of `bash.exe` for a portable or non-standard installation.
 
 - validates the backup first unless `--no-validate` is passed
 - merge-imports by default so local-only rows are not deleted
-- `--replace` restores exactly from backup and deletes local portable rows first
+- `--restore` restores exactly from backup and deletes local portable rows first (`--replace` remains a deprecated alias)
 - rebuilds tweet and DM FTS from the JSONL text
 
 ```bash
@@ -252,7 +254,9 @@ birdclaw backup validate ~/Projects/birdclaw-store --json
 
 - validate archive
 - analyze contents
-- import selected slices
+- merge selected slices without deleting destination-only rows
+- retain explicit deleted-tweet records as source-attributed tombstones; absence alone is never a deletion
+- use `--restore` for deliberate exact replacement of the imported slices
 - stream bundled media files from `data/tweets_media/`, `data/direct_messages_media/`, `data/community_tweet_media/`, `data/deleted_tweets_media/`, `data/profile_media/`, `data/moments_tweets_media/`, and `data/direct_messages_group_media/` into `~/.birdclaw/media/originals/archive/<kind>/<id>/<filename>`
 - extract `extended_entities.media[].video_info.variants[]` onto each tweet media row for archive video and animated GIFs
 - parse `data/follower.js` and `data/following.js` into the local follow graph
@@ -269,7 +273,7 @@ Flags:
 - valid aliases for `directMessages`: `directmessages`, `direct-messages`, `dms`
 - duplicate names are ignored
 - empty values and unknown names exit as invalid usage
-- selected imports validate that existing `acct_primary` matches the archive account before writing
+- merge imports and selected restores validate that existing `acct_primary` matches the archive account before writing; only a full `--restore` may replace it
 - selected imports preserve compatible existing profile rows unless `profiles` is selected
 
 Examples:

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -188,6 +188,7 @@ Native SQLite only. Transactional, append-only migrations define the schema; foc
 - `tweet_revisions`
   - ordered revision identities from observable X edit history
   - retains raw revision payloads only when the body was actually observed
+  - an explicit deletion on any revision tombstones every retained body in the chain
 - `tweet_subordinate_tombstones`
   - media and quote-relation tombstones derived from explicitly deleted parent tweets
 - `follow_edges`

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -183,10 +183,13 @@ Native SQLite only. Transactional, append-only migrations define the schema; foc
 - `tweets`
   - canonical tweet rows
   - text, metrics, timestamps, references, author id
-  - raw JSON payload column
-- `tweet_media`
-- `tweet_urls`
-- `tweet_mentions`
+  - explicit deletion timestamp, source, and reason; absence from a later snapshot never sets them
+  - supersession timestamp and terminal revision ID keep older edit bodies lossless but inactive
+- `tweet_revisions`
+  - ordered revision identities from observable X edit history
+  - retains raw revision payloads only when the body was actually observed
+- `tweet_subordinate_tombstones`
+  - media and quote-relation tombstones derived from explicitly deleted parent tweets
 - `follow_edges`
   - current complete directional graph for `followers` and `following`
 - `follow_snapshots`
@@ -348,10 +351,14 @@ Principles:
 
 - idempotent reruns
 - preserve richer existing data
-- raw source retained optionally
-- full import refreshes all supported archive slices together
-- selected import refreshes only requested slices and preserves unselected local data
-- selected import validates `acct_primary` identity before writing
+- merge destination-only rows by default; a record missing from a later archive is not a deletion
+- only explicit deleted-tweet records create source-attributed tombstones
+- hide tombstoned tweets and their subordinate media/quote relations from active indexes while retaining lossless archive state
+- retain observable edit-history identities and payloads without inventing unobserved revision bodies; superseded revisions are not active content
+- full import merges all supported archive slices together
+- selected import merges only requested slices and preserves unselected local data
+- explicit `--restore` replaces imported slices exactly
+- merge imports and selected restores validate `acct_primary` identity before writing; only a full restore may replace it
 - selected collection imports preserve live collection rows and local tweet ownership
 - selected DM imports are scoped to `acct_primary` and preserve other accounts
 

--- a/docs/dms.md
+++ b/docs/dms.md
@@ -119,7 +119,7 @@ Replies use the active live transport (`auto` by default). Without a working tra
 
 Twitter archives include full DM history but the JSON is awkward. `import archive` imports message bodies into SQLite and makes them FTS5-searchable.
 
-Use `--select directMessages` when a newer archive has fresher DMs and you do not want to touch tweets, likes, bookmarks, profiles, or follow data. The selected re-import clears only archive DM rows for `acct_primary`, preserves other accounts, then rebuilds DM FTS. `dms` is accepted as a shorter alias.
+Use `--select directMessages` when a newer archive has fresher DMs and you do not want to touch tweets, likes, bookmarks, profiles, or follow data. The selected re-import merges archive DM rows for `acct_primary` and preserves other accounts. Add `--restore` to clear and exactly replay that account's archive DMs before rebuilding DM FTS. `dms` is accepted as a shorter alias.
 
 ```bash
 birdclaw import archive ~/Downloads/twitter-archive.zip --select directMessages --json

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -881,7 +881,7 @@ describe("cli", () => {
 			"backup",
 			"import",
 			"/tmp/bak",
-			"--replace",
+			"--restore",
 			"--no-validate",
 		]);
 		await runCli([
@@ -1434,6 +1434,25 @@ describe("cli", () => {
 
 		expect(importArchiveMock).toHaveBeenCalledWith("/tmp/explicit.zip", {
 			select: ["tweets", "directMessages", "likes"],
+		});
+	});
+
+	it("passes explicit archive restore mode", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"archive",
+			"/tmp/explicit.zip",
+			"--restore",
+		]);
+
+		expect(importArchiveMock).toHaveBeenCalledWith("/tmp/explicit.zip", {
+			select: undefined,
+			restore: true,
 		});
 	});
 

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -17,6 +17,7 @@ import { printError, type CliCommandContext } from "./command-context";
 
 const IMPORT_SLICE_LABELS: Record<ImportProgressSlice, string> = {
 	tweets: "tweets",
+	deletedTweets: "deleted tweets",
 	noteTweets: "note tweets",
 	directMessages: "direct messages",
 	likes: "likes",
@@ -203,27 +204,34 @@ export function registerCoreCommands({
 			"--select <kinds>",
 			`Import only selected archive slices: ${ARCHIVE_IMPORT_SLICES.join(", ")}`,
 		)
-		.action(async (archivePath, options: { select?: string }) => {
-			const select = parseArchiveImportSelect(options.select);
-			if (options.select !== undefined && !select) return;
-			let resolvedArchivePath = archivePath;
-			if (!resolvedArchivePath) {
-				const [latestArchive] = await findArchives();
-				resolvedArchivePath = latestArchive?.path;
-			}
-			if (!resolvedArchivePath) {
-				throw new Error(
-					"No archive found. Pass a path or place one in Downloads.",
-				);
-			}
-			const json = Boolean(asJson());
-			const result = await importArchive(resolvedArchivePath, {
-				select,
-				onProgress: json ? undefined : logImportProgress,
-			});
-			await autoSyncAfterWrite();
-			print(result, json);
-		});
+		.option(
+			"--restore",
+			"Exactly replace imported archive slices instead of safely merging",
+		)
+		.action(
+			async (archivePath, options: { select?: string; restore?: boolean }) => {
+				const select = parseArchiveImportSelect(options.select);
+				if (options.select !== undefined && !select) return;
+				let resolvedArchivePath = archivePath;
+				if (!resolvedArchivePath) {
+					const [latestArchive] = await findArchives();
+					resolvedArchivePath = latestArchive?.path;
+				}
+				if (!resolvedArchivePath) {
+					throw new Error(
+						"No archive found. Pass a path or place one in Downloads.",
+					);
+				}
+				const json = Boolean(asJson());
+				const result = await importArchive(resolvedArchivePath, {
+					select,
+					...(options.restore ? { restore: true } : {}),
+					...(!json ? { onProgress: logImportProgress } : {}),
+				});
+				await autoSyncAfterWrite();
+				print(result, json);
+			},
+		);
 	importCommand
 		.command("tweet <tweets...>")
 		.description(

--- a/src/cli/register-storage.ts
+++ b/src/cli/register-storage.ts
@@ -64,12 +64,13 @@ export function registerStorageCommands({
 		.command("import <repo>")
 		.description("Merge a canonical JSONL backup into the local SQLite store")
 		.option("--no-validate", "Skip backup validation before import")
-		.option("--replace", "Replace local portable tables instead of merging")
+		.option("--restore", "Exactly replace local portable tables")
+		.option("--replace", "Deprecated alias for --restore")
 		.action(async (repo, options) => {
 			const result = await importBackup({
 				repoPath: repo,
 				validate: options.validate,
-				mode: options.replace ? "replace" : "merge",
+				mode: options.restore || options.replace ? "replace" : "merge",
 			});
 			print(result, true);
 		});

--- a/src/lib/archive-import-plan.ts
+++ b/src/lib/archive-import-plan.ts
@@ -13,6 +13,11 @@ export type ArchiveTweetRow = {
 	entitiesJson: string;
 	mediaJson: string;
 	quotedTweetId: string | null;
+	deletedAt?: string | null;
+	deletionSource?: string | null;
+	deletionReason?: string | null;
+	editHistoryIds?: string[];
+	rawJson?: string | null;
 };
 
 export type ArchiveCollectionRow = {
@@ -86,9 +91,44 @@ export class ArchiveImportPlan {
 	addTweet(row: ArchiveTweetRow) {
 		const existing = this.tweetsById.get(row.id);
 		if (existing) {
+			const epoch = new Date(0).toISOString();
 			existing.bookmarked = Math.max(existing.bookmarked, row.bookmarked);
 			existing.liked = Math.max(existing.liked, row.liked);
 			if (!existing.text && row.text) existing.text = row.text;
+			if (existing.createdAt === epoch && row.createdAt !== epoch) {
+				existing.createdAt = row.createdAt;
+			}
+			existing.isReplied = Math.max(existing.isReplied, row.isReplied);
+			existing.replyToId ??= row.replyToId;
+			existing.likeCount = Math.max(existing.likeCount, row.likeCount);
+			existing.mediaCount = Math.max(existing.mediaCount, row.mediaCount);
+			if (existing.entitiesJson === "{}" && row.entitiesJson !== "{}") {
+				existing.entitiesJson = row.entitiesJson;
+			}
+			if (existing.mediaJson === "[]" && row.mediaJson !== "[]") {
+				existing.mediaJson = row.mediaJson;
+			}
+			existing.quotedTweetId ??= row.quotedTweetId;
+			if (
+				row.deletedAt &&
+				(!existing.deletedAt || row.deletedAt < existing.deletedAt)
+			) {
+				existing.deletedAt = row.deletedAt;
+				existing.deletionSource = row.deletionSource;
+				existing.deletionReason = row.deletionReason;
+			}
+			const existingEditIds = existing.editHistoryIds ?? [];
+			const rowEditIds = row.editHistoryIds ?? [];
+			const primaryEditIds =
+				rowEditIds.length > existingEditIds.length
+					? rowEditIds
+					: existingEditIds;
+			const secondaryEditIds =
+				primaryEditIds === rowEditIds ? existingEditIds : rowEditIds;
+			existing.editHistoryIds = Array.from(
+				new Set([...primaryEditIds, ...secondaryEditIds]),
+			);
+			if (!existing.rawJson && row.rawJson) existing.rawJson = row.rawJson;
 			return existing;
 		}
 		this.tweets.push(row);

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -15,6 +15,7 @@ import {
 	insertTestDmConversation,
 	insertTestDmMessage,
 	insertTestProfile,
+	insertTestTweet,
 	useTestHome,
 } from "../test/test-home";
 import { __test__, importArchive, importArchiveEffect } from "./archive-import";
@@ -344,6 +345,71 @@ function makeTweetRetentionArchive({
 			])}`,
 		);
 	}
+	const archivePath = path.join(root, "archive.zip");
+	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
+	return archivePath;
+}
+
+function makeLateDeletedTweetBodyArchive() {
+	const root = testHome().makeTempDir("birdclaw-archive-late-tombstone-body-");
+	const archiveDir = path.join(root, "sample", "data");
+	mkdirSync(archiveDir, { recursive: true });
+	writeFileSync(
+		path.join(archiveDir, "account.js"),
+		'window.YTD.account.part0 = [{ "account": { "accountId": "25401953", "username": "steipete" } }]',
+	);
+	writeFileSync(
+		path.join(archiveDir, "tweets.js"),
+		`window.YTD.tweets.part0 = ${JSON.stringify([
+			{
+				tweet: {
+					id_str: "header-only",
+					created_at: "Mon Jun 02 19:32:20 +0000 2025",
+					full_text: "late body for an already deleted tweet",
+					quoted_status_id_str: "late-quote",
+					entities: {
+						media: [
+							{
+								media_url_https: "https://img.example.com/late.jpg",
+								type: "photo",
+							},
+						],
+					},
+					extended_entities: {
+						media: [
+							{
+								media_url_https: "https://img.example.com/late.jpg",
+								type: "photo",
+							},
+						],
+					},
+				},
+			},
+			{
+				tweet: {
+					id_str: "legacy-unknown-source",
+					created_at: "Sun Jun 01 19:32:20 +0000 2025",
+					full_text: "late body for a legacy source-less tombstone",
+					entities: {
+						media: [
+							{
+								media_url_https: "https://img.example.com/legacy.jpg",
+								type: "photo",
+							},
+						],
+					},
+					extended_entities: {
+						media: [
+							{
+								media_url_https: "https://img.example.com/legacy.jpg",
+								type: "photo",
+							},
+						],
+					},
+				},
+			},
+		])}`,
+	);
 	const archivePath = path.join(root, "archive.zip");
 	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
 	return archivePath;
@@ -696,6 +762,22 @@ describe("archive import", () => {
 				)
 				.get(),
 		).toEqual({ count: 0 });
+		db.prepare(
+			`update tweets
+			 set deleted_at = '2027-01-01T00:00:00.000Z',
+			     deletion_source = 'local_later',
+			     deletion_reason = 'later_local_event'
+			 where id = 'edit-1'`,
+		).run();
+		insertTestTweet(db, {
+			id: "header-only",
+			authorProfileId: "profile_me",
+			text: "header placeholder",
+			createdAt: "2025-06-02T19:32:20.000Z",
+		});
+		db.prepare(
+			"update tweets set deleted_at = '2026-07-17T12:00:00.000Z' where id = 'header-only'",
+		).run();
 
 		const deletionArchive = makeTweetRetentionArchive({
 			includeEditable: false,
@@ -740,7 +822,7 @@ describe("archive import", () => {
 		expect(
 			db
 				.prepare(
-					"select revision_id, payload_json, created_at, deleted_at from tweet_revisions join tweets on tweets.id = tweet_revisions.revision_id where revision_id = 'header-only'",
+					"select revision_id, payload_json, created_at, deleted_at, deletion_source, deletion_reason from tweet_revisions join tweets on tweets.id = tweet_revisions.revision_id where revision_id = 'header-only'",
 				)
 				.get(),
 		).toEqual({
@@ -748,6 +830,8 @@ describe("archive import", () => {
 			payload_json: null,
 			created_at: "2025-06-02T19:32:20.000Z",
 			deleted_at: "2026-07-17T12:00:00.000Z",
+			deletion_source: "twitter_archive",
+			deletion_reason: "explicit_deleted_tweet_record",
 		});
 		expect(
 			db
@@ -771,6 +855,56 @@ describe("archive import", () => {
 				)
 				.get(),
 		).toEqual({ count: 0 });
+
+		insertTestTweet(db, {
+			id: "legacy-unknown-source",
+			authorProfileId: "profile_me",
+			text: "legacy placeholder",
+			createdAt: "2025-06-01T19:32:20.000Z",
+		});
+		db.prepare(
+			"update tweets set deleted_at = '2020-01-01T00:00:00.000Z' where id = 'legacy-unknown-source'",
+		).run();
+		await importArchive(makeLateDeletedTweetBodyArchive());
+		expect(
+			db
+				.prepare(
+					"select kind, subordinate_id, deletion_source from tweet_subordinate_tombstones where tweet_id = 'header-only' order by kind, subordinate_id",
+				)
+				.all(),
+		).toEqual([
+			{
+				kind: "media",
+				subordinate_id: "https://img.example.com/late.jpg",
+				deletion_source: "twitter_archive",
+			},
+			{
+				kind: "quote",
+				subordinate_id: "late-quote",
+				deletion_source: "twitter_archive",
+			},
+		]);
+		expect(
+			db
+				.prepare(
+					"select deleted_at, deletion_source from tweet_subordinate_tombstones where tweet_id = 'legacy-unknown-source' and kind = 'media'",
+				)
+				.get(),
+		).toEqual({
+			deleted_at: "2020-01-01T00:00:00.000Z",
+			deletion_source: null,
+		});
+		db.prepare(
+			"update tweet_subordinate_tombstones set deletion_source = 'trusted_existing' where tweet_id = 'header-only' and kind = 'media'",
+		).run();
+		await importArchive(makeLateDeletedTweetBodyArchive());
+		expect(
+			db
+				.prepare(
+					"select deletion_source from tweet_subordinate_tombstones where tweet_id = 'header-only' and kind = 'media'",
+				)
+				.get(),
+		).toEqual({ deletion_source: "trusted_existing" });
 
 		await importArchive(initialArchive);
 		expect(

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -237,10 +237,12 @@ function makeTweetRetentionArchive({
 	includeEditable = true,
 	includeVanishing = true,
 	deleteEditable = false,
+	deletedRevisionId = "edit-2",
 }: {
 	includeEditable?: boolean;
 	includeVanishing?: boolean;
 	deleteEditable?: boolean;
+	deletedRevisionId?: "edit-1" | "edit-2";
 } = {}) {
 	const root = testHome().makeTempDir("birdclaw-archive-retention-");
 	const archiveDir = path.join(root, "sample", "data");
@@ -310,9 +312,12 @@ function makeTweetRetentionArchive({
 			`window.YTD.deleted_tweets.part0 = ${JSON.stringify([
 				{
 					tweet: {
-						id_str: "edit-2",
+						id_str: deletedRevisionId,
 						created_at: "Tue Jun 03 19:32:20 +0000 2025",
-						full_text: "edited tweet with retained media",
+						full_text:
+							deletedRevisionId === "edit-1"
+								? "original body"
+								: "edited tweet with retained media",
 					},
 				},
 			])}`,
@@ -322,7 +327,7 @@ function makeTweetRetentionArchive({
 			`window.YTD.deleted_tweet_headers.part0 = ${JSON.stringify([
 				{
 					tweet: {
-						tweetId: "edit-2",
+						tweetId: deletedRevisionId,
 						userId: "25401953",
 						createdAt: "2025-06-03T19:32:20.000Z",
 						deletedAt: "2026-07-18T12:00:00.000Z",
@@ -696,6 +701,7 @@ describe("archive import", () => {
 			includeEditable: false,
 			includeVanishing: false,
 			deleteEditable: true,
+			deletedRevisionId: "edit-1",
 		});
 		const result = await importArchive(deletionArchive);
 
@@ -750,7 +756,7 @@ describe("archive import", () => {
 				)
 				.all(),
 		).toEqual([
-			{ revision_id: "edit-1", revision_index: 0, hydrated: 0 },
+			{ revision_id: "edit-1", revision_index: 0, hydrated: 1 },
 			{ revision_id: "edit-2", revision_index: 1, hydrated: 1 },
 		]);
 		expect(
@@ -2606,7 +2612,7 @@ describe("archive import", () => {
 			{ external_user_id: "900", source: "xurl", current: 1 },
 		]);
 		const partialArchivePath = makeFollowArchive({
-			followers: ["102", "103"],
+			followers: ["102", "103", "103"],
 			includeFollowing: false,
 		});
 		await importArchive(partialArchivePath);

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -233,6 +233,117 @@ function makeRootDataArchive() {
 	return archivePath;
 }
 
+function makeTweetRetentionArchive({
+	includeEditable = true,
+	includeVanishing = true,
+	deleteEditable = false,
+}: {
+	includeEditable?: boolean;
+	includeVanishing?: boolean;
+	deleteEditable?: boolean;
+} = {}) {
+	const root = testHome().makeTempDir("birdclaw-archive-retention-");
+	const archiveDir = path.join(root, "sample", "data");
+	mkdirSync(archiveDir, { recursive: true });
+	writeFileSync(
+		path.join(archiveDir, "account.js"),
+		'window.YTD.account.part0 = [{ "account": { "accountId": "25401953", "username": "steipete" } }]',
+	);
+	const tweets = [
+		...(includeEditable
+			? [
+					{
+						tweet: {
+							id_str: "edit-2",
+							created_at: "Tue Jun 03 19:32:20 +0000 2025",
+							full_text: "edited tweet with retained media",
+							quoted_status_id_str: "quote-1",
+							edit_info: {
+								edit: {
+									initialTweetId: "edit-1",
+									editControlInitial: {
+										editTweetIds: ["edit-1", "edit-2"],
+									},
+								},
+							},
+							entities: {
+								media: [
+									{
+										id_str: "media-1",
+										media_url_https: "https://img.example.com/deleted.jpg",
+										type: "photo",
+									},
+								],
+							},
+							extended_entities: {
+								media: [
+									{
+										id_str: "media-1",
+										media_url_https: "https://img.example.com/deleted.jpg",
+										type: "photo",
+									},
+								],
+							},
+						},
+					},
+				]
+			: []),
+		...(includeVanishing
+			? [
+					{
+						tweet: {
+							id_str: "vanishing",
+							created_at: "Wed Jun 04 19:32:20 +0000 2025",
+							full_text: "absence from a later snapshot is not deletion",
+						},
+					},
+				]
+			: []),
+	];
+	writeFileSync(
+		path.join(archiveDir, "tweets.js"),
+		`window.YTD.tweets.part0 = ${JSON.stringify(tweets)}`,
+	);
+	if (deleteEditable) {
+		writeFileSync(
+			path.join(archiveDir, "deleted-tweets.js"),
+			`window.YTD.deleted_tweets.part0 = ${JSON.stringify([
+				{
+					tweet: {
+						id_str: "edit-2",
+						created_at: "Tue Jun 03 19:32:20 +0000 2025",
+						full_text: "edited tweet with retained media",
+					},
+				},
+			])}`,
+		);
+		writeFileSync(
+			path.join(archiveDir, "deleted-tweet-headers.js"),
+			`window.YTD.deleted_tweet_headers.part0 = ${JSON.stringify([
+				{
+					tweet: {
+						tweetId: "edit-2",
+						userId: "25401953",
+						createdAt: "2025-06-03T19:32:20.000Z",
+						deletedAt: "2026-07-18T12:00:00.000Z",
+					},
+				},
+				{
+					tweet: {
+						tweetId: "header-only",
+						userId: "25401953",
+						createdAt: "2025-06-02T19:32:20.000Z",
+						deletedAt: "2026-07-17T12:00:00.000Z",
+					},
+				},
+			])}`,
+		);
+	}
+	const archivePath = path.join(root, "archive.zip");
+	execFileSync("zip", ["-qr", archivePath, "sample"], { cwd: root });
+	return archivePath;
+}
+
 function makeWeirdArchive({ followers = [] }: { followers?: string[] } = {}) {
 	const root = testHome().makeTempDir("birdclaw-archive-weird-");
 	const archiveDir = path.join(root, "sample", "data");
@@ -543,6 +654,155 @@ function makeMediaVariantsArchive() {
 }
 
 describe("archive import", () => {
+	it("retains explicit tweet tombstones without inferring deletion from absence", async () => {
+		const initialArchive = makeTweetRetentionArchive();
+		await importArchive(initialArchive, { restore: true });
+		const db = getNativeDb({ seedDemoData: false });
+		db.exec(`
+			insert into tweets (
+				id, author_profile_id, text, created_at, is_replied, reply_to_id,
+				like_count, media_count, entities_json, media_json, quoted_tweet_id
+			) values (
+				'edit-1', 'profile_me', 'original body', '2025-06-03T19:30:20.000Z',
+				0, null, 0, 0, '{}', '[]', null
+			);
+			insert into tweet_account_edges (
+				account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
+				source, raw_json, updated_at
+			) values (
+				'acct_primary', 'edit-1', 'authored', '2025-06-03T19:30:20.000Z',
+				'2025-06-03T19:30:20.000Z', 1, 'archive', '{}',
+				'2025-06-03T19:30:20.000Z'
+			);
+			insert into tweets_fts (tweet_id, text) values ('edit-1', 'original body');
+		`);
+		await importArchive(initialArchive);
+		expect(
+			db
+				.prepare(
+					"select superseded_at is not null as superseded, superseded_by_id from tweets where id = 'edit-1'",
+				)
+				.get(),
+		).toEqual({ superseded: 1, superseded_by_id: "edit-2" });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweet_id = 'edit-1'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+
+		const deletionArchive = makeTweetRetentionArchive({
+			includeEditable: false,
+			includeVanishing: false,
+			deleteEditable: true,
+		});
+		const result = await importArchive(deletionArchive);
+
+		expect(result.mode).toBe("merge");
+		expect(
+			db
+				.prepare(
+					"select created_at, deleted_at, deletion_source, deletion_reason, media_json, quoted_tweet_id from tweets where id = 'edit-2'",
+				)
+				.get(),
+		).toMatchObject({
+			created_at: "2025-06-03T19:32:20.000Z",
+			deleted_at: "2026-07-18T12:00:00.000Z",
+			deletion_source: "twitter_archive",
+			deletion_reason: "explicit_deleted_tweet_record",
+			quoted_tweet_id: "quote-1",
+		});
+		expect(
+			db
+				.prepare(
+					"select kind, subordinate_id, deletion_reason from tweet_subordinate_tombstones where tweet_id = 'edit-2' order by kind, subordinate_id",
+				)
+				.all(),
+		).toEqual([
+			{
+				kind: "media",
+				subordinate_id: "https://img.example.com/deleted.jpg",
+				deletion_reason: "parent_tweet_deleted",
+			},
+			{
+				kind: "quote",
+				subordinate_id: "quote-1",
+				deletion_reason: "parent_tweet_deleted",
+			},
+		]);
+		expect(
+			db
+				.prepare(
+					"select revision_id, payload_json, created_at, deleted_at from tweet_revisions join tweets on tweets.id = tweet_revisions.revision_id where revision_id = 'header-only'",
+				)
+				.get(),
+		).toEqual({
+			revision_id: "header-only",
+			payload_json: null,
+			created_at: "2025-06-02T19:32:20.000Z",
+			deleted_at: "2026-07-17T12:00:00.000Z",
+		});
+		expect(
+			db
+				.prepare(
+					"select revision_id, revision_index, payload_json is not null as hydrated from tweet_revisions where root_tweet_id = 'edit-1' order by revision_index",
+				)
+				.all(),
+		).toEqual([
+			{ revision_id: "edit-1", revision_index: 0, hydrated: 0 },
+			{ revision_id: "edit-2", revision_index: 1, hydrated: 1 },
+		]);
+		expect(
+			listTimelineItems({ resource: "home", limit: 10 }).map(
+				(tweet) => tweet.id,
+			),
+		).toEqual(["vanishing"]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweet_id = 'edit-2'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+
+		await importArchive(initialArchive);
+		expect(
+			db.prepare("select deleted_at from tweets where id = 'edit-2'").get(),
+		).toEqual({ deleted_at: "2026-07-18T12:00:00.000Z" });
+
+		const emptyRestore = makeTweetRetentionArchive({
+			includeEditable: false,
+			includeVanishing: false,
+		});
+		const restoreResult = await importArchive(emptyRestore, {
+			restore: true,
+			select: ["tweets"],
+		});
+		expect(restoreResult.mode).toBe("restore");
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets where id in ('edit-2', 'vanishing')",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweet_subordinate_tombstones where tweet_id = 'edit-2'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweet_revisions where root_tweet_id = 'edit-1'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+	});
+
 	it("imports tweets, dms, profiles, and envelope stats from a zip archive", async () => {
 		const archivePath = makeArchive();
 		const staleDb = getNativeDb();
@@ -559,7 +819,7 @@ describe("archive import", () => {
       );
     `);
 
-		const result = await importArchive(archivePath);
+		const result = await importArchive(archivePath, { restore: true });
 		const db = getNativeDb();
 		const envelope = await getQueryEnvelope({ includeArchives: false });
 		const tweets = listTimelineItems({ resource: "home", limit: 10 });
@@ -777,7 +1037,7 @@ describe("archive import", () => {
 		});
 	});
 
-	it("clears mention sync state on full archive re-import", async () => {
+	it("clears mention sync state on an explicit full archive restore", async () => {
 		const archivePath = makeArchive();
 		const db = getNativeDb();
 		db.prepare(
@@ -788,7 +1048,7 @@ describe("archive import", () => {
 			"2026-05-01T00:00:00.000Z",
 		);
 
-		await importArchive(archivePath);
+		await importArchive(archivePath, { restore: true });
 
 		expect(
 			db
@@ -830,7 +1090,10 @@ describe("archive import", () => {
 		db.prepare(
 			"update tweet_collections set source = 'legacy' where tweet_id = '5' and kind = 'likes'",
 		).run();
-		await importArchive(makeRootDataArchive(), { select: ["likes"] });
+		await importArchive(makeRootDataArchive(), {
+			select: ["likes"],
+			restore: true,
+		});
 
 		expect(
 			db.prepare("select id from tweets where id = '5'").get(),
@@ -926,6 +1189,25 @@ describe("archive import", () => {
 		).rejects.toThrow("does not match archive account 25401953");
 		expect(
 			db.prepare("select id from tweets where id = '5'").get(),
+		).toBeUndefined();
+	});
+
+	it("rejects full merge imports for a different existing primary account", async () => {
+		const archivePath = makeArchive();
+		const db = getNativeDb({ seedDemoData: false });
+		insertTestAccount(db, {
+			id: "acct_primary",
+			name: "Other Primary",
+			handle: "@other",
+			externalUserId: "999",
+			transport: "xurl",
+		});
+
+		await expect(importArchive(archivePath)).rejects.toThrow(
+			"does not match archive account 25401953",
+		);
+		expect(
+			db.prepare("select id from tweets where id = '100'").get(),
 		).toBeUndefined();
 	});
 
@@ -1171,7 +1453,10 @@ describe("archive import", () => {
 	      );
 	    `);
 
-		await importArchive(archivePath, { select: ["directMessages"] });
+		await importArchive(archivePath, {
+			select: ["directMessages"],
+			restore: true,
+		});
 
 		expect(
 			(
@@ -1446,7 +1731,10 @@ describe("archive import", () => {
 				account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
 			) values ('acct_other', '5', 'likes', null, 'bird', '{}', '2026-01-02T00:00:00.000Z')`,
 		).run();
-		await importArchive(makeRootDataArchive(), { select: ["likes"] });
+		await importArchive(makeRootDataArchive(), {
+			select: ["likes"],
+			restore: true,
+		});
 
 		expect(
 			db
@@ -1488,7 +1776,10 @@ describe("archive import", () => {
       );
     `);
 
-		await importArchive(archivePath, { select: ["tweets"] });
+		await importArchive(archivePath, {
+			select: ["tweets"],
+			restore: true,
+		});
 
 		expect(
 			db.prepare("select id from profiles where id = 'profile_me'").get(),
@@ -1628,7 +1919,10 @@ describe("archive import", () => {
         'acct_other', '300', 'likes', '2026-01-03T00:00:00.000Z', 'bird', '{}', '2026-01-03T00:00:00.000Z'
       );
 	    `);
-		await importArchive(nextArchivePath, { select: ["tweets"] });
+		await importArchive(nextArchivePath, {
+			select: ["tweets"],
+			restore: true,
+		});
 		const db = getNativeDb();
 
 		expect(
@@ -1787,8 +2081,8 @@ describe("archive import", () => {
 			"following:103:started",
 		]);
 		expect(snapshots.map((row) => row.value)).toEqual([
-			"followers:archive:complete:2",
-			"following:archive:complete:2",
+			"followers:archive:partial:2",
+			"following:archive:partial:2",
 		]);
 		expect(
 			db
@@ -2254,7 +2548,7 @@ describe("archive import", () => {
 		});
 	});
 
-	it("clears archive follower rows when follower file is absent", async () => {
+	it("preserves absent archive follower rows unless restoring", async () => {
 		const firstArchivePath = makeFollowArchive({
 			followers: ["101", "102"],
 			includeFollowing: false,
@@ -2294,6 +2588,47 @@ describe("archive import", () => {
 		).run();
 
 		await importArchive(secondArchivePath);
+
+		expect(
+			db
+				.prepare(
+					`
+          select external_user_id, source, current
+          from follow_edges
+          where direction = 'followers'
+          order by external_user_id
+        `,
+				)
+				.all(),
+		).toEqual([
+			{ external_user_id: "101", source: "archive", current: 1 },
+			{ external_user_id: "102", source: "archive", current: 1 },
+			{ external_user_id: "900", source: "xurl", current: 1 },
+		]);
+		const partialArchivePath = makeFollowArchive({
+			followers: ["102", "103"],
+			includeFollowing: false,
+		});
+		await importArchive(partialArchivePath);
+		expect(
+			db
+				.prepare(
+					`
+          select external_user_id, source, current
+          from follow_edges
+          where direction = 'followers'
+          order by external_user_id
+        `,
+				)
+				.all(),
+		).toEqual([
+			{ external_user_id: "101", source: "archive", current: 1 },
+			{ external_user_id: "102", source: "archive", current: 1 },
+			{ external_user_id: "103", source: "archive", current: 1 },
+			{ external_user_id: "900", source: "xurl", current: 1 },
+		]);
+
+		await importArchive(secondArchivePath, { restore: true });
 
 		expect(
 			db
@@ -2420,7 +2755,7 @@ describe("archive import", () => {
 		).toBe(0);
 	});
 
-	it("keeps live follow source on xurl edges absent from the archive", async () => {
+	it("does not end live follow edges absent from a merge archive", async () => {
 		const archivePath = makeFollowArchive({
 			followers: ["101"],
 			includeFollowing: false,
@@ -2454,14 +2789,26 @@ describe("archive import", () => {
 
 		expect(rows).toEqual([
 			{ profile_id: "profile_user_101", source: "xurl", current: 1 },
-			{ profile_id: "profile_user_900", source: "xurl", current: 0 },
+			{ profile_id: "profile_user_900", source: "xurl", current: 1 },
 		]);
-		expect(events).toEqual([{ external_user_id: "900", kind: "ended" }]);
+		expect(events).toEqual([]);
 		expect(
 			listUnfollowedSince({ date: "2000-01-01" }).items.map(
 				(item) => item.profile.handle,
 			),
-		).toEqual(["id900"]);
+		).toEqual([]);
+
+		await importArchive(archivePath, { restore: true });
+		expect(
+			db
+				.prepare(
+					"select profile_id, source, current from follow_edges where direction = 'followers' order by profile_id",
+				)
+				.all(),
+		).toEqual([
+			{ profile_id: "profile_user_101", source: "xurl", current: 1 },
+			{ profile_id: "profile_user_900", source: "xurl", current: 0 },
+		]);
 		expect(
 			listFollowEvents({
 				direction: "followers",

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -941,6 +941,9 @@ describe("archive import", () => {
 				)
 				.get(),
 		).toEqual({ count: 0 });
+		expect(
+			db.prepare("select count(*) as count from tweet_revision_edges").get(),
+		).toEqual({ count: 0 });
 	});
 
 	it("imports tweets, dms, profiles, and envelope stats from a zip archive", async () => {

--- a/src/lib/archive-import.ts
+++ b/src/lib/archive-import.ts
@@ -12,6 +12,7 @@ import {
 } from "./archive/follow-slice";
 import { createArchiveProfileReconciler } from "./archive/profile-reconciler";
 import {
+	parseDeletedTweetSliceEffect,
 	parseNoteTweetSliceEffect,
 	parseTweetSliceEffect,
 } from "./archive/tweet-slices";
@@ -66,6 +67,7 @@ function importArchiveInternalEffect(
 ): Effect.Effect<ImportedArchiveSummary, unknown> {
 	return Effect.gen(function* () {
 		const onProgress = options.onProgress ?? (() => {});
+		const observedAt = new Date().toISOString();
 		const entries = yield* listArchiveEntriesEffect(archivePath);
 		onProgress({ kind: "scanned", entryCount: entries.length });
 		const selection = selectedSlices(options);
@@ -80,6 +82,7 @@ function importArchiveInternalEffect(
 			accountEntry,
 			profileEntry,
 			tweetEntries,
+			deletedTweetEntries,
 			noteTweetEntries,
 			likeEntries,
 			bookmarkEntries,
@@ -103,7 +106,7 @@ function importArchiveInternalEffect(
 			parseArchiveArray(accountContent)[0] ?? null,
 			parseArchiveArray(profileContent)[0] ?? null,
 		);
-		const db = getNativeDb();
+		const db = getNativeDb({ seedDemoData: false });
 		const repository = getImportRepository(db);
 		const plan = new ArchiveImportPlan();
 		const {
@@ -121,6 +124,13 @@ function importArchiveInternalEffect(
 			plan,
 			onProgress,
 		});
+		yield* parseDeletedTweetSliceEffect({
+			archivePath,
+			entries: deletedTweetEntries,
+			plan,
+			onProgress,
+			observedAt,
+		});
 		yield* parseNoteTweetSliceEffect({
 			archivePath,
 			entries: noteTweetEntries,
@@ -132,10 +142,15 @@ function importArchiveInternalEffect(
 		const profileReconciler = createArchiveProfileReconciler({
 			repository,
 			selection,
+			preserveExisting: !(
+				options.restore === true &&
+				(!selection || selection.has("profiles"))
+			),
+			allowAccountReplacement: options.restore === true && !selection,
 			accountPayload,
 			profiles,
 		});
-		profileReconciler.assertSelectedAccountMatchesArchive();
+		profileReconciler.assertAccountMatchesArchive();
 		const localProfile =
 			profileReconciler.initializeLocalProfile(includeProfiles);
 		yield* parseDirectMessagesEffect({
@@ -226,11 +241,13 @@ function importArchiveInternalEffect(
 			followerEntryCount: followerEntries.length,
 			followingEntryCount: followingEntries.length,
 			onProgress,
+			restore: options.restore === true,
 		});
 		onProgress({ kind: "done" });
 
 		return {
 			ok: true,
+			mode: options.restore === true ? "restore" : "merge",
 			archivePath,
 			account: {
 				id: accountPayload.accountId,

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -389,6 +389,11 @@ export function applyArchiveImportPlanEffect({
 		      )
 		    )
 		  `);
+		const deleteOrphanTweetRevisionEdges = db.prepare(`
+			delete from tweet_revision_edges
+			where older_revision_id not in (select revision_id from tweet_revisions)
+			   or newer_revision_id not in (select revision_id from tweet_revisions)
+		`);
 		const clearDmFts = db.prepare(`
 		    delete from dm_fts
 		    where message_id in (
@@ -607,6 +612,7 @@ export function applyArchiveImportPlanEffect({
 					deleteOrphanTweetLinkOccurrences.run();
 					deleteOrphanTweetSubordinateTombstones.run();
 					deleteOrphanTweetRevisionChains.run();
+					deleteOrphanTweetRevisionEdges.run();
 				}
 				if (includeDirectMessages) {
 					clearDmLinkOccurrences.run("acct_primary");

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -426,10 +426,23 @@ export function applyArchiveImportPlanEffect({
 				profile_id: string;
 				external_user_id: string;
 			}>;
-			const incomingRows = rows.map((row) => ({
-				profileId: resolveProfileId(row.profileId),
-				externalUserId: row.externalUserId,
-			}));
+			const existingProfileIds = new Set(
+				existingMembers.map((row) => row.profile_id),
+			);
+			const incomingByProfileId = new Map<
+				string,
+				{ profileId: string; externalUserId: string }
+			>();
+			for (const row of rows) {
+				const profileId = resolveProfileId(row.profileId);
+				if (!incomingByProfileId.has(profileId)) {
+					incomingByProfileId.set(profileId, {
+						profileId,
+						externalUserId: row.externalUserId,
+					});
+				}
+			}
+			const incomingRows = Array.from(incomingByProfileId.values());
 			const effectiveRows = restore
 				? incomingRows
 				: [
@@ -438,10 +451,7 @@ export function applyArchiveImportPlanEffect({
 							externalUserId: row.external_user_id,
 						})),
 						...incomingRows.filter(
-							(row) =>
-								!existingMembers.some(
-									(member) => member.profile_id === row.profileId,
-								),
+							(row) => !existingProfileIds.has(row.profileId),
 						),
 					];
 			const existingMemberKey = existingMembers

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -153,8 +153,22 @@ export function applyArchiveImportPlanEffect({
 		        when excluded.deleted_at is null then tweets.deleted_at
 		        else min(tweets.deleted_at, excluded.deleted_at)
 		      end,
-		      deletion_source = coalesce(tweets.deletion_source, excluded.deletion_source),
-		      deletion_reason = coalesce(tweets.deletion_reason, excluded.deletion_reason)
+		      deletion_source = case
+		        when excluded.deleted_at is not null
+		          and (tweets.deleted_at is null or excluded.deleted_at < tweets.deleted_at)
+		          then excluded.deletion_source
+		        when excluded.deleted_at = tweets.deleted_at
+		          then coalesce(tweets.deletion_source, excluded.deletion_source)
+		        else tweets.deletion_source
+		      end,
+		      deletion_reason = case
+		        when excluded.deleted_at is not null
+		          and (tweets.deleted_at is null or excluded.deleted_at < tweets.deleted_at)
+		          then excluded.deletion_reason
+		        when excluded.deleted_at = tweets.deleted_at
+		          then coalesce(tweets.deletion_reason, excluded.deletion_reason)
+		        else tweets.deletion_reason
+		      end
 		  `);
 		const deleteTweetFts = db.prepare(
 			"delete from tweets_fts where tweet_id = ?",
@@ -163,7 +177,7 @@ export function applyArchiveImportPlanEffect({
 			"insert into tweets_fts (tweet_id, text) values (?, ?)",
 		);
 		const selectTweetFtsState = db.prepare(
-			"select text, deleted_at from tweets where id = ?",
+			"select text, deleted_at, deletion_source from tweets where id = ?",
 		);
 		const insertTimelineEdge = db.prepare(`
 		    insert into tweet_account_edges (
@@ -703,7 +717,11 @@ export function applyArchiveImportPlanEffect({
 					);
 				}
 				const storedTweet = selectTweetFtsState.get(tweet.id) as
-					| { text: string; deleted_at: string | null }
+					| {
+							text: string;
+							deleted_at: string | null;
+							deletion_source: string | null;
+					  }
 					| undefined;
 				if (!storedTweet?.deleted_at) {
 					insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
@@ -711,7 +729,11 @@ export function applyArchiveImportPlanEffect({
 					tombstoneTweetSubordinates(db, {
 						tweetId: tweet.id,
 						deletedAt: storedTweet.deleted_at,
-						deletionSource: tweet.deletionSource ?? "archive_import",
+						deletionSource:
+							storedTweet.deletion_source ??
+							(tweet.deletedAt === storedTweet.deleted_at
+								? (tweet.deletionSource ?? null)
+								: null),
 					});
 				}
 				recordTweetRevision(db, {

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -7,6 +7,11 @@ import type {
 import { databaseWriteEffect } from "../database-writer";
 import type { ImportRepository } from "../import-repository";
 import type { Database } from "../sqlite";
+import {
+	reconcileTweetTombstones,
+	recordTweetRevision,
+	tombstoneTweetSubordinates,
+} from "../tweet-retention";
 import type {
 	ArchiveAccountPayload,
 	ArchiveFollowDirection,
@@ -34,6 +39,7 @@ interface ApplyArchiveImportParams {
 	followerEntryCount: number;
 	followingEntryCount: number;
 	onProgress: (event: ImportProgressEvent) => void;
+	restore: boolean;
 }
 
 export function applyArchiveImportPlanEffect({
@@ -55,6 +61,7 @@ export function applyArchiveImportPlanEffect({
 	followerEntryCount,
 	followingEntryCount,
 	onProgress,
+	restore,
 }: ApplyArchiveImportParams) {
 	const {
 		tweets: tweetRows,
@@ -116,8 +123,9 @@ export function applyArchiveImportPlanEffect({
 		const insertTweet = db.prepare(`
 		    insert into tweets (
 		      id, author_profile_id, text, created_at, is_replied, reply_to_id,
-		      like_count, media_count, entities_json, media_json, quoted_tweet_id
-		    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		      like_count, media_count, entities_json, media_json, quoted_tweet_id,
+		      deleted_at, deletion_source, deletion_reason
+		    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		    on conflict(id) do update set
 		      author_profile_id = case
 		        when tweets.author_profile_id = 'profile_unknown' then excluded.author_profile_id
@@ -139,7 +147,14 @@ export function applyArchiveImportPlanEffect({
 		      media_count = max(tweets.media_count, excluded.media_count),
 		      entities_json = case when excluded.entities_json <> '{}' then excluded.entities_json else tweets.entities_json end,
 		      media_json = case when excluded.media_json <> '[]' then excluded.media_json else tweets.media_json end,
-		      quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id)
+		      quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id),
+		      deleted_at = case
+		        when tweets.deleted_at is null then excluded.deleted_at
+		        when excluded.deleted_at is null then tweets.deleted_at
+		        else min(tweets.deleted_at, excluded.deleted_at)
+		      end,
+		      deletion_source = coalesce(tweets.deletion_source, excluded.deletion_source),
+		      deletion_reason = coalesce(tweets.deletion_reason, excluded.deletion_reason)
 		  `);
 		const deleteTweetFts = db.prepare(
 			"delete from tweets_fts where tweet_id = ?",
@@ -147,8 +162,8 @@ export function applyArchiveImportPlanEffect({
 		const insertTweetFts = db.prepare(
 			"insert into tweets_fts (tweet_id, text) values (?, ?)",
 		);
-		const selectTweetFtsText = db.prepare(
-			"select text from tweets where id = ?",
+		const selectTweetFtsState = db.prepare(
+			"select text, deleted_at from tweets where id = ?",
 		);
 		const insertTimelineEdge = db.prepare(`
 		    insert into tweet_account_edges (
@@ -180,20 +195,35 @@ export function applyArchiveImportPlanEffect({
 		    insert into dm_conversations (
 		      id, account_id, participant_profile_id, title, last_message_at, unread_count, needs_reply
 		    ) values (?, ?, ?, ?, ?, ?, ?)
+		    on conflict(id) do update set
+		      participant_profile_id = excluded.participant_profile_id,
+		      title = excluded.title,
+		      last_message_at = max(dm_conversations.last_message_at, excluded.last_message_at),
+		      unread_count = max(dm_conversations.unread_count, excluded.unread_count),
+		      needs_reply = max(dm_conversations.needs_reply, excluded.needs_reply)
 		  `);
 		const insertMessage = db.prepare(`
 		    insert into dm_messages (
 		      id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
 		    ) values (?, ?, ?, ?, ?, ?, ?, ?)
+		    on conflict(id) do update set
+		      conversation_id = excluded.conversation_id,
+		      sender_profile_id = excluded.sender_profile_id,
+		      text = excluded.text,
+		      created_at = excluded.created_at,
+		      direction = excluded.direction,
+		      is_replied = max(dm_messages.is_replied, excluded.is_replied),
+		      media_count = max(dm_messages.media_count, excluded.media_count)
 		  `);
 		const insertDmFts = db.prepare(
 			"insert into dm_fts (message_id, text) values (?, ?)",
 		);
+		const deleteDmFts = db.prepare("delete from dm_fts where message_id = ?");
 		const insertFollowSnapshot = db.prepare(`
 		    insert into follow_snapshots (
 		      id, account_id, direction, source, status, page_count, result_count,
 		      started_at, completed_at, raw_meta_json
-		    ) values (?, ?, ?, 'archive', 'complete', ?, ?, ?, ?, ?)
+		    ) values (?, ?, ?, 'archive', ?, ?, ?, ?, ?, ?)
 		    on conflict(id) do update set
 		      account_id = excluded.account_id,
 		      direction = excluded.direction,
@@ -327,6 +357,24 @@ export function applyArchiveImportPlanEffect({
 		    delete from tweets_fts
 		    where tweet_id not in (select id from tweets)
 		  `);
+		const deleteOrphanTweetSubordinateTombstones = db.prepare(`
+		    delete from tweet_subordinate_tombstones
+		    where tweet_id not in (select id from tweets)
+		  `);
+		const deleteOrphanTweetRevisionChains = db.prepare(`
+		    delete from tweet_revisions
+		    where root_tweet_id in (
+		      select revisions.root_tweet_id
+		      from tweet_revisions revisions
+		      group by revisions.root_tweet_id
+		      having not exists (
+		        select 1
+		        from tweet_revisions retained_revision
+		        join tweets on tweets.id = retained_revision.revision_id
+		        where retained_revision.root_tweet_id = revisions.root_tweet_id
+		      )
+		    )
+		  `);
 		const clearDmFts = db.prepare(`
 		    delete from dm_fts
 		    where message_id in (
@@ -372,18 +420,37 @@ export function applyArchiveImportPlanEffect({
 					}>
 				).map((row) => [row.profile_id, row]),
 			);
-			const existingMemberKey = (
-				selectFollowSnapshotMembers.all(snapshotId) as Array<{
-					profile_id: string;
-					external_user_id: string;
-				}>
-			)
+			const existingMembers = selectFollowSnapshotMembers.all(
+				snapshotId,
+			) as Array<{
+				profile_id: string;
+				external_user_id: string;
+			}>;
+			const incomingRows = rows.map((row) => ({
+				profileId: resolveProfileId(row.profileId),
+				externalUserId: row.externalUserId,
+			}));
+			const effectiveRows = restore
+				? incomingRows
+				: [
+						...existingMembers.map((row) => ({
+							profileId: row.profile_id,
+							externalUserId: row.external_user_id,
+						})),
+						...incomingRows.filter(
+							(row) =>
+								!existingMembers.some(
+									(member) => member.profile_id === row.profileId,
+								),
+						),
+					];
+			const existingMemberKey = existingMembers
 				.map(
 					(row, index) =>
 						`${String(index)}:${row.profile_id}:${row.external_user_id}`,
 				)
 				.join("\n");
-			const nextMemberKey = rows
+			const nextMemberKey = effectiveRows
 				.map(
 					(row, index) =>
 						`${String(index)}:${row.profileId}:${row.externalUserId}`,
@@ -396,19 +463,23 @@ export function applyArchiveImportPlanEffect({
 				snapshotId,
 				"acct_primary",
 				direction,
+				restore ? "complete" : "partial",
 				entryCount,
-				rows.length,
+				effectiveRows.length,
 				now,
 				now,
-				JSON.stringify({ archivePath, result_count: rows.length }),
+				JSON.stringify({
+					archivePath,
+					result_count: incomingRows.length,
+					merged_result_count: effectiveRows.length,
+				}),
 			);
 
 			if (membersChanged) {
 				deleteFollowSnapshotMembers.run(snapshotId);
 			}
-			rows.forEach((row, index) => {
-				const profileId = resolveProfileId(row.profileId);
-				currentProfileIds.add(profileId);
+			effectiveRows.forEach((row, index) => {
+				const profileId = row.profileId;
 				if (membersChanged) {
 					insertFollowSnapshotMember.run(
 						snapshotId,
@@ -417,6 +488,10 @@ export function applyArchiveImportPlanEffect({
 						index,
 					);
 				}
+			});
+			incomingRows.forEach((row) => {
+				const profileId = row.profileId;
+				currentProfileIds.add(profileId);
 
 				const previous = existingEdges.get(profileId);
 				insertFollowEdge.run(
@@ -442,6 +517,7 @@ export function applyArchiveImportPlanEffect({
 				}
 			});
 
+			if (!restore) return;
 			for (const [profileId, previous] of existingEdges) {
 				if (previous.current === 0 || currentProfileIds.has(profileId)) {
 					continue;
@@ -485,12 +561,12 @@ export function applyArchiveImportPlanEffect({
 			}
 		}
 		yield* databaseWriteEffect(() => {
-			if (!selection) {
+			if (restore && !selection) {
 				repository.clearArchiveImport();
 				repository.clearMentionSyncState();
 			}
 
-			if (selection) {
+			if (restore && selection) {
 				if (includeTweets) {
 					repository.clearAuthoredSyncCursors("acct_primary");
 					clearSelectedArchiveTweetEdges.run("acct_primary", localProfile.id);
@@ -505,6 +581,8 @@ export function applyArchiveImportPlanEffect({
 					deleteOrphanTweets.run();
 					deleteOrphanTweetFts.run();
 					deleteOrphanTweetLinkOccurrences.run();
+					deleteOrphanTweetSubordinateTombstones.run();
+					deleteOrphanTweetRevisionChains.run();
 				}
 				if (includeDirectMessages) {
 					clearDmLinkOccurrences.run("acct_primary");
@@ -526,6 +604,7 @@ export function applyArchiveImportPlanEffect({
 
 			const writeProfile =
 				!selection || includeProfiles ? insertProfile : insertProfileIfMissing;
+			const importedAt = new Date().toISOString();
 			const profilesTotal = profiles.size;
 			if (profilesTotal > 0) {
 				onProgress({
@@ -566,6 +645,10 @@ export function applyArchiveImportPlanEffect({
 			}
 			let tweetWriteIndex = 0;
 			for (const tweet of tweetRows) {
+				const preserveExistingBody =
+					Boolean(tweet.deletedAt) ||
+					tweet.kind === "like" ||
+					tweet.kind === "bookmark";
 				const authorProfileId =
 					tweet.authorProfileId === "profile_me"
 						? localProfile.id
@@ -582,8 +665,11 @@ export function applyArchiveImportPlanEffect({
 					tweet.entitiesJson,
 					tweet.mediaJson,
 					tweet.quotedTweetId,
-					tweet.kind === "like" || tweet.kind === "bookmark" ? 1 : 0,
-					tweet.kind === "like" || tweet.kind === "bookmark" ? 1 : 0,
+					tweet.deletedAt ?? null,
+					tweet.deletionSource ?? null,
+					tweet.deletionReason ?? null,
+					preserveExistingBody ? 1 : 0,
+					preserveExistingBody ? 1 : 0,
 				);
 				deleteTweetFts.run(tweet.id);
 				if (tweet.kind === "home") {
@@ -606,15 +692,29 @@ export function applyArchiveImportPlanEffect({
 						new Date().toISOString(),
 					);
 				}
-				const storedTweet = selectTweetFtsText.get(tweet.id) as
-					| { text: string }
+				const storedTweet = selectTweetFtsState.get(tweet.id) as
+					| { text: string; deleted_at: string | null }
 					| undefined;
-				insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
+				if (!storedTweet?.deleted_at) {
+					insertTweetFts.run(tweet.id, storedTweet?.text ?? tweet.text);
+				} else {
+					tombstoneTweetSubordinates(db, {
+						tweetId: tweet.id,
+						deletedAt: storedTweet.deleted_at,
+						deletionSource: tweet.deletionSource ?? "archive_import",
+					});
+				}
+				recordTweetRevision(db, {
+					tweetId: tweet.id,
+					editHistoryIds: tweet.editHistoryIds ?? [tweet.id],
+					payloadJson: tweet.rawJson ?? null,
+					source: "twitter_archive",
+					observedAt: importedAt,
+				});
 				tweetWriteIndex += 1;
 				tickWrite("tweets", tweetWriteIndex, tweetRows.length);
 			}
 
-			const importedAt = new Date().toISOString();
 			if (collectionRows.length > 0) {
 				onProgress({
 					kind: "write-start",
@@ -668,6 +768,7 @@ export function applyArchiveImportPlanEffect({
 					message.direction === "outbound" ? 1 : 0,
 					message.mediaCount,
 				);
+				deleteDmFts.run(message.id);
 				insertDmFts.run(message.id, message.text);
 				dmWriteIndex += 1;
 				tickWrite("dmMessages", dmWriteIndex, dmMessages.length);
@@ -680,7 +781,7 @@ export function applyArchiveImportPlanEffect({
 					followerEntryCount,
 					importedAt,
 				);
-			} else if (includeFollowers) {
+			} else if (includeFollowers && restore) {
 				clearArchiveFollowRows("followers");
 			}
 			if (includeFollowing && followingEntryCount > 0) {
@@ -690,9 +791,10 @@ export function applyArchiveImportPlanEffect({
 					followingEntryCount,
 					importedAt,
 				);
-			} else if (includeFollowing) {
+			} else if (includeFollowing && restore) {
 				clearArchiveFollowRows("following");
 			}
+			reconcileTweetTombstones(db);
 		}, db);
 	});
 }

--- a/src/lib/archive/profile-reconciler.ts
+++ b/src/lib/archive/profile-reconciler.ts
@@ -115,11 +115,15 @@ function existingProfileToProfileRow(
 export function createArchiveProfileReconciler({
 	repository,
 	selection,
+	preserveExisting = true,
+	allowAccountReplacement = false,
 	accountPayload,
 	profiles,
 }: {
 	repository: ImportRepository;
 	selection: Set<ArchiveImportSlice> | null;
+	preserveExisting?: boolean;
+	allowAccountReplacement?: boolean;
 	accountPayload: ArchiveAccountPayload;
 	profiles: Map<string, ArchiveProfileRow>;
 }) {
@@ -149,8 +153,10 @@ export function createArchiveProfileReconciler({
 	const profileIdAliases = new Map<string, string>();
 
 	function merge(incoming: ArchiveProfileRow) {
-		const existingById = existingProfiles.get(incoming.id);
-		const existingByHandle = selection
+		const existingById = preserveExisting
+			? existingProfiles.get(incoming.id)
+			: undefined;
+		const existingByHandle = preserveExisting
 			? existingProfilesByHandle.get(incoming.handle.toLowerCase())
 			: undefined;
 		const targetExisting = existingById ?? existingByHandle;
@@ -231,8 +237,8 @@ export function createArchiveProfileReconciler({
 		});
 	}
 
-	function assertSelectedAccountMatchesArchive() {
-		if (!selection || !existingPrimaryAccount) return;
+	function assertAccountMatchesArchive() {
+		if (allowAccountReplacement || !existingPrimaryAccount) return;
 		const existingExternalUserId = existingPrimaryAccount.external_user_id;
 		if (
 			existingExternalUserId &&
@@ -257,7 +263,7 @@ export function createArchiveProfileReconciler({
 
 	function initializeLocalProfile(includeProfiles: boolean) {
 		const existingLocalProfile =
-			selection &&
+			preserveExisting &&
 			(existingProfiles.get("profile_me") ??
 				[...existingProfiles.values()].find(
 					(profile) =>
@@ -349,7 +355,7 @@ export function createArchiveProfileReconciler({
 		resolveId,
 		uniqueHandle,
 		addFollowProfile,
-		assertSelectedAccountMatchesArchive,
+		assertAccountMatchesArchive,
 		initializeLocalProfile,
 		retainExistingFollowProfiles,
 		ensureUnknownProfile,

--- a/src/lib/archive/slices.ts
+++ b/src/lib/archive/slices.ts
@@ -5,6 +5,7 @@ export interface ArchiveSliceEntries {
 	accountEntry: string | undefined;
 	profileEntry: string | undefined;
 	tweetEntries: string[];
+	deletedTweetEntries: string[];
 	noteTweetEntries: string[];
 	likeEntries: string[];
 	bookmarkEntries: string[];
@@ -39,6 +40,10 @@ export function selectArchiveSliceEntries(
 		tweetEntries: selected(
 			"tweets",
 			/(?:^|\/)data\/(?:tweets|community-tweet)(?:-part\d+)?\.js$/i,
+		),
+		deletedTweetEntries: selected(
+			"tweets",
+			/(?:^|\/)data\/(?:deleted-tweets?|deleted-tweet-headers)(?:-part\d+)?\.js$/i,
 		),
 		noteTweetEntries: selected(
 			"tweets",

--- a/src/lib/archive/tweet-slices.ts
+++ b/src/lib/archive/tweet-slices.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 import type { ArchiveImportPlan } from "../archive-import-plan";
 import {
+	ARCHIVE_DELETION_REASON,
+	ARCHIVE_DELETION_SOURCE,
+	editHistoryIdsFromPayload,
+} from "../tweet-retention";
+import {
 	asArray,
 	asRecord,
 	extractTweetEntities,
@@ -82,6 +87,11 @@ export function parseTweetSliceEffect({
 					quotedTweetId: tweet.quoted_status_id_str
 						? String(tweet.quoted_status_id_str)
 						: null,
+					editHistoryIds: editHistoryIdsFromPayload(
+						String(tweet.id_str ?? tweet.id),
+						tweet,
+					),
+					rawJson: JSON.stringify(tweet),
 				});
 			});
 			onProgress({
@@ -96,6 +106,94 @@ export function parseTweetSliceEffect({
 				kind: "slice-done",
 				slice: "tweets",
 				count: plan.tweets.length,
+			});
+		}
+	});
+}
+
+export function parseDeletedTweetSliceEffect({
+	archivePath,
+	entries,
+	plan,
+	onProgress,
+	observedAt,
+}: ParseTweetSliceParams & { observedAt: string }) {
+	return Effect.gen(function* () {
+		if (entries.length > 0) {
+			onProgress({
+				kind: "slice-start",
+				slice: "deletedTweets",
+				files: entries.length,
+			});
+		}
+		const rowsBefore = plan.tweets.length;
+		for (const [fileIndex, entry] of entries.entries()) {
+			const isHeaderFile =
+				/(?:^|\/)deleted-tweet-headers(?:-part\d+)?\.js$/i.test(entry);
+			yield* processArchiveEntryRecordsEffect(archivePath, entry, (wrapper) => {
+				const deletedTweet = asRecord(
+					wrapper.deletedTweet ??
+						wrapper.deleted_tweet ??
+						wrapper.deletedTweetHeader ??
+						wrapper.deleted_tweet_header ??
+						wrapper.tweetHeader ??
+						wrapper.tweet_header ??
+						wrapper.tweet,
+				);
+				if (!deletedTweet) return;
+				const id = String(
+					deletedTweet.id_str ??
+						deletedTweet.id ??
+						deletedTweet.tweetId ??
+						deletedTweet.tweet_id ??
+						"",
+				);
+				if (!id) return;
+				const explicitDeletedAt = String(
+					deletedTweet.deleted_at ?? deletedTweet.deletedAt ?? "",
+				).trim();
+				const createdAtValue =
+					deletedTweet.created_at ?? deletedTweet.createdAt;
+				plan.addTweet({
+					id,
+					kind: "home",
+					authorProfileId: "profile_me",
+					text: String(deletedTweet.full_text ?? deletedTweet.text ?? ""),
+					createdAt: createdAtValue
+						? parseTwitterDate(createdAtValue)
+						: new Date(0).toISOString(),
+					isReplied: deletedTweet.in_reply_to_status_id_str ? 1 : 0,
+					replyToId: deletedTweet.in_reply_to_status_id_str
+						? String(deletedTweet.in_reply_to_status_id_str)
+						: null,
+					likeCount: toInt(deletedTweet.favorite_count),
+					mediaCount: getTweetMediaCount(deletedTweet),
+					bookmarked: 0,
+					liked: 0,
+					entitiesJson: JSON.stringify(extractTweetEntities(deletedTweet)),
+					mediaJson: JSON.stringify(extractTweetMedia(deletedTweet)),
+					quotedTweetId: deletedTweet.quoted_status_id_str
+						? String(deletedTweet.quoted_status_id_str)
+						: null,
+					deletedAt: explicitDeletedAt || observedAt,
+					deletionSource: ARCHIVE_DELETION_SOURCE,
+					deletionReason: ARCHIVE_DELETION_REASON,
+					editHistoryIds: editHistoryIdsFromPayload(id, deletedTweet),
+					rawJson: isHeaderFile ? null : JSON.stringify(deletedTweet),
+				});
+			});
+			onProgress({
+				kind: "slice-file",
+				slice: "deletedTweets",
+				processed: fileIndex + 1,
+				files: entries.length,
+			});
+		}
+		if (entries.length > 0) {
+			onProgress({
+				kind: "slice-done",
+				slice: "deletedTweets",
+				count: plan.tweets.length - rowsBefore,
 			});
 		}
 	});
@@ -136,6 +234,10 @@ export function parseNoteTweetSliceEffect({
 					entitiesJson: "{}",
 					mediaJson: "[]",
 					quotedTweetId: null,
+					editHistoryIds: [
+						String(noteTweet.noteTweetId ?? noteTweet.id ?? ""),
+					].filter(Boolean),
+					rawJson: JSON.stringify(noteTweet),
 				});
 			});
 			onProgress({

--- a/src/lib/archive/types.ts
+++ b/src/lib/archive/types.ts
@@ -12,6 +12,7 @@ export type ArchiveImportSlice = (typeof ARCHIVE_IMPORT_SLICES)[number];
 
 export type ImportProgressSlice =
 	| "tweets"
+	| "deletedTweets"
 	| "noteTweets"
 	| "directMessages"
 	| "likes"
@@ -48,6 +49,7 @@ export type ImportProgressEvent =
 
 export interface ImportArchiveOptions {
 	select?: ArchiveImportSlice[];
+	restore?: boolean;
 	onProgress?: (event: ImportProgressEvent) => void;
 }
 
@@ -77,6 +79,7 @@ export type ArchiveFollowKey = "follower" | "following";
 
 export interface ImportedArchiveSummary {
 	ok: true;
+	mode: "merge" | "restore";
 	archivePath: string;
 	account: {
 		id: string;

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -746,7 +746,7 @@ describe("live authored tweet sync", () => {
 		}
 	});
 
-	it("commits archive baseline after clearImportedData invalidates authored cursor", async () => {
+	it("commits archive baseline after a full restore invalidates authored cursor", async () => {
 		makeTempHome();
 		getNativeDb()
 			.prepare(
@@ -763,7 +763,7 @@ describe("live authored tweet sync", () => {
 				"2026-05-12T12:00:00.000Z",
 			);
 		const { importArchive } = await import("./archive-import");
-		await importArchive(makeArchiveWithTweet("1000"));
+		await importArchive(makeArchiveWithTweet("1000"), { restore: true });
 		mocks.listUserTweets.mockResolvedValueOnce({
 			items: [],
 			nextToken: null,
@@ -782,7 +782,7 @@ describe("live authored tweet sync", () => {
 		});
 	});
 
-	it("commits archive baseline after selected tweet import invalidates authored cursor", async () => {
+	it("commits archive baseline after selected tweet restore invalidates authored cursor", async () => {
 		makeTempHome();
 		const { importArchive } = await import("./archive-import");
 		await importArchive(makeArchiveWithTweet("800"));
@@ -804,7 +804,10 @@ describe("live authored tweet sync", () => {
 				JSON.stringify({ state: "committed", sinceId: "1200" }),
 				"2026-05-12T12:00:00.000Z",
 			);
-		await importArchive(makeArchiveWithTweet("1000"), { select: ["tweets"] });
+		await importArchive(makeArchiveWithTweet("1000"), {
+			select: ["tweets"],
+			restore: true,
+		});
 		mocks.listUserTweets.mockResolvedValueOnce({
 			items: [],
 			nextToken: null,

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -1,4 +1,9 @@
 import type { Database } from "./sqlite";
+import {
+	editHistoryIdsFromPayload,
+	reconcileTweetTombstones,
+	recordTweetRevision,
+} from "./tweet-retention";
 import { Effect } from "effect";
 import { databaseWriteEffect } from "./database-writer";
 import { getNativeDb } from "./db";
@@ -547,6 +552,12 @@ function getReferencedTweetId(tweet: XurlMentionData, type: string) {
 
 function replaceTweetFts(db: Database, tweetId: string, text: string) {
 	db.prepare("delete from tweets_fts where tweet_id = ?").run(tweetId);
+	const row = db
+		.prepare("select deleted_at, superseded_at from tweets where id = ?")
+		.get(tweetId) as
+		| { deleted_at: string | null; superseded_at: string | null }
+		| undefined;
+	if (row?.deleted_at || row?.superseded_at) return;
 	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
 		tweetId,
 		text,
@@ -611,6 +622,7 @@ function mergeAuthoredPayloadIntoLocalStore({
       quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id)
     `,
 	);
+	const observedAt = new Date().toISOString();
 
 	const writeTweet = (tweet: XurlMentionData) => {
 		const author =
@@ -643,11 +655,18 @@ function mergeAuthoredPayloadIntoLocalStore({
 			JSON.stringify(media),
 			quotedTweetId,
 		);
+		recordTweetRevision(db, {
+			tweetId: tweet.id,
+			editHistoryIds: editHistoryIdsFromPayload(tweet.id, tweet),
+			payloadJson: JSON.stringify(tweet),
+			source: "xurl",
+			observedAt,
+		});
 		replaceTweetFts(db, tweet.id, tweet.text);
 	};
 
 	db.transaction(() => {
-		const seenAt = new Date().toISOString();
+		const seenAt = observedAt;
 		for (const includedTweet of payload.includes?.tweets ?? []) {
 			writeTweet(includedTweet);
 		}
@@ -662,6 +681,7 @@ function mergeAuthoredPayloadIntoLocalStore({
 				rawJson: JSON.stringify(tweet),
 			});
 		}
+		reconcileTweetTombstones(db);
 	})();
 }
 

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -623,8 +623,10 @@ function mergeAuthoredPayloadIntoLocalStore({
     `,
 	);
 	const observedAt = new Date().toISOString();
+	const touchedTweetIds = new Set<string>();
 
 	const writeTweet = (tweet: XurlMentionData) => {
+		touchedTweetIds.add(tweet.id);
 		const author =
 			usersById.get(tweet.author_id) ??
 			({
@@ -681,7 +683,7 @@ function mergeAuthoredPayloadIntoLocalStore({
 				rawJson: JSON.stringify(tweet),
 			});
 		}
-		reconcileTweetTombstones(db);
+		reconcileTweetTombstones(db, Array.from(touchedTweetIds));
 	})();
 }
 

--- a/src/lib/backup-table-codecs.test.ts
+++ b/src/lib/backup-table-codecs.test.ts
@@ -13,7 +13,7 @@ import {
 describe("backup table codecs", () => {
 	it("owns every portable table and path exactly once", () => {
 		expect(assertBackupTableCodecRegistry()).toBe(true);
-		expect(BACKUP_TABLE_CODECS).toHaveLength(25);
+		expect(BACKUP_TABLE_CODECS).toHaveLength(26);
 		expect(BACKUP_TABLE_CODECS.map((codec) => codec.name)).toEqual([
 			"accounts",
 			"profiles",
@@ -24,6 +24,7 @@ describe("backup table codecs", () => {
 			"x_list_members",
 			"tweets",
 			"tweet_revisions",
+			"tweet_revision_edges",
 			"tweet_subordinate_tombstones",
 			"tweet_sources",
 			"tweet_collections",
@@ -45,7 +46,7 @@ describe("backup table codecs", () => {
 			BACKUP_TABLE_CODECS.map((codec) => codec.merge.order).sort(
 				(left, right) => left - right,
 			),
-		).toEqual(Array.from({ length: 25 }, (_, index) => index));
+		).toEqual(Array.from({ length: 26 }, (_, index) => index));
 
 		const sample = { created_at: "2026-01-02T00:00:00.000Z", kind: "likes" };
 		for (const codec of BACKUP_TABLE_CODECS) {

--- a/src/lib/backup-table-codecs.test.ts
+++ b/src/lib/backup-table-codecs.test.ts
@@ -13,7 +13,7 @@ import {
 describe("backup table codecs", () => {
 	it("owns every portable table and path exactly once", () => {
 		expect(assertBackupTableCodecRegistry()).toBe(true);
-		expect(BACKUP_TABLE_CODECS).toHaveLength(23);
+		expect(BACKUP_TABLE_CODECS).toHaveLength(25);
 		expect(BACKUP_TABLE_CODECS.map((codec) => codec.name)).toEqual([
 			"accounts",
 			"profiles",
@@ -23,6 +23,8 @@ describe("backup table codecs", () => {
 			"x_lists",
 			"x_list_members",
 			"tweets",
+			"tweet_revisions",
+			"tweet_subordinate_tombstones",
 			"tweet_sources",
 			"tweet_collections",
 			"tweet_account_edges",
@@ -43,7 +45,7 @@ describe("backup table codecs", () => {
 			BACKUP_TABLE_CODECS.map((codec) => codec.merge.order).sort(
 				(left, right) => left - right,
 			),
-		).toEqual(Array.from({ length: 23 }, (_, index) => index));
+		).toEqual(Array.from({ length: 25 }, (_, index) => index));
 
 		const sample = { created_at: "2026-01-02T00:00:00.000Z", kind: "likes" };
 		for (const codec of BACKUP_TABLE_CODECS) {

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -117,6 +117,16 @@ function sanitizeImportedTweets(rows: BackupJsonRecord[]) {
 	}));
 }
 
+function sanitizeImportedTweetRevisions(rows: BackupJsonRecord[]) {
+	return rows.map((row) => ({
+		...row,
+		payload_json:
+			row.payload_json === null || row.payload_json === undefined
+				? null
+				: sanitizeJsonTextUrls(row.payload_json, {}),
+	}));
+}
+
 function sanitizeImportedUrlExpansions(rows: BackupJsonRecord[]) {
 	return rows.map((row) => {
 		const shortUrl =
@@ -468,7 +478,8 @@ const definitions = {
 	tweets: {
 		exportSql: `
       select id, author_profile_id, text, created_at, is_replied, reply_to_id,
-        like_count, media_count, entities_json, media_json, quoted_tweet_id
+        like_count, media_count, entities_json, media_json, quoted_tweet_id,
+		deleted_at, deletion_source, deletion_reason, superseded_at, superseded_by_id
       from tweets
       order by created_at, id
     `,
@@ -482,8 +493,9 @@ const definitions = {
 			sql: `
       insert into tweets (
         id, author_profile_id, text, created_at, is_replied, reply_to_id,
-        like_count, media_count, entities_json, media_json, quoted_tweet_id
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        like_count, media_count, entities_json, media_json, quoted_tweet_id,
+		deleted_at, deletion_source, deletion_reason, superseded_at, superseded_by_id
+	  ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       on conflict(id) do update set
         author_profile_id = coalesce(nullif(excluded.author_profile_id, ''), tweets.author_profile_id),
         text = coalesce(nullif(excluded.text, ''), tweets.text),
@@ -500,7 +512,20 @@ const definitions = {
           when excluded.media_json not in ('', '[]', 'null') then excluded.media_json
           else tweets.media_json
         end,
-        quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id)
+        quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id),
+		deleted_at = case
+		  when tweets.deleted_at is null then excluded.deleted_at
+		  when excluded.deleted_at is null then tweets.deleted_at
+		  else min(tweets.deleted_at, excluded.deleted_at)
+		end,
+		deletion_source = coalesce(tweets.deletion_source, excluded.deletion_source),
+		deletion_reason = coalesce(tweets.deletion_reason, excluded.deletion_reason),
+		superseded_at = case
+		  when tweets.superseded_at is null then excluded.superseded_at
+		  when excluded.superseded_at is null then tweets.superseded_at
+		  else min(tweets.superseded_at, excluded.superseded_at)
+		end,
+		superseded_by_id = coalesce(excluded.superseded_by_id, tweets.superseded_by_id)
       `,
 			columns: [
 				"id",
@@ -514,12 +539,93 @@ const definitions = {
 				"entities_json",
 				"media_json",
 				"quoted_tweet_id",
+				"deleted_at",
+				"deletion_source",
+				"deletion_reason",
+				"superseded_at",
+				"superseded_by_id",
 			],
 			fts: {
 				target: { table: "tweets_fts", idColumn: "tweet_id" },
 				idKey: "id",
 				textKey: "text",
 			},
+		},
+	},
+	tweet_revisions: {
+		exportSql: `
+      select root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+      from tweet_revisions
+      order by root_tweet_id, revision_index, revision_id
+    `,
+		...fixedShard("data/tweet_revisions.jsonl", "tweet_revisions"),
+		merge: {
+			order: 12,
+			transform: sanitizeImportedTweetRevisions,
+			sql: `
+      insert into tweet_revisions (
+        root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+      ) values (?, ?, ?, ?, ?, ?)
+      on conflict(revision_id) do update set
+        root_tweet_id = case
+          when tweet_revisions.root_tweet_id = tweet_revisions.revision_id
+            and excluded.root_tweet_id <> excluded.revision_id
+            then excluded.root_tweet_id
+          else tweet_revisions.root_tweet_id
+        end,
+        revision_index = case
+          when tweet_revisions.root_tweet_id = tweet_revisions.revision_id
+            and excluded.root_tweet_id <> excluded.revision_id
+            then excluded.revision_index
+          else tweet_revisions.revision_index
+        end,
+        payload_json = coalesce(tweet_revisions.payload_json, excluded.payload_json),
+        source = case
+          when tweet_revisions.payload_json is null and excluded.payload_json is not null
+            then excluded.source
+          else tweet_revisions.source
+        end,
+        observed_at = max(tweet_revisions.observed_at, excluded.observed_at)
+      `,
+			columns: [
+				"root_tweet_id",
+				"revision_id",
+				"revision_index",
+				"payload_json",
+				"source",
+				"observed_at",
+			],
+		},
+	},
+	tweet_subordinate_tombstones: {
+		exportSql: `
+      select tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
+      from tweet_subordinate_tombstones
+      order by tweet_id, kind, subordinate_id
+    `,
+		...fixedShard(
+			"data/tweet_subordinate_tombstones.jsonl",
+			"tweet_subordinate_tombstones",
+		),
+		merge: {
+			order: 13,
+			sql: `
+      insert into tweet_subordinate_tombstones (
+        tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
+      ) values (?, ?, ?, ?, ?, ?)
+      on conflict(tweet_id, kind, subordinate_id) do update set
+		deleted_at = min(tweet_subordinate_tombstones.deleted_at, excluded.deleted_at),
+        deletion_source = coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source),
+        deletion_reason = coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+      `,
+			columns: [
+				"tweet_id",
+				"kind",
+				"subordinate_id",
+				"deleted_at",
+				"deletion_source",
+				"deletion_reason",
+			],
 		},
 	},
 	tweet_sources: {
@@ -530,7 +636,7 @@ const definitions = {
     `,
 		...fixedShard("data/tweet_sources.jsonl", "tweet_sources"),
 		merge: {
-			order: 12,
+			order: 14,
 			sql: `
       insert into tweet_sources (tweet_id, source, source_url, observed_at)
       values (?, ?, ?, ?)
@@ -559,7 +665,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`collections_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 13,
+			order: 15,
 			sql: `
       insert into tweet_collections (
         account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
@@ -605,7 +711,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`timeline_edges_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 14,
+			order: 16,
 			sql: `
       insert into tweet_account_edges (
         account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
@@ -644,7 +750,7 @@ const definitions = {
     `,
 		...fixedShard("data/dms/conversations.jsonl", "dm_conversations"),
 		merge: {
-			order: 15,
+			order: 17,
 			sql: `
       insert into dm_conversations (
         id, account_id, participant_profile_id, title, inbox_kind, last_message_at, unread_count, needs_reply
@@ -687,7 +793,7 @@ const definitions = {
 			candidate !== "data/dms/conversations.jsonl",
 		countKey: () => "dm_messages",
 		merge: {
-			order: 16,
+			order: 18,
 			sql: `
       insert into dm_messages (
         id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
@@ -728,7 +834,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/url_expansions.jsonl", "url_expansions"),
 		merge: {
-			order: 17,
+			order: 19,
 			transform: sanitizeImportedUrlExpansions,
 			sql: `
       insert into url_expansions (
@@ -776,7 +882,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/occurrences.jsonl", "link_occurrences"),
 		merge: {
-			order: 18,
+			order: 20,
 			sql: `
       insert into link_occurrences (
         source_kind, source_id, source_position, short_url, account_id,
@@ -808,7 +914,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/blocks.jsonl", "blocks"),
 		merge: {
-			order: 19,
+			order: 21,
 			sql: `
       insert into blocks (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -827,7 +933,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/mutes.jsonl", "mutes"),
 		merge: {
-			order: 20,
+			order: 22,
 			sql: `
       insert into mutes (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -846,7 +952,7 @@ const definitions = {
     `,
 		...fixedShard("data/actions/tweet_actions.jsonl", "tweet_actions"),
 		merge: {
-			order: 21,
+			order: 23,
 			sql: `
       insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at)
       values (?, ?, ?, ?, ?, ?)
@@ -868,7 +974,7 @@ const definitions = {
     `,
 		...fixedShard("data/ai_scores.jsonl", "ai_scores"),
 		merge: {
-			order: 22,
+			order: 24,
 			sql: `
       insert into ai_scores (
         entity_kind, entity_id, model, score, summary, reasoning, updated_at

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -611,6 +611,44 @@ const definitions = {
 			],
 		},
 	},
+	tweet_revision_edges: {
+		exportSql: `
+      select older_revision_id, newer_revision_id, source, observed_at
+      from tweet_revision_edges
+      order by older_revision_id, newer_revision_id
+    `,
+		...fixedShard("data/tweet_revision_edges.jsonl", "tweet_revision_edges"),
+		merge: {
+			order: 13,
+			sql: `
+      insert into tweet_revision_edges (
+        older_revision_id, newer_revision_id, source, observed_at
+      ) values (?, ?, ?, ?)
+      on conflict(older_revision_id, newer_revision_id) do update set
+        source = case
+          when excluded.observed_at > tweet_revision_edges.observed_at
+            then excluded.source
+          when excluded.observed_at = tweet_revision_edges.observed_at then case
+            when tweet_revision_edges.source in ('backup_migration', 'migration')
+              and excluded.source not in ('backup_migration', 'migration')
+              then excluded.source
+            when excluded.source in ('backup_migration', 'migration')
+              and tweet_revision_edges.source not in ('backup_migration', 'migration')
+              then tweet_revision_edges.source
+            else min(tweet_revision_edges.source, excluded.source)
+          end
+          else tweet_revision_edges.source
+        end,
+        observed_at = max(tweet_revision_edges.observed_at, excluded.observed_at)
+      `,
+			columns: [
+				"older_revision_id",
+				"newer_revision_id",
+				"source",
+				"observed_at",
+			],
+		},
+	},
 	tweet_subordinate_tombstones: {
 		exportSql: `
       select tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
@@ -622,7 +660,7 @@ const definitions = {
 			"tweet_subordinate_tombstones",
 		),
 		merge: {
-			order: 13,
+			order: 14,
 			sql: `
       insert into tweet_subordinate_tombstones (
         tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
@@ -662,7 +700,7 @@ const definitions = {
     `,
 		...fixedShard("data/tweet_sources.jsonl", "tweet_sources"),
 		merge: {
-			order: 14,
+			order: 15,
 			sql: `
       insert into tweet_sources (tweet_id, source, source_url, observed_at)
       values (?, ?, ?, ?)
@@ -691,7 +729,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`collections_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 15,
+			order: 16,
 			sql: `
       insert into tweet_collections (
         account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
@@ -737,7 +775,7 @@ const definitions = {
 		countKey: (candidate) =>
 			`timeline_edges_${pathLeaf(candidate).replace(/\.jsonl$/, "") || "unknown"}`,
 		merge: {
-			order: 16,
+			order: 17,
 			sql: `
       insert into tweet_account_edges (
         account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
@@ -776,7 +814,7 @@ const definitions = {
     `,
 		...fixedShard("data/dms/conversations.jsonl", "dm_conversations"),
 		merge: {
-			order: 17,
+			order: 18,
 			sql: `
       insert into dm_conversations (
         id, account_id, participant_profile_id, title, inbox_kind, last_message_at, unread_count, needs_reply
@@ -819,7 +857,7 @@ const definitions = {
 			candidate !== "data/dms/conversations.jsonl",
 		countKey: () => "dm_messages",
 		merge: {
-			order: 18,
+			order: 19,
 			sql: `
       insert into dm_messages (
         id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count
@@ -860,7 +898,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/url_expansions.jsonl", "url_expansions"),
 		merge: {
-			order: 19,
+			order: 20,
 			transform: sanitizeImportedUrlExpansions,
 			sql: `
       insert into url_expansions (
@@ -908,7 +946,7 @@ const definitions = {
     `,
 		...fixedShard("data/links/occurrences.jsonl", "link_occurrences"),
 		merge: {
-			order: 20,
+			order: 21,
 			sql: `
       insert into link_occurrences (
         source_kind, source_id, source_position, short_url, account_id,
@@ -940,7 +978,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/blocks.jsonl", "blocks"),
 		merge: {
-			order: 21,
+			order: 22,
 			sql: `
       insert into blocks (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -959,7 +997,7 @@ const definitions = {
     `,
 		...fixedShard("data/moderation/mutes.jsonl", "mutes"),
 		merge: {
-			order: 22,
+			order: 23,
 			sql: `
       insert into mutes (account_id, profile_id, source, created_at)
       values (?, ?, ?, ?)
@@ -978,7 +1016,7 @@ const definitions = {
     `,
 		...fixedShard("data/actions/tweet_actions.jsonl", "tweet_actions"),
 		merge: {
-			order: 23,
+			order: 24,
 			sql: `
       insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at)
       values (?, ?, ?, ?, ?, ?)
@@ -1000,7 +1038,7 @@ const definitions = {
     `,
 		...fixedShard("data/ai_scores.jsonl", "ai_scores"),
 		merge: {
-			order: 24,
+			order: 25,
 			sql: `
       insert into ai_scores (
         entity_kind, entity_id, model, score, summary, reasoning, updated_at

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -518,8 +518,22 @@ const definitions = {
 		  when excluded.deleted_at is null then tweets.deleted_at
 		  else min(tweets.deleted_at, excluded.deleted_at)
 		end,
-		deletion_source = coalesce(tweets.deletion_source, excluded.deletion_source),
-		deletion_reason = coalesce(tweets.deletion_reason, excluded.deletion_reason),
+		deletion_source = case
+		  when excluded.deleted_at is not null
+		    and (tweets.deleted_at is null or excluded.deleted_at < tweets.deleted_at)
+		    then excluded.deletion_source
+		  when excluded.deleted_at = tweets.deleted_at
+		    then coalesce(tweets.deletion_source, excluded.deletion_source)
+		  else tweets.deletion_source
+		end,
+		deletion_reason = case
+		  when excluded.deleted_at is not null
+		    and (tweets.deleted_at is null or excluded.deleted_at < tweets.deleted_at)
+		    then excluded.deletion_reason
+		  when excluded.deleted_at = tweets.deleted_at
+		    then coalesce(tweets.deletion_reason, excluded.deletion_reason)
+		  else tweets.deletion_reason
+		end,
 		superseded_at = case
 		  when tweets.superseded_at is null then excluded.superseded_at
 		  when excluded.superseded_at is null then tweets.superseded_at
@@ -615,8 +629,20 @@ const definitions = {
       ) values (?, ?, ?, ?, ?, ?)
       on conflict(tweet_id, kind, subordinate_id) do update set
 		deleted_at = min(tweet_subordinate_tombstones.deleted_at, excluded.deleted_at),
-        deletion_source = coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source),
-        deletion_reason = coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+		deletion_source = case
+		  when excluded.deleted_at < tweet_subordinate_tombstones.deleted_at
+		    then excluded.deletion_source
+		  when excluded.deleted_at = tweet_subordinate_tombstones.deleted_at
+		    then coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source)
+		  else tweet_subordinate_tombstones.deletion_source
+		end,
+		deletion_reason = case
+		  when excluded.deleted_at < tweet_subordinate_tombstones.deleted_at
+		    then excluded.deletion_reason
+		  when excluded.deleted_at = tweet_subordinate_tombstones.deleted_at
+		    then coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+		  else tweet_subordinate_tombstones.deletion_reason
+		end
       `,
 			columns: [
 				"tweet_id",

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -63,9 +63,11 @@ function clearData() {
     delete from mutes;
     delete from dm_fts;
     delete from tweets_fts;
-    delete from dm_messages;
-    delete from dm_conversations;
-    delete from tweets;
+		delete from dm_messages;
+		delete from dm_conversations;
+		delete from tweet_subordinate_tombstones;
+		delete from tweet_revisions;
+		delete from tweets;
     delete from profile_bio_entities;
     delete from profile_snapshots;
     delete from profile_affiliations;
@@ -606,7 +608,7 @@ describe("text backup", () => {
 		expect(validation.ok).toBe(true);
 	}, 20000);
 
-	it("emits byte-identical schema-v5 data and hashes for the same database", async () => {
+	it("emits byte-identical schema-v6 data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");
 		seedBackupFixture();
 		const firstRepoPath = makeTempDir("birdclaw-backup-stable-first-");
@@ -615,10 +617,7 @@ describe("text backup", () => {
 		const first = await exportBackup({ repoPath: firstRepoPath });
 		const second = await exportBackup({ repoPath: secondRepoPath });
 
-		expect(first.manifest.schemaVersion).toBe(5);
-		expect(first.manifest.backupHash).toBe(
-			"43fd00e172a6a69a205eb13ecd3179ac0089a1ea252c3697dc3ab26d1a7dacb7",
-		);
+		expect(first.manifest.schemaVersion).toBe(6);
 		expect(second.manifest.files).toEqual(first.manifest.files);
 		expect(second.manifest.counts).toEqual(first.manifest.counts);
 		expect(second.manifest.backupHash).toBe(first.manifest.backupHash);
@@ -733,6 +732,102 @@ describe("text backup", () => {
 				.prepare("select count(*) from tweets where id = 'tweet_2025'")
 				.get() as { "count(*)": number },
 		).toEqual({ "count(*)": 1 });
+	}, 20000);
+
+	it("round-trips tweet tombstones, subordinate deletions, and edit revisions", async () => {
+		switchHome("birdclaw-backup-tombstone-src-");
+		seedBackupFixture();
+		const sourceDb = getNativeDb({ seedDemoData: false });
+		sourceDb.exec(`
+			insert into tweets (
+				id, author_profile_id, text, created_at, is_replied, reply_to_id,
+				like_count, media_count, entities_json, media_json, quoted_tweet_id,
+				superseded_at, superseded_by_id
+			) values (
+				'tweet_2025_v1', 'profile_me', 'before edit',
+				'2025-01-02T07:00:00.000Z', 0, null, 0, 0, '{}', '[]', null,
+				'2025-01-02T08:00:00.000Z', 'tweet_2025'
+			);
+			update tweets
+			set deleted_at = '2026-07-18T12:00:00.000Z',
+				deletion_source = 'twitter_archive',
+				deletion_reason = 'explicit_deleted_tweet_record',
+				media_json = '[{"media_key":"media-1","type":"photo"}]'
+			where id = 'tweet_2025';
+			insert into tweet_revisions (
+				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+			) values
+				('tweet_2025_v1', 'tweet_2025_v1', 0, null, 'xurl', '2025-01-02T07:00:00.000Z'),
+				('tweet_2025_v1', 'tweet_2025', 1, '{"text":"after"}', 'xurl', '2025-01-02T08:00:00.000Z');
+			insert into tweet_subordinate_tombstones (
+				tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
+			) values
+				('tweet_2025', 'media', 'media-1', '2026-07-18T12:00:00.000Z', 'twitter_archive', 'parent_tweet_deleted'),
+				('tweet_2025', 'quote', 'tweet_quote', '2026-07-18T12:00:00.000Z', 'twitter_archive', 'parent_tweet_deleted');
+		`);
+		const repoPath = makeTempDir("birdclaw-tombstone-store-");
+		await exportBackup({ repoPath });
+
+		switchHome("birdclaw-backup-tombstone-dst-");
+		const result = await importBackup({ repoPath });
+		const db = getNativeDb({ seedDemoData: false });
+
+		expect(result.mode).toBe("merge");
+		expect(
+			db
+				.prepare(
+					"select superseded_at, superseded_by_id from tweets where id = 'tweet_2025_v1'",
+				)
+				.get(),
+		).toEqual({
+			superseded_at: "2025-01-02T08:00:00.000Z",
+			superseded_by_id: "tweet_2025",
+		});
+		expect(
+			db
+				.prepare(
+					"select deleted_at, deletion_source, deletion_reason from tweets where id = 'tweet_2025'",
+				)
+				.get(),
+		).toEqual({
+			deleted_at: "2026-07-18T12:00:00.000Z",
+			deletion_source: "twitter_archive",
+			deletion_reason: "explicit_deleted_tweet_record",
+		});
+		expect(
+			db
+				.prepare(
+					"select kind, subordinate_id from tweet_subordinate_tombstones where tweet_id = 'tweet_2025' order by kind, subordinate_id",
+				)
+				.all(),
+		).toEqual([
+			{ kind: "media", subordinate_id: "media-1" },
+			{ kind: "quote", subordinate_id: "tweet_quote" },
+		]);
+		expect(
+			db
+				.prepare(
+					"select revision_id, revision_index, payload_json is not null as hydrated from tweet_revisions where root_tweet_id = 'tweet_2025_v1' order by revision_index",
+				)
+				.all(),
+		).toEqual([
+			{ revision_id: "tweet_2025_v1", revision_index: 0, hydrated: 0 },
+			{ revision_id: "tweet_2025", revision_index: 1, hydrated: 1 },
+		]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweet_id = 'tweet_2025'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweet_id = 'tweet_2025_v1'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
 	}, 20000);
 
 	it("syncs through git by pulling, merging, exporting, committing, and pushing", async () => {

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -769,8 +769,31 @@ describe("text backup", () => {
 		await exportBackup({ repoPath });
 
 		switchHome("birdclaw-backup-tombstone-dst-");
-		const result = await importBackup({ repoPath });
 		const db = getNativeDb({ seedDemoData: false });
+		insertTestTweet(db, {
+			id: "tweet_2025",
+			authorProfileId: "profile_me",
+			text: "later local copy",
+		});
+		db.exec(`
+			update tweets
+			set deleted_at = '2026-07-18T12:00:00.000Z',
+				deletion_source = null,
+				deletion_reason = null
+			where id = 'tweet_2025';
+			insert into tweet_subordinate_tombstones (
+				tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
+			) values
+			(
+				'tweet_2025', 'media', 'media-1', '2027-01-01T00:00:00.000Z',
+				'local_later', 'later_local_event'
+			),
+			(
+				'tweet_2025', 'quote', 'tweet_quote', '2026-07-18T12:00:00.000Z',
+				null, 'parent_tweet_deleted'
+			);
+		`);
+		const result = await importBackup({ repoPath });
 
 		expect(result.mode).toBe("merge");
 		expect(
@@ -797,12 +820,24 @@ describe("text backup", () => {
 		expect(
 			db
 				.prepare(
-					"select kind, subordinate_id from tweet_subordinate_tombstones where tweet_id = 'tweet_2025' order by kind, subordinate_id",
+					"select kind, subordinate_id, deleted_at, deletion_source, deletion_reason from tweet_subordinate_tombstones where tweet_id = 'tweet_2025' order by kind, subordinate_id",
 				)
 				.all(),
 		).toEqual([
-			{ kind: "media", subordinate_id: "media-1" },
-			{ kind: "quote", subordinate_id: "tweet_quote" },
+			{
+				kind: "media",
+				subordinate_id: "media-1",
+				deleted_at: "2026-07-18T12:00:00.000Z",
+				deletion_source: "twitter_archive",
+				deletion_reason: "parent_tweet_deleted",
+			},
+			{
+				kind: "quote",
+				subordinate_id: "tweet_quote",
+				deleted_at: "2026-07-18T12:00:00.000Z",
+				deletion_source: "twitter_archive",
+				deletion_reason: "parent_tweet_deleted",
+			},
 		]);
 		expect(
 			db

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -66,6 +66,7 @@ function clearData() {
 		delete from dm_messages;
 		delete from dm_conversations;
 		delete from tweet_subordinate_tombstones;
+		delete from tweet_revision_edges;
 		delete from tweet_revisions;
 		delete from tweets;
     delete from profile_bio_entities;
@@ -608,7 +609,7 @@ describe("text backup", () => {
 		expect(validation.ok).toBe(true);
 	}, 20000);
 
-	it("emits byte-identical schema-v6 data and hashes for the same database", async () => {
+	it("emits byte-identical schema-v7 data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");
 		seedBackupFixture();
 		const firstRepoPath = makeTempDir("birdclaw-backup-stable-first-");
@@ -617,7 +618,7 @@ describe("text backup", () => {
 		const first = await exportBackup({ repoPath: firstRepoPath });
 		const second = await exportBackup({ repoPath: secondRepoPath });
 
-		expect(first.manifest.schemaVersion).toBe(6);
+		expect(first.manifest.schemaVersion).toBe(7);
 		expect(second.manifest.files).toEqual(first.manifest.files);
 		expect(second.manifest.counts).toEqual(first.manifest.counts);
 		expect(second.manifest.backupHash).toBe(first.manifest.backupHash);
@@ -747,6 +748,10 @@ describe("text backup", () => {
 				'tweet_2025_v1', 'profile_me', 'before edit',
 				'2025-01-02T07:00:00.000Z', 0, null, 0, 0, '{}', '[]', null,
 				'2025-01-02T08:00:00.000Z', 'tweet_2025'
+			), (
+				'tweet_2025_v2', 'profile_me', 'middle edit',
+				'2025-01-02T07:30:00.000Z', 0, null, 0, 0, '{}', '[]', null,
+				'2025-01-02T08:00:00.000Z', 'tweet_2025'
 			);
 			update tweets
 			set deleted_at = '2026-07-18T12:00:00.000Z',
@@ -758,7 +763,21 @@ describe("text backup", () => {
 				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
 			) values
 				('tweet_2025_v1', 'tweet_2025_v1', 0, null, 'xurl', '2025-01-02T07:00:00.000Z'),
-				('tweet_2025_v1', 'tweet_2025', 1, '{"text":"after"}', 'xurl', '2025-01-02T08:00:00.000Z');
+				('tweet_2025_v1', 'tweet_2025_v2', 1, '{"text":"middle"}', 'xurl', '2025-01-02T07:30:00.000Z'),
+				('tweet_2025_v1', 'tweet_2025', 2, '{"text":"after"}', 'xurl', '2025-01-02T08:00:00.000Z');
+			insert into tweet_revisions (
+				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+			) values
+				('partial_root', 'partial_root', 0, null, 'xurl', '2025-01-02T07:00:00.000Z'),
+				('partial_root', 'partial_left', 1, null, 'xurl', '2025-01-02T08:00:00.000Z'),
+				('partial_root', 'partial_right', 1, null, 'xurl', '2025-01-02T08:00:00.000Z');
+			insert into tweet_revision_edges (
+				older_revision_id, newer_revision_id, source, observed_at
+			) values
+				('tweet_2025_v1', 'tweet_2025_v2', 'xurl', '2025-01-02T07:30:00.000Z'),
+				('tweet_2025_v2', 'tweet_2025', 'xurl', '2025-01-02T08:00:00.000Z'),
+				('partial_root', 'partial_left', 'xurl', '2025-01-02T08:00:00.000Z'),
+				('partial_root', 'partial_right', 'xurl', '2025-01-02T08:00:00.000Z');
 			insert into tweet_subordinate_tombstones (
 				tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
 			) values
@@ -792,6 +811,15 @@ describe("text backup", () => {
 				'tweet_2025', 'quote', 'tweet_quote', '2026-07-18T12:00:00.000Z',
 				null, 'parent_tweet_deleted'
 			);
+			insert into tweet_revisions (
+				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+			) values
+				('tweet_2025_v2', 'tweet_2025_v2', 0, null, 'xurl', '2025-01-02T07:30:00.000Z'),
+				('tweet_2025_v2', 'tweet_2025', 1, null, 'xurl', '2025-01-02T08:00:00.000Z');
+			insert into tweet_revision_edges (
+				older_revision_id, newer_revision_id, source, observed_at
+			) values
+				('tweet_2025_v2', 'tweet_2025', 'xurl', '2025-01-02T08:00:00.000Z');
 		`);
 		const result = await importBackup({ repoPath });
 
@@ -847,7 +875,19 @@ describe("text backup", () => {
 				.all(),
 		).toEqual([
 			{ revision_id: "tweet_2025_v1", revision_index: 0, hydrated: 0 },
-			{ revision_id: "tweet_2025", revision_index: 1, hydrated: 1 },
+			{ revision_id: "tweet_2025_v2", revision_index: 1, hydrated: 1 },
+			{ revision_id: "tweet_2025", revision_index: 2, hydrated: 1 },
+		]);
+		expect(
+			db
+				.prepare(
+					"select revision_id, revision_index from tweet_revisions where root_tweet_id = 'partial_root' order by revision_index, revision_id",
+				)
+				.all(),
+		).toEqual([
+			{ revision_id: "partial_root", revision_index: 0 },
+			{ revision_id: "partial_left", revision_index: 1 },
+			{ revision_id: "partial_right", revision_index: 1 },
 		]);
 		expect(
 			db

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -21,14 +21,17 @@ import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { getImportRepository } from "./import-repository";
-import { reconcileTweetTombstones } from "./tweet-retention";
+import {
+	mergeTweetRevisionChain,
+	reconcileTweetTombstones,
+} from "./tweet-retention";
 import {
 	collectIngestionSourcesEffect,
 	streamJsonLines,
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 
-const BACKUP_SCHEMA_VERSION = 6;
+const BACKUP_SCHEMA_VERSION = 7;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_BACKUP_SHARD_BYTES = 48 * 1024 * 1024;
 const MANIFEST_PATH = "manifest.json";
@@ -1085,6 +1088,55 @@ export function importBackupEffect({
 		);
 		importRows.tweet_collections = canonicalTweetState.collections;
 		importRows.tweet_account_edges = canonicalTweetState.timelineEdges;
+		if (manifest.schemaVersion < 7) {
+			const revisionsByRoot = new Map<string, JsonRecord[]>();
+			for (const row of importRows.tweet_revisions) {
+				if (typeof row.root_tweet_id !== "string") continue;
+				const revisions = revisionsByRoot.get(row.root_tweet_id) ?? [];
+				revisions.push(row);
+				revisionsByRoot.set(row.root_tweet_id, revisions);
+			}
+			for (const revisions of revisionsByRoot.values()) {
+				const ordered = revisions
+					.filter(
+						(row) =>
+							typeof row.revision_id === "string" &&
+							typeof row.revision_index === "number",
+					)
+					.sort(
+						(left, right) =>
+							Number(left.revision_index) - Number(right.revision_index) ||
+							(String(left.revision_id) < String(right.revision_id)
+								? -1
+								: String(left.revision_id) > String(right.revision_id)
+									? 1
+									: 0),
+					);
+				const rankGroups = new Map<number, JsonRecord[]>();
+				for (const revision of ordered) {
+					const rank = Number(revision.revision_index);
+					const group = rankGroups.get(rank) ?? [];
+					group.push(revision);
+					rankGroups.set(rank, group);
+				}
+				const groups = [...rankGroups.values()];
+				for (let groupIndex = 1; groupIndex < groups.length; groupIndex += 1) {
+					const older = groups[groupIndex - 1]?.[0];
+					if (!older) continue;
+					for (const newer of groups[groupIndex] ?? []) {
+						importRows.tweet_revision_edges.push({
+							older_revision_id: String(older.revision_id),
+							newer_revision_id: String(newer.revision_id),
+							source: "backup_migration",
+							observed_at:
+								typeof newer.observed_at === "string"
+									? newer.observed_at
+									: new Date(0).toISOString(),
+						});
+					}
+				}
+			}
+		}
 		const fingerprint = yield* databaseWriteEffect((writeDb) => {
 			const repository = getImportRepository(writeDb);
 			if (mode === "replace") {
@@ -1116,6 +1168,40 @@ export function importBackupEffect({
 					textKey: fts.textKey,
 					existingIds: existingFtsIds.get(codec.name),
 				});
+			}
+			const importedRevisionChains = new Map<
+				string,
+				Array<{ revisionId: string; revisionIndex: number }>
+			>();
+			for (const row of importRows.tweet_revisions) {
+				if (
+					typeof row.root_tweet_id !== "string" ||
+					typeof row.revision_id !== "string" ||
+					typeof row.revision_index !== "number"
+				)
+					continue;
+				const chain = importedRevisionChains.get(row.root_tweet_id) ?? [];
+				chain.push({
+					revisionId: row.revision_id,
+					revisionIndex: row.revision_index,
+				});
+				importedRevisionChains.set(row.root_tweet_id, chain);
+			}
+			const processedRevisionIds = new Set<string>();
+			for (const chain of importedRevisionChains.values()) {
+				if (
+					chain.some((revision) =>
+						processedRevisionIds.has(revision.revisionId),
+					)
+				)
+					continue;
+				const component = mergeTweetRevisionChain(
+					writeDb,
+					chain.map((revision) => revision.revisionId),
+				);
+				for (const revisionId of component) {
+					processedRevisionIds.add(revisionId);
+				}
 			}
 			reconcileTweetTombstones(writeDb);
 			return getBackupDatabaseFingerprint(writeDb);

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -21,13 +21,14 @@ import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { getImportRepository } from "./import-repository";
+import { reconcileTweetTombstones } from "./tweet-retention";
 import {
 	collectIngestionSourcesEffect,
 	streamJsonLines,
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 
-const BACKUP_SCHEMA_VERSION = 5;
+const BACKUP_SCHEMA_VERSION = 6;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_BACKUP_SHARD_BYTES = 48 * 1024 * 1024;
 const MANIFEST_PATH = "manifest.json";
@@ -1116,6 +1117,7 @@ export function importBackupEffect({
 					existingIds: existingFtsIds.get(codec.name),
 				});
 			}
+			reconcileTweetTombstones(writeDb);
 			return getBackupDatabaseFingerprint(writeDb);
 		}, db);
 

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -189,6 +189,11 @@ describe("database init", () => {
 				"entities_json",
 				"media_json",
 				"quoted_tweet_id",
+				"deleted_at",
+				"deletion_source",
+				"deletion_reason",
+				"superseded_at",
+				"superseded_by_id",
 			]),
 		);
 		expect(columnNames.map((column) => column.name)).not.toEqual(
@@ -250,6 +255,20 @@ describe("database init", () => {
 		expect(replyIndex).toEqual([
 			expect.objectContaining({ name: "reply_to_id" }),
 		]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweet_revisions where revision_id in ('legacy_saved_home', 'legacy_authored', 'legacy_search')",
+				)
+				.get(),
+		).toEqual({ count: 3 });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets where deleted_at is not null",
+				)
+				.get(),
+		).toEqual({ count: 0 });
 
 		const syncCacheColumnNames = db
 			.prepare("pragma table_info(sync_cache)")
@@ -399,7 +418,7 @@ describe("database init", () => {
 		}) as number;
 		expect(busyTimeout).toBe(SQLITE_BUSY_TIMEOUT_MS);
 		expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
-		expect(db.pragma("user_version", { simple: true })).toBe(5);
+		expect(db.pragma("user_version", { simple: true })).toBe(6);
 	});
 
 	it("does not request a write lock for completed startup backfills", async () => {
@@ -484,7 +503,7 @@ describe("database init", () => {
 
 	it.each([
 		{ kind: "stale", version: 4 },
-		{ kind: "future", version: 6 },
+		{ kind: "future", version: 7 },
 	])(
 		"rejects a $kind schema and closes its provisional reader",
 		({ version }) => {
@@ -519,10 +538,10 @@ describe("database init", () => {
 
 		const writer = getNativeDb({ seedDemoData: false });
 		getReadDb({ seedDemoData: false });
-		writer.pragma("user_version = 6");
+		writer.pragma("user_version = 7");
 
 		expect(() => getStrictReadDb()).toThrow(
-			/schema 6 is not ready for version 5/,
+			/schema 7 is not ready for version 6/,
 		);
 	});
 

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -418,7 +418,53 @@ describe("database init", () => {
 		}) as number;
 		expect(busyTimeout).toBe(SQLITE_BUSY_TIMEOUT_MS);
 		expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
-		expect(db.pragma("user_version", { simple: true })).toBe(6);
+		expect(db.pragma("user_version", { simple: true })).toBe(7);
+	});
+
+	it("adds revision edges without rewriting v6 revision rows", () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const db = getNativeDb({ seedDemoData: false });
+		db.exec(`
+			insert into tweet_revisions (
+				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+			) values
+				('legacy-root', 'legacy-root', 0, null, 'migration', '2026-01-01T00:00:00.000Z'),
+				('legacy-root', 'legacy-left', 1, null, 'migration', '2026-01-02T00:00:00.000Z'),
+				('legacy-root', 'legacy-right', 1, null, 'migration', '2026-01-02T00:00:00.000Z'),
+				('legacy-root', 'legacy-final', 2, null, 'migration', '2026-01-03T00:00:00.000Z');
+			drop table tweet_revision_edges;
+			pragma user_version = 6;
+		`);
+		resetDatabaseForTests();
+
+		const migrated = getNativeDb({ seedDemoData: false });
+		expect(migrated.pragma("user_version", { simple: true })).toBe(7);
+		expect(
+			migrated
+				.prepare(
+					"select revision_id, revision_index from tweet_revisions where root_tweet_id = 'legacy-root' order by revision_index, revision_id",
+				)
+				.all(),
+		).toEqual([
+			{ revision_id: "legacy-root", revision_index: 0 },
+			{ revision_id: "legacy-left", revision_index: 1 },
+			{ revision_id: "legacy-right", revision_index: 1 },
+			{ revision_id: "legacy-final", revision_index: 2 },
+		]);
+		expect(
+			migrated
+				.prepare(
+					"select older_revision_id, newer_revision_id from tweet_revision_edges order by older_revision_id, newer_revision_id",
+				)
+				.all(),
+		).toEqual([
+			{ older_revision_id: "legacy-left", newer_revision_id: "legacy-final" },
+			{ older_revision_id: "legacy-root", newer_revision_id: "legacy-left" },
+			{ older_revision_id: "legacy-root", newer_revision_id: "legacy-right" },
+		]);
 	});
 
 	it("does not request a write lock for completed startup backfills", async () => {
@@ -503,7 +549,7 @@ describe("database init", () => {
 
 	it.each([
 		{ kind: "stale", version: 4 },
-		{ kind: "future", version: 7 },
+		{ kind: "future", version: 8 },
 	])(
 		"rejects a $kind schema and closes its provisional reader",
 		({ version }) => {
@@ -538,10 +584,10 @@ describe("database init", () => {
 
 		const writer = getNativeDb({ seedDemoData: false });
 		getReadDb({ seedDemoData: false });
-		writer.pragma("user_version = 7");
+		writer.pragma("user_version = 8");
 
 		expect(() => getStrictReadDb()).toThrow(
-			/schema 7 is not ready for version 6/,
+			/schema 8 is not ready for version 7/,
 		);
 	});
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -127,7 +127,31 @@ const BASE_SCHEMA_SQL = `
     liked integer not null default 0,
     entities_json text not null default '{}',
     media_json text not null default '[]',
-    quoted_tweet_id text
+    quoted_tweet_id text,
+    deleted_at text,
+    deletion_source text,
+    deletion_reason text,
+    superseded_at text,
+    superseded_by_id text
+  );
+
+  create table if not exists tweet_revisions (
+    root_tweet_id text not null,
+    revision_id text primary key,
+    revision_index integer not null,
+    payload_json text,
+    source text not null,
+    observed_at text not null
+  );
+
+  create table if not exists tweet_subordinate_tombstones (
+    tweet_id text not null,
+    kind text not null check (kind in ('media', 'quote')),
+    subordinate_id text not null,
+    deleted_at text not null,
+    deletion_source text,
+    deletion_reason text not null,
+    primary key (tweet_id, kind, subordinate_id)
   );
 
   create table if not exists tweet_sources (
@@ -440,6 +464,53 @@ function ensureTweetMetadataColumns(db: Database) {
 	if (!columnNames.has("quoted_tweet_id")) {
 		db.exec("alter table tweets add column quoted_tweet_id text");
 	}
+}
+
+function ensureTweetRetentionSchema(db: Database) {
+	const columnNames = getColumnNames(db, "tweets");
+	if (!columnNames.has("deleted_at")) {
+		db.exec("alter table tweets add column deleted_at text");
+	}
+	if (!columnNames.has("deletion_source")) {
+		db.exec("alter table tweets add column deletion_source text");
+	}
+	if (!columnNames.has("deletion_reason")) {
+		db.exec("alter table tweets add column deletion_reason text");
+	}
+	if (!columnNames.has("superseded_at")) {
+		db.exec("alter table tweets add column superseded_at text");
+	}
+	if (!columnNames.has("superseded_by_id")) {
+		db.exec("alter table tweets add column superseded_by_id text");
+	}
+	db.exec(`
+		create table if not exists tweet_revisions (
+			root_tweet_id text not null,
+			revision_id text primary key,
+			revision_index integer not null,
+			payload_json text,
+			source text not null,
+			observed_at text not null
+		);
+		create table if not exists tweet_subordinate_tombstones (
+			tweet_id text not null,
+			kind text not null check (kind in ('media', 'quote')),
+			subordinate_id text not null,
+			deleted_at text not null,
+			deletion_source text,
+			deletion_reason text not null,
+			primary key (tweet_id, kind, subordinate_id)
+		);
+		create index if not exists idx_tweets_deleted on tweets(deleted_at);
+		create index if not exists idx_tweets_superseded on tweets(superseded_at);
+		create index if not exists idx_tweet_revisions_root on tweet_revisions(root_tweet_id, revision_index);
+		create index if not exists idx_tweet_subordinate_tombstones_tweet on tweet_subordinate_tombstones(tweet_id);
+		insert or ignore into tweet_revisions (
+			root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+		)
+		select id, id, 0, null, 'migration', created_at
+		from tweets;
+	`);
 }
 
 function ensureProfileAvatarColumns(db: Database) {
@@ -863,15 +934,22 @@ function normalizeTweetState(db: Database) {
 	    media_count integer not null default 0,
 	    entities_json text not null default '{}',
 	    media_json text not null default '[]',
-	    quoted_tweet_id text
+	    quoted_tweet_id text,
+	    deleted_at text,
+	    deletion_source text,
+	    deletion_reason text,
+	    superseded_at text,
+	    superseded_by_id text
 	  );
 	  insert into tweets (
 	    id, author_profile_id, text, created_at, is_replied, reply_to_id,
-	    like_count, media_count, entities_json, media_json, quoted_tweet_id
+	    like_count, media_count, entities_json, media_json, quoted_tweet_id,
+	    deleted_at, deletion_source, deletion_reason, superseded_at, superseded_by_id
 	  )
 	  select
 	    id, author_profile_id, text, created_at, is_replied, reply_to_id,
-	    like_count, media_count, entities_json, media_json, quoted_tweet_id
+	    like_count, media_count, entities_json, media_json, quoted_tweet_id,
+	    null, null, null, null, null
 	  from tweets_legacy_state;
 	  drop table tweets_legacy_state;
 	  create index idx_tweets_created on tweets(created_at desc);
@@ -927,6 +1005,11 @@ const DATABASE_MIGRATIONS: readonly DatabaseMigration[] = [
 		version: 5,
 		name: "add durable tweet source provenance",
 		up: ensureTweetSourcesTable,
+	},
+	{
+		version: 6,
+		name: "retain tweet deletions and observable revisions",
+		up: ensureTweetRetentionSchema,
 	},
 ];
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -144,6 +144,14 @@ const BASE_SCHEMA_SQL = `
     observed_at text not null
   );
 
+  create table if not exists tweet_revision_edges (
+    older_revision_id text not null,
+    newer_revision_id text not null,
+    source text not null,
+    observed_at text not null,
+    primary key (older_revision_id, newer_revision_id)
+  );
+
   create table if not exists tweet_subordinate_tombstones (
     tweet_id text not null,
     kind text not null check (kind in ('media', 'quote')),
@@ -466,6 +474,61 @@ function ensureTweetMetadataColumns(db: Database) {
 	}
 }
 
+function ensureTweetRevisionEdgeSchema(db: Database) {
+	db.exec(`
+		create table if not exists tweet_revision_edges (
+			older_revision_id text not null,
+			newer_revision_id text not null,
+			source text not null,
+			observed_at text not null,
+			primary key (older_revision_id, newer_revision_id)
+		);
+		create index if not exists idx_tweet_revision_edges_newer
+			on tweet_revision_edges(newer_revision_id);
+	`);
+	const revisions = db.prepare(
+		`select root_tweet_id, revision_id, revision_index, observed_at
+		 from tweet_revisions
+		 order by root_tweet_id, revision_index, revision_id`,
+	);
+	type RevisionRow = {
+		root_tweet_id: string;
+		revision_id: string;
+		revision_index: number;
+		observed_at: string;
+	};
+	const insertEdge = db.prepare(`
+		insert or ignore into tweet_revision_edges (
+			older_revision_id, newer_revision_id, source, observed_at
+		) values (?, ?, 'migration', ?)
+	`);
+	let currentRoot: string | undefined;
+	let currentRank: number | undefined;
+	let currentRankRepresentative: RevisionRow | undefined;
+	let previousRankRepresentative: RevisionRow | undefined;
+	for (const revision of revisions.iterate() as IterableIterator<RevisionRow>) {
+		if (revision.root_tweet_id !== currentRoot) {
+			currentRoot = revision.root_tweet_id;
+			currentRank = revision.revision_index;
+			currentRankRepresentative = revision;
+			previousRankRepresentative = undefined;
+			continue;
+		}
+		if (revision.revision_index !== currentRank) {
+			previousRankRepresentative = currentRankRepresentative;
+			currentRankRepresentative = revision;
+			currentRank = revision.revision_index;
+		}
+		if (previousRankRepresentative) {
+			insertEdge.run(
+				previousRankRepresentative.revision_id,
+				revision.revision_id,
+				revision.observed_at,
+			);
+		}
+	}
+}
+
 function ensureTweetRetentionSchema(db: Database) {
 	const columnNames = getColumnNames(db, "tweets");
 	if (!columnNames.has("deleted_at")) {
@@ -511,6 +574,7 @@ function ensureTweetRetentionSchema(db: Database) {
 		select id, id, 0, null, 'migration', created_at
 		from tweets;
 	`);
+	ensureTweetRevisionEdgeSchema(db);
 }
 
 function ensureProfileAvatarColumns(db: Database) {
@@ -1010,6 +1074,11 @@ const DATABASE_MIGRATIONS: readonly DatabaseMigration[] = [
 		version: 6,
 		name: "retain tweet deletions and observable revisions",
 		up: ensureTweetRetentionSchema,
+	},
+	{
+		version: 7,
+		name: "retain observable tweet revision ordering",
+		up: ensureTweetRevisionEdgeSchema,
 	},
 ];
 

--- a/src/lib/import-repository.ts
+++ b/src/lib/import-repository.ts
@@ -49,6 +49,12 @@ export class ImportRepository {
 		for (const row of rows) {
 			const id = row[idKey];
 			if (typeof id !== "string" || existingIds.has(id)) continue;
+			if (
+				(row.deleted_at !== undefined && row.deleted_at !== null) ||
+				(row.superseded_at !== undefined && row.superseded_at !== null)
+			) {
+				continue;
+			}
 			const text = row[textKey];
 			statement.run(id, typeof text === "string" ? text : "");
 			existingIds.add(id);
@@ -67,6 +73,8 @@ export class ImportRepository {
       delete from tweets_fts;
       delete from dm_messages;
       delete from dm_conversations;
+	  delete from tweet_subordinate_tombstones;
+	  delete from tweet_revisions;
       delete from tweets;
       delete from profiles;
       delete from accounts;
@@ -114,6 +122,8 @@ export class ImportRepository {
       delete from tweets_fts;
       delete from dm_messages;
       delete from dm_conversations;
+	  delete from tweet_subordinate_tombstones;
+	  delete from tweet_revisions;
       delete from tweets;
       delete from profile_bio_entities;
       delete from profile_snapshots;

--- a/src/lib/import-repository.ts
+++ b/src/lib/import-repository.ts
@@ -74,6 +74,7 @@ export class ImportRepository {
       delete from dm_messages;
       delete from dm_conversations;
 	  delete from tweet_subordinate_tombstones;
+	  delete from tweet_revision_edges;
 	  delete from tweet_revisions;
       delete from tweets;
       delete from profiles;
@@ -123,6 +124,7 @@ export class ImportRepository {
       delete from dm_messages;
       delete from dm_conversations;
 	  delete from tweet_subordinate_tombstones;
+	  delete from tweet_revision_edges;
 	  delete from tweet_revisions;
       delete from tweets;
       delete from profile_bio_entities;

--- a/src/lib/link-index.ts
+++ b/src/lib/link-index.ts
@@ -211,7 +211,9 @@ function rebuildOccurrences(
         tweet.text,
         tweet.entities_json
       from tweets tweet
-      where text like '%://%' or entities_json like '%://%'
+	  where tweet.deleted_at is null
+	    and tweet.superseded_at is null
+	    and (text like '%://%' or entities_json like '%://%')
     `)
 						.all() as Array<Record<string, unknown>>);
 		for (const row of tweetRows) {

--- a/src/lib/media-fetch.test.ts
+++ b/src/lib/media-fetch.test.ts
@@ -136,6 +136,24 @@ describe("media fetch", () => {
 		);
 	});
 
+	it("does not fetch media belonging to a tombstoned tweet", async () => {
+		home();
+		insertTweet("tweet_deleted", [pbs("deleted_media")]);
+		getNativeDb()
+			.prepare(
+				"update tweets set deleted_at = ?, deletion_reason = ? where id = ?",
+			)
+			.run(
+				"2026-07-18T12:00:00.000Z",
+				"explicit_deleted_tweet_record",
+				"tweet_deleted",
+			);
+
+		const result = await fetchTweetMedia({ dryRun: true });
+
+		expect(result.would_fetch).toEqual([]);
+	});
+
 	it("scopes kind filters through tweet account edges", async () => {
 		const root = home();
 		insertTweet("tweet_1", [pbs("edge_media")]);

--- a/src/lib/media-fetch.ts
+++ b/src/lib/media-fetch.ts
@@ -334,6 +334,8 @@ function queryRows(options: MediaFetchOptions) {
     select t.id, t.media_json
     from tweets t
     where t.media_json not in ('', '[]', 'null')
+	  and t.deleted_at is null
+	  and t.superseded_at is null
   `;
 	const scopeClause = buildScopeClause(params, account, kind);
 	if (scopeClause) sql += ` and (${scopeClause})`;

--- a/src/lib/mention-threads-live.ts
+++ b/src/lib/mention-threads-live.ts
@@ -191,7 +191,9 @@ function listRecentMentions(
           edge.raw_json as rawJson
         from tweet_account_edges edge
         join tweets t on t.id = edge.tweet_id
-        where edge.kind = 'mention' and edge.account_id = ?
+		where edge.kind = 'mention' and edge.account_id = ?
+		  and t.deleted_at is null
+		  and t.superseded_at is null
       )
       select id, createdAt, replyToId, rawJson
       from local_mentions
@@ -247,6 +249,8 @@ function listMentionsByIds(
         and edge.account_id = ?
         and edge.kind = 'mention'
       where t.id in (${placeholders})
+		and t.deleted_at is null
+		and t.superseded_at is null
       order by t.created_at desc
       limit ?
       `,

--- a/src/lib/mentions-live.ts
+++ b/src/lib/mentions-live.ts
@@ -448,6 +448,8 @@ function findNewestArchiveMentionId(db: Database, accountId: string) {
       where e.account_id = ?
         and e.kind = 'mention'
         and e.source in ('archive', 'legacy')
+		and t.deleted_at is null
+		and t.superseded_at is null
         and length(t.id) > 0
         and t.id glob '[0-9]*'
         and t.id not glob '*[^0-9]*'

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -382,12 +382,14 @@ function mergeXurlTweetsIntoLocalStore(
 	);
 	const existingTweet = db.prepare("select text from tweets where id = ?");
 	const seenAt = new Date().toISOString();
+	const touchedTweetIds: string[] = [];
 	db.transaction(() => {
 		for (const tweet of payload.data) {
 			const authorId = tweet.author_id;
 			if (!authorId) continue;
 			const author = usersById.get(authorId);
 			if (!author) continue;
+			touchedTweetIds.push(tweet.id);
 			const profile = upsertProfileFromXUser(db, author);
 			const replyToId =
 				tweet.referenced_tweets?.find((item) => item.type === "replied_to")
@@ -431,7 +433,7 @@ function mergeXurlTweetsIntoLocalStore(
 			});
 			refreshTweetFts(db, tweet.id, tweet.text, previousText);
 		}
-		reconcileTweetTombstones(db);
+		reconcileTweetTombstones(db, touchedTweetIds);
 	})();
 }
 

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -12,6 +12,11 @@ import { getNativeDb } from "./db";
 import { runEffectPromise, tryPromise } from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import type { Database } from "./sqlite";
+import {
+	editHistoryIdsFromPayload,
+	reconcileTweetTombstones,
+	recordTweetRevision,
+} from "./tweet-retention";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
@@ -315,6 +320,12 @@ function tweetUrl(handle: string, id: string) {
 
 function replaceTweetFts(db: Database, tweetId: string, text: string) {
 	db.prepare("delete from tweets_fts where tweet_id = ?").run(tweetId);
+	const row = db
+		.prepare("select deleted_at, superseded_at from tweets where id = ?")
+		.get(tweetId) as
+		| { deleted_at: string | null; superseded_at: string | null }
+		| undefined;
+	if (row?.deleted_at || row?.superseded_at) return;
 	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
 		tweetId,
 		text,
@@ -403,6 +414,13 @@ function mergeXurlTweetsIntoLocalStore(
 				buildMediaJsonFromIncludes(tweet, payload.includes?.media),
 				quotedTweetId,
 			);
+			recordTweetRevision(db, {
+				tweetId: tweet.id,
+				editHistoryIds: editHistoryIdsFromPayload(tweet.id, tweet),
+				payloadJson: JSON.stringify(tweet),
+				source,
+				observedAt: seenAt,
+			});
 			upsertTweetAccountEdge(db, {
 				accountId,
 				tweetId: tweet.id,
@@ -413,6 +431,7 @@ function mergeXurlTweetsIntoLocalStore(
 			});
 			refreshTweetFts(db, tweet.id, tweet.text, previousText);
 		}
+		reconcileTweetTombstones(db);
 	})();
 }
 

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -1542,6 +1542,144 @@ describe("birdclaw queries", () => {
 		expect(conversation?.truncated).toBe(false);
 	});
 
+	it("traverses hidden replies to retain active descendants", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		insertTestTweet(db, {
+			id: "hidden_thread_root",
+			text: "Visible root",
+			createdAt: "2026-03-10T10:00:00.000Z",
+		});
+		insertTestTweet(db, {
+			id: "hidden_thread_middle",
+			text: "Deleted middle reply",
+			createdAt: "2026-03-10T10:01:00.000Z",
+			replyToId: "hidden_thread_root",
+		});
+		insertTestTweet(db, {
+			id: "hidden_thread_leaf",
+			text: "Visible reply below the deletion",
+			createdAt: "2026-03-10T10:02:00.000Z",
+			replyToId: "hidden_thread_middle",
+		});
+		db.prepare(
+			"update tweets set deleted_at = '2026-03-11T00:00:00.000Z' where id = 'hidden_thread_middle'",
+		).run();
+
+		const conversation = getTweetConversation("hidden_thread_root", 10, db);
+		expect(conversation?.items.map((tweet) => tweet.id)).toEqual([
+			"hidden_thread_root",
+			"hidden_thread_leaf",
+		]);
+		expect(conversation?.truncated).toBe(false);
+		expect(getTweetConversation("hidden_thread_root", 1, db)?.truncated).toBe(
+			true,
+		);
+	});
+
+	it("does not spend the visible result budget on broad hidden branches", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		insertTestTweet(db, {
+			id: "broad_hidden_root",
+			text: "Visible root",
+			createdAt: "2026-03-10T10:00:00.000Z",
+		});
+		for (let index = 0; index < 160; index += 1) {
+			const id = `broad_hidden_${String(index).padStart(3, "0")}`;
+			insertTestTweet(db, {
+				id,
+				text: "Deleted reply",
+				createdAt: new Date(
+					Date.parse("2026-03-10T10:01:00.000Z") + index * 1_000,
+				).toISOString(),
+				replyToId: "broad_hidden_root",
+			});
+			db.prepare(
+				"update tweets set deleted_at = '2026-03-11T00:00:00.000Z' where id = ?",
+			).run(id);
+		}
+		insertTestTweet(db, {
+			id: "broad_hidden_visible_leaf",
+			text: "Visible leaf after the broad hidden level",
+			createdAt: "2026-03-10T11:00:00.000Z",
+			replyToId: "broad_hidden_159",
+		});
+
+		const conversation = getTweetConversation("broad_hidden_root", 5, db);
+		expect(conversation?.items.map((tweet) => tweet.id)).toEqual([
+			"broad_hidden_root",
+			"broad_hidden_visible_leaf",
+		]);
+		expect(conversation?.truncated).toBe(false);
+	});
+
+	it("ignores hidden-only descendants beyond the thread depth limit", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		insertTestTweet(db, {
+			id: "hidden_depth_root",
+			text: "Visible root",
+			createdAt: "2026-03-10T10:00:00.000Z",
+		});
+		let parentId = "hidden_depth_root";
+		for (let depth = 1; depth <= 10; depth += 1) {
+			const id = `hidden_depth_${String(depth)}`;
+			insertTestTweet(db, {
+				id,
+				text: "Deleted depth node",
+				createdAt: `2026-03-10T10:${String(depth).padStart(2, "0")}:00.000Z`,
+				replyToId: parentId,
+			});
+			db.prepare(
+				"update tweets set deleted_at = '2026-03-11T00:00:00.000Z' where id = ?",
+			).run(id);
+			parentId = id;
+		}
+
+		const conversation = getTweetConversation("hidden_depth_root", 10, db);
+		expect(conversation?.items.map((tweet) => tweet.id)).toEqual([
+			"hidden_depth_root",
+		]);
+		expect(conversation?.truncated).toBe(false);
+	});
+
+	it("retains truncation state when the first active descendant is too deep", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		insertTestTweet(db, {
+			id: "hidden_cutoff_root",
+			text: "Visible root",
+			createdAt: "2026-03-10T10:00:00.000Z",
+		});
+		let parentId = "hidden_cutoff_root";
+		for (let depth = 1; depth <= 8; depth += 1) {
+			const id = `hidden_cutoff_${String(depth)}`;
+			insertTestTweet(db, {
+				id,
+				text: "Deleted depth node",
+				createdAt: `2026-03-10T10:${String(depth).padStart(2, "0")}:00.000Z`,
+				replyToId: parentId,
+			});
+			db.prepare(
+				"update tweets set deleted_at = '2026-03-11T00:00:00.000Z' where id = ?",
+			).run(id);
+			parentId = id;
+		}
+		insertTestTweet(db, {
+			id: "hidden_cutoff_active_leaf",
+			text: "Active reply beyond the depth cutoff",
+			createdAt: "2026-03-10T10:09:00.000Z",
+			replyToId: parentId,
+		});
+
+		const conversation = getTweetConversation("hidden_cutoff_root", 10, db);
+		expect(conversation?.items.map((tweet) => tweet.id)).toEqual([
+			"hidden_cutoff_root",
+		]);
+		expect(conversation?.truncated).toBe(true);
+	});
+
 	it("excludes ancestors and descendants cached only for another account", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/query-status.ts
+++ b/src/lib/query-status.ts
@@ -24,7 +24,12 @@ function countTimelineEdges(db: Database, kind: "home" | "mention") {
       select count(distinct tweet_id) as count
 		from tweet_account_edges edge
 		where edge.kind = ?
-		  and exists (select 1 from tweets t where t.id = edge.tweet_id)
+		  and exists (
+			select 1 from tweets t
+			where t.id = edge.tweet_id
+			  and t.deleted_at is null
+			  and t.superseded_at is null
+		  )
       `,
 		)
 		.get(kind) as { count: number | bigint } | undefined;

--- a/src/lib/research.test.ts
+++ b/src/lib/research.test.ts
@@ -214,6 +214,27 @@ describe("research mode", () => {
 		]);
 	});
 
+	it("keeps active research replies below a hidden intermediate reply", async () => {
+		getNativeDb()
+			.prepare(
+				"update tweets set deleted_at = '2026-05-02T00:00:00.000Z' where id = 'tweet_reply_1'",
+			)
+			.run();
+		const { runResearchMode } = await import("./research");
+
+		const report = await runResearchMode({
+			account: "acct_research",
+			limit: 5,
+			maxThreadDepth: 6,
+		});
+
+		expect(report.items[0]?.thread.map((node) => node.id)).toEqual([
+			"tweet_root",
+			"tweet_reply_3",
+			"tweet_reply_2",
+		]);
+	});
+
 	it("writes the markdown brief to disk when requested", async () => {
 		const { runResearchMode } = await import("./research");
 		const outputPath = path.join(process.env.BIRDCLAW_HOME ?? "", "brief.md");

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -262,8 +262,6 @@ function getTweetDescendants(
         from tweets child
         join thread on child.reply_to_id = thread.id
         where thread.depth < ?
-		  and child.deleted_at is null
-		  and child.superseded_at is null
           and instr(thread.path, ',' || child.id || ',') = 0
       )
       select

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -237,7 +237,7 @@ function getTweetRowById(tweetId: string): ResearchRow | null {
         p.created_at as author_created_at
       from tweets t
       join profiles p on p.id = t.author_profile_id
-      where t.id = ?
+	  where t.id = ? and t.deleted_at is null and t.superseded_at is null
       `,
 		)
 		.get(tweetId) as ResearchRow | undefined;
@@ -256,12 +256,14 @@ function getTweetDescendants(
       with recursive thread(id, depth, path) as (
         select id, 0 as depth, ',' || id || ',' as path
         from tweets
-        where id = ?
+		where id = ? and deleted_at is null and superseded_at is null
         union all
         select child.id, thread.depth + 1, thread.path || child.id || ','
         from tweets child
         join thread on child.reply_to_id = thread.id
         where thread.depth < ?
+		  and child.deleted_at is null
+		  and child.superseded_at is null
           and instr(thread.path, ',' || child.id || ',') = 0
       )
       select
@@ -292,6 +294,8 @@ function getTweetDescendants(
         thread.depth as thread_depth
       from thread
       join tweets t on t.id = thread.id
+	  and t.deleted_at is null
+	  and t.superseded_at is null
       join profiles p on p.id = t.author_profile_id
       order by t.created_at asc, t.id asc
       `,

--- a/src/lib/search-discussion.ts
+++ b/src/lib/search-discussion.ts
@@ -268,7 +268,8 @@ function collectLiveSearchTweets(
         p.created_at as profile_created_at
       from tweets t
       join profiles p on p.id = t.author_profile_id
-      where t.id in (${placeholders})
+	  where t.deleted_at is null and t.superseded_at is null
+	    and t.id in (${placeholders})
     `)
 		.all(accountId, accountId, ...ids) as Array<Record<string, unknown>>;
 

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -1357,31 +1357,14 @@ function listTweetDescendants(
 	resolveProfileByHandle?: (handle: string) => ProfileRecord,
 	accountId?: string,
 ) {
-	if (limit <= 0) {
-		const membershipClause =
-			accountId !== undefined
-				? ` and ${tweetAccountMembershipPredicate("child")}`
-				: "";
-		return {
-			items: [],
-			truncated: Boolean(
-				db
-					.prepare(
-						`select 1 from tweets child
-						 where child.reply_to_id = ? and child.id != ? and child.deleted_at is null and child.superseded_at is null${membershipClause}
-						 limit 1`,
-					)
-					.get(
-						rootId,
-						rootId,
-						...(accountId !== undefined ? [accountId, accountId] : []),
-					),
-			),
-		};
-	}
+	const visibleLimit = Number.isFinite(limit)
+		? Math.max(0, Math.floor(limit))
+		: 0;
 	const maxDepth = 8;
-	const maxCandidates = Math.max(128, limit * 8);
-	const cteLimit = maxCandidates + 2;
+	// Keep the traversal safety cap independent from the visible result budget:
+	// retained hidden nodes are graph bridges, not returned candidates.
+	const maxTraversalRows = Math.max(10_000, visibleLimit * 64);
+	const cteLimit = maxTraversalRows + 1;
 	const stateParams = accountId !== undefined ? [accountId, accountId] : [];
 	const scopedChildClause =
 		accountId !== undefined
@@ -1404,44 +1387,72 @@ function listTweetDescendants(
 		from tweets child
 		join branch on child.reply_to_id = branch.id
 		where branch.depth < ?
-		  and child.deleted_at is null
-		  and child.superseded_at is null
 		  ${scopedChildClause}
 		  and instr(branch.path, char(31) || child.id || char(31)) = 0
 		order by 3 asc, 1 asc, 2 asc
 		limit ?
 	  ),
+	  beyond_depth(id, path) as (
+		select
+		  child.id,
+		  cutoff.path || child.id || char(31)
+		from branch cutoff
+		join tweets child on child.reply_to_id = cutoff.id
+		where cutoff.depth = ?
+		  ${scopedChildClause}
+		  and instr(
+			cutoff.path,
+			char(31) || child.id || char(31)
+		  ) = 0
+		union all
+		select
+		  child.id,
+		  beyond_depth.path || child.id || char(31)
+		from beyond_depth
+		join tweets hidden on hidden.id = beyond_depth.id
+		join tweets child on child.reply_to_id = beyond_depth.id
+		where (hidden.deleted_at is not null or hidden.superseded_at is not null)
+		  ${scopedChildClause}
+		  and instr(
+			beyond_depth.path,
+			char(31) || child.id || char(31)
+		  ) = 0
+		limit ?
+	  ),
 	  branch_stats as (
 		select
 		  (select count(*) from branch) > ? as candidate_limited,
-		  exists (
+		  (
+			exists (
 			select 1
-			from branch cutoff
-			join tweets child on child.reply_to_id = cutoff.id
-			where cutoff.depth = ?
-			  and child.deleted_at is null
-			  and child.superseded_at is null
-			  ${scopedChildClause}
-			  and instr(
-				cutoff.path,
-				char(31) || child.id || char(31)
-			  ) = 0
+			from beyond_depth
+			join tweets visible on visible.id = beyond_depth.id
+			where visible.deleted_at is null
+			  and visible.superseded_at is null
 			limit 1
+			)
+			or (select count(*) from beyond_depth) > ?
 		  ) as depth_limited
-      )
+	  ),
+	  visible_branch as (
+		select branch.id
+		from branch
+		join tweets visible on visible.id = branch.id
+		where branch.id != ?
+		  and visible.deleted_at is null
+		  and visible.superseded_at is null
+		order by visible.created_at asc, visible.id asc
+		limit ?
+	  )
       ${conversationTweetSelect(
 				accountId,
 				"branch_stats.candidate_limited, branch_stats.depth_limited,",
-				`from branch
-	  cross join tweets t on t.id = branch.id
-	  join profiles p on p.id = t.author_profile_id`,
+				`from branch_stats
+	  left join visible_branch on true
+	  left join tweets t on t.id = visible_branch.id
+	  left join profiles p on p.id = t.author_profile_id`,
 			)}
-	  cross join branch_stats
-      where t.id != ?
-	    and t.deleted_at is null
-	    and t.superseded_at is null
 	  order by t.created_at asc, t.id asc
-      limit ?
       `,
 		)
 		.all(
@@ -1449,16 +1460,20 @@ function listTweetDescendants(
 			maxDepth,
 			...scopeParams,
 			cteLimit,
-			maxCandidates + 1,
 			maxDepth,
 			...scopeParams,
-			...stateParams,
+			...scopeParams,
+			cteLimit,
+			maxTraversalRows,
+			maxTraversalRows,
 			rootId,
-			limit + 1,
+			visibleLimit + 1,
+			...stateParams,
 		) as Array<Record<string, unknown>>;
 
-	const items = rows
-		.slice(0, limit)
+	const visibleRows = rows.filter((row) => typeof row.id === "string");
+	const items = visibleRows
+		.slice(0, visibleLimit)
 		.map((row) =>
 			buildEmbeddedTweet(
 				db,
@@ -1472,7 +1487,7 @@ function listTweetDescendants(
 	return {
 		items,
 		truncated:
-			rows.length > limit ||
+			visibleRows.length > visibleLimit ||
 			Boolean(rows[0]?.candidate_limited) ||
 			Boolean(rows[0]?.depth_limited),
 	};

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -635,6 +635,7 @@ export function buildTimelineItemsQuery(
 	          and tweet_id in (
             select id
             from tweets
+            where deleted_at is null and superseded_at is null
             order by created_at desc
 	            limit ?
 	          )
@@ -662,6 +663,7 @@ export function buildTimelineItemsQuery(
 		where = "where e.kind = ?";
 		params.push(kind);
 	}
+	where += " and t.deleted_at is null and t.superseded_at is null";
 
 	if (
 		hasLiteralAccountId ||
@@ -863,9 +865,9 @@ export function buildTimelineItemsQuery(
       join tweets t on t.id = e.tweet_id
       join accounts a on a.id = e.account_id
       join profiles p on p.id = t.author_profile_id
-      left join tweets rt on rt.id = t.reply_to_id
+      left join tweets rt on rt.id = t.reply_to_id and rt.deleted_at is null and rt.superseded_at is null
       left join profiles rp on rp.id = rt.author_profile_id
-      left join tweets qt on qt.id = t.quoted_tweet_id
+      left join tweets qt on qt.id = t.quoted_tweet_id and qt.deleted_at is null and qt.superseded_at is null
       left join profiles qp on qp.id = qt.author_profile_id
       ${ftsSearch ? "" : where}
       order by t.created_at desc, t.id desc
@@ -1250,7 +1252,7 @@ function getTweetById(
 			: [];
 	const row = db
 		.prepare(
-			`${conversationTweetSelect(options.stateAccountId)} where t.id = ?${membershipClause}`,
+			`${conversationTweetSelect(options.stateAccountId)} where t.id = ? and t.deleted_at is null and t.superseded_at is null${membershipClause}`,
 		)
 		.get(...stateParams, tweetId, ...membershipParams) as
 		| Record<string, unknown>
@@ -1277,6 +1279,8 @@ function hasTweetAccountMembership(
 				select 1
 				from tweets tweet
 				where tweet.id = ?
+					and tweet.deleted_at is null
+					and tweet.superseded_at is null
 					and ${tweetAccountMembershipPredicate("tweet")}
 				limit 1
 				`,
@@ -1296,7 +1300,9 @@ function getAccountMemberTweetIds(
 		.prepare(
 			`select tweet.id
 			 from tweets tweet
-			 where tweet.id in (${uniqueTweetIds.map(() => "?").join(", ")})
+				 where tweet.id in (${uniqueTweetIds.map(() => "?").join(", ")})
+				   and tweet.deleted_at is null
+				   and tweet.superseded_at is null
 			   and ${tweetAccountMembershipPredicate("tweet")}`,
 		)
 		.all(...uniqueTweetIds, accountId, accountId) as Array<{ id: string }>;
@@ -1362,7 +1368,7 @@ function listTweetDescendants(
 				db
 					.prepare(
 						`select 1 from tweets child
-						 where child.reply_to_id = ? and child.id != ?${membershipClause}
+						 where child.reply_to_id = ? and child.id != ? and child.deleted_at is null and child.superseded_at is null${membershipClause}
 						 limit 1`,
 					)
 					.get(
@@ -1388,16 +1394,18 @@ function listTweetDescendants(
       with recursive branch(id, depth, created_at, path) as (
         select t.id, 0, t.created_at, char(31) || t.id || char(31)
         from tweets t
-        where t.id = ?
+        where t.id = ? and t.deleted_at is null and t.superseded_at is null
         union all
         select
 		  child.id,
 		  branch.depth + 1,
 		  child.created_at,
 		  branch.path || child.id || char(31)
-        from tweets child
-        join branch on child.reply_to_id = branch.id
+		from tweets child
+		join branch on child.reply_to_id = branch.id
 		where branch.depth < ?
+		  and child.deleted_at is null
+		  and child.superseded_at is null
 		  ${scopedChildClause}
 		  and instr(branch.path, char(31) || child.id || char(31)) = 0
 		order by 3 asc, 1 asc, 2 asc
@@ -1411,6 +1419,8 @@ function listTweetDescendants(
 			from branch cutoff
 			join tweets child on child.reply_to_id = cutoff.id
 			where cutoff.depth = ?
+			  and child.deleted_at is null
+			  and child.superseded_at is null
 			  ${scopedChildClause}
 			  and instr(
 				cutoff.path,
@@ -1428,6 +1438,8 @@ function listTweetDescendants(
 			)}
 	  cross join branch_stats
       where t.id != ?
+	    and t.deleted_at is null
+	    and t.superseded_at is null
 	  order by t.created_at asc, t.id asc
       limit ?
       `,

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -6,6 +6,7 @@ import { afterEach, expect, it } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { ingestTweetPayload } from "./tweet-repository";
+import { editHistoryIdsFromPayload } from "./tweet-retention";
 
 let tempRoot: string | undefined;
 
@@ -71,4 +72,157 @@ it("marks only primary replies as replied", () => {
 		{ id: "liked_reply", is_replied: 1, reply_to_id: "primary_parent" },
 		{ id: "quoted_reply", is_replied: 0, reply_to_id: "quoted_parent" },
 	]);
+});
+
+it("records observable edit chains without re-indexing a tombstoned tweet", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		edgeKind: "home",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-1",
+					author_id: "42",
+					text: "original body",
+					created_at: "2026-07-01T09:00:00.000Z",
+				},
+			],
+			includes: {
+				users: [{ id: "42", username: "sam", name: "Sam" }],
+			},
+		},
+	});
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		edgeKind: "home",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-2",
+					author_id: "42",
+					text: "edited body",
+					created_at: "2026-07-01T10:00:00.000Z",
+					edit_history_tweet_ids: ["edit-1", "edit-2"],
+					attachments: { media_keys: ["media-1"] },
+					referenced_tweets: [{ type: "quoted", id: "quote-1" }],
+				},
+			],
+			includes: {
+				users: [{ id: "42", username: "sam", name: "Sam" }],
+				media: [
+					{
+						media_key: "media-1",
+						type: "photo",
+						url: "https://pbs.twimg.com/media/edit.jpg",
+					},
+				],
+			},
+		},
+	});
+	db.prepare(
+		"update tweets set deleted_at = ?, deletion_reason = ? where id = ?",
+	).run("2026-07-02T00:00:00.000Z", "explicit_delete", "edit-2");
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-2",
+					author_id: "42",
+					text: "edited body",
+					created_at: "2026-07-01T10:00:00.000Z",
+					edit_history_tweet_ids: ["edit-1", "edit-2"],
+					attachments: { media_keys: ["media-1"] },
+					referenced_tweets: [{ type: "quoted", id: "quote-1" }],
+				},
+			],
+			includes: {
+				users: [{ id: "42", username: "sam", name: "Sam" }],
+				media: [
+					{
+						media_key: "media-1",
+						type: "photo",
+						url: "https://pbs.twimg.com/media/edit.jpg",
+					},
+				],
+			},
+		},
+	});
+
+	expect(
+		db
+			.prepare(
+				"select revision_id, revision_index, payload_json is not null as hydrated from tweet_revisions where root_tweet_id = 'edit-1' order by revision_index",
+			)
+			.all(),
+	).toEqual([
+		{ revision_id: "edit-1", revision_index: 0, hydrated: 1 },
+		{ revision_id: "edit-2", revision_index: 1, hydrated: 1 },
+	]);
+	expect(
+		db
+			.prepare(
+				"select superseded_at is not null as superseded, superseded_by_id from tweets where id = 'edit-1'",
+			)
+			.get(),
+	).toEqual({ superseded: 1, superseded_by_id: "edit-2" });
+	expect(
+		db
+			.prepare(
+				"select count(*) as count from tweets_fts where tweet_id = 'edit-1'",
+			)
+			.get(),
+	).toEqual({ count: 0 });
+	expect(
+		db
+			.prepare(
+				"select count(*) as count from tweets_fts where tweet_id = 'edit-2'",
+			)
+			.get(),
+	).toEqual({ count: 0 });
+	expect(
+		db
+			.prepare(
+				"select kind, subordinate_id from tweet_subordinate_tombstones where tweet_id = 'edit-2' order by kind",
+			)
+			.all(),
+	).toEqual([
+		{
+			kind: "media",
+			subordinate_id: "https://pbs.twimg.com/media/edit.jpg",
+		},
+		{ kind: "quote", subordinate_id: "quote-1" },
+	]);
+});
+
+it("reads both X archive edit-info variants", () => {
+	expect(
+		editHistoryIdsFromPayload("edit-2", {
+			edit_info: {
+				initial: { editTweetIds: ["edit-1", "edit-2"] },
+			},
+		}),
+	).toEqual(["edit-1", "edit-2"]);
+	expect(
+		editHistoryIdsFromPayload("edit-3", {
+			edit_info: {
+				edit: {
+					initialTweetId: "edit-1",
+					editControlInitial: {
+						editTweetIds: ["edit-1", "edit-2", "edit-3"],
+					},
+				},
+			},
+		}),
+	).toEqual(["edit-1", "edit-2", "edit-3"]);
 });

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -9,6 +9,7 @@ import { ingestTweetPayload } from "./tweet-repository";
 import {
 	editHistoryIdsFromPayload,
 	mergeTweetRevisionChain,
+	reconcileTweetTombstones,
 	recordTweetRevision,
 } from "./tweet-retention";
 
@@ -519,6 +520,27 @@ it("merges edge-connected roots while preserving order outside a cycle", () => {
 			)
 			.get(),
 	).toEqual({ source: "archive_observation" });
+	db.exec(`
+		insert into tweets (
+			id, author_profile_id, text, created_at, is_replied, like_count,
+			media_count, entities_json, media_json
+		) values
+			('terminal-root', 'profile_me', 'root', '2026-07-01T00:00:00.000Z', 0, 0, 0, '{}', '[]'),
+			('terminal-a', 'profile_me', 'a', '2026-07-01T00:01:00.000Z', 0, 0, 0, '{}', '[]'),
+			('terminal-b', 'profile_me', 'b', '2026-07-01T00:01:00.000Z', 0, 0, 0, '{}', '[]');
+		insert into tweet_revisions (
+			root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+		) values
+			('terminal-root', 'terminal-root', 0, null, 'test', '2026-07-01T00:00:00.000Z'),
+			('terminal-root', 'terminal-a', 1, null, 'test', '2026-07-01T00:01:00.000Z'),
+			('terminal-root', 'terminal-b', 1, null, 'test', '2026-07-01T00:01:00.000Z');
+	`);
+	reconcileTweetTombstones(db, ["terminal-root"]);
+	expect(
+		db
+			.prepare("select superseded_by_id from tweets where id = 'terminal-root'")
+			.get(),
+	).toEqual({ superseded_by_id: "terminal-a" });
 });
 
 it("merges revision components beyond SQLite's traditional variable limit", () => {

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -128,8 +128,21 @@ it("records observable edit chains without re-indexing a tombstoned tweet", () =
 		},
 	});
 	db.prepare(
-		"update tweets set deleted_at = ?, deletion_reason = ? where id = ?",
-	).run("2026-07-02T00:00:00.000Z", "explicit_delete", "edit-2");
+		"update tweets set deleted_at = ?, deletion_source = ?, deletion_reason = ? where id = ?",
+	).run(
+		"2026-07-02T00:00:00.000Z",
+		"archive_first",
+		"explicit_delete_first",
+		"edit-1",
+	);
+	db.prepare(
+		"update tweets set deleted_at = ?, deletion_source = ?, deletion_reason = ? where id = ?",
+	).run(
+		"2026-07-03T00:00:00.000Z",
+		"archive_second",
+		"explicit_delete_second",
+		"edit-2",
+	);
 
 	ingestTweetPayload(db, {
 		accountId: "acct_primary",
@@ -193,6 +206,26 @@ it("records observable edit chains without re-indexing a tombstoned tweet", () =
 	expect(
 		db
 			.prepare(
+				"select id, deleted_at, deletion_source, deletion_reason from tweets where id in ('edit-1', 'edit-2') order by id",
+			)
+			.all(),
+	).toEqual([
+		{
+			id: "edit-1",
+			deleted_at: "2026-07-02T00:00:00.000Z",
+			deletion_source: "archive_first",
+			deletion_reason: "explicit_delete_first",
+		},
+		{
+			id: "edit-2",
+			deleted_at: "2026-07-02T00:00:00.000Z",
+			deletion_source: "archive_first",
+			deletion_reason: "explicit_delete_first",
+		},
+	]);
+	expect(
+		db
+			.prepare(
 				"select kind, subordinate_id from tweet_subordinate_tombstones where tweet_id = 'edit-2' order by kind",
 			)
 			.all(),
@@ -203,6 +236,84 @@ it("records observable edit chains without re-indexing a tombstoned tweet", () =
 		},
 		{ kind: "quote", subordinate_id: "quote-1" },
 	]);
+});
+
+it("scopes live tombstone reconciliation to the ingested edit chains", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	const user = [{ id: "42", username: "sam", name: "Sam" }];
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "unrelated-edit-1",
+					author_id: "42",
+					text: "old unrelated revision",
+					created_at: "2026-07-01T09:00:00.000Z",
+				},
+			],
+			includes: { users: user },
+		},
+	});
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "unrelated-edit-2",
+					author_id: "42",
+					text: "new unrelated revision",
+					created_at: "2026-07-01T10:00:00.000Z",
+					edit_history_tweet_ids: ["unrelated-edit-1", "unrelated-edit-2"],
+				},
+			],
+			includes: { users: user },
+		},
+	});
+	db.prepare(
+		"update tweets set superseded_at = null, superseded_by_id = null where id = 'unrelated-edit-1'",
+	).run();
+	db.prepare(
+		"insert into tweets_fts (tweet_id, text) values ('unrelated-edit-1', 'scope sentinel')",
+	).run();
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "isolated-tweet",
+					author_id: "42",
+					text: "isolated payload",
+					created_at: "2026-07-01T11:00:00.000Z",
+				},
+			],
+			includes: { users: user },
+		},
+	});
+
+	expect(
+		db
+			.prepare(
+				"select superseded_at, superseded_by_id from tweets where id = 'unrelated-edit-1'",
+			)
+			.get(),
+	).toEqual({ superseded_at: null, superseded_by_id: null });
+	expect(
+		db
+			.prepare(
+				"select count(*) as count from tweets_fts where tweet_id = 'unrelated-edit-1'",
+			)
+			.get(),
+	).toEqual({ count: 1 });
 });
 
 it("reads both X archive edit-info variants", () => {

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -6,7 +6,11 @@ import { afterEach, expect, it } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { ingestTweetPayload } from "./tweet-repository";
-import { editHistoryIdsFromPayload } from "./tweet-retention";
+import {
+	editHistoryIdsFromPayload,
+	mergeTweetRevisionChain,
+	recordTweetRevision,
+} from "./tweet-retention";
 
 let tempRoot: string | undefined;
 
@@ -236,6 +240,321 @@ it("records observable edit chains without re-indexing a tombstoned tweet", () =
 		},
 		{ kind: "quote", subordinate_id: "quote-1" },
 	]);
+});
+
+it("merges an enriched edit history into one revision chain", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	const users = [{ id: "42", username: "sam", name: "Sam" }];
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-3",
+					author_id: "42",
+					text: "latest body",
+					created_at: "2026-07-01T11:00:00.000Z",
+					edit_history_tweet_ids: ["edit-2", "edit-3"],
+				},
+			],
+			includes: { users },
+		},
+	});
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-2",
+					author_id: "42",
+					text: "middle body",
+					created_at: "2026-07-01T10:00:00.000Z",
+					edit_history_tweet_ids: ["edit-1", "edit-2", "edit-3"],
+				},
+			],
+			includes: { users },
+		},
+	});
+
+	expect(
+		db
+			.prepare(
+				"select root_tweet_id, revision_id, revision_index from tweet_revisions order by revision_index",
+			)
+			.all(),
+	).toEqual([
+		{ root_tweet_id: "edit-1", revision_id: "edit-1", revision_index: 0 },
+		{ root_tweet_id: "edit-1", revision_id: "edit-2", revision_index: 1 },
+		{ root_tweet_id: "edit-1", revision_id: "edit-3", revision_index: 2 },
+	]);
+	for (const [id, history] of [
+		["gap-3", ["gap-1", "gap-3"]],
+		["gap-2", ["gap-1", "gap-2", "gap-3"]],
+	] as const) {
+		ingestTweetPayload(db, {
+			accountId: "acct_primary",
+			source: "xurl",
+			payload: {
+				data: [
+					{
+						id,
+						author_id: "42",
+						text: `${id} body`,
+						created_at: "2026-07-01T11:00:00.000Z",
+						edit_history_tweet_ids: [...history],
+					},
+				],
+				includes: { users },
+			},
+		});
+	}
+	expect(
+		db
+			.prepare(
+				"select revision_id, revision_index from tweet_revisions where root_tweet_id = 'gap-1' order by revision_index",
+			)
+			.all(),
+	).toEqual([
+		{ revision_id: "gap-1", revision_index: 0 },
+		{ revision_id: "gap-2", revision_index: 1 },
+		{ revision_id: "gap-3", revision_index: 2 },
+	]);
+	for (const [id, history] of [
+		["branch-b", ["branch-a", "branch-b"]],
+		["branch-c", ["branch-a", "branch-c"]],
+		["branch-b", ["branch-a", "branch-c", "branch-b"]],
+	] as const) {
+		ingestTweetPayload(db, {
+			accountId: "acct_primary",
+			source: "xurl",
+			payload: {
+				data: [
+					{
+						id,
+						author_id: "42",
+						text: `${id} body`,
+						created_at: "2026-07-01T11:00:00.000Z",
+						edit_history_tweet_ids: [...history],
+					},
+				],
+				includes: { users },
+			},
+		});
+	}
+	expect(
+		db
+			.prepare(
+				"select revision_id, revision_index from tweet_revisions where root_tweet_id = 'branch-a' order by revision_index, revision_id",
+			)
+			.all(),
+	).toEqual([
+		{ revision_id: "branch-a", revision_index: 0 },
+		{ revision_id: "branch-c", revision_index: 1 },
+		{ revision_id: "branch-b", revision_index: 2 },
+	]);
+	db.prepare(
+		"update tweets set deleted_at = ?, deletion_source = ?, deletion_reason = ? where id = ?",
+	).run(
+		"2026-07-02T00:00:00.000Z",
+		"twitter_archive",
+		"explicit_deleted_tweet_record",
+		"edit-2",
+	);
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-3",
+					author_id: "42",
+					text: "latest body",
+					created_at: "2026-07-01T11:00:00.000Z",
+					edit_history_tweet_ids: ["edit-1", "edit-2", "edit-3"],
+				},
+			],
+			includes: { users },
+		},
+	});
+	expect(
+		db
+			.prepare(
+				"select deleted_at, deletion_source from tweets where id = 'edit-3'",
+			)
+			.get(),
+	).toEqual({
+		deleted_at: "2026-07-02T00:00:00.000Z",
+		deletion_source: "twitter_archive",
+	});
+});
+
+it("prefers attributed deletion provenance when revision timestamps tie", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	const users = [{ id: "42", username: "sam", name: "Sam" }];
+	for (const [id, history] of [
+		["edit-1", ["edit-1"]],
+		["edit-2", ["edit-1", "edit-2"]],
+	] as const) {
+		ingestTweetPayload(db, {
+			accountId: "acct_primary",
+			source: "xurl",
+			payload: {
+				data: [
+					{
+						id,
+						author_id: "42",
+						text: `${id} body`,
+						created_at: "2026-07-01T10:00:00.000Z",
+						edit_history_tweet_ids: [...history],
+					},
+				],
+				includes: { users },
+			},
+		});
+	}
+	const deletedAt = "2026-07-02T00:00:00.000Z";
+	db.prepare("update tweets set deleted_at = ? where id = 'edit-1'").run(
+		deletedAt,
+	);
+	db.prepare(
+		"update tweets set deleted_at = ?, deletion_source = ?, deletion_reason = ? where id = 'edit-2'",
+	).run(deletedAt, "twitter_archive", "explicit_deleted_tweet_record");
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "edit-2",
+					author_id: "42",
+					text: "edit-2 body",
+					created_at: "2026-07-01T10:00:00.000Z",
+					edit_history_tweet_ids: ["edit-1", "edit-2"],
+				},
+			],
+			includes: { users },
+		},
+	});
+	expect(
+		db
+			.prepare(
+				"select id, deletion_source, deletion_reason from tweets where id in ('edit-1', 'edit-2') order by id",
+			)
+			.all(),
+	).toEqual([
+		{
+			id: "edit-1",
+			deletion_source: "twitter_archive",
+			deletion_reason: "explicit_deleted_tweet_record",
+		},
+		{
+			id: "edit-2",
+			deletion_source: "twitter_archive",
+			deletion_reason: "explicit_deleted_tweet_record",
+		},
+	]);
+});
+
+it("merges edge-connected roots while preserving order outside a cycle", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	db.exec(`
+		insert into tweet_revisions (
+			root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+		) values
+			('cycle-a', 'cycle-a', 0, null, 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-a', 'cycle-b', 1, null, 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-c', 'cycle-c', 0, null, 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-c', 'cycle-d', 1, null, 'test', '2026-07-01T00:00:00.000Z');
+		insert into tweet_revision_edges (
+			older_revision_id, newer_revision_id, source, observed_at
+		) values
+			('cycle-a', 'cycle-b', 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-b', 'cycle-c', 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-c', 'cycle-b', 'test', '2026-07-01T00:00:00.000Z'),
+			('cycle-c', 'cycle-d', 'test', '2026-07-01T00:00:00.000Z');
+	`);
+
+	mergeTweetRevisionChain(db, ["cycle-a"]);
+
+	expect(
+		db
+			.prepare(
+				"select root_tweet_id, revision_id, revision_index from tweet_revisions order by revision_index, revision_id",
+			)
+			.all(),
+	).toEqual([
+		{ root_tweet_id: "cycle-a", revision_id: "cycle-a", revision_index: 0 },
+		{ root_tweet_id: "cycle-a", revision_id: "cycle-b", revision_index: 1 },
+		{ root_tweet_id: "cycle-a", revision_id: "cycle-c", revision_index: 1 },
+		{ root_tweet_id: "cycle-a", revision_id: "cycle-d", revision_index: 2 },
+	]);
+	for (const source of ["archive_observation", "backup_migration"]) {
+		recordTweetRevision(db, {
+			tweetId: "provenance-b",
+			editHistoryIds: ["provenance-a", "provenance-b"],
+			payloadJson: null,
+			source,
+			observedAt: "2026-07-01T00:00:00.000Z",
+		});
+	}
+	expect(
+		db
+			.prepare(
+				"select source from tweet_revision_edges where older_revision_id = 'provenance-a' and newer_revision_id = 'provenance-b'",
+			)
+			.get(),
+	).toEqual({ source: "archive_observation" });
+});
+
+it("merges revision components beyond SQLite's traditional variable limit", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	const insertRevision = db.prepare(`
+		insert into tweet_revisions (
+			root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+		) values (?, ?, 0, null, 'test', '2026-07-01T00:00:00.000Z')
+	`);
+	const insertEdge = db.prepare(`
+		insert into tweet_revision_edges (
+			older_revision_id, newer_revision_id, source, observed_at
+		) values (?, ?, 'test', '2026-07-01T00:00:00.000Z')
+	`);
+	for (let index = 0; index < 5_000; index += 1) {
+		const revisionId = `scale-${String(index).padStart(4, "0")}`;
+		insertRevision.run(revisionId, revisionId);
+		if (index > 0) {
+			insertEdge.run(`scale-${String(index - 1).padStart(4, "0")}`, revisionId);
+		}
+	}
+
+	const component = mergeTweetRevisionChain(db, ["scale-0000"]);
+
+	expect(component).toHaveLength(5_000);
+	expect(
+		db
+			.prepare(
+				"select count(*) as count, max(revision_index) as max_rank from tweet_revisions where root_tweet_id = 'scale-0000'",
+			)
+			.get(),
+	).toEqual({ count: 5_000, max_rank: 4_999 });
 });
 
 it("scopes live tombstone reconciliation to the ingested edit chains", () => {

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -555,7 +555,7 @@ it("merges revision components beyond SQLite's traditional variable limit", () =
 			)
 			.get(),
 	).toEqual({ count: 5_000, max_rank: 4_999 });
-});
+}, 20_000);
 
 it("scopes live tombstone reconciliation to the ingested edit chains", () => {
 	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -103,6 +103,7 @@ export function ingestTweetPayload(
       `)
 		: undefined;
 	const tweetIds: string[] = [];
+	const touchedTweetIds: string[] = [];
 	const upsertSource = provenance
 		? db.prepare(`
         insert into tweet_sources (tweet_id, source, source_url, observed_at)
@@ -117,6 +118,7 @@ export function ingestTweetPayload(
 		const observedAt = new Date().toISOString();
 		const primaryTweetIds = new Set(payload.data.map((tweet) => tweet.id));
 		for (const tweet of toCanonicalTweets(payload)) {
+			touchedTweetIds.push(tweet.id);
 			const isPrimaryTweet = primaryTweetIds.has(tweet.id);
 			const author = usersById.get(tweet.author_id);
 			const profile = author
@@ -179,7 +181,7 @@ export function ingestTweetPayload(
 				tweetIds.push(tweet.id);
 			}
 		}
-		reconcileTweetTombstones(db);
+		reconcileTweetTombstones(db, touchedTweetIds);
 	})();
 
 	return tweetIds;

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -3,6 +3,11 @@ import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import { tweetEntitiesFromXurl } from "./tweet-render";
 import type { XurlMentionData, XurlMentionsResponse } from "./types";
 import {
+	editHistoryIdsFromPayload,
+	reconcileTweetTombstones,
+	recordTweetRevision,
+} from "./tweet-retention";
+import {
 	type TweetAccountEdgeKind,
 	upsertTweetAccountEdge,
 } from "./tweet-account-edges";
@@ -39,6 +44,12 @@ function toCanonicalTweets(payload: XurlMentionsResponse) {
 
 export function replaceTweetFts(db: Database, tweetId: string, text: string) {
 	db.prepare("delete from tweets_fts where tweet_id = ?").run(tweetId);
+	const row = db
+		.prepare("select deleted_at, superseded_at from tweets where id = ?")
+		.get(tweetId) as
+		| { deleted_at: string | null; superseded_at: string | null }
+		| undefined;
+	if (row?.deleted_at || row?.superseded_at) return;
 	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
 		tweetId,
 		text,
@@ -132,6 +143,13 @@ export function ingestTweetPayload(
 					? 1
 					: 0,
 			);
+			recordTweetRevision(db, {
+				tweetId: tweet.id,
+				editHistoryIds: editHistoryIdsFromPayload(tweet.id, tweet),
+				payloadJson: JSON.stringify(tweet),
+				source,
+				observedAt,
+			});
 			const sourceUrl = provenance?.sourceUrlByTweetId.get(tweet.id);
 			if (sourceUrl) {
 				upsertSource?.run(tweet.id, source, sourceUrl, observedAt);
@@ -161,6 +179,7 @@ export function ingestTweetPayload(
 				tweetIds.push(tweet.id);
 			}
 		}
+		reconcileTweetTombstones(db);
 	})();
 
 	return tweetIds;

--- a/src/lib/tweet-retention.ts
+++ b/src/lib/tweet-retention.ts
@@ -185,8 +185,65 @@ export function tombstoneTweetSubordinates(
 	}
 }
 
-export function reconcileTweetTombstones(db: Database) {
-	db.exec(`
+interface TweetRevisionRow {
+	root_tweet_id: string;
+	revision_id: string;
+}
+
+interface DeletedTweetRow {
+	id: string;
+	deleted_at: string;
+	deletion_source: string | null;
+	deletion_reason: string | null;
+}
+
+function placeholders(values: readonly unknown[]) {
+	return values.map(() => "?").join(", ");
+}
+
+function selectRevisionScope(db: Database, tweetIds?: readonly string[]) {
+	if (tweetIds === undefined) {
+		return db
+			.prepare(
+				"select root_tweet_id, revision_id from tweet_revisions order by root_tweet_id, revision_index, revision_id",
+			)
+			.all() as TweetRevisionRow[];
+	}
+	if (tweetIds.length === 0) return [];
+	const roots = (
+		db
+			.prepare(
+				`select distinct root_tweet_id from tweet_revisions where revision_id in (${placeholders(tweetIds)})`,
+			)
+			.all(...tweetIds) as Array<{ root_tweet_id: string }>
+	).map((row) => row.root_tweet_id);
+	if (roots.length === 0) return [];
+	return db
+		.prepare(
+			`select root_tweet_id, revision_id from tweet_revisions where root_tweet_id in (${placeholders(roots)}) order by root_tweet_id, revision_index, revision_id`,
+		)
+		.all(...roots) as TweetRevisionRow[];
+}
+
+export function reconcileTweetTombstones(
+	db: Database,
+	touchedTweetIds?: readonly string[],
+) {
+	const requestedIds =
+		touchedTweetIds === undefined
+			? undefined
+			: Array.from(new Set(touchedTweetIds.filter(Boolean)));
+	if (requestedIds?.length === 0) return;
+	const revisionRows = selectRevisionScope(db, requestedIds);
+	const scopedIds = requestedIds
+		? Array.from(
+				new Set([
+					...requestedIds,
+					...revisionRows.map((row) => row.revision_id),
+				]),
+			)
+		: undefined;
+	const supersessionSql = `
 		update tweets
 		set superseded_at = coalesce(
 				superseded_at,
@@ -215,19 +272,71 @@ export function reconcileTweetTombstones(db: Database) {
 				on newer.root_tweet_id = current_revision.root_tweet_id
 				and newer.revision_index > current_revision.revision_index
 			where current_revision.revision_id = tweets.id
-		);
+		)
+		${scopedIds ? `and tweets.id in (${placeholders(scopedIds)})` : ""}
+	`;
+	if (scopedIds) {
+		db.prepare(supersessionSql).run(...scopedIds);
+	} else {
+		db.exec(supersessionSql);
+	}
+
+	const deletedSql = `
+		select id, deleted_at, deletion_source, deletion_reason
+		from tweets
+		where deleted_at is not null
+		${scopedIds ? `and id in (${placeholders(scopedIds)})` : ""}
+	`;
+	let deletedTweets = db
+		.prepare(deletedSql)
+		.all(...(scopedIds ?? [])) as DeletedTweetRow[];
+	const rootByRevisionId = new Map(
+		revisionRows.map((row) => [row.revision_id, row.root_tweet_id]),
+	);
+	const membersByRoot = new Map<string, string[]>();
+	for (const revision of revisionRows) {
+		const members = membersByRoot.get(revision.root_tweet_id) ?? [];
+		members.push(revision.revision_id);
+		membersByRoot.set(revision.root_tweet_id, members);
+	}
+	const deletionByRoot = new Map<string, DeletedTweetRow>();
+	for (const tweet of deletedTweets) {
+		const rootTweetId = rootByRevisionId.get(tweet.id);
+		if (!rootTweetId) continue;
+		const current = deletionByRoot.get(rootTweetId);
+		if (
+			!current ||
+			tweet.deleted_at < current.deleted_at ||
+			(tweet.deleted_at === current.deleted_at && tweet.id < current.id)
+		) {
+			deletionByRoot.set(rootTweetId, tweet);
+		}
+	}
+	const propagateDeletion = db.prepare(`
+		update tweets
+		set deleted_at = ?,
+			deletion_source = ?,
+			deletion_reason = ?
+		where id = ?
 	`);
-	const deletedTweets = db
+	for (const [rootTweetId, deletion] of deletionByRoot) {
+		for (const revisionId of membersByRoot.get(rootTweetId) ?? []) {
+			propagateDeletion.run(
+				deletion.deleted_at,
+				deletion.deletion_source,
+				deletion.deletion_reason,
+				revisionId,
+			);
+		}
+	}
+	deletedTweets = db
 		.prepare(`
-			select id, deleted_at, deletion_source
+			select id, deleted_at, deletion_source, deletion_reason
 			from tweets
 			where deleted_at is not null
+			${scopedIds ? `and id in (${placeholders(scopedIds)})` : ""}
 		`)
-		.all() as Array<{
-		id: string;
-		deleted_at: string;
-		deletion_source: string | null;
-	}>;
+		.all(...(scopedIds ?? [])) as DeletedTweetRow[];
 	for (const tweet of deletedTweets) {
 		tombstoneTweetSubordinates(db, {
 			tweetId: tweet.id,
@@ -235,46 +344,28 @@ export function reconcileTweetTombstones(db: Database) {
 			deletionSource: tweet.deletion_source ?? "import",
 		});
 	}
-	const revisionsOfDeletedTweets = db
-		.prepare(`
-			select earlier.id, terminal.deleted_at, terminal.deletion_source
-			from tweets earlier
-			join tweet_revisions earlier_revision
-				on earlier_revision.revision_id = earlier.id
-			join tweet_revisions terminal_revision
-				on terminal_revision.root_tweet_id = earlier_revision.root_tweet_id
-			join tweets terminal on terminal.id = terminal_revision.revision_id
-			where terminal_revision.revision_index = (
-				select max(candidate.revision_index)
-				from tweet_revisions candidate
-				where candidate.root_tweet_id = earlier_revision.root_tweet_id
-			)
-			and terminal.deleted_at is not null
-			and earlier.id <> terminal.id
-		`)
-		.all() as Array<{
-		id: string;
-		deleted_at: string;
-		deletion_source: string | null;
-	}>;
-	for (const tweet of revisionsOfDeletedTweets) {
-		tombstoneTweetSubordinates(db, {
-			tweetId: tweet.id,
-			deletedAt: tweet.deleted_at,
-			deletionSource: tweet.deletion_source ?? "revision_parent",
-		});
-	}
-	db.exec(`
+	const cleanupFtsSql = `
 		delete from tweets_fts
 		where tweet_id in (
 			select id from tweets
-			where deleted_at is not null or superseded_at is not null
+			where (deleted_at is not null or superseded_at is not null)
+			${scopedIds ? `and id in (${placeholders(scopedIds)})` : ""}
 		);
+	`;
+	const cleanupLinksSql = `
 		delete from link_occurrences
 		where source_kind = 'tweet'
 			and source_id in (
 				select id from tweets
-				where deleted_at is not null or superseded_at is not null
+				where (deleted_at is not null or superseded_at is not null)
+				${scopedIds ? `and id in (${placeholders(scopedIds)})` : ""}
 			);
-	`);
+	`;
+	if (scopedIds) {
+		db.prepare(cleanupFtsSql).run(...scopedIds);
+		db.prepare(cleanupLinksSql).run(...scopedIds);
+	} else {
+		db.exec(cleanupFtsSql);
+		db.exec(cleanupLinksSql);
+	}
 }

--- a/src/lib/tweet-retention.ts
+++ b/src/lib/tweet-retention.ts
@@ -544,7 +544,7 @@ export function reconcileTweetTombstones(
 					join tweet_revisions latest
 						on latest.root_tweet_id = current_revision.root_tweet_id
 					where current_revision.revision_id = tweets.id
-					order by latest.revision_index desc
+					order by latest.revision_index desc, latest.revision_id asc
 					limit 1
 			)
 		where exists (

--- a/src/lib/tweet-retention.ts
+++ b/src/lib/tweet-retention.ts
@@ -145,7 +145,7 @@ export function tombstoneTweetSubordinates(
 	}: {
 		tweetId: string;
 		deletedAt: string;
-		deletionSource: string;
+		deletionSource: string | null;
 		deletionReason?: string;
 	},
 ) {
@@ -170,8 +170,20 @@ export function tombstoneTweetSubordinates(
 		) values (?, ?, ?, ?, ?, ?)
 		on conflict(tweet_id, kind, subordinate_id) do update set
 			deleted_at = min(tweet_subordinate_tombstones.deleted_at, excluded.deleted_at),
-			deletion_source = coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source),
-			deletion_reason = coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+			deletion_source = case
+				when excluded.deleted_at < tweet_subordinate_tombstones.deleted_at
+					then excluded.deletion_source
+				when excluded.deleted_at = tweet_subordinate_tombstones.deleted_at
+					then coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source)
+				else tweet_subordinate_tombstones.deletion_source
+			end,
+			deletion_reason = case
+				when excluded.deleted_at < tweet_subordinate_tombstones.deleted_at
+					then excluded.deletion_reason
+				when excluded.deleted_at = tweet_subordinate_tombstones.deleted_at
+					then coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+				else tweet_subordinate_tombstones.deletion_reason
+			end
 	`);
 	for (const row of rows) {
 		insert.run(
@@ -341,7 +353,7 @@ export function reconcileTweetTombstones(
 		tombstoneTweetSubordinates(db, {
 			tweetId: tweet.id,
 			deletedAt: tweet.deleted_at,
-			deletionSource: tweet.deletion_source ?? "import",
+			deletionSource: tweet.deletion_source,
 		});
 	}
 	const cleanupFtsSql = `

--- a/src/lib/tweet-retention.ts
+++ b/src/lib/tweet-retention.ts
@@ -100,6 +100,31 @@ export function recordTweetRevision(
 			observedAt,
 		);
 	});
+	const insertEdge = db.prepare(`
+		insert into tweet_revision_edges (
+			older_revision_id, newer_revision_id, source, observed_at
+		) values (?, ?, ?, ?)
+		on conflict(older_revision_id, newer_revision_id) do update set
+			source = case
+				when excluded.observed_at > tweet_revision_edges.observed_at
+					then excluded.source
+				when excluded.observed_at = tweet_revision_edges.observed_at then case
+					when tweet_revision_edges.source in ('backup_migration', 'migration')
+						and excluded.source not in ('backup_migration', 'migration')
+						then excluded.source
+					when excluded.source in ('backup_migration', 'migration')
+						and tweet_revision_edges.source not in ('backup_migration', 'migration')
+						then tweet_revision_edges.source
+					else min(tweet_revision_edges.source, excluded.source)
+				end
+				else tweet_revision_edges.source
+			end,
+			observed_at = max(tweet_revision_edges.observed_at, excluded.observed_at)
+	`);
+	for (let index = 1; index < ids.length; index += 1) {
+		insertEdge.run(ids[index - 1], ids[index], source, observedAt);
+	}
+	mergeTweetRevisionChain(db, ids);
 	const terminalRevisionId = ids.at(-1) ?? tweetId;
 	const markSuperseded = db.prepare(`
 		update tweets
@@ -113,6 +138,251 @@ export function recordTweetRevision(
 	for (const revisionId of ids.slice(0, -1)) {
 		markSuperseded.run(observedAt, observedAt, terminalRevisionId, revisionId);
 	}
+}
+
+interface TweetRevisionTopologyRow {
+	root_tweet_id: string;
+	revision_id: string;
+}
+
+function addRevisionEdge(
+	edges: Map<string, Set<string>>,
+	indegree: Map<string, number>,
+	olderRevisionId: string,
+	newerRevisionId: string,
+) {
+	if (olderRevisionId === newerRevisionId) return;
+	const outgoing = edges.get(olderRevisionId) ?? new Set<string>();
+	if (outgoing.has(newerRevisionId)) return;
+	outgoing.add(newerRevisionId);
+	edges.set(olderRevisionId, outgoing);
+	indegree.set(newerRevisionId, (indegree.get(newerRevisionId) ?? 0) + 1);
+}
+
+function compareRevisionIds(left: string, right: string) {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function stronglyConnectedRevisionComponents(
+	nodes: readonly string[],
+	edges: ReadonlyMap<string, ReadonlySet<string>>,
+) {
+	const reverseEdges = new Map<string, Set<string>>();
+	for (const [olderRevisionId, newerRevisionIds] of edges) {
+		for (const newerRevisionId of newerRevisionIds) {
+			const incoming = reverseEdges.get(newerRevisionId) ?? new Set<string>();
+			incoming.add(olderRevisionId);
+			reverseEdges.set(newerRevisionId, incoming);
+		}
+	}
+	const visited = new Set<string>();
+	const finished: string[] = [];
+	for (const revisionId of nodes) {
+		if (visited.has(revisionId)) continue;
+		const traversal: Array<{ revisionId: string; expanded: boolean }> = [
+			{ revisionId, expanded: false },
+		];
+		while (traversal.length > 0) {
+			const current = traversal.pop();
+			if (!current) break;
+			if (current.expanded) {
+				finished.push(current.revisionId);
+				continue;
+			}
+			if (visited.has(current.revisionId)) continue;
+			visited.add(current.revisionId);
+			traversal.push({ revisionId: current.revisionId, expanded: true });
+			for (const newerRevisionId of edges.get(current.revisionId) ?? []) {
+				if (!visited.has(newerRevisionId)) {
+					traversal.push({ revisionId: newerRevisionId, expanded: false });
+				}
+			}
+		}
+	}
+	const assigned = new Set<string>();
+	const components: string[][] = [];
+	for (let index = finished.length - 1; index >= 0; index -= 1) {
+		const revisionId = finished[index];
+		if (!revisionId || assigned.has(revisionId)) continue;
+		const component: string[] = [];
+		const traversal = [revisionId];
+		assigned.add(revisionId);
+		while (traversal.length > 0) {
+			const member = traversal.pop();
+			if (!member) break;
+			component.push(member);
+			for (const olderRevisionId of reverseEdges.get(member) ?? []) {
+				if (assigned.has(olderRevisionId)) continue;
+				assigned.add(olderRevisionId);
+				traversal.push(olderRevisionId);
+			}
+		}
+		components.push(component);
+	}
+	return components;
+}
+
+/** Merge stored revision components using only explicitly observed order. */
+export function mergeTweetRevisionChain(
+	db: Database,
+	observedRevisionIds: readonly string[],
+) {
+	const observedIds = Array.from(
+		new Set(
+			observedRevisionIds
+				.map((revisionId) => revisionId.trim())
+				.filter(Boolean),
+		),
+	);
+	if (observedIds.length === 0) return [];
+	const seedJson = JSON.stringify(observedIds);
+	const rows = db
+		.prepare(
+			`with recursive component(revision_id) as (
+				select value from json_each(?)
+				union
+				select sibling.revision_id
+				from component
+				join tweet_revisions current
+					on current.revision_id = component.revision_id
+				join tweet_revisions sibling
+					on sibling.root_tweet_id = current.root_tweet_id
+				union
+				select edges.newer_revision_id
+				from component
+				join tweet_revision_edges edges
+					on edges.older_revision_id = component.revision_id
+				join tweet_revisions newer
+					on newer.revision_id = edges.newer_revision_id
+				union
+				select edges.older_revision_id
+				from component
+				join tweet_revision_edges edges
+					on edges.newer_revision_id = component.revision_id
+				join tweet_revisions older
+					on older.revision_id = edges.older_revision_id
+			)
+			select distinct revisions.root_tweet_id, revisions.revision_id
+			from component
+			join tweet_revisions revisions
+				on revisions.revision_id = component.revision_id
+			order by revisions.revision_id`,
+		)
+		.all(seedJson) as TweetRevisionTopologyRow[];
+	const nodes = rows.map((row) => row.revision_id);
+	if (nodes.length === 0) return [];
+	const nodeJson = JSON.stringify(nodes);
+	const edges = new Map<string, Set<string>>();
+	const nodeIndegree = new Map(nodes.map((revisionId) => [revisionId, 0]));
+	const storedEdges = db
+		.prepare(
+			`select older_revision_id, newer_revision_id
+			 from tweet_revision_edges
+			 where older_revision_id in (select value from json_each(?))
+			   and newer_revision_id in (select value from json_each(?))`,
+		)
+		.all(nodeJson, nodeJson) as Array<{
+		older_revision_id: string;
+		newer_revision_id: string;
+	}>;
+	for (const edge of storedEdges) {
+		addRevisionEdge(
+			edges,
+			nodeIndegree,
+			edge.older_revision_id,
+			edge.newer_revision_id,
+		);
+	}
+	const components = stronglyConnectedRevisionComponents(nodes, edges);
+	const componentByRevisionId = new Map<string, number>();
+	components.forEach((component, componentId) => {
+		for (const revisionId of component) {
+			componentByRevisionId.set(revisionId, componentId);
+		}
+	});
+	const componentEdges = new Map<number, Set<number>>();
+	const componentIndegree = new Map(
+		components.map((_, componentId) => [componentId, 0]),
+	);
+	for (const [olderRevisionId, newerRevisionIds] of edges) {
+		const olderComponentId = componentByRevisionId.get(olderRevisionId);
+		if (olderComponentId === undefined) continue;
+		for (const newerRevisionId of newerRevisionIds) {
+			const newerComponentId = componentByRevisionId.get(newerRevisionId);
+			if (
+				newerComponentId === undefined ||
+				newerComponentId === olderComponentId
+			)
+				continue;
+			const outgoing = componentEdges.get(olderComponentId) ?? new Set();
+			if (outgoing.has(newerComponentId)) continue;
+			outgoing.add(newerComponentId);
+			componentEdges.set(olderComponentId, outgoing);
+			componentIndegree.set(
+				newerComponentId,
+				(componentIndegree.get(newerComponentId) ?? 0) + 1,
+			);
+		}
+	}
+	const componentStableOrder = (componentId: number) =>
+		[...components[componentId]!].sort(compareRevisionIds)[0] ?? "";
+	const ready = components
+		.map((_, componentId) => componentId)
+		.filter((componentId) => componentIndegree.get(componentId) === 0)
+		.sort((left, right) =>
+			compareRevisionIds(
+				componentStableOrder(left),
+				componentStableOrder(right),
+			),
+		);
+	const componentRanks = new Map(
+		components.map((_, componentId) => [componentId, 0]),
+	);
+	while (ready.length > 0) {
+		const componentId = ready.shift();
+		if (componentId === undefined) break;
+		for (const newerComponentId of componentEdges.get(componentId) ?? []) {
+			componentRanks.set(
+				newerComponentId,
+				Math.max(
+					componentRanks.get(newerComponentId) ?? 0,
+					(componentRanks.get(componentId) ?? 0) + 1,
+				),
+			);
+			const nextIndegree = (componentIndegree.get(newerComponentId) ?? 0) - 1;
+			componentIndegree.set(newerComponentId, nextIndegree);
+			if (nextIndegree === 0) {
+				ready.push(newerComponentId);
+				ready.sort((left, right) =>
+					compareRevisionIds(
+						componentStableOrder(left),
+						componentStableOrder(right),
+					),
+				);
+			}
+		}
+	}
+	const ranks = new Map(
+		nodes.map((revisionId) => [
+			revisionId,
+			componentRanks.get(componentByRevisionId.get(revisionId) ?? -1) ?? 0,
+		]),
+	);
+	const rootTweetId = [...nodes].sort(
+		(left, right) =>
+			(ranks.get(left) ?? 0) - (ranks.get(right) ?? 0) ||
+			compareRevisionIds(left, right),
+	)[0];
+	if (!rootTweetId) return [];
+	const update = db.prepare(`
+		update tweet_revisions
+		set root_tweet_id = ?, revision_index = ?
+		where revision_id = ?
+	`);
+	for (const revisionId of nodes) {
+		update.run(rootTweetId, ranks.get(revisionId) ?? 0, revisionId);
+	}
+	return nodes;
 }
 
 function mediaIdentifiers(mediaJson: string) {
@@ -319,7 +589,11 @@ export function reconcileTweetTombstones(
 		if (
 			!current ||
 			tweet.deleted_at < current.deleted_at ||
-			(tweet.deleted_at === current.deleted_at && tweet.id < current.id)
+			(tweet.deleted_at === current.deleted_at &&
+				(deletionAttributionScore(tweet) > deletionAttributionScore(current) ||
+					(deletionAttributionScore(tweet) ===
+						deletionAttributionScore(current) &&
+						tweet.id < current.id)))
 		) {
 			deletionByRoot.set(rootTweetId, tweet);
 		}
@@ -380,4 +654,11 @@ export function reconcileTweetTombstones(
 		db.exec(cleanupFtsSql);
 		db.exec(cleanupLinksSql);
 	}
+}
+
+function deletionAttributionScore(tweet: DeletedTweetRow) {
+	return (
+		Number(tweet.deletion_source !== null) +
+		Number(tweet.deletion_reason !== null)
+	);
 }

--- a/src/lib/tweet-retention.ts
+++ b/src/lib/tweet-retention.ts
@@ -1,0 +1,280 @@
+import type { Database } from "./sqlite";
+
+export const ARCHIVE_DELETION_SOURCE = "twitter_archive";
+export const ARCHIVE_DELETION_REASON = "explicit_deleted_tweet_record";
+export const PARENT_DELETION_REASON = "parent_tweet_deleted";
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as JsonRecord)
+		: null;
+}
+
+function stringArray(value: unknown) {
+	return Array.isArray(value)
+		? value
+				.map((item) => String(item ?? "").trim())
+				.filter((item) => item.length > 0)
+		: [];
+}
+
+export function editHistoryIdsFromPayload(tweetId: string, payload: unknown) {
+	const record = asRecord(payload);
+	const legacyHistory = asRecord(record?.edit_history);
+	const archiveEditInfo = asRecord(record?.edit_info);
+	const archiveInitial = asRecord(archiveEditInfo?.initial);
+	const archiveEdit = asRecord(archiveEditInfo?.edit);
+	const archiveEditControl = asRecord(archiveEdit?.editControlInitial);
+	const ids = [
+		...stringArray(archiveInitial?.editTweetIds),
+		...stringArray(archiveEditControl?.editTweetIds),
+		...stringArray(record?.edit_history_tweet_ids),
+		...stringArray(legacyHistory?.edit_tweet_ids),
+	];
+	const initialTweetId = String(archiveEdit?.initialTweetId ?? "").trim();
+	if (initialTweetId && !ids.includes(initialTweetId))
+		ids.unshift(initialTweetId);
+	const unique = Array.from(new Set(ids));
+	if (!unique.includes(tweetId)) unique.push(tweetId);
+	return unique.length > 0 ? unique : [tweetId];
+}
+
+export function recordTweetRevision(
+	db: Database,
+	{
+		tweetId,
+		editHistoryIds,
+		payloadJson,
+		source,
+		observedAt,
+	}: {
+		tweetId: string;
+		editHistoryIds: readonly string[];
+		payloadJson: string | null;
+		source: string;
+		observedAt: string;
+	},
+) {
+	const ids = Array.from(
+		new Set(
+			[...editHistoryIds, tweetId]
+				.map((id) => id.trim())
+				.filter((id) => id.length > 0),
+		),
+	);
+	const rootTweetId = ids[0] ?? tweetId;
+	const insert = db.prepare(`
+		insert into tweet_revisions (
+			root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+		) values (?, ?, ?, ?, ?, ?)
+		on conflict(revision_id) do update set
+			root_tweet_id = case
+				when tweet_revisions.root_tweet_id = tweet_revisions.revision_id
+					and excluded.root_tweet_id <> excluded.revision_id
+					then excluded.root_tweet_id
+				else tweet_revisions.root_tweet_id
+			end,
+			revision_index = case
+				when tweet_revisions.root_tweet_id = tweet_revisions.revision_id
+					and excluded.root_tweet_id <> excluded.revision_id
+					then excluded.revision_index
+				else tweet_revisions.revision_index
+			end,
+			payload_json = coalesce(tweet_revisions.payload_json, excluded.payload_json),
+			source = case
+				when tweet_revisions.payload_json is null and excluded.payload_json is not null
+					then excluded.source
+				else tweet_revisions.source
+			end,
+			observed_at = max(tweet_revisions.observed_at, excluded.observed_at)
+	`);
+	ids.forEach((revisionId, revisionIndex) => {
+		insert.run(
+			rootTweetId,
+			revisionId,
+			revisionIndex,
+			revisionId === tweetId ? payloadJson : null,
+			source,
+			observedAt,
+		);
+	});
+	const terminalRevisionId = ids.at(-1) ?? tweetId;
+	const markSuperseded = db.prepare(`
+		update tweets
+		set superseded_at = case
+				when superseded_at is null or superseded_at > ? then ?
+				else superseded_at
+			end,
+			superseded_by_id = ?
+		where id = ?
+	`);
+	for (const revisionId of ids.slice(0, -1)) {
+		markSuperseded.run(observedAt, observedAt, terminalRevisionId, revisionId);
+	}
+}
+
+function mediaIdentifiers(mediaJson: string) {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(mediaJson);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(parsed)) return [];
+	const identifiers = parsed.flatMap((item, index) => {
+		const media = asRecord(item);
+		if (!media) return [];
+		for (const key of ["media_key", "mediaKey", "id_str", "id", "url"]) {
+			const value = media[key];
+			if (typeof value === "string" && value.length > 0) return [value];
+		}
+		return [`media:${String(index)}`];
+	});
+	return Array.from(new Set(identifiers));
+}
+
+export function tombstoneTweetSubordinates(
+	db: Database,
+	{
+		tweetId,
+		deletedAt,
+		deletionSource,
+		deletionReason = PARENT_DELETION_REASON,
+	}: {
+		tweetId: string;
+		deletedAt: string;
+		deletionSource: string;
+		deletionReason?: string;
+	},
+) {
+	const tweet = db
+		.prepare("select media_json, quoted_tweet_id from tweets where id = ?")
+		.get(tweetId) as
+		| { media_json: string; quoted_tweet_id: string | null }
+		| undefined;
+	if (!tweet) return;
+	const rows = [
+		...mediaIdentifiers(tweet.media_json).map((subordinateId) => ({
+			kind: "media",
+			subordinateId,
+		})),
+		...(tweet.quoted_tweet_id
+			? [{ kind: "quote", subordinateId: tweet.quoted_tweet_id }]
+			: []),
+	];
+	const insert = db.prepare(`
+		insert into tweet_subordinate_tombstones (
+			tweet_id, kind, subordinate_id, deleted_at, deletion_source, deletion_reason
+		) values (?, ?, ?, ?, ?, ?)
+		on conflict(tweet_id, kind, subordinate_id) do update set
+			deleted_at = min(tweet_subordinate_tombstones.deleted_at, excluded.deleted_at),
+			deletion_source = coalesce(tweet_subordinate_tombstones.deletion_source, excluded.deletion_source),
+			deletion_reason = coalesce(tweet_subordinate_tombstones.deletion_reason, excluded.deletion_reason)
+	`);
+	for (const row of rows) {
+		insert.run(
+			tweetId,
+			row.kind,
+			row.subordinateId,
+			deletedAt,
+			deletionSource,
+			deletionReason,
+		);
+	}
+}
+
+export function reconcileTweetTombstones(db: Database) {
+	db.exec(`
+		update tweets
+		set superseded_at = coalesce(
+				superseded_at,
+				(
+					select min(newer.observed_at)
+					from tweet_revisions current_revision
+					join tweet_revisions newer
+						on newer.root_tweet_id = current_revision.root_tweet_id
+						and newer.revision_index > current_revision.revision_index
+					where current_revision.revision_id = tweets.id
+				)
+			),
+			superseded_by_id = (
+					select latest.revision_id
+					from tweet_revisions current_revision
+					join tweet_revisions latest
+						on latest.root_tweet_id = current_revision.root_tweet_id
+					where current_revision.revision_id = tweets.id
+					order by latest.revision_index desc
+					limit 1
+			)
+		where exists (
+			select 1
+			from tweet_revisions current_revision
+			join tweet_revisions newer
+				on newer.root_tweet_id = current_revision.root_tweet_id
+				and newer.revision_index > current_revision.revision_index
+			where current_revision.revision_id = tweets.id
+		);
+	`);
+	const deletedTweets = db
+		.prepare(`
+			select id, deleted_at, deletion_source
+			from tweets
+			where deleted_at is not null
+		`)
+		.all() as Array<{
+		id: string;
+		deleted_at: string;
+		deletion_source: string | null;
+	}>;
+	for (const tweet of deletedTweets) {
+		tombstoneTweetSubordinates(db, {
+			tweetId: tweet.id,
+			deletedAt: tweet.deleted_at,
+			deletionSource: tweet.deletion_source ?? "import",
+		});
+	}
+	const revisionsOfDeletedTweets = db
+		.prepare(`
+			select earlier.id, terminal.deleted_at, terminal.deletion_source
+			from tweets earlier
+			join tweet_revisions earlier_revision
+				on earlier_revision.revision_id = earlier.id
+			join tweet_revisions terminal_revision
+				on terminal_revision.root_tweet_id = earlier_revision.root_tweet_id
+			join tweets terminal on terminal.id = terminal_revision.revision_id
+			where terminal_revision.revision_index = (
+				select max(candidate.revision_index)
+				from tweet_revisions candidate
+				where candidate.root_tweet_id = earlier_revision.root_tweet_id
+			)
+			and terminal.deleted_at is not null
+			and earlier.id <> terminal.id
+		`)
+		.all() as Array<{
+		id: string;
+		deleted_at: string;
+		deletion_source: string | null;
+	}>;
+	for (const tweet of revisionsOfDeletedTweets) {
+		tombstoneTweetSubordinates(db, {
+			tweetId: tweet.id,
+			deletedAt: tweet.deleted_at,
+			deletionSource: tweet.deletion_source ?? "revision_parent",
+		});
+	}
+	db.exec(`
+		delete from tweets_fts
+		where tweet_id in (
+			select id from tweets
+			where deleted_at is not null or superseded_at is not null
+		);
+		delete from link_occurrences
+		where source_kind = 'tweet'
+			and source_id in (
+				select id from tweets
+				where deleted_at is not null or superseded_at is not null
+			);
+	`);
+}

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -273,7 +273,7 @@ describe("X List sync and local filtering", () => {
 		tempRoots.push(backupRoot);
 		const exported = await exportBackup({ repoPath: backupRoot });
 		expect(exported.manifest).toMatchObject({
-			schemaVersion: 6,
+			schemaVersion: 7,
 			counts: { x_lists: 1, x_list_members: 1 },
 		});
 

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -273,7 +273,7 @@ describe("X List sync and local filtering", () => {
 		tempRoots.push(backupRoot);
 		const exported = await exportBackup({ repoPath: backupRoot });
 		expect(exported.manifest).toMatchObject({
-			schemaVersion: 5,
+			schemaVersion: 6,
 			counts: { x_lists: 1, x_list_members: 1 },
 		});
 


### PR DESCRIPTION
## Summary

- add lossless tweet deletion tombstones with timestamp, source, and reason provenance
- treat missing archive/timeline rows as absence of evidence, never deletion evidence
- merge archive and backup imports by default, with explicit `--restore` exact replacement
- retain observable edit chains while hiding superseded revisions from active views
- cascade deletion across edit chains and to retained media and quote references
- carry tombstones, subordinate tombstones, revision history, and observed revision edges through canonical backups

## Contract

This brings Birdclaw's Twitter/X archive store in line with the L-tier family tombstone behavior used by the related archive tools. Twitter archive deletion records are the only archive-level deletion signal. A tweet disappearing from a later home timeline or archive does not mark it deleted.

Schema 7 is additive and lossless. Existing tweets are backfilled as single-revision roots with no inferred deletion state, and existing schema-6 revision ranks migrate to portable observed edges without rewriting revision rows. When X exposes edit history, deleting any observed revision tombstones the retained chain while active replies below hidden nodes remain discoverable.

## Proof

- 147 test files, 1,313 tests passed
- format, zero-warning lint, TypeScript, and diff checks passed
- final whole-branch AutoReview completed with no accepted/actionable findings after adversarial revision, traversal, provenance, migration, determinism, and 5,000-node scale hardening
- packed `birdclaw-0.11.0.tgz` installed into a fresh temporary project and exercised through the real CLI from exact head `1e098d6`
- ten packed-runtime assertions covered schema 7, real `deleted-tweets.js`, `deleted-tweet-headers.js`, archive `edit_info`, observed revision edges, older-revision deletion propagation, not-seen preservation, media and quote tombstones, active FTS removal, and exact selected `--restore` including orphan-edge cleanup
- packed tarball SHA-256: `bcd23ed3417bd977fa09deb05bb8861ec194e3b9881dcf8ceca94861edeaab68`
