### PR TITLE
chore: remove duplicate pnpm store ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.pnpm-store
 .DS_Store
 dist
 dist-ssr


### PR DESCRIPTION
## Summary

- remove the redundant `.pnpm-store` ignore entry
- retain the directory-scoped `.pnpm-store/` rule, so pnpm's repository-local store remains ignored

## Hygiene evidence

- `.gitignore`: the removed `.pnpm-store` line was introduced by `0dafbe47` (`feat: add selective archive import`). It duplicates the existing `.pnpm-store/` rule introduced by `0d207370` (`chore: stop tracking .pnpm-store/ artifacts`) for the same generated directory. `git check-ignore -v .pnpm-store/probe` still resolves to the retained rule after this cleanup.

No tracked files were removed: the other unusual-looking root and nested files were either referenced by code, tests, workflows, or docs, or had clear purpose-specific introduction history.

## Verification

- `CI=true BIRDCLAW_DISABLE_LIVE_WRITES=1 pnpm check`
- `CI=true BIRDCLAW_DISABLE_LIVE_WRITES=1 pnpm coverage` (147 files, 1,316 tests)
- `CI=true BIRDCLAW_DISABLE_LIVE_WRITES=1 pnpm build`
- `CI=true BIRDCLAW_DISABLE_LIVE_WRITES=1 pnpm pack:smoke`
- `CI=true BIRDCLAW_DISABLE_LIVE_WRITES=1 pnpm e2e` (12 tests)
- Codex autoreview: clean; no accepted/actionable findings
