### PR TITLE
fix(follow-graph): validate --limit before binding it into SQL

### DIFF
--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -245,11 +245,16 @@ describe("follow graph sync and cache-only queries", () => {
 		// A negative limit is "no limit" in SQLite, so an unvalidated value
 		// silently returns the whole table instead of respecting --limit.
 		expect(() => listTopFollowers({ limit: -1 })).toThrow(
-			"--limit must be a non-negative number",
+			"--limit must be a non-negative integer",
 		);
 		expect(listTopFollowers({ limit: 0 }).items).toEqual([]);
 		expect(() => listTopFollowers({ limit: Number.NaN })).toThrow(
-			"--limit must be a non-negative number",
+			"--limit must be a non-negative integer",
+		);
+		// A fractional limit used to be silently floored (1.9 -> 1) instead of
+		// being treated as invalid input.
+		expect(() => listTopFollowers({ limit: 1.9 })).toThrow(
+			"--limit must be a non-negative integer",
 		);
 	});
 

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -224,7 +224,7 @@ describe("follow graph sync and cache-only queries", () => {
 		});
 	});
 
-	it("rejects non-positive limits instead of returning every row", async () => {
+	it("rejects negative and non-finite limits instead of returning every row", async () => {
 		setupTempHome();
 		mocks.listFollowUsersViaXurl.mockResolvedValueOnce({
 			data: [user("1", "alice", 100), user("2", "bob", 500)],
@@ -245,13 +245,11 @@ describe("follow graph sync and cache-only queries", () => {
 		// A negative limit is "no limit" in SQLite, so an unvalidated value
 		// silently returns the whole table instead of respecting --limit.
 		expect(() => listTopFollowers({ limit: -1 })).toThrow(
-			"--limit must be at least 1",
+			"--limit must be a non-negative number",
 		);
-		expect(() => listTopFollowers({ limit: 0 })).toThrow(
-			"--limit must be at least 1",
-		);
+		expect(listTopFollowers({ limit: 0 }).items).toEqual([]);
 		expect(() => listTopFollowers({ limit: Number.NaN })).toThrow(
-			"--limit must be at least 1",
+			"--limit must be a non-negative number",
 		);
 	});
 

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -224,6 +224,37 @@ describe("follow graph sync and cache-only queries", () => {
 		});
 	});
 
+	it("rejects non-positive limits instead of returning every row", async () => {
+		setupTempHome();
+		mocks.listFollowUsersViaXurl.mockResolvedValueOnce({
+			data: [user("1", "alice", 100), user("2", "bob", 500)],
+			meta: { result_count: 2 },
+		});
+		const { listTopFollowers, syncFollowGraph } =
+			await import("./follow-graph");
+
+		await syncFollowGraph({
+			direction: "followers",
+			yes: true,
+			refresh: true,
+		});
+
+		expect(
+			listTopFollowers({ limit: 1 }).items.map((item) => item.handle),
+		).toEqual(["bob"]);
+		// A negative limit is "no limit" in SQLite, so an unvalidated value
+		// silently returns the whole table instead of respecting --limit.
+		expect(() => listTopFollowers({ limit: -1 })).toThrow(
+			"--limit must be at least 1",
+		);
+		expect(() => listTopFollowers({ limit: 0 })).toThrow(
+			"--limit must be at least 1",
+		);
+		expect(() => listTopFollowers({ limit: Number.NaN })).toThrow(
+			"--limit must be at least 1",
+		);
+	});
+
 	it("reuses fresh cache for duplicate sync requests instead of calling xurl again", async () => {
 		setupTempHome();
 		mocks.listFollowUsersViaXurl.mockResolvedValueOnce({

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -66,8 +66,8 @@ function parseLimit(value = DEFAULT_FOLLOW_PAGE_LIMIT) {
 }
 
 function parseRowLimit(value: number) {
-	if (!Number.isFinite(value) || value < 1) {
-		throw new Error("--limit must be at least 1");
+	if (!Number.isFinite(value) || value < 0) {
+		throw new Error("--limit must be a non-negative number");
 	}
 	return Math.floor(value);
 }

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -66,10 +66,10 @@ function parseLimit(value = DEFAULT_FOLLOW_PAGE_LIMIT) {
 }
 
 function parseRowLimit(value: number) {
-	if (!Number.isFinite(value) || value < 0) {
-		throw new Error("--limit must be a non-negative number");
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error("--limit must be a non-negative integer");
 	}
-	return Math.floor(value);
+	return value;
 }
 
 function parseOptionalPositiveInteger(name: string, value?: number) {

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -65,6 +65,13 @@ function parseLimit(value = DEFAULT_FOLLOW_PAGE_LIMIT) {
 	return Math.floor(value);
 }
 
+function parseRowLimit(value: number) {
+	if (!Number.isFinite(value) || value < 1) {
+		throw new Error("--limit must be at least 1");
+	}
+	return Math.floor(value);
+}
+
 function parseOptionalPositiveInteger(name: string, value?: number) {
 	if (value === undefined) {
 		return undefined;
@@ -784,7 +791,9 @@ export function listTopFollowers({
       limit ?
       `,
 		)
-		.all(resolved.accountId, limit) as Array<Record<string, unknown>>;
+		.all(resolved.accountId, parseRowLimit(limit)) as Array<
+		Record<string, unknown>
+	>;
 	return {
 		accountId: resolved.accountId,
 		items: rows.map(toGraphProfile),
@@ -827,7 +836,9 @@ export function listMutuals({
       limit ?
       `,
 		)
-		.all(resolved.accountId, limit) as Array<Record<string, unknown>>;
+		.all(resolved.accountId, parseRowLimit(limit)) as Array<
+		Record<string, unknown>
+	>;
 	return {
 		accountId: resolved.accountId,
 		items: rows.map(toGraphProfile),
@@ -877,7 +888,9 @@ export function listNonMutualFollowing({
       limit ?
       `,
 		)
-		.all(resolved.accountId, limit) as Array<Record<string, unknown>>;
+		.all(resolved.accountId, parseRowLimit(limit)) as Array<
+		Record<string, unknown>
+	>;
 	return {
 		accountId: resolved.accountId,
 		items: rows.map(toGraphProfile),
@@ -922,7 +935,7 @@ export function listUnfollowedSince({
       limit ?
       `,
 		)
-		.all(resolved.accountId, direction, since, limit) as Array<
+		.all(resolved.accountId, direction, since, parseRowLimit(limit)) as Array<
 		Record<string, unknown>
 	>;
 	return {
@@ -973,7 +986,7 @@ export function listFollowEvents({
 		params.push(until.includes("T") ? until : `${until}T00:00:00.000Z`);
 	}
 
-	params.push(limit);
+	params.push(parseRowLimit(limit));
 	const rows = db
 		.prepare(
 			`


### PR DESCRIPTION
## Problem

The five cache-only graph queries in `src/lib/follow-graph.ts` bind the caller's `limit` straight into `limit ?` with no validation:

- `listTopFollowers`
- `listMutuals`
- `listNonMutualFollowing`
- `listUnfollowedSince`
- `listFollowEvents`

SQLite treats a negative `LIMIT` as **no limit at all**, so a negative value silently returns the entire table instead of respecting the option's documented "Limit results" contract. There is no error and nothing in the output signals that the limit was ignored.

The value reaches those functions unvalidated. `src/cli/register-graph.ts` passes `limit: Number(options.limit)` for every one of these commands, so:

```
birdclaw graph top-followers --limit -1     # returns every follower, not 20
birdclaw graph mutuals --limit -1           # returns every mutual
birdclaw graph events --limit abc           # Number("abc") is NaN -> raw driver binding error
```

Verified against `node:sqlite` directly, on the same query shape the module uses:

| bound limit | rows returned (5-row table) |
| --- | --- |
| `2` | 2 |
| `-1` | **5 (all)** |
| `0` | 0 |
| `NaN` | throws |

## Fix

Validate the limit before binding it, matching the validation this file already performs elsewhere. `parseLimit` guards the follow-sync limit and `parseOptionalPositiveInteger` guards `--max-pages` and `--max-resources`; neither fit these call sites (one imposes the sync-specific 1000 cap and message, the other is typed for genuinely optional values), so this adds the same shape for row limits:

```ts
function parseRowLimit(value: number) {
	if (!Number.isFinite(value) || value < 1) {
		throw new Error("--limit must be at least 1");
	}
	return Math.floor(value);
}
```

Deliberately no upper bound: capping would be a second behaviour change, and a large `--limit` on `graph events` is a legitimate request.

## Verification

Added a regression test in `src/lib/follow-graph.test.ts` alongside the existing limit-validation test. Confirmed it **fails against the unpatched module** (`AssertionError: expected [Function] to throw an error`) and passes with the fix.

- `follow-graph.test.ts`: 12 passed
- `follow-graph.test.ts` + `cli.test.ts` + `archive-import.test.ts`: 114 passed
- `oxlint` on the changed file: 0 warnings, 0 errors
- `oxfmt --check`: clean
- `tsc --noEmit`: no new errors (unchanged error count; none in `follow-graph.ts`)

Valid limits are unaffected, and fractional values still floor as before.


## Follow-up: zero stays an empty-result limit

The review was right, and I had this wrong. My first pass rejected every value below 1, but SQLite only treats a **negative** bound limit as "no limit" - a bound limit of `0` returns an empty result, which is the behaviour callers already had. Rejecting `0` was a compatibility regression, and the regression test locked it in by asserting it throws.

Checked the premise against the real driver (`node:sqlite` `DatabaseSync`, the same one `src/lib/sqlite.ts` uses) rather than assuming, on a table with 3 rows:

```
$ node --input-type=module -e 'import { DatabaseSync } from "node:sqlite"; ...
                               db.prepare("select id from items order by id limit ?").all(limit)'
limit=0 rows=0
limit=-1 rows=3
limit=1 rows=1
```

So `0` is a legitimate bounded empty result and only negatives disable the limit. `parseRowLimit` now rejects only negative and non-finite values, and the test asserts `listTopFollowers({ limit: 0 }).items` is `[]` instead of expecting a throw. The `-1` and `NaN` cases still throw, which is the original bug this PR is about. Error message updated to `--limit must be a non-negative number` to match the new rule. The five call sites are unchanged.

```
$ pnpm test src/lib/follow-graph.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ pnpm run lint
Found 0 warnings and 0 errors.
```

`pnpm run typecheck` fails on this machine with 79 errors, all of them pre-existing and unrelated (`@tanstack/react-query` and `@modelcontextprotocol/sdk` are missing from my local `node_modules`, so every `src/routes/*` and `src/components/*` file errors). I confirmed the identical 79 errors reproduce on the base commit with my change stashed, and none of them reference `follow-graph.ts`.


### Follow-up: fractional limits rejected, and proof against a real cache

**Fractional limits.** Right again, and the history here makes it worse than it first looks. `Math.floor` was mine, and it did not merely round a value the old code also rounded: SQLite enforces integer affinity on LIMIT operands specifically, so genuinely unvalidated code *errors* on a fractional limit rather than truncating it.

```
$ node -e 'DatabaseSync ... prepare("select id from items order by id limit ?")'
limit=1.9 -> THROWS: datatype mismatch
limit=2   -> 2 rows
limit=0   -> 0 rows
limit=-1  -> 3 rows
non-limit param 1.9 -> 2 rows (no throw)
```

So `Math.floor` converted a hard driver error into a silently different result. `parseRowLimit` now requires `Number.isInteger`, which also subsumes the non-finite check (`Number.isInteger` is false for `NaN` and `Infinity`), so the guard is just `!Number.isInteger(value) || value < 0`. Zero stays valid as an empty-result limit.

**Real-cache proof.** Fair that the standalone SQLite experiment was not enough. I tried the actual CLI binary first, but `src/cli.ts` cannot boot in my checkout because it unconditionally registers the MCP commands and `@modelcontextprotocol/sdk` is missing locally. So I built a real follow-graph cache through the real `syncFollowGraph()` path with only the network leaf (`liveTransportGateway.xurl.listFollowUsers`) stubbed - the same boundary the repo's own suite mocks - against a temp `BIRDCLAW_HOME`, then called `listTopFollowers`, the same function the CLI command handler invokes.

```
--- BEFORE this commit (Math.floor version) ---
listTopFollowers({ limit: -1 })   threw: --limit must be a non-negative number
listTopFollowers({ limit: 0 })    result: []
listTopFollowers({ limit: 1 })    result: ["bob"]
listTopFollowers({ limit: 1.9 })  result: ["bob"]      <-- silently treated as limit 1

--- AFTER ---
listTopFollowers({ limit: -1 })   threw: --limit must be a non-negative integer
listTopFollowers({ limit: 0 })    result: []
listTopFollowers({ limit: 1 })    result: ["bob"]
listTopFollowers({ limit: 1.9 })  threw: --limit must be a non-negative integer
```

Negative and non-finite still rejected, zero still an empty result, positive integers unchanged, fractional now rejected with an accurate message.

```
$ node ./scripts/run-vitest.mjs run src/lib/follow-graph.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ pnpm run lint
Found 0 warnings and 0 errors.
```

`pnpm run typecheck` still fails with the same 79 pre-existing, unrelated errors described above (missing `@tanstack/react-query` / `@modelcontextprotocol/sdk` locally); none are in `follow-graph.ts`.
