### PR TITLE
fix: accelerate large backup imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.2 - Unreleased
 
+### Fixed
+
+- Stream portable database fingerprint rows after the import transaction commits and skip recursive topology rewrites for canonical singleton revisions, reducing large Birdclaw backup imports from hour-scale work to seconds while keeping the same deterministic fingerprint contract.
+
 ## 0.11.1 - 2026-07-27
 
 ### Highlights

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -109,6 +109,10 @@ Validates the backup first (unless `--no-validate`), then merge-imports rows int
 
 The FTS5 shadow tables for tweets and DMs are rebuilt from the JSONL text after import, so search is immediately available.
 
+The portable database fingerprint is computed after the write transaction commits and streams rows in canonical order inside a read snapshot. Large first imports therefore keep bounded memory, do not hold the SQLite write lock while producing the verification hash, and remain atomically usable even while the fingerprint is being calculated.
+
+Revision topology reconciliation visits only multi-revision or explicitly edge-connected components. Canonical singleton revisions are imported directly instead of each triggering an identical recursive component query and rewrite.
+
 ## `backup validate`
 
 ```bash

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -32,8 +32,10 @@ import {
 	validateBackup,
 	validateBackupEffect,
 } from "./backup";
+import { BACKUP_TABLE_CODECS } from "./backup-table-codecs";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb } from "./db";
+import type { Database } from "./sqlite";
 
 const testHome = useTestHome({ prefix: "birdclaw-backup-home-" });
 
@@ -608,6 +610,65 @@ describe("text backup", () => {
 		const validation = await validateBackup(repoPath);
 		expect(validation.ok).toBe(true);
 	}, 20000);
+
+	it("streams fingerprint rows instead of materializing every table", () => {
+		let iterateCalls = 0;
+		const database = {
+			prepare(sql: string) {
+				return {
+					all() {
+						throw new Error("fingerprinting must not materialize result sets");
+					},
+					iterate() {
+						iterateCalls += 1;
+						return [{ sql }].values();
+					},
+				};
+			},
+		} as unknown as Database;
+
+		const fingerprint = getBackupDatabaseFingerprint(database);
+
+		expect(iterateCalls).toBe(BACKUP_TABLE_CODECS.length);
+		expect(Object.values(fingerprint.counts)).toEqual(
+			BACKUP_TABLE_CODECS.map(() => 1),
+		);
+	});
+
+	it("skips topology normalization for canonical singleton revisions", async () => {
+		switchHome("birdclaw-backup-singleton-src-");
+		seedBackupFixture();
+		const sourceDb = getNativeDb({ seedDemoData: false });
+		sourceDb.exec(`
+			insert into tweet_revisions (
+				root_tweet_id, revision_id, revision_index, payload_json, source, observed_at
+			) values (
+				'singleton', 'singleton', 0, null, 'xurl', '2026-08-01T00:00:00.000Z'
+			)
+		`);
+		const repoPath = makeTempDir("birdclaw-singleton-store-");
+		await exportBackup({ repoPath });
+
+		switchHome("birdclaw-backup-singleton-dst-");
+		const db = getNativeDb({ seedDemoData: false });
+		let topologyQueries = 0;
+		const instrumentedDb = new Proxy(db, {
+			get(target, property, receiver) {
+				if (property === "prepare") {
+					return (sql: string) => {
+						if (sql.includes("with recursive component")) topologyQueries += 1;
+						return target.prepare(sql);
+					};
+				}
+				const value = Reflect.get(target, property, receiver) as unknown;
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		}) as Database;
+
+		await importBackup({ repoPath, db: instrumentedDb, mode: "replace" });
+
+		expect(topologyQueries).toBe(0);
+	});
 
 	it("emits byte-identical schema-v7 data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1137,7 +1137,7 @@ export function importBackupEffect({
 				}
 			}
 		}
-		const fingerprint = yield* databaseWriteEffect((writeDb) => {
+		yield* databaseWriteEffect((writeDb) => {
 			const repository = getImportRepository(writeDb);
 			if (mode === "replace") {
 				repository.clearBackupImport();
@@ -1173,6 +1173,15 @@ export function importBackupEffect({
 				string,
 				Array<{ revisionId: string; revisionIndex: number }>
 			>();
+			const connectedRevisionIds = new Set<string>();
+			for (const row of importRows.tweet_revision_edges) {
+				if (typeof row.older_revision_id === "string") {
+					connectedRevisionIds.add(row.older_revision_id);
+				}
+				if (typeof row.newer_revision_id === "string") {
+					connectedRevisionIds.add(row.newer_revision_id);
+				}
+			}
 			for (const row of importRows.tweet_revisions) {
 				if (
 					typeof row.root_tweet_id !== "string" ||
@@ -1188,7 +1197,14 @@ export function importBackupEffect({
 				importedRevisionChains.set(row.root_tweet_id, chain);
 			}
 			const processedRevisionIds = new Set<string>();
-			for (const chain of importedRevisionChains.values()) {
+			for (const [rootTweetId, chain] of importedRevisionChains) {
+				const onlyRevision = chain.length === 1 ? chain[0] : undefined;
+				if (
+					onlyRevision?.revisionId === rootTweetId &&
+					!connectedRevisionIds.has(onlyRevision.revisionId)
+				) {
+					continue;
+				}
 				if (
 					chain.some((revision) =>
 						processedRevisionIds.has(revision.revisionId),
@@ -1204,8 +1220,10 @@ export function importBackupEffect({
 				}
 			}
 			reconcileTweetTombstones(writeDb);
-			return getBackupDatabaseFingerprint(writeDb);
 		}, db);
+		const fingerprint = yield* trySync(() =>
+			db.readTransaction(() => getBackupDatabaseFingerprint(db))(),
+		);
 
 		return {
 			ok: true,
@@ -1779,13 +1797,19 @@ export function getBackupDatabaseFingerprint(
 ): BackupDatabaseFingerprint {
 	const counts: Record<string, number> = {};
 	const hash = createHash("sha256");
-	for (const rowSet of getExportRowSets(db)) {
-		counts[rowSet.logicalName] = rowSet.rows.length;
-		hash.update(`${rowSet.logicalName}\n`);
-		for (const row of rowSet.rows) {
+	for (const codec of BACKUP_TABLE_CODECS) {
+		let count = 0;
+		hash.update(`${codec.name}\n`);
+		const rows = db.prepare(codec.exportSql).iterate() as IterableIterator<
+			Record<string, unknown>
+		>;
+		for (const rawRow of rows) {
+			const row = toJsonRecord(rawRow);
 			hash.update(canonicalStringify(row));
 			hash.update("\n");
+			count += 1;
 		}
+		counts[codec.name] = count;
 	}
 	return { counts, hash: hash.digest("hex") };
 }


### PR DESCRIPTION
## Summary

- stream portable fingerprint rows instead of materializing every export table
- calculate the fingerprint after the write commits, inside a consistent read snapshot
- skip recursive topology reconciliation for canonical singleton revisions while preserving it for multi-revision and edge-connected components

## Proof

- full suite: 147 files, 1,315 tests passed
- format, lint, and typecheck passed
- structured Codex autoreview reported no actionable findings
- a large backup restore that previously remained CPU-bound for more than 74 minutes completed in 35 seconds with validation enabled and a deterministic fingerprint
