### PR TITLE
Harden web sync: identity guard for collections, structured job logging, configurable transport mode

### DIFF
--- a/src/lib/fxtwitter.ts
+++ b/src/lib/fxtwitter.ts
@@ -459,7 +459,7 @@ export function importTweetsViaFxTwitterEffect(
 						payload: result.payload,
 						source: "fxtwitter",
 						provenance: { sourceUrlByTweetId: result.provenance },
-					})) {
+					}).tweetIds) {
 						importedIds.add(tweetId);
 					}
 				}

--- a/src/lib/live-sync-engine.test.ts
+++ b/src/lib/live-sync-engine.test.ts
@@ -84,11 +84,16 @@ describe("live sync engine", () => {
 	});
 
 	it("falls through transport adapters in order", async () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
 		const result = await runEffectPromise(
 			fetchWithTransportFallbackEffect([
 				{
 					source: "xurl",
-					fetch: Effect.fail(new Error("unavailable")),
+					fetch: Effect.fail(
+						new Error("unavailable auth_token=do-not-log-this"),
+					),
 				},
 				{
 					source: "bird",
@@ -98,6 +103,15 @@ describe("live sync engine", () => {
 		);
 
 		expect(result).toEqual({ source: "bird", payload: { value: 2 } });
+		expect(consoleError).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] live-sync transport-fallback source=xurl reason=unavailable auth_token=\[REDACTED\]$/,
+			),
+		);
+		expect(consoleError).not.toHaveBeenCalledWith(
+			expect.stringContaining("do-not-log-this"),
+		);
+		consoleError.mockRestore();
 	});
 
 	it("returns a fresh cache without fetching", async () => {

--- a/src/lib/live-sync-engine.ts
+++ b/src/lib/live-sync-engine.ts
@@ -37,6 +37,22 @@ export interface CachedLiveSyncResult<
 	persisted: Persisted | undefined;
 }
 
+export function redactSensitiveLogText(
+	value: string,
+	sensitiveValues: readonly string[] = [],
+) {
+	let redacted = value;
+	for (const secret of sensitiveValues) {
+		if (secret) redacted = redacted.replaceAll(secret, "[REDACTED]");
+	}
+	return redacted
+		.replace(/\bBearer\s+\S+/gi, "Bearer [REDACTED]")
+		.replace(
+			/((?:authorization|cookie|auth[_-]?token|ct0)\s*[:=]\s*)\S+/gi,
+			"$1[REDACTED]",
+		);
+}
+
 export function resolveLiveSyncAccount(
 	db: Database,
 	accountId?: string,
@@ -132,11 +148,14 @@ export function fetchWithTransportFallbackEffect<
 	}
 	return first.fetch.pipe(
 		Effect.map((payload) => ({ source: first.source, payload })),
-		Effect.catchAll((error) =>
-			rest.length > 0
-				? fetchWithTransportFallbackEffect(rest)
-				: Effect.fail(toError(error)),
-		),
+		Effect.catchAll((error) => {
+			const reason = toError(error);
+			if (rest.length === 0) return Effect.fail(reason);
+			console.error(
+				`[${new Date().toISOString()}] live-sync transport-fallback source=${first.source} reason=${redactSensitiveLogText(reason.message)}`,
+			);
+			return fetchWithTransportFallbackEffect(rest);
+		}),
 	);
 }
 

--- a/src/lib/mentions-live.ts
+++ b/src/lib/mentions-live.ts
@@ -465,7 +465,7 @@ function mergeMentionsIntoLocalStore(
 	payload: XurlMentionsResponse,
 	source: MentionsDataSource,
 ) {
-	ingestTweetPayload(db, {
+	return ingestTweetPayload(db, {
 		accountId,
 		payload,
 		edgeKind: "mention",
@@ -772,7 +772,7 @@ export function syncMentionsEffect({
 			cached &&
 			cacheAgeMs <= ttlMs
 		) {
-			yield* databaseWriteEffect((writeDb) =>
+			const cachedPersisted = yield* databaseWriteEffect((writeDb) =>
 				mergeMentionsIntoLocalStore(
 					writeDb,
 					resolvedAccount.accountId,
@@ -794,6 +794,7 @@ export function syncMentionsEffect({
 				kind: "mentions",
 				accountId: resolvedAccount.accountId,
 				count: cached.value.data.length,
+				newCount: cachedPersisted.newTweetIds.length,
 				partial: isMaxPagesPartial({
 					payload: cached.value,
 					maxPages: parsedMaxPages,
@@ -852,7 +853,7 @@ export function syncMentionsEffect({
 				}),
 			);
 		}
-		yield* databaseWriteEffect((writeDb) =>
+		const persisted = yield* databaseWriteEffect((writeDb) =>
 			mergeMentionsIntoLocalStore(
 				writeDb,
 				resolvedAccount.accountId,
@@ -931,6 +932,7 @@ export function syncMentionsEffect({
 			kind: "mentions",
 			accountId: resolvedAccount.accountId,
 			count: payload.data.length,
+			newCount: persisted.newTweetIds.length,
 			partial: isMaxPagesPartial({ payload, maxPages: parsedMaxPages }),
 			payload,
 		};

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -3,12 +3,13 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listTimelineItems } from "./queries";
 
 const mocks = vi.hoisted(() => ({
+	getAuthenticatedBirdAccount: vi.fn(),
 	listBookmarkedTweetsViaBird: vi.fn(),
 	listHomeTimelineViaBird: vi.fn(),
 	listLikedTweetsViaBird: vi.fn(),
@@ -18,6 +19,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./bird", () => ({
+	getAuthenticatedBirdAccountEffect: () =>
+		Effect.tryPromise({
+			try: () => mocks.getAuthenticatedBirdAccount(),
+			catch: (error) => error,
+		}),
 	listBookmarkedTweetsViaBird: mocks.listBookmarkedTweetsViaBird,
 	listBookmarkedTweetsViaBirdEffect: (options: unknown) =>
 		Effect.tryPromise({
@@ -57,6 +63,13 @@ vi.mock("./xurl", () => ({
 }));
 
 const tempRoots: string[] = [];
+
+beforeEach(() => {
+	mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+		id: "25401953",
+		username: "steipete",
+	});
+});
 
 function makeTweet(id: string, text = id, authorId = "42") {
 	return {
@@ -761,6 +774,35 @@ describe("live timeline collection sync", () => {
 		});
 	});
 
+	it("rejects bird collection writes for a mismatched authenticated account", async () => {
+		setupTempHome();
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			id: "999",
+			username: "other",
+		});
+		mocks.listLikedTweetsViaBird.mockResolvedValue({
+			data: [makeTweet("wrong_account_like")],
+			meta: { result_count: 1 },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		await expect(
+			syncTimelineCollection({
+				kind: "likes",
+				mode: "bird",
+				limit: 5,
+				refresh: true,
+			}),
+		).rejects.toThrow("refusing to sync");
+		expect(mocks.listLikedTweetsViaBird).not.toHaveBeenCalled();
+		expect(
+			getNativeDb()
+				.prepare("select id from tweets where id = ?")
+				.get("wrong_account_like"),
+		).toBeUndefined();
+	});
+
 	it("does not pass the implicit early-stop cap to bird fallback", async () => {
 		setupTempHome();
 		const consoleError = vi
@@ -796,6 +838,9 @@ describe("live timeline collection sync", () => {
 
 	it("keeps live saved-state scoped to the syncing account", async () => {
 		setupTempHome();
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			username: "birdclaw_lab",
+		});
 		mocks.listLikedTweetsViaBird.mockResolvedValue({
 			data: [
 				{

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -167,7 +167,7 @@ function mergeTimelineCollectionIntoLocalStore(
 	payload: XurlMentionsResponse,
 	source: "xurl" | "bird",
 ) {
-	ingestTweetPayload(db, {
+	return ingestTweetPayload(db, {
 		accountId,
 		payload,
 		collectionKind: kind,
@@ -406,6 +406,7 @@ export function syncTimelineCollectionEffect({
 			kind,
 			accountId: resolvedAccount.accountId,
 			count: payload.data.length,
+			newCount: syncResult.persisted?.newTweetIds.length ?? 0,
 			payload,
 			...(saturatedAtPage === undefined
 				? {}

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -1,9 +1,11 @@
 import type { Database } from "./sqlite";
 import { Effect } from "effect";
+import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
 import { liveTransportGateway } from "./live-transport-gateway";
 import {
+	assertLiveAccountMatches,
 	createLiveTransportAdapter,
 	normalizeCacheTtlMs,
 	resolveLiveSyncAccount,
@@ -351,11 +353,22 @@ export function syncTimelineCollectionEffect({
 			maxPages: xurlMaxPages,
 			earlyStop,
 		});
-		const birdFetch = fetchBirdCollectionEffect({
-			kind,
-			limit,
-			all,
-			maxPages: parsedMaxPages,
+		const birdFetch = Effect.gen(function* () {
+			const authenticated = yield* getAuthenticatedBirdAccountEffect();
+			yield* trySync(() =>
+				assertLiveAccountMatches({
+					source: "bird",
+					account: resolvedAccount,
+					liveUsername: authenticated.username,
+					liveExternalUserId: authenticated.id,
+				}),
+			);
+			return yield* fetchBirdCollectionEffect({
+				kind,
+				limit,
+				all,
+				maxPages: parsedMaxPages,
+			});
 		});
 		const transports =
 			mode === "bird"

--- a/src/lib/timeline-live.ts
+++ b/src/lib/timeline-live.ts
@@ -131,7 +131,7 @@ function mergeHomeTimelineIntoLocalStore(
 	payload: XurlMentionsResponse,
 	source: "bird" | "xurl",
 ) {
-	ingestTweetPayload(db, {
+	return ingestTweetPayload(db, {
 		accountId,
 		payload,
 		edgeKind: "home",
@@ -158,6 +158,7 @@ export function syncHomeTimelineEffect({
 		accountId: string;
 		feed: "following" | "for-you";
 		count: number;
+		newCount: number;
 		payload: XurlMentionsResponse;
 	},
 	unknown
@@ -296,6 +297,7 @@ export function syncHomeTimelineEffect({
 			accountId,
 			feed: following ? "following" : "for-you",
 			count: payload.data.length,
+			newCount: syncResult.persisted?.newTweetIds.length ?? 0,
 			payload,
 		} as const;
 	});

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -20,6 +20,20 @@ export interface IngestTweetPayloadOptions {
 	};
 }
 
+export interface IngestTweetPayloadResult {
+	/** All primary tweet ids from payload.data that were ingested (existing or new). */
+	tweetIds: string[];
+	/**
+	 * Primary tweet ids that were NOT already a member of the scope this ingest
+	 * writes to (tweet_collections for a given kind, or tweet_account_edges for a
+	 * given kind) before this call. This is "new" as in "actually added", not
+	 * "never seen anywhere before" — a tweet already on the timeline that gets
+	 * bookmarked today is new to the bookmarks collection even though its row in
+	 * `tweets` already existed.
+	 */
+	newTweetIds: string[];
+}
+
 function getReferencedTweetId(tweet: XurlMentionData, type: string) {
 	return (
 		tweet.referenced_tweets?.find((item) => item.type === type)?.id ?? null
@@ -56,7 +70,7 @@ export function ingestTweetPayload(
 		markRepliesAsReplied = false,
 		provenance,
 	}: IngestTweetPayloadOptions,
-) {
+): IngestTweetPayloadResult {
 	const usersById = new Map(
 		(payload.includes?.users ?? []).map((user) => [user.id, user]),
 	);
@@ -92,6 +106,7 @@ export function ingestTweetPayload(
       `)
 		: undefined;
 	const tweetIds: string[] = [];
+	const newTweetIds: string[] = [];
 	const upsertSource = provenance
 		? db.prepare(`
         insert into tweet_sources (tweet_id, source, source_url, observed_at)
@@ -101,12 +116,39 @@ export function ingestTweetPayload(
           observed_at = excluded.observed_at
       `)
 		: undefined;
+	// "New" means not already a member of the scope this ingest writes to.
+	// Point-lookup per id (rather than a single WHERE IN (...tweetIds)) so a
+	// large --all merged payload never trips SQLite's bound-variable limit.
+	const checkCollectionMember = collectionKind
+		? db.prepare(
+				"select 1 from tweet_collections where account_id = ? and tweet_id = ? and kind = ?",
+			)
+		: undefined;
+	const checkEdgeMember = edgeKind
+		? db.prepare(
+				"select 1 from tweet_account_edges where account_id = ? and tweet_id = ? and kind = ?",
+			)
+		: undefined;
+	const checkTweetExists = db.prepare("select 1 from tweets where id = ?");
 
 	db.transaction(() => {
 		const observedAt = new Date().toISOString();
 		const primaryTweetIds = new Set(payload.data.map((tweet) => tweet.id));
 		for (const tweet of toCanonicalTweets(payload)) {
 			const isPrimaryTweet = primaryTweetIds.has(tweet.id);
+			if (isPrimaryTweet) {
+				// Existence must be checked before this tweet's own upserts run below,
+				// since those upserts are what create the membership row.
+				const alreadyMember = checkCollectionMember
+					? checkCollectionMember.get(accountId, tweet.id, collectionKind) !==
+						undefined
+					: checkEdgeMember
+						? checkEdgeMember.get(accountId, tweet.id, edgeKind) !== undefined
+						: checkTweetExists.get(tweet.id) !== undefined;
+				if (!alreadyMember) {
+					newTweetIds.push(tweet.id);
+				}
+			}
 			const author = usersById.get(tweet.author_id);
 			const profile = author
 				? upsertProfileFromXUser(db, author)
@@ -163,5 +205,5 @@ export function ingestTweetPayload(
 		}
 	})();
 
-	return tweetIds;
+	return { tweetIds, newTweetIds };
 }

--- a/src/lib/tweet-search-live.ts
+++ b/src/lib/tweet-search-live.ts
@@ -279,7 +279,7 @@ function runModeEffect(
 				),
 		});
 		const { payload, source } = syncResult;
-		const tweetIds = syncResult.persisted ?? [];
+		const tweetIds = syncResult.persisted?.tweetIds ?? [];
 
 		return {
 			ok: true,

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -88,6 +88,7 @@ function deferred<T>() {
 }
 
 const originalBirdclawHome = process.env.BIRDCLAW_HOME;
+const originalWebSyncMode = process.env.BIRDCLAW_WEB_SYNC_MODE;
 const tempRoots: string[] = [];
 
 function setupDefaultAccount(accountId: string) {
@@ -108,8 +109,10 @@ function setupDefaultAccount(accountId: string) {
 
 describe("web sync dispatcher", () => {
 	beforeEach(() => {
+		delete process.env.BIRDCLAW_WEB_SYNC_MODE;
 		vi.spyOn(console, "info").mockImplementation(() => {});
 		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
 		clearWebSyncLocksForTests();
 		vi.useRealTimers();
 		maybeAutoSyncBackupMock.mockReset();
@@ -133,6 +136,11 @@ describe("web sync dispatcher", () => {
 			delete process.env.BIRDCLAW_HOME;
 		} else {
 			process.env.BIRDCLAW_HOME = originalBirdclawHome;
+		}
+		if (originalWebSyncMode === undefined) {
+			delete process.env.BIRDCLAW_WEB_SYNC_MODE;
+		} else {
+			process.env.BIRDCLAW_WEB_SYNC_MODE = originalWebSyncMode;
 		}
 		for (const tempRoot of tempRoots.splice(0)) {
 			rmSync(tempRoot, { recursive: true, force: true });
@@ -291,6 +299,80 @@ describe("web sync dispatcher", () => {
 			refresh: true,
 			earlyStop: true,
 		});
+	});
+
+	it("forces bird mode across transport-aware web sync steps", async () => {
+		process.env.BIRDCLAW_WEB_SYNC_MODE = "bird";
+		syncHomeTimelineMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 1,
+		});
+		syncMentionsMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 1,
+			partial: false,
+		});
+		syncMentionThreadsMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			mergedTweets: 1,
+			partial: false,
+		});
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 1,
+		});
+		syncDirectMessagesViaCachedBirdMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			conversations: 1,
+			messages: 1,
+		});
+
+		await runWebSync("timeline");
+		await runWebSync("mentions");
+		await runWebSync("bookmarks");
+		await runWebSync("dms");
+
+		expect(syncHomeTimelineMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "bird" }),
+		);
+		expect(syncMentionsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "bird" }),
+		);
+		expect(syncMentionThreadsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "bird" }),
+		);
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "bird" }),
+		);
+		expect(syncDirectMessagesViaCachedBirdMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "bird" }),
+		);
+	});
+
+	it("warns once and uses the upstream auto mode for an invalid override", async () => {
+		process.env.BIRDCLAW_WEB_SYNC_MODE = "invalid";
+		syncTimelineCollectionMock.mockResolvedValue({
+			ok: true,
+			source: "bird",
+			count: 1,
+		});
+
+		await runWebSync("bookmarks");
+
+		expect(syncTimelineCollectionMock).toHaveBeenCalledWith(
+			expect.objectContaining({ mode: "auto" }),
+		);
+		expect(console.warn).toHaveBeenCalledTimes(1);
+		expect(console.warn).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync invalid BIRDCLAW_WEB_SYNC_MODE; falling back to auto$/,
+			),
+		);
 	});
 
 	it("returns an in-progress response for duplicate sync clicks", async () => {

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -108,6 +108,8 @@ function setupDefaultAccount(accountId: string) {
 
 describe("web sync dispatcher", () => {
 	beforeEach(() => {
+		vi.spyOn(console, "info").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
 		clearWebSyncLocksForTests();
 		vi.useRealTimers();
 		maybeAutoSyncBackupMock.mockReset();
@@ -124,6 +126,7 @@ describe("web sync dispatcher", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		resetDatabaseForTests();
 		resetBirdclawPathsForTests();
 		if (originalBirdclawHome === undefined) {
@@ -459,6 +462,16 @@ describe("web sync dispatcher", () => {
 				summary: "Synced 5 items",
 			});
 		});
+		expect(console.info).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync start jobId=.* kind=timeline accountId=acct_primary transport=pending fetched=0$/,
+			),
+		);
+		expect(console.info).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=bird fetched=5 status=succeeded$/,
+			),
+		);
 	});
 
 	it("keeps non-Error background failure messages in job snapshots", async () => {
@@ -473,6 +486,42 @@ describe("web sync dispatcher", () => {
 				error: "rate limited",
 			});
 		});
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=unknown fetched=0 status=failed error=rate limited$/,
+			),
+		);
+	});
+
+	it("logs full background errors without exposing configured secrets", async () => {
+		const previousToken = process.env.BIRDCLAW_WEB_TOKEN;
+		process.env.BIRDCLAW_WEB_TOKEN = "do-not-log-web-secret";
+		try {
+			syncHomeTimelineMock.mockRejectedValue(
+				new Error("sync exploded: do-not-log-web-secret"),
+			);
+
+			const job = startWebSync("timeline");
+			await vi.waitFor(() => {
+				expect(getWebSyncJob(job.id)).toMatchObject({ status: "failed" });
+			});
+
+			const failureLine = vi
+				.mocked(console.error)
+				.mock.calls.flat()
+				.map(String)
+				.find((line) => line.includes(`jobId=${job.id}`));
+			expect(failureLine).toContain(
+				"error=Error: sync exploded: [REDACTED]\\n",
+			);
+			expect(failureLine).not.toContain("do-not-log-web-secret");
+		} finally {
+			if (previousToken === undefined) {
+				delete process.env.BIRDCLAW_WEB_TOKEN;
+			} else {
+				process.env.BIRDCLAW_WEB_TOKEN = previousToken;
+			}
+		}
 	});
 
 	it("expires completed background sync jobs after the polling window", async () => {

--- a/src/lib/web-sync.test.ts
+++ b/src/lib/web-sync.test.ts
@@ -524,7 +524,12 @@ describe("web sync dispatcher", () => {
 	});
 
 	it("tracks background sync jobs through completion", async () => {
-		const pending = deferred<{ ok: boolean; source: string; count: number }>();
+		const pending = deferred<{
+			ok: boolean;
+			source: string;
+			count: number;
+			newCount: number;
+		}>();
 		syncHomeTimelineMock.mockReturnValue(pending.promise);
 
 		const job = startWebSync("timeline");
@@ -536,7 +541,7 @@ describe("web sync dispatcher", () => {
 		});
 		expect(getWebSyncJob(job.id)).toMatchObject({ status: "running" });
 
-		pending.resolve({ ok: true, source: "bird", count: 5 });
+		pending.resolve({ ok: true, source: "bird", count: 5, newCount: 3 });
 		await vi.waitFor(() => {
 			expect(getWebSyncJob(job.id)).toMatchObject({
 				status: "succeeded",
@@ -551,7 +556,7 @@ describe("web sync dispatcher", () => {
 		);
 		expect(console.info).toHaveBeenCalledWith(
 			expect.stringMatching(
-				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=bird fetched=5 status=succeeded$/,
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=bird fetched=5 new=3 status=succeeded$/,
 			),
 		);
 	});
@@ -570,7 +575,7 @@ describe("web sync dispatcher", () => {
 		});
 		expect(console.error).toHaveBeenCalledWith(
 			expect.stringMatching(
-				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=unknown fetched=0 status=failed error=rate limited$/,
+				/^\[\d{4}-\d{2}-\d{2}T.*Z\] web-sync end jobId=.* kind=timeline accountId=acct_primary transport=unknown fetched=0 new=0 status=failed error=rate limited$/,
 			),
 		);
 	});

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -82,6 +82,21 @@ const completedJobCleanupTimers = new Map<
 >();
 const COMPLETED_JOB_TTL_MS = 5 * 60 * 1000;
 
+function readWebSyncModeOverride(
+	runtime: ServerRuntimeServices,
+): "bird" | "xurl" | undefined {
+	const configured = runtime.env("BIRDCLAW_WEB_SYNC_MODE");
+	if (configured === undefined || configured.trim() === "auto") {
+		return undefined;
+	}
+	const mode = configured.trim();
+	if (mode === "bird" || mode === "xurl") return mode;
+	console.warn(
+		`[${runtime.now().toISOString()}] web-sync invalid BIRDCLAW_WEB_SYNC_MODE; falling back to auto`,
+	);
+	return undefined;
+}
+
 function assertRecord(
 	value: unknown,
 ): asserts value is Record<string, unknown> {
@@ -159,12 +174,14 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 		accountAware: true,
 		run: (account, _options, runtime) =>
 			Effect.gen(function* () {
+				const modeOverride = readWebSyncModeOverride(runtime);
 				const result = yield* syncHomeTimelineEffect({
 					account,
 					mode:
-						!account || account === resolveDefaultSyncAccountId(runtime)
+						modeOverride ??
+						(!account || account === resolveDefaultSyncAccountId(runtime)
 							? "auto"
-							: "xurl",
+							: "xurl"),
 					limit: 100,
 					maxPages: 3,
 					following: true,
@@ -183,11 +200,12 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	mentions: {
 		label: "Mentions",
 		accountAware: true,
-		run: (account) =>
+		run: (account, _options, runtime) =>
 			Effect.gen(function* () {
+				const modeOverride = readWebSyncModeOverride(runtime);
 				const mentions = yield* syncMentionsEffect({
 					account,
-					mode: "auto",
+					mode: modeOverride ?? "auto",
 					limit: 100,
 					maxPages: 3,
 					refresh: true,
@@ -204,7 +222,7 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 
 				const threads = yield* syncMentionThreadsEffect({
 					account,
-					mode: "xurl",
+					mode: modeOverride ?? "xurl",
 					limit: 30,
 					delayMs: 1500,
 					timeoutMs: 15000,
@@ -238,11 +256,13 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 	dms: {
 		label: "Direct messages",
 		accountAware: false,
-		run: (account, options) =>
+		run: (account, options, runtime) =>
 			Effect.gen(function* () {
 				const inbox = options.inbox ?? "all";
+				const modeOverride = readWebSyncModeOverride(runtime);
 				const result = yield* syncDirectMessagesViaCachedBirdEffect({
 					account,
+					...(modeOverride ? { mode: modeOverride } : {}),
 					inbox,
 					limit: options.limit ?? (inbox === "requests" ? 200 : 50),
 					...(options.maxPages !== undefined
@@ -272,12 +292,13 @@ function syncSavedCollection(
 	runtime: ServerRuntimeServices,
 ): Effect.Effect<WebSyncStep[], unknown> {
 	return Effect.gen(function* () {
+		const modeOverride = readWebSyncModeOverride(runtime);
 		const isNonDefaultAccount =
 			account !== undefined && account !== resolveDefaultSyncAccountId(runtime);
 		const result = yield* syncTimelineCollectionEffect({
 			kind,
 			account,
-			mode: isNonDefaultAccount ? "xurl" : "auto",
+			mode: modeOverride ?? (isNonDefaultAccount ? "xurl" : "auto"),
 			limit: 100,
 			maxPages: 5,
 			refresh: true,

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -21,6 +21,12 @@ export interface WebSyncStep {
 	kind: WebSyncKind | "mention-threads";
 	label: string;
 	count: number;
+	/**
+	 * Items actually added to their scope by this step (deduplicated), as
+	 * opposed to `count`, which is everything the transport fetched. Undefined
+	 * where a step doesn't track this distinction (e.g. mention-threads).
+	 */
+	newCount?: number;
 	source?: string;
 	partial?: boolean;
 	warnings?: string[];
@@ -148,6 +154,10 @@ function summarizeSyncResult(result: WebSyncResponse) {
 	return {
 		transport: transports.join(",") || "unknown",
 		fetched: result.steps.reduce((sum, step) => sum + step.count, 0),
+		newCount: result.steps.reduce(
+			(sum, step) => sum + (step.newCount ?? 0),
+			0,
+		),
 	};
 }
 
@@ -192,6 +202,7 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 						kind: "timeline",
 						label: "Home timeline",
 						count: readNumber(result, "count"),
+						newCount: readNumber(result, "newCount"),
 						source: readString(result, "source"),
 					},
 				];
@@ -215,6 +226,7 @@ const WEB_SYNC_PLANS: Record<WebSyncKind, WebSyncPlan> = {
 						kind: "mentions",
 						label: "Mentions",
 						count: readNumber(mentions, "count"),
+						newCount: readNumber(mentions, "newCount"),
 						source: readString(mentions, "source"),
 						partial: readBoolean(mentions, "partial"),
 					},
@@ -309,6 +321,7 @@ function syncSavedCollection(
 				kind,
 				label: kind === "likes" ? "Likes" : "Bookmarks",
 				count: readNumber(result, "count"),
+				newCount: readNumber(result, "newCount"),
 				source: readString(result, "source"),
 			},
 		];
@@ -482,9 +495,9 @@ export function startWebSync(
 		performWebSyncEffect(kind, effectiveAccountId, options, runtime),
 		{
 			onSuccess: (result) => {
-				const { transport, fetched } = summarizeSyncResult(result);
+				const { transport, fetched, newCount } = summarizeSyncResult(result);
 				console.info(
-					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=${transport} fetched=${String(fetched)} status=succeeded`,
+					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=${transport} fetched=${String(fetched)} new=${String(newCount)} status=succeeded`,
 				);
 				setJobSnapshot({
 					...job,
@@ -513,7 +526,7 @@ export function startWebSync(
 					error: result.error,
 				});
 				console.error(
-					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=unknown fetched=0 status=failed error=${formatFullError(error, runtime)}`,
+					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=unknown fetched=0 new=0 status=failed error=${formatFullError(error, runtime)}`,
 				);
 			},
 		},

--- a/src/lib/web-sync.ts
+++ b/src/lib/web-sync.ts
@@ -9,6 +9,7 @@ import {
 	defaultServerRuntimeServices,
 	type ServerRuntimeServices,
 } from "./server-runtime-services";
+import { redactSensitiveLogText } from "./live-sync-engine";
 import NativeSqliteDatabase from "./sqlite";
 import { syncTimelineCollectionEffect } from "./timeline-collections-live";
 import { syncHomeTimelineEffect } from "./timeline-live";
@@ -109,6 +110,30 @@ function readBoolean(value: unknown, key: string) {
 
 function messageFromError(error: unknown) {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function formatFullError(error: unknown, runtime: ServerRuntimeServices) {
+	const value =
+		error instanceof Error ? (error.stack ?? error.message) : String(error);
+	const secrets = [
+		"AUTH_TOKEN",
+		"CT0",
+		"BIRDCLAW_WEB_TOKEN",
+		"BIRDCLAW_MCP_TOKEN",
+		"OPENAI_API_KEY",
+		"OPENCAGE_API_KEY",
+	].map((name) => runtime.env(name) ?? "");
+	return redactSensitiveLogText(value, secrets).replaceAll("\n", "\\n");
+}
+
+function summarizeSyncResult(result: WebSyncResponse) {
+	const transports = [
+		...new Set(result.steps.map((step) => step.source).filter(Boolean)),
+	];
+	return {
+		transport: transports.join(",") || "unknown",
+		fetched: result.steps.reduce((sum, step) => sum + step.count, 0),
+	};
 }
 
 export function parseWebSyncKind(value: unknown): WebSyncKind | null {
@@ -426,11 +451,20 @@ export function startWebSync(
 	};
 	webSyncJobKeys.set(job.id, syncKey);
 	setJobSnapshot(job);
+	const resolvedAccountId =
+		effectiveAccountId ?? resolveDefaultSyncAccountId(runtime);
+	console.info(
+		`[${startedAt}] web-sync start jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=pending fetched=0`,
+	);
 
 	runEffectBackground(
 		performWebSyncEffect(kind, effectiveAccountId, options, runtime),
 		{
 			onSuccess: (result) => {
+				const { transport, fetched } = summarizeSyncResult(result);
+				console.info(
+					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=${transport} fetched=${String(fetched)} status=succeeded`,
+				);
 				setJobSnapshot({
 					...job,
 					status: "succeeded",
@@ -457,6 +491,9 @@ export function startWebSync(
 					result,
 					error: result.error,
 				});
+				console.error(
+					`[${result.finishedAt}] web-sync end jobId=${job.id} kind=${kind} accountId=${resolvedAccountId} transport=unknown fetched=0 status=failed error=${formatFullError(error, runtime)}`,
+				);
 			},
 		},
 	);


### PR DESCRIPTION
## What

Three related hardening changes to the live sync path, found while operating birdclaw as a long-running PM2 service:

1. **Identity guard for bookmarks/likes** (`05bad4d`): `assertLiveAccountMatches` already protects DMs, mentions, actions and X Lists, but `timeline-collections-live.ts` never called it. If the bird cookies are regenerated for a different X account, its bookmarks/likes are silently ingested into `acct_primary`. The guard now runs before fetch/persist in bird and auto modes, using the same pattern as `dms-live.ts`.

2. **Structured web sync job logging** (`9b80311`): web sync jobs lived only in the in-memory `webSyncJobs` map (TTL 5 min) and wrote nothing to stdout — a failed sync left no trace, and the xurl→bird transport fallback swallowed its reason. Jobs now log one ISO-timestamped start line and one end line (jobId, kind, accountId, transport actually used, fetched count, full error on failure), and the fallback logs why the first transport failed. Secrets are redacted.

3. **`BIRDCLAW_WEB_SYNC_MODE` env knob** (`1aa457a`): the web UI sync path hardcodes `mode: "auto"` (xurl first). Self-hosters using cookie-based bird as their only free transport currently can't prevent auto from silently switching to the metered X API once xurl credentials are present. Default stays `auto` (unchanged behavior); `bird`/`xurl` force a transport; invalid values warn once and fall back to `auto`.

## Related bug (not fixed here)

`birdclaw import hydrate-profiles` aborts with `UNIQUE constraint failed: profiles.handle` when the authenticated user already exists as a `profile_user_<id>` row (created by prior ingestion): it renames the seeded `profile_me` to the same handle before reconciling the two rows. It should merge/repoint duplicate-profile references first. Can open a separate issue with repro details if useful.

## Tests

`vitest`: 3 files, 64 passed (incl. new coverage: divergent bird account is rejected without writes; env knob forcing bird; invalid value fallback). `tsc --noEmit` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)