### PR TITLE
feat: add FxTwitter phase 2 public reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.11.3 - Unreleased
 
+### Highlights
+
+- Expand the explicit fixed-origin FxTwitter transport with public thread, conversation, profile, and bounded search imports while treating ambiguous or interrupted collections conservatively and preserving only positive observations.
+
+### Added
+
+- Add typed FxTwitter failures, cursor-aware public search, conservative partial-state metadata, monotonic canonical provenance, portable fetch/observation shards, and fixture coverage for silent truncation, cursor anomalies, rate limits, and mid-pagination failures. (#99)
+
 ### Fixed
 
 - Stream portable database fingerprint rows after the import transaction commits and skip recursive topology rewrites for canonical singleton revisions, reducing large Birdclaw backup imports from hour-scale work to seconds while keeping the same deterministic fingerprint contract.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,6 +69,10 @@ birdclaw sync following
 birdclaw sync lists
 birdclaw lists list
 birdclaw lists members [name]
+birdclaw import tweet <tweet-id-or-url...> --fxtwitter
+birdclaw import thread <tweet-id-or-url> --fxtwitter
+birdclaw import conversation <tweet-id-or-url> --fxtwitter
+birdclaw import profile <handle> --fxtwitter
 birdclaw search tweets <query>
 birdclaw search dms <query>
 birdclaw discuss <query>
@@ -147,6 +151,19 @@ Account-capable commands accept `--account <username>` or a stored account ID. S
 
 See [Public tweet import](public-tweets.md) for the full privacy and capability boundary.
 
+### `import thread|conversation <tweet-id-or-url>`
+
+- disabled unless `--fxtwitter` is passed on the same invocation
+- imports only positively observed public tweets through the fixed FxTwitter origin
+- accepts `--limit <n>` up to 1,000 and always reports the collection as `partial` because the endpoint cannot prove exhaustion
+- preserves the upstream reply count and next cursor as evidence, never as completeness proof
+
+### `import profile <handle>`
+
+- disabled unless `--fxtwitter` is passed on the same invocation
+- imports the named public profile object, not its statuses or another timeline
+- rejects URLs, custom origins, private/account data, and write capabilities before network access
+
 ### `auth status`
 
 - show transport availability
@@ -186,6 +203,8 @@ Shard contract:
 
 - tweets: `data/tweets/YYYY.jsonl`
 - tweet provenance: `data/tweet_sources.jsonl`
+- FxTwitter fetch/completeness metadata: `data/fxtwitter/fetches.jsonl`
+- FxTwitter positive item observations: `data/fxtwitter/observations.jsonl`
 - unknown tweet dates: `data/tweets/unknown.jsonl`
 - tweet revisions: `data/tweet_revisions.jsonl`
 - subordinate tweet tombstones: `data/tweet_subordinate_tombstones.jsonl`
@@ -422,6 +441,9 @@ Flags:
 - `--hide-low-quality`
 - `--liked`
 - `--bookmarked`
+- `--fxtwitter` (explicit public-service opt-in)
+- `--max-pages <n>` (FxTwitter only, maximum 10)
+- `--feed latest|top|media` (FxTwitter only)
 - `--limit <n>`
 
 Examples:
@@ -430,6 +452,7 @@ Examples:
 birdclaw search tweets --liked --limit 20 --json
 birdclaw search tweets --bookmarked --limit 20 --json
 birdclaw search tweets "sqlite" --list Builders --limit 50 --json
+birdclaw search tweets "local-first" --fxtwitter --limit 50 --max-pages 3 --json
 ```
 
 ### `search dms <query>`

--- a/docs/public-tweets.md
+++ b/docs/public-tweets.md
@@ -1,29 +1,44 @@
 ---
-title: Public Tweet Import
-description: "Explicitly import individual public tweets through the fixed, read-only FxTwitter endpoint, with durable source provenance and third-party disclosure guidance."
+title: Public FxTwitter Import
+description: "Explicitly import public tweets, threads, conversations, profiles, and bounded searches through the fixed read-only FxTwitter endpoint."
 ---
 
-# Public tweet import
+# Public FxTwitter import
 
-Birdclaw can import individual public tweets through FxTwitter without X credentials. This transport is off by default and only runs when `--fxtwitter` is present on that invocation:
+Birdclaw can import selected public X data through FxTwitter without X credentials. This transport is off by default and runs only when `--fxtwitter` is present on that invocation:
 
 ```bash
 birdclaw import tweet 20 2030857479001960633 --fxtwitter --json
-birdclaw import tweet https://x.com/jack/status/20 --fxtwitter --json
+birdclaw import thread 2030857479001960633 --fxtwitter --json
+birdclaw import conversation 2030857479001960633 --fxtwitter --limit 200 --json
+birdclaw import profile @jack --fxtwitter --json
+birdclaw search tweets "local-first software" --fxtwitter --limit 50 --max-pages 3 --json
 ```
 
-The input must be a numeric tweet ID or a canonical HTTPS `x.com/<handle>/status/<id>` or `twitter.com/<handle>/status/<id>` URL. Birdclaw extracts the numeric ID and requests only the hardcoded `https://api.fxtwitter.com/2/status/<id>` endpoint. There is no configuration, environment variable, or flag for a custom or self-hosted origin, and redirects are rejected.
+Tweet inputs must be numeric IDs or canonical HTTPS `x.com/<handle>/status/<id>` or `twitter.com/<handle>/status/<id>` URLs. Profile lookup accepts a public handle. Search accepts a non-empty query and the `latest`, `top`, or `media` feed.
+
+Every request uses the hardcoded `https://api.fxtwitter.com` origin. There is no configuration, environment variable, or flag for a custom or self-hosted origin. Birdclaw sends no cookies or credentials, rejects redirects without following them, limits response size and total time, fetches sequentially, caps searches at 10 pages and 1,000 results, and applies capped Retry-After-aware backoff to rate limits and transient failures.
 
 ## Privacy and disclosure
 
-FxTwitter is a third-party service. Passing `--fxtwitter` sends each requested public tweet ID to `api.fxtwitter.com`. The service and its hosting/network providers can also observe ordinary request metadata such as your IP address, request time, and Birdclaw user agent. Do not use this transport if that disclosure is unacceptable.
+FxTwitter is a third-party service. Passing `--fxtwitter` sends the requested tweet IDs, handles, or search queries to `api.fxtwitter.com`. The service and its hosting/network providers can also observe your IP address, request timing, and versioned Birdclaw user agent. Do not use this transport if that disclosure is unacceptable.
 
-Birdclaw does not send Twitter cookies, X API credentials, Birdclaw account data, DMs, local searches, or archive contents to FxTwitter. It does not automatically fall back to FxTwitter from another command. Every invocation requires the explicit flag.
+Birdclaw does not send X cookies, OAuth credentials, Birdclaw account data, DMs, unrelated local searches, or archive contents. It never falls back to FxTwitter from another transport, performs background polling, or turns an ordinary local read into a network request.
+
+## Completeness and partial results
+
+Every thread, conversation, and search result reports `collection.state`, `partialReasons`, `pagesFetched`, `itemsObserved`, retrieval time, and cursor/count evidence where available.
+
+Thread and conversation responses are always `partial` with `endpoint_has_no_exhaustion_proof`: a clean `200`, a successful provider code, or a matching reply count cannot prove that FxTwitter did not silently omit a tail. Those rows remain useful and are imported.
+
+Search is `complete` only when Birdclaw follows the documented bottom-cursor chain to an explicit terminal cursor. Caller limits, page budgets, timeouts, rate limits, upstream/decode failures, and missing, repeated, or cyclic cursors produce a successful `partial` result when at least one valid tweet was imported. If no usable item exists, JSON errors retain a typed `kind`, HTTP status, and `retryAfterMs` where applicable.
+
+## Canonical persistence
+
+Fetched tweets and profiles merge into the existing canonical tables and FTS index. Canonical tweet provenance remains in `tweet_sources` with `source = 'fxtwitter'`. Append-only fetch metadata and positive item observations live in `fxtwitter_fetches` and `fxtwitter_observations`; backups preserve them in `data/fxtwitter/fetches.jsonl` and `data/fxtwitter/observations.jsonl`.
+
+Partial refreshes never delete rows, remove relationships, or interpret a missing result as negative evidence. Repeated and overlapping pages converge on the same canonical records while retaining endpoint, request context, retrieval, cursor, completeness, and per-item source evidence.
 
 ## Read-only boundary
 
-The FxTwitter transport exposes one capability: fetch a named public tweet by ID. It cannot search, enumerate timelines, fetch DMs or private account data, follow links returned by the service, or perform X writes. A single invocation accepts at most 20 tweet IDs and fetches them sequentially.
-
-Imported tweets use the same canonical `tweets`, `profiles`, media metadata, and FTS rows as archive and authenticated live imports. Provenance is stored separately in `tweet_sources` with `source = 'fxtwitter'`, the fixed request URL, and observation time. Git-friendly backups preserve those markers in `data/tweet_sources.jsonl`.
-
-Quoted public tweets included in the response are stored as reference context and receive their own FxTwitter provenance marker. Threads, conversations, profiles, timelines, search, follower lists, and arbitrary URLs are intentionally outside this transport.
+The FxTwitter transport supports named public tweet, author-thread, conversation, profile-object, and bounded post-search reads only. It does not expose user timelines/status feeds, followers/following, trends, typeahead, standalone quote/repost products, bulk archival sync, DMs, home timelines, bookmarks, likes, authenticated mentions, private content, or any write.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -14,6 +14,10 @@ const seedDemoDataMock = vi.fn();
 const findArchivesMock = vi.fn();
 const importArchiveMock = vi.fn();
 const importTweetsViaFxTwitterMock = vi.fn();
+const importThreadViaFxTwitterMock = vi.fn();
+const importConversationViaFxTwitterMock = vi.fn();
+const importProfileViaFxTwitterMock = vi.fn();
+const importSearchViaFxTwitterMock = vi.fn();
 const importBlocklistMock = vi.fn();
 const addBlockMock = vi.fn();
 const recordBlockMock = vi.fn();
@@ -80,6 +84,24 @@ const execFileAsyncMock = vi.fn();
 const execFileMock = vi.fn();
 const consoleLogMock = vi.spyOn(console, "log").mockImplementation(() => {});
 
+class FxTwitterErrorMock extends Error {
+	readonly kind: string;
+	readonly status?: number;
+	readonly retryAfterMs?: number;
+
+	constructor(options: {
+		kind: string;
+		message: string;
+		status?: number;
+		retryAfterMs?: number;
+	}) {
+		super(options.message);
+		this.kind = options.kind;
+		this.status = options.status;
+		this.retryAfterMs = options.retryAfterMs;
+	}
+}
+
 Object.defineProperty(
 	execFileMock,
 	Symbol.for("nodejs.util.promisify.custom"),
@@ -135,6 +157,15 @@ vi.mock("#/lib/archive-import", () => ({
 }));
 
 vi.mock("#/lib/fxtwitter", () => ({
+	FxTwitterError: FxTwitterErrorMock,
+	importConversationViaFxTwitter: (...args: unknown[]) =>
+		importConversationViaFxTwitterMock(...args),
+	importProfileViaFxTwitter: (...args: unknown[]) =>
+		importProfileViaFxTwitterMock(...args),
+	importSearchViaFxTwitter: (...args: unknown[]) =>
+		importSearchViaFxTwitterMock(...args),
+	importThreadViaFxTwitter: (...args: unknown[]) =>
+		importThreadViaFxTwitterMock(...args),
 	importTweetsViaFxTwitter: (...args: unknown[]) =>
 		importTweetsViaFxTwitterMock(...args),
 }));
@@ -331,6 +362,10 @@ describe("cli", () => {
 		findArchivesMock.mockReset();
 		importArchiveMock.mockReset();
 		importTweetsViaFxTwitterMock.mockReset();
+		importThreadViaFxTwitterMock.mockReset();
+		importConversationViaFxTwitterMock.mockReset();
+		importProfileViaFxTwitterMock.mockReset();
+		importSearchViaFxTwitterMock.mockReset();
 		importBlocklistMock.mockReset();
 		addBlockMock.mockReset();
 		recordBlockMock.mockReset();
@@ -460,6 +495,29 @@ describe("cli", () => {
 					sourceUrl: "https://api.fxtwitter.com/2/status/20",
 				},
 			],
+		});
+		for (const mock of [
+			importThreadViaFxTwitterMock,
+			importConversationViaFxTwitterMock,
+			importSearchViaFxTwitterMock,
+		]) {
+			mock.mockResolvedValue({
+				ok: true,
+				readOnlyTransport: true,
+				source: "fxtwitter",
+				endpoint: "https://api.fxtwitter.com",
+				collection: {
+					state: "partial",
+					partialReasons: ["endpoint_has_no_exhaustion_proof"],
+				},
+			});
+		}
+		importProfileViaFxTwitterMock.mockResolvedValue({
+			ok: true,
+			readOnlyTransport: true,
+			source: "fxtwitter",
+			endpoint: "https://api.fxtwitter.com",
+			profile: { handle: "example" },
 		});
 		importBlocklistMock.mockResolvedValue({
 			ok: true,
@@ -1494,6 +1552,145 @@ describe("cli", () => {
 		expect(consoleLogMock).toHaveBeenCalledWith(
 			expect.stringContaining('"source": "fxtwitter"'),
 		);
+	});
+
+	it("keeps Phase 2 FxTwitter reads disabled without explicit opt-in", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli(["node", "birdclaw", "import", "thread", "100"]);
+		await runCli(["node", "birdclaw", "import", "profile", "example"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(importThreadViaFxTwitterMock).not.toHaveBeenCalled();
+		expect(importProfileViaFxTwitterMock).not.toHaveBeenCalled();
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining("off by default"),
+		);
+		consoleErrorMock.mockRestore();
+	});
+
+	it("routes explicit Phase 2 public reads through FxTwitter and persists them", async () => {
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"thread",
+			"100",
+			"--fxtwitter",
+			"--limit",
+			"3",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"conversation",
+			"100",
+			"--fxtwitter",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"import",
+			"profile",
+			"@example",
+			"--fxtwitter",
+		]);
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"search",
+			"tweets",
+			"local first",
+			"--fxtwitter",
+			"--limit",
+			"7",
+			"--max-pages",
+			"2",
+			"--feed",
+			"top",
+		]);
+
+		expect(importThreadViaFxTwitterMock).toHaveBeenCalledWith("100", {
+			limit: 3,
+		});
+		expect(importConversationViaFxTwitterMock).toHaveBeenCalledWith("100", {
+			limit: 500,
+		});
+		expect(importProfileViaFxTwitterMock).toHaveBeenCalledWith("@example");
+		expect(importSearchViaFxTwitterMock).toHaveBeenCalledWith("local first", {
+			limit: 7,
+			maxPages: 2,
+			feed: "top",
+		});
+		expect(listTimelineItemsMock).not.toHaveBeenCalled();
+		expect(maybeAutoUpdateBackupMock).not.toHaveBeenCalled();
+		expect(maybeAutoSyncBackupMock).toHaveBeenCalledTimes(4);
+	});
+
+	it("prints typed FxTwitter failures without syncing partial command state", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		importSearchViaFxTwitterMock.mockRejectedValue(
+			new FxTwitterErrorMock({
+				kind: "rate_limited",
+				message: "Too many requests",
+				status: 429,
+				retryAfterMs: 1000,
+			}),
+		);
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"--json",
+			"search",
+			"tweets",
+			"busy query",
+			"--fxtwitter",
+		]);
+
+		expect(process.exitCode).toBe(1);
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining('"kind":"rate_limited"'),
+		);
+		expect(maybeAutoSyncBackupMock).not.toHaveBeenCalled();
+		consoleErrorMock.mockRestore();
+	});
+
+	it("rejects account-scoped filters before FxTwitter public search", async () => {
+		const consoleErrorMock = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const { runCli } = await loadCli();
+
+		await runCli([
+			"node",
+			"birdclaw",
+			"search",
+			"tweets",
+			"public query",
+			"--liked",
+			"--fxtwitter",
+		]);
+
+		expect(process.exitCode).toBe(1);
+		expect(importSearchViaFxTwitterMock).not.toHaveBeenCalled();
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringContaining('"kind":"capability_rejected"'),
+		);
+		consoleErrorMock.mockRestore();
 	});
 
 	it("rejects unknown archive import slices", async () => {

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -9,7 +9,13 @@ import {
 } from "#/lib/archive-import";
 import { ensureBirdclawDirs, setActionsTransport } from "#/lib/config";
 import { getNativeDb } from "#/lib/db";
-import { importTweetsViaFxTwitter } from "#/lib/fxtwitter";
+import {
+	FxTwitterError,
+	importConversationViaFxTwitter,
+	importProfileViaFxTwitter,
+	importThreadViaFxTwitter,
+	importTweetsViaFxTwitter,
+} from "#/lib/fxtwitter";
 import { hydrateProfilesFromX } from "#/lib/profile-hydration";
 import { getQueryEnvelope } from "#/lib/queries";
 import { seedDemoData } from "#/lib/seed";
@@ -139,7 +145,37 @@ export function registerCoreCommands({
 	print,
 	asJson,
 	autoSyncAfterWrite,
+	parsePositiveIntegerOption,
 }: CliCommandContext) {
+	async function runFxTwitterCommand<T>(run: () => Promise<T>) {
+		try {
+			return await run();
+		} catch (error) {
+			if (!(error instanceof FxTwitterError)) throw error;
+			console.error(
+				JSON.stringify({
+					error: {
+						kind: error.kind,
+						message: error.message,
+						status: error.status,
+						retryAfterMs: error.retryAfterMs,
+					},
+				}),
+			);
+			process.exitCode = 1;
+			return undefined;
+		}
+	}
+
+	function requireFxTwitterOptIn(enabled: boolean | undefined) {
+		if (enabled) return true;
+		printError(
+			"FxTwitter public reads are off by default. Pass --fxtwitter to disclose the requested tweet IDs, handles, or queries plus network metadata and timing to api.fxtwitter.com.",
+		);
+		process.exitCode = 1;
+		return false;
+	}
+
 	program
 		.command("init")
 		.description("Create an empty local birdclaw workspace")
@@ -242,14 +278,59 @@ export function registerCoreCommands({
 			"Send tweet IDs to the fixed third-party api.fxtwitter.com endpoint",
 		)
 		.action(async (tweets: string[], options: { fxtwitter?: boolean }) => {
-			if (!options.fxtwitter) {
-				printError(
-					"Public tweet import is off by default. Pass --fxtwitter to disclose the requested tweet IDs and network metadata to api.fxtwitter.com.",
-				);
-				process.exitCode = 1;
-				return;
-			}
-			const result = await importTweetsViaFxTwitter(tweets);
+			if (!requireFxTwitterOptIn(options.fxtwitter)) return;
+			const result = await runFxTwitterCommand(() =>
+				importTweetsViaFxTwitter(tweets),
+			);
+			if (!result) return;
+			await autoSyncAfterWrite();
+			print(result, asJson());
+		});
+	for (const endpointFamily of ["thread", "conversation"] as const) {
+		importCommand
+			.command(`${endpointFamily} <tweet>`)
+			.description(
+				`Import an explicitly requested public ${endpointFamily} through FxTwitter`,
+			)
+			.option(
+				"--fxtwitter",
+				"Send the tweet ID to the fixed third-party api.fxtwitter.com endpoint",
+			)
+			.option("--limit <n>", "Maximum observed tweets to import", "500")
+			.action(
+				async (
+					tweet: string,
+					options: { fxtwitter?: boolean; limit?: string },
+				) => {
+					if (!requireFxTwitterOptIn(options.fxtwitter)) return;
+					const limit = parsePositiveIntegerOption(options.limit, "--limit");
+					if (limit === undefined) return;
+					const result = await runFxTwitterCommand(() =>
+						endpointFamily === "thread"
+							? importThreadViaFxTwitter(tweet, { limit })
+							: importConversationViaFxTwitter(tweet, { limit }),
+					);
+					if (!result) return;
+					await autoSyncAfterWrite();
+					print(result, asJson());
+				},
+			);
+	}
+	importCommand
+		.command("profile <handle>")
+		.description(
+			"Import an explicitly requested public profile through FxTwitter",
+		)
+		.option(
+			"--fxtwitter",
+			"Send the handle to the fixed third-party api.fxtwitter.com endpoint",
+		)
+		.action(async (handle: string, options: { fxtwitter?: boolean }) => {
+			if (!requireFxTwitterOptIn(options.fxtwitter)) return;
+			const result = await runFxTwitterCommand(() =>
+				importProfileViaFxTwitter(handle),
+			);
+			if (!result) return;
 			await autoSyncAfterWrite();
 			print(result, asJson());
 		});

--- a/src/cli/register-search.ts
+++ b/src/cli/register-search.ts
@@ -1,4 +1,5 @@
 import { backfillLinkIndex, searchLinks } from "#/lib/link-index";
+import { FxTwitterError, importSearchViaFxTwitter } from "#/lib/fxtwitter";
 import { fetchTweetMedia, formatMediaFetchResult } from "#/lib/media-fetch";
 import { listTimelineItems } from "#/lib/queries";
 import { formatWhois, runWhois } from "#/lib/whois";
@@ -35,7 +36,9 @@ export function registerSearchCommands({
 }: CliCommandContext) {
 	const searchCommand = program
 		.command("search")
-		.description("Search local data");
+		.description(
+			"Search local data or an explicitly selected public transport",
+		);
 
 	searchCommand
 		.command("tweets [query]")
@@ -56,8 +59,84 @@ export function registerSearchCommands({
 		.option("--quality-reason", "Include qualityReason on each row")
 		.option("--liked", "Only liked tweets")
 		.option("--bookmarked", "Only bookmarked tweets")
+		.option(
+			"--fxtwitter",
+			"Send the query to the fixed third-party api.fxtwitter.com endpoint",
+		)
+		.option("--max-pages <n>", "Maximum FxTwitter search pages", "5")
+		.option("--feed <feed>", "FxTwitter search feed: latest, top, or media")
 		.option("--limit <n>", "Limit results", "20")
 		.action(async (query, options) => {
+			if (options.fxtwitter) {
+				const incompatible = [
+					[options.account, "--account"],
+					[options.list, "--list"],
+					[options.listId, "--list-id"],
+					[options.replied, "--replied"],
+					[options.unreplied, "--unreplied"],
+					[options.since, "--since"],
+					[options.until, "--until"],
+					[options.originalsOnly, "--originals-only"],
+					[options.hideLowQuality, "--hide-low-quality"],
+					[options.minLikes, "--min-likes"],
+					[options.qualityReason, "--quality-reason"],
+					[options.liked, "--liked"],
+					[options.bookmarked, "--bookmarked"],
+				].find(([value]) => Boolean(value));
+				if (incompatible) {
+					console.error(
+						JSON.stringify({
+							error: {
+								kind: "capability_rejected",
+								message: `${String(incompatible[1])} is a local or account-scoped filter and cannot be used with FxTwitter public search`,
+							},
+						}),
+					);
+					process.exitCode = 1;
+					return;
+				}
+				if (typeof query !== "string" || query.trim().length === 0) {
+					console.error(
+						JSON.stringify({
+							error: {
+								kind: "input_rejected",
+								message: "FxTwitter search requires a query",
+							},
+						}),
+					);
+					process.exitCode = 1;
+					return;
+				}
+				const limit = parsePositiveIntegerOption(options.limit, "--limit");
+				const maxPages = parsePositiveIntegerOption(
+					options.maxPages,
+					"--max-pages",
+				);
+				if (limit === undefined || maxPages === undefined) return;
+				try {
+					const result = await importSearchViaFxTwitter(query, {
+						limit,
+						maxPages,
+						feed: options.feed,
+					});
+					await autoSyncAfterWrite();
+					print(result, asJson());
+				} catch (error) {
+					if (!(error instanceof FxTwitterError)) throw error;
+					console.error(
+						JSON.stringify({
+							error: {
+								kind: error.kind,
+								message: error.message,
+								status: error.status,
+								retryAfterMs: error.retryAfterMs,
+							},
+						}),
+					);
+					process.exitCode = 1;
+				}
+				return;
+			}
 			const minLikes = parseNonNegativeIntegerOption(
 				options.minLikes,
 				"--min-likes",

--- a/src/lib/backup-table-codecs.test.ts
+++ b/src/lib/backup-table-codecs.test.ts
@@ -13,7 +13,7 @@ import {
 describe("backup table codecs", () => {
 	it("owns every portable table and path exactly once", () => {
 		expect(assertBackupTableCodecRegistry()).toBe(true);
-		expect(BACKUP_TABLE_CODECS).toHaveLength(26);
+		expect(BACKUP_TABLE_CODECS).toHaveLength(28);
 		expect(BACKUP_TABLE_CODECS.map((codec) => codec.name)).toEqual([
 			"accounts",
 			"profiles",
@@ -27,6 +27,8 @@ describe("backup table codecs", () => {
 			"tweet_revision_edges",
 			"tweet_subordinate_tombstones",
 			"tweet_sources",
+			"fxtwitter_fetches",
+			"fxtwitter_observations",
 			"tweet_collections",
 			"tweet_account_edges",
 			"dm_conversations",
@@ -46,7 +48,7 @@ describe("backup table codecs", () => {
 			BACKUP_TABLE_CODECS.map((codec) => codec.merge.order).sort(
 				(left, right) => left - right,
 			),
-		).toEqual(Array.from({ length: 26 }, (_, index) => index));
+		).toEqual(Array.from({ length: 28 }, (_, index) => index));
 
 		const sample = { created_at: "2026-01-02T00:00:00.000Z", kind: "likes" };
 		for (const codec of BACKUP_TABLE_CODECS) {

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -714,6 +714,88 @@ const definitions = {
 			columns: ["tweet_id", "source", "source_url", "observed_at"],
 		},
 	},
+	fxtwitter_fetches: {
+		exportSql: `
+      select id, endpoint_family, request_key, source_url, retrieved_at,
+        collection_state, partial_reasons_json, pages_fetched, items_observed,
+        terminal_cursor, next_cursor, upstream_count, failure_json
+      from fxtwitter_fetches
+      order by retrieved_at, id
+    `,
+		...fixedShard("data/fxtwitter/fetches.jsonl", "fxtwitter_fetches"),
+		merge: {
+			order: 26,
+			sql: `
+      insert into fxtwitter_fetches (
+        id, endpoint_family, request_key, source_url, retrieved_at,
+        collection_state, partial_reasons_json, pages_fetched, items_observed,
+        terminal_cursor, next_cursor, upstream_count, failure_json
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(id) do nothing
+      `,
+			columns: [
+				"id",
+				"endpoint_family",
+				"request_key",
+				"source_url",
+				"retrieved_at",
+				"collection_state",
+				"partial_reasons_json",
+				"pages_fetched",
+				"items_observed",
+				"terminal_cursor",
+				"next_cursor",
+				"upstream_count",
+				"failure_json",
+			],
+		},
+	},
+	fxtwitter_observations: {
+		exportSql: `
+      select endpoint_family, request_key, item_kind, item_id, source_url,
+        first_seen_at, last_seen_at, seen_count, last_fetch_id
+      from fxtwitter_observations
+      order by endpoint_family, request_key, item_kind, item_id
+    `,
+		...fixedShard(
+			"data/fxtwitter/observations.jsonl",
+			"fxtwitter_observations",
+		),
+		merge: {
+			order: 27,
+			sql: `
+      insert into fxtwitter_observations (
+        endpoint_family, request_key, item_kind, item_id, source_url,
+        first_seen_at, last_seen_at, seen_count, last_fetch_id
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(endpoint_family, request_key, item_kind, item_id) do update set
+        source_url = case
+          when excluded.last_seen_at >= fxtwitter_observations.last_seen_at
+            then excluded.source_url
+          else fxtwitter_observations.source_url
+        end,
+        first_seen_at = min(fxtwitter_observations.first_seen_at, excluded.first_seen_at),
+        last_seen_at = max(fxtwitter_observations.last_seen_at, excluded.last_seen_at),
+        seen_count = max(fxtwitter_observations.seen_count, excluded.seen_count),
+        last_fetch_id = case
+          when excluded.last_seen_at >= fxtwitter_observations.last_seen_at
+            then excluded.last_fetch_id
+          else fxtwitter_observations.last_fetch_id
+        end
+      `,
+			columns: [
+				"endpoint_family",
+				"request_key",
+				"item_kind",
+				"item_id",
+				"source_url",
+				"first_seen_at",
+				"last_seen_at",
+				"seen_count",
+				"last_fetch_id",
+			],
+		},
+	},
 	tweet_collections: {
 		exportSql: `
       select account_id, tweet_id, kind, collected_at, source, raw_json, updated_at

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -59,6 +59,8 @@ function clearData() {
     delete from tweet_account_edges;
     delete from tweet_collections;
 		delete from tweet_sources;
+		delete from fxtwitter_observations;
+		delete from fxtwitter_fetches;
     delete from link_occurrences;
     delete from url_expansions;
     delete from blocks;
@@ -176,6 +178,27 @@ function seedBackupFixture() {
       'https://api.fxtwitter.com/2/status/tweet_2024',
       '2025-01-03T00:00:00.000Z'
     );
+
+		insert into fxtwitter_fetches (
+			id, endpoint_family, request_key, source_url, retrieved_at,
+			collection_state, partial_reasons_json, pages_fetched, items_observed,
+			terminal_cursor, next_cursor, upstream_count, failure_json
+		) values (
+			'fx_fetch_1', 'search', 'local-first',
+			'https://api.fxtwitter.com/2/search?q=local-first',
+			'2025-01-03T00:00:00.000Z', 'partial', '["caller_limit"]',
+			1, 1, null, 'next-cursor', null, null
+		);
+
+		insert into fxtwitter_observations (
+			endpoint_family, request_key, item_kind, item_id, source_url,
+			first_seen_at, last_seen_at, seen_count, last_fetch_id
+		) values (
+			'search', 'local-first', 'tweet', 'tweet_2024',
+			'https://api.fxtwitter.com/2/search?q=local-first',
+			'2025-01-03T00:00:00.000Z', '2025-01-03T00:00:00.000Z', 1,
+			'fx_fetch_1'
+		);
 
     insert into dm_conversations (
       id, account_id, participant_profile_id, title, inbox_kind, last_message_at, unread_count, needs_reply
@@ -423,6 +446,8 @@ describe("text backup", () => {
 			profile_bio_entities: 2,
 			tweets: 3,
 			tweet_sources: 1,
+			fxtwitter_fetches: 1,
+			fxtwitter_observations: 1,
 			timeline_edges_home: 1,
 			timeline_edges_search: 1,
 			collections_bookmarks: 1,
@@ -452,6 +477,12 @@ describe("text backup", () => {
 		expect(existsSync(path.join(repoPath, "data/tweet_sources.jsonl"))).toBe(
 			true,
 		);
+		expect(
+			existsSync(path.join(repoPath, "data/fxtwitter/fetches.jsonl")),
+		).toBe(true);
+		expect(
+			existsSync(path.join(repoPath, "data/fxtwitter/observations.jsonl")),
+		).toBe(true);
 		expect(existsSync(path.join(repoPath, "data/dms/2025.jsonl"))).toBe(true);
 		expect(
 			existsSync(path.join(repoPath, "data/links/url_expansions.jsonl")),
@@ -592,6 +623,28 @@ describe("text backup", () => {
 		expect(
 			getNativeDb({ seedDemoData: false })
 				.prepare(
+					"select collection_state, partial_reasons_json, next_cursor from fxtwitter_fetches where id = 'fx_fetch_1'",
+				)
+				.get(),
+		).toEqual({
+			collection_state: "partial",
+			partial_reasons_json: '["caller_limit"]',
+			next_cursor: "next-cursor",
+		});
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare(
+					"select endpoint_family, request_key, item_id from fxtwitter_observations where item_id = 'tweet_2024'",
+				)
+				.get(),
+		).toEqual({
+			endpoint_family: "search",
+			request_key: "local-first",
+			item_id: "tweet_2024",
+		});
+		expect(
+			getNativeDb({ seedDemoData: false })
+				.prepare(
 					"select public_metrics_json from profiles where id = 'profile_friend'",
 				)
 				.get(),
@@ -670,7 +723,7 @@ describe("text backup", () => {
 		expect(topologyQueries).toBe(0);
 	});
 
-	it("emits byte-identical schema-v7 data and hashes for the same database", async () => {
+	it("emits byte-identical schema-v8 data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");
 		seedBackupFixture();
 		const firstRepoPath = makeTempDir("birdclaw-backup-stable-first-");
@@ -679,7 +732,7 @@ describe("text backup", () => {
 		const first = await exportBackup({ repoPath: firstRepoPath });
 		const second = await exportBackup({ repoPath: secondRepoPath });
 
-		expect(first.manifest.schemaVersion).toBe(7);
+		expect(first.manifest.schemaVersion).toBe(8);
 		expect(second.manifest.files).toEqual(first.manifest.files);
 		expect(second.manifest.counts).toEqual(first.manifest.counts);
 		expect(second.manifest.backupHash).toBe(first.manifest.backupHash);

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -31,7 +31,7 @@ import {
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 
-const BACKUP_SCHEMA_VERSION = 7;
+const BACKUP_SCHEMA_VERSION = 8;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_BACKUP_SHARD_BYTES = 48 * 1024 * 1024;
 const MANIFEST_PATH = "manifest.json";
@@ -439,6 +439,8 @@ data/profile_snapshots.jsonl
 data/profile_bio_entities.jsonl
 data/tweets/YYYY.jsonl
 data/tweets/unknown.jsonl
+data/fxtwitter/fetches.jsonl
+data/fxtwitter/observations.jsonl
 data/timeline_edges/home.jsonl
 data/timeline_edges/mention.jsonl
 data/collections/likes.jsonl

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -418,7 +418,17 @@ describe("database init", () => {
 		}) as number;
 		expect(busyTimeout).toBe(SQLITE_BUSY_TIMEOUT_MS);
 		expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
-		expect(db.pragma("user_version", { simple: true })).toBe(7);
+		expect(
+			db
+				.prepare(
+					"select name from sqlite_master where type = 'table' and name in ('fxtwitter_fetches', 'fxtwitter_observations') order by name",
+				)
+				.all(),
+		).toEqual([
+			{ name: "fxtwitter_fetches" },
+			{ name: "fxtwitter_observations" },
+		]);
+		expect(db.pragma("user_version", { simple: true })).toBe(8);
 	});
 
 	it("adds revision edges without rewriting v6 revision rows", () => {
@@ -441,7 +451,7 @@ describe("database init", () => {
 		resetDatabaseForTests();
 
 		const migrated = getNativeDb({ seedDemoData: false });
-		expect(migrated.pragma("user_version", { simple: true })).toBe(7);
+		expect(migrated.pragma("user_version", { simple: true })).toBe(8);
 		expect(
 			migrated
 				.prepare(
@@ -549,7 +559,7 @@ describe("database init", () => {
 
 	it.each([
 		{ kind: "stale", version: 4 },
-		{ kind: "future", version: 8 },
+		{ kind: "future", version: 9 },
 	])(
 		"rejects a $kind schema and closes its provisional reader",
 		({ version }) => {
@@ -584,10 +594,10 @@ describe("database init", () => {
 
 		const writer = getNativeDb({ seedDemoData: false });
 		getReadDb({ seedDemoData: false });
-		writer.pragma("user_version = 8");
+		writer.pragma("user_version = 9");
 
 		expect(() => getStrictReadDb()).toThrow(
-			/schema 8 is not ready for version 7/,
+			/schema 9 is not ready for version 8/,
 		);
 	});
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -170,6 +170,35 @@ const BASE_SCHEMA_SQL = `
     primary key (tweet_id, source)
   );
 
+  create table if not exists fxtwitter_fetches (
+    id text primary key,
+    endpoint_family text not null,
+    request_key text not null,
+    source_url text not null,
+    retrieved_at text not null,
+    collection_state text,
+    partial_reasons_json text not null default '[]',
+    pages_fetched integer not null,
+    items_observed integer not null,
+    terminal_cursor text,
+    next_cursor text,
+    upstream_count integer,
+    failure_json text
+  );
+
+  create table if not exists fxtwitter_observations (
+    endpoint_family text not null,
+    request_key text not null,
+    item_kind text not null,
+    item_id text not null,
+    source_url text not null,
+    first_seen_at text not null,
+    last_seen_at text not null,
+    seen_count integer not null default 1,
+    last_fetch_id text not null,
+    primary key (endpoint_family, request_key, item_kind, item_id)
+  );
+
   create table if not exists tweet_collections (
     account_id text not null,
     tweet_id text not null,
@@ -656,6 +685,44 @@ function ensureTweetSourcesTable(db: Database) {
   `);
 }
 
+function ensureFxTwitterProvenanceTables(db: Database) {
+	db.exec(`
+    create table if not exists fxtwitter_fetches (
+      id text primary key,
+      endpoint_family text not null,
+      request_key text not null,
+      source_url text not null,
+      retrieved_at text not null,
+      collection_state text,
+      partial_reasons_json text not null default '[]',
+      pages_fetched integer not null,
+      items_observed integer not null,
+      terminal_cursor text,
+      next_cursor text,
+      upstream_count integer,
+      failure_json text
+    );
+
+    create table if not exists fxtwitter_observations (
+      endpoint_family text not null,
+      request_key text not null,
+      item_kind text not null,
+      item_id text not null,
+      source_url text not null,
+      first_seen_at text not null,
+      last_seen_at text not null,
+      seen_count integer not null default 1,
+      last_fetch_id text not null,
+      primary key (endpoint_family, request_key, item_kind, item_id)
+    );
+
+    create index if not exists idx_fxtwitter_fetches_request
+      on fxtwitter_fetches(endpoint_family, request_key, retrieved_at desc);
+    create index if not exists idx_fxtwitter_observations_item
+      on fxtwitter_observations(item_kind, item_id);
+  `);
+}
+
 function ensureTweetAccountEdgesTable(db: Database) {
 	db.exec(`
     create table if not exists tweet_account_edges (
@@ -1079,6 +1146,11 @@ const DATABASE_MIGRATIONS: readonly DatabaseMigration[] = [
 		version: 7,
 		name: "retain observable tweet revision ordering",
 		up: ensureTweetRevisionEdgeSchema,
+	},
+	{
+		version: 8,
+		name: "retain FxTwitter fetch and positive observation provenance",
+		up: ensureFxTwitterProvenanceTables,
 	},
 ];
 

--- a/src/lib/fxtwitter-store.ts
+++ b/src/lib/fxtwitter-store.ts
@@ -1,0 +1,138 @@
+import { createHash } from "node:crypto";
+import type { Database } from "./sqlite";
+
+export type FxTwitterEndpointFamily =
+	| "status"
+	| "thread"
+	| "conversation"
+	| "profile"
+	| "search";
+
+export type FxTwitterCollectionState = "complete" | "partial";
+
+export type FxTwitterPartialReason =
+	| "endpoint_has_no_exhaustion_proof"
+	| "caller_limit"
+	| "max_pages"
+	| "timeout"
+	| "rate_limited"
+	| "upstream_error"
+	| "decode_error"
+	| "cursor_missing_or_malformed"
+	| "cursor_repeated"
+	| "cursor_cycle";
+
+export interface FxTwitterFailureSummary {
+	kind: string;
+	message: string;
+	status?: number;
+	retryAfterMs?: number;
+}
+
+export interface FxTwitterCollectionMetadata {
+	state: FxTwitterCollectionState;
+	partialReasons: FxTwitterPartialReason[];
+	pagesFetched: number;
+	itemsObserved: number;
+	retrievedAt: string;
+	terminalCursor: string | null;
+	nextCursor?: string;
+	upstreamCount?: number;
+	interruption?: FxTwitterFailureSummary;
+}
+
+export interface FxTwitterPersistedFetch {
+	endpointFamily: FxTwitterEndpointFamily;
+	requestKey: string;
+	sourceUrl: string;
+	retrievedAt: string;
+	pagesFetched: number;
+	itemsObserved: number;
+	collection?: FxTwitterCollectionMetadata;
+	items: ReadonlyArray<{ kind: "tweet" | "profile"; id: string }>;
+}
+
+function fetchIdFor(fetch: FxTwitterPersistedFetch) {
+	const stable = JSON.stringify({
+		endpointFamily: fetch.endpointFamily,
+		requestKey: fetch.requestKey,
+		sourceUrl: fetch.sourceUrl,
+		retrievedAt: fetch.retrievedAt,
+		pagesFetched: fetch.pagesFetched,
+		itemsObserved: fetch.itemsObserved,
+		collection: fetch.collection,
+		items: [...fetch.items].sort((left, right) =>
+			`${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`),
+		),
+	});
+	return createHash("sha256").update(stable).digest("hex");
+}
+
+export function recordFxTwitterFetch(
+	db: Database,
+	fetch: FxTwitterPersistedFetch,
+) {
+	const fetchId = fetchIdFor(fetch);
+	const collection = fetch.collection;
+	db.transaction(() => {
+		db.prepare(
+			`
+        insert into fxtwitter_fetches (
+          id, endpoint_family, request_key, source_url, retrieved_at,
+          collection_state, partial_reasons_json, pages_fetched, items_observed,
+          terminal_cursor, next_cursor, upstream_count, failure_json
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        on conflict(id) do nothing
+        `,
+		).run(
+			fetchId,
+			fetch.endpointFamily,
+			fetch.requestKey,
+			fetch.sourceUrl,
+			fetch.retrievedAt,
+			collection?.state ?? null,
+			JSON.stringify(collection?.partialReasons ?? []),
+			fetch.pagesFetched,
+			fetch.itemsObserved,
+			collection?.terminalCursor ?? null,
+			collection?.nextCursor ?? null,
+			collection?.upstreamCount ?? null,
+			collection?.interruption ? JSON.stringify(collection.interruption) : null,
+		);
+
+		const upsertObservation = db.prepare(`
+      insert into fxtwitter_observations (
+        endpoint_family, request_key, item_kind, item_id, source_url,
+        first_seen_at, last_seen_at, seen_count, last_fetch_id
+      ) values (?, ?, ?, ?, ?, ?, ?, 1, ?)
+      on conflict(endpoint_family, request_key, item_kind, item_id) do update set
+        source_url = case
+          when excluded.last_seen_at >= fxtwitter_observations.last_seen_at
+            then excluded.source_url
+          else fxtwitter_observations.source_url
+        end,
+        first_seen_at = min(fxtwitter_observations.first_seen_at, excluded.first_seen_at),
+        last_seen_at = max(fxtwitter_observations.last_seen_at, excluded.last_seen_at),
+        seen_count = fxtwitter_observations.seen_count +
+          case when excluded.last_fetch_id = fxtwitter_observations.last_fetch_id then 0 else 1 end,
+        last_fetch_id = case
+          when excluded.last_seen_at >= fxtwitter_observations.last_seen_at
+            then excluded.last_fetch_id
+          else fxtwitter_observations.last_fetch_id
+        end
+    `);
+		for (const item of fetch.items) {
+			upsertObservation.run(
+				fetch.endpointFamily,
+				fetch.requestKey,
+				item.kind,
+				item.id,
+				fetch.sourceUrl,
+				fetch.retrievedAt,
+				fetch.retrievedAt,
+				fetchId,
+			);
+		}
+	})();
+	return fetchId;
+}

--- a/src/lib/fxtwitter.test.ts
+++ b/src/lib/fxtwitter.test.ts
@@ -1,12 +1,20 @@
 // @vitest-environment node
+import { readFileSync } from "node:fs";
 import { Effect } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import { useTestHome } from "../test/test-home";
 import { createRuntimeServices } from "./runtime-services";
 import {
 	FXTWITTER_ORIGIN,
+	assertFxTwitterCapability,
 	getTweetByIdViaFxTwitterEffect,
+	importConversationViaFxTwitterEffect,
+	importProfileViaFxTwitterEffect,
+	importSearchViaFxTwitterEffect,
+	importThreadViaFxTwitterEffect,
 	importTweetsViaFxTwitterEffect,
+	parseFxTwitterHandle,
+	parseFxTwitterSearchQuery,
 	parseFxTwitterTweetId,
 } from "./fxtwitter";
 
@@ -16,6 +24,26 @@ function fxResponse(status: Record<string, unknown>, code = 200) {
 	return new Response(JSON.stringify({ status, code }), {
 		status: code,
 		headers: { "content-type": "application/json" },
+	});
+}
+
+function fixture(name: string) {
+	return JSON.parse(
+		readFileSync(
+			new URL(`../test/fixtures/fxtwitter/${name}.json`, import.meta.url),
+			"utf8",
+		),
+	) as Record<string, unknown>;
+}
+
+function jsonResponse(
+	body: Record<string, unknown>,
+	status = Number(body.code ?? 200),
+	headers: Record<string, string> = {},
+) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json", ...headers },
 	});
 }
 
@@ -100,6 +128,18 @@ describe("FxTwitter public tweet transport", () => {
 		}
 	});
 
+	it("validates public capabilities, handles, and queries before network access", () => {
+		expect(parseFxTwitterHandle("@Example_1")).toBe("Example_1");
+		expect(parseFxTwitterSearchQuery(" local first ")).toBe("local first");
+		expect(() => parseFxTwitterHandle("https://example.com/user")).toThrow(
+			/public @handle/,
+		);
+		expect(() => parseFxTwitterSearchQuery("\n")).toThrow(/non-empty query/);
+		expect(() => assertFxTwitterCapability("dms")).toThrow(
+			expect.objectContaining({ kind: "capability_rejected" }),
+		);
+	});
+
 	it("uses the fixed endpoint, rejects redirects, and marks normalized rows", async () => {
 		const fetch = vi.fn().mockResolvedValue(fxResponse(fixtureStatus()));
 		const result = await Effect.runPromise(
@@ -110,15 +150,21 @@ describe("FxTwitter public tweet transport", () => {
 		);
 
 		expect(fetch).toHaveBeenCalledOnce();
-		expect(fetch).toHaveBeenCalledWith(`${FXTWITTER_ORIGIN}/2/status/20`, {
+		const [requestedUrl, requestInit] = fetch.mock.calls[0] ?? [];
+		expect(String(requestedUrl)).toBe(`${FXTWITTER_ORIGIN}/2/status/20`);
+		expect(requestInit).toMatchObject({
 			method: "GET",
 			headers: {
 				Accept: "application/json",
-				"User-Agent": "birdclaw/fxtwitter-read-only",
 			},
-			redirect: "error",
-			signal: expect.any(AbortSignal),
+			redirect: "manual",
 		});
+		expect((requestInit as RequestInit).headers).toMatchObject({
+			"User-Agent": expect.stringMatching(
+				/^birdclaw\/\d+[.]\d+[.]\d+ \(fxtwitter-read-only\)$/,
+			),
+		});
+		expect((requestInit as RequestInit).signal).toBeTruthy();
 		expect(result.payload).toMatchObject({
 			data: [
 				{
@@ -151,6 +197,357 @@ describe("FxTwitter public tweet transport", () => {
 		expect([...result.provenance.entries()]).toEqual([
 			["56", `${FXTWITTER_ORIGIN}/2/status/20`],
 			["20", `${FXTWITTER_ORIGIN}/2/status/20`],
+		]);
+	});
+
+	it("imports clean-but-truncated thread and conversation fixtures as partial", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("thread-truncated")))
+			.mockResolvedValueOnce(jsonResponse(fixture("conversation-truncated")));
+		const runtime = createRuntimeServices({
+			fetch,
+			now: () => new Date("2026-08-02T20:00:00.000Z"),
+		});
+
+		const thread = await Effect.runPromise(
+			importThreadViaFxTwitterEffect("100", {}, runtime),
+		);
+		const conversation = await Effect.runPromise(
+			importConversationViaFxTwitterEffect("100", {}, runtime),
+		);
+
+		expect(thread.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["endpoint_has_no_exhaustion_proof"],
+			pagesFetched: 1,
+			itemsObserved: 2,
+			upstreamCount: 9,
+		});
+		expect(conversation.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["endpoint_has_no_exhaustion_proof"],
+			itemsObserved: 2,
+			nextCursor: "conversation-next",
+		});
+		expect(
+			testHome().db.prepare("select id from tweets order by id").all(),
+		).toEqual([{ id: "100" }, { id: "101" }, { id: "102" }]);
+		expect(
+			testHome()
+				.db.prepare(
+					"select endpoint_family, collection_state, partial_reasons_json from fxtwitter_fetches order by endpoint_family",
+				)
+				.all(),
+		).toEqual([
+			{
+				endpoint_family: "conversation",
+				collection_state: "partial",
+				partial_reasons_json: '["endpoint_has_no_exhaustion_proof"]',
+			},
+			{
+				endpoint_family: "thread",
+				collection_state: "partial",
+				partial_reasons_json: '["endpoint_has_no_exhaustion_proof"]',
+			},
+		]);
+	});
+
+	it("imports a fixture-backed public profile with durable provenance", async () => {
+		const runtime = createRuntimeServices({
+			fetch: vi.fn().mockResolvedValue(jsonResponse(fixture("profile"))),
+			now: () => new Date("2026-08-02T20:01:00.000Z"),
+		});
+		const result = await Effect.runPromise(
+			importProfileViaFxTwitterEffect("@example", runtime),
+		);
+
+		expect(result).toMatchObject({
+			endpointFamily: "profile",
+			request: "example",
+			itemsObserved: 1,
+			profile: {
+				handle: "example",
+				displayName: "Example Person",
+				followersCount: 123,
+			},
+		});
+		expect(
+			testHome()
+				.db.prepare(
+					"select endpoint_family, request_key, item_kind, item_id from fxtwitter_observations",
+				)
+				.get(),
+		).toEqual({
+			endpoint_family: "profile",
+			request_key: "example",
+			item_kind: "profile",
+			item_id: "profile_user_12",
+		});
+	});
+
+	it("follows a fixture-backed search cursor to proven exhaustion", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-terminal")));
+		const result = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"local first",
+				{ limit: 10, maxPages: 3 },
+				createRuntimeServices({
+					fetch,
+					now: () => new Date("2026-08-02T20:02:00.000Z"),
+				}),
+			),
+		);
+
+		expect(result.collection).toEqual({
+			state: "complete",
+			partialReasons: [],
+			pagesFetched: 2,
+			itemsObserved: 3,
+			retrievedAt: "2026-08-02T20:02:00.000Z",
+			terminalCursor: "cursor-2",
+			nextCursor: undefined,
+			interruption: undefined,
+		});
+		expect(result.tweetIds).toEqual(["200", "201", "202"]);
+		expect(fetch).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				search: expect.stringContaining("cursor=cursor-2"),
+			}),
+			expect.anything(),
+		);
+		expect(
+			testHome()
+				.db.prepare(
+					"select item_id from fxtwitter_observations where endpoint_family = 'search' order by item_id",
+				)
+				.all(),
+		).toEqual([{ item_id: "200" }, { item_id: "201" }, { item_id: "202" }]);
+	});
+
+	it("fails closed on repeated search cursors while preserving valid items", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockResolvedValueOnce(jsonResponse(fixture("search-cursor-cycle")));
+		const result = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"cursor test",
+				{ limit: 10, maxPages: 3 },
+				createRuntimeServices({ fetch }),
+			),
+		);
+
+		expect(result.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["cursor_repeated"],
+			pagesFetched: 2,
+			itemsObserved: 2,
+			nextCursor: "cursor-2",
+			interruption: { kind: "cursor_repeated" },
+		});
+	});
+
+	it("detects a fixture-backed search cursor cycle", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockResolvedValueOnce(jsonResponse(fixture("search-cursor-next")))
+			.mockResolvedValueOnce(jsonResponse(fixture("search-cursor-cycle")));
+		const result = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"cursor cycle",
+				{ limit: 10, maxPages: 5 },
+				createRuntimeServices({ fetch }),
+			),
+		);
+
+		expect(result.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["cursor_cycle"],
+			pagesFetched: 3,
+			itemsObserved: 2,
+			nextCursor: "cursor-2",
+			interruption: { kind: "cursor_cycle" },
+		});
+	});
+
+	it("records caller and page bounds as partial reasons", async () => {
+		const limited = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"bounded limit",
+				{ limit: 1, maxPages: 5 },
+				createRuntimeServices({
+					fetch: vi
+						.fn()
+						.mockResolvedValue(jsonResponse(fixture("search-page-1"))),
+				}),
+			),
+		);
+		const paged = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"bounded pages",
+				{ limit: 10, maxPages: 1 },
+				createRuntimeServices({
+					fetch: vi
+						.fn()
+						.mockResolvedValue(jsonResponse(fixture("search-page-1"))),
+				}),
+			),
+		);
+
+		expect(limited.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["caller_limit"],
+			itemsObserved: 1,
+			nextCursor: "cursor-2",
+		});
+		expect(paged.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["max_pages"],
+			pagesFetched: 1,
+			itemsObserved: 2,
+			nextCursor: "cursor-2",
+		});
+	});
+
+	it("returns a typed rate-limit error before any usable result", async () => {
+		const fetch = vi
+			.fn()
+			.mockImplementation(() =>
+				Promise.resolve(
+					jsonResponse(fixture("rate-limit"), 429, { "retry-after": "0" }),
+				),
+			);
+		const outcome = await Effect.runPromise(
+			Effect.either(
+				importSearchViaFxTwitterEffect(
+					"rate limit",
+					{ limit: 10 },
+					createRuntimeServices({ fetch, random: () => 0 }),
+				),
+			),
+		);
+
+		expect(outcome).toEqual(
+			expect.objectContaining({
+				_tag: "Left",
+				left: expect.objectContaining({
+					_tag: "FxTwitterError",
+					kind: "rate_limited",
+					status: 429,
+					retryAfterMs: 0,
+				}),
+			}),
+		);
+		expect(fetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("keeps first-page rows when a later page is rate limited", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockImplementation(() =>
+				Promise.resolve(
+					jsonResponse(fixture("rate-limit"), 429, { "retry-after": "0" }),
+				),
+			);
+		const result = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"partial rate limit",
+				{ limit: 10 },
+				createRuntimeServices({ fetch, random: () => 0 }),
+			),
+		);
+
+		expect(result.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["rate_limited"],
+			pagesFetched: 1,
+			itemsObserved: 2,
+			nextCursor: "cursor-2",
+			interruption: { kind: "rate_limited", status: 429, retryAfterMs: 0 },
+		});
+		expect(result.tweetIds).toEqual(["200", "201"]);
+	});
+
+	it("keeps first-page rows on a fixture-backed mid-pagination upstream failure", async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockImplementation(() =>
+				Promise.resolve(jsonResponse(fixture("upstream-error"), 500)),
+			);
+		const result = await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"partial upstream",
+				{ limit: 10 },
+				createRuntimeServices({ fetch, random: () => 0 }),
+			),
+		);
+
+		expect(result.collection).toMatchObject({
+			state: "partial",
+			partialReasons: ["upstream_error"],
+			pagesFetched: 1,
+			itemsObserved: 2,
+			nextCursor: "cursor-2",
+			interruption: { kind: "http_status", status: 500 },
+		});
+		expect(result.tweetIds).toEqual(["200", "201"]);
+	});
+
+	it("keeps persistence monotonic across a later smaller partial search", async () => {
+		const completeFetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-1")))
+			.mockResolvedValueOnce(jsonResponse(fixture("search-page-terminal")));
+		await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"monotonic",
+				{ limit: 10 },
+				createRuntimeServices({
+					fetch: completeFetch,
+					now: () => new Date("2026-08-02T20:03:00.000Z"),
+				}),
+			),
+		);
+		await Effect.runPromise(
+			importSearchViaFxTwitterEffect(
+				"monotonic",
+				{ limit: 1 },
+				createRuntimeServices({
+					fetch: vi
+						.fn()
+						.mockResolvedValue(jsonResponse(fixture("search-page-1"))),
+					now: () => new Date("2026-08-02T20:04:00.000Z"),
+				}),
+			),
+		);
+
+		expect(
+			testHome().db.prepare("select id from tweets order by id").all(),
+		).toEqual([{ id: "200" }, { id: "201" }, { id: "202" }]);
+		expect(
+			testHome()
+				.db.prepare(
+					"select item_id from fxtwitter_observations where endpoint_family = 'search' order by item_id",
+				)
+				.all(),
+		).toEqual([{ item_id: "200" }, { item_id: "201" }, { item_id: "202" }]);
+		expect(
+			testHome()
+				.db.prepare(
+					"select collection_state from fxtwitter_fetches order by retrieved_at",
+				)
+				.all(),
+		).toEqual([
+			{ collection_state: "complete" },
+			{ collection_state: "partial" },
 		]);
 	});
 

--- a/src/lib/fxtwitter.ts
+++ b/src/lib/fxtwitter.ts
@@ -1,26 +1,41 @@
 import { Buffer } from "node:buffer";
 import { Data, Effect } from "effect";
+import packageManifest from "../../package.json";
 import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
+import {
+	recordFxTwitterFetch,
+	type FxTwitterCollectionMetadata,
+	type FxTwitterFailureSummary,
+	type FxTwitterPartialReason,
+} from "./fxtwitter-store";
 import {
 	defaultRuntimeServices,
 	type RuntimeServices,
 } from "./runtime-services";
 import { ingestTweetPayload } from "./tweet-repository";
 import type {
+	ProfileRecord,
 	XurlMediaItem,
 	XurlMentionUser,
 	XurlTweetData,
 	XurlTweetsResponse,
 } from "./types";
+import { upsertProfileFromXUser } from "./x-profile";
 
 export const FXTWITTER_ORIGIN = "https://api.fxtwitter.com";
 
 const FXTWITTER_TWEET_ID_PATTERN = /^\d{2,20}$/;
 const TWITTER_ENTITY_ID_PATTERN = /^\d{1,20}$/;
+const FXTWITTER_HANDLE_PATTERN = /^[A-Za-z0-9_]{1,15}$/;
 const FXTWITTER_TIMEOUT_MS = 15_000;
+const FXTWITTER_TOTAL_DEADLINE_MS = 30_000;
 const FXTWITTER_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const FXTWITTER_MAX_TWEETS_PER_IMPORT = 20;
+const FXTWITTER_MAX_COLLECTION_ITEMS = 1_000;
+const FXTWITTER_MAX_PAGES = 10;
+const FXTWITTER_MAX_ATTEMPTS = 3;
+const FXTWITTER_MAX_BACKOFF_MS = 2_000;
 const TWITTER_STATUS_HOSTS = new Set([
 	"twitter.com",
 	"www.twitter.com",
@@ -29,14 +44,50 @@ const TWITTER_STATUS_HOSTS = new Set([
 ]);
 const TWITTER_IMAGE_HOSTS = new Set(["pbs.twimg.com"]);
 const TWITTER_VIDEO_HOSTS = new Set(["video.twimg.com"]);
+const FXTWITTER_USER_AGENT = `birdclaw/${packageManifest.version} (fxtwitter-read-only)`;
 
 type JsonRecord = Record<string, unknown>;
 
+export type FxTwitterErrorKind =
+	| "capability_rejected"
+	| "input_rejected"
+	| "origin_policy"
+	| "network"
+	| "timeout"
+	| "http_status"
+	| "rate_limited"
+	| "api_failure"
+	| "response_too_large"
+	| "decode_error"
+	| "not_found"
+	| "unavailable"
+	| "protected"
+	| "cursor_missing_or_malformed"
+	| "cursor_repeated"
+	| "cursor_cycle";
+
 export class FxTwitterError extends Data.TaggedError("FxTwitterError")<{
+	readonly kind: FxTwitterErrorKind;
 	readonly message: string;
 	readonly status?: number;
+	readonly retryAfterMs?: number;
 	readonly cause?: unknown;
 }> {}
+
+export type FxTwitterCapability =
+	| "tweet"
+	| "thread"
+	| "conversation"
+	| "profile"
+	| "search";
+
+const FXTWITTER_CAPABILITIES = new Set<FxTwitterCapability>([
+	"tweet",
+	"thread",
+	"conversation",
+	"profile",
+	"search",
+]);
 
 export interface FxTwitterTweet {
 	payload: XurlTweetsResponse;
@@ -55,6 +106,44 @@ export interface FxTwitterImportResult {
 		source: "fxtwitter";
 		sourceUrl: string;
 	}>;
+}
+
+export interface FxTwitterCollectionImportResult {
+	ok: true;
+	readOnlyTransport: true;
+	source: "fxtwitter";
+	endpoint: typeof FXTWITTER_ORIGIN;
+	endpointFamily: "thread" | "conversation" | "search";
+	request: string;
+	importedCount: number;
+	tweetIds: string[];
+	collection: FxTwitterCollectionMetadata;
+}
+
+export interface FxTwitterProfileImportResult {
+	ok: true;
+	readOnlyTransport: true;
+	source: "fxtwitter";
+	endpoint: typeof FXTWITTER_ORIGIN;
+	endpointFamily: "profile";
+	request: string;
+	retrievedAt: string;
+	pagesFetched: 1;
+	itemsObserved: 1;
+	profile: ProfileRecord;
+}
+
+export interface FxTwitterCollectionOptions {
+	limit?: number;
+	maxPages?: number;
+	feed?: "latest" | "top" | "media";
+}
+
+interface NormalizedStatusTree {
+	primary: XurlTweetData;
+	tweets: Map<string, XurlTweetData>;
+	users: Map<string, XurlMentionUser>;
+	media: Map<string, XurlMediaItem>;
 }
 
 function asRecord(value: unknown): JsonRecord | null {
@@ -81,19 +170,57 @@ function asCount(value: unknown) {
 	return Math.max(0, Math.trunc(asNumber(value) ?? 0));
 }
 
+function unique<T>(values: readonly T[]) {
+	return [...new Set(values)];
+}
+
+function inputError(message: string) {
+	return new FxTwitterError({ kind: "input_rejected", message });
+}
+
+function decodeError(message: string, cause?: unknown) {
+	return new FxTwitterError({ kind: "decode_error", message, cause });
+}
+
 function toIsoDate(value: unknown, field: string) {
 	const raw = asString(value);
 	const timestamp = raw ? Date.parse(raw) : Number.NaN;
 	if (!Number.isFinite(timestamp)) {
-		throw new FxTwitterError({
-			message: `FxTwitter response has an invalid ${field}`,
-		});
+		throw decodeError(`FxTwitter response has an invalid ${field}`);
 	}
 	return new Date(timestamp).toISOString();
 }
 
 function sourceUrlForTweet(tweetId: string) {
 	return `${FXTWITTER_ORIGIN}/2/status/${tweetId}`;
+}
+
+function endpointUrl(
+	path: string,
+	query?: Readonly<Record<string, string | number | undefined>>,
+) {
+	const url = new URL(path, FXTWITTER_ORIGIN);
+	if (url.origin !== FXTWITTER_ORIGIN || url.username || url.password) {
+		throw new FxTwitterError({
+			kind: "origin_policy",
+			message: "FxTwitter requests must use the fixed public origin",
+		});
+	}
+	for (const [key, value] of Object.entries(query ?? {})) {
+		if (value !== undefined) url.searchParams.set(key, String(value));
+	}
+	return url;
+}
+
+export function assertFxTwitterCapability(
+	capability: string,
+): asserts capability is FxTwitterCapability {
+	if (!FXTWITTER_CAPABILITIES.has(capability as FxTwitterCapability)) {
+		throw new FxTwitterError({
+			kind: "capability_rejected",
+			message: `FxTwitter does not support ${capability}; authenticated, private, and write capabilities are unavailable`,
+		});
+	}
 }
 
 export function parseFxTwitterTweetId(value: string) {
@@ -104,9 +231,9 @@ export function parseFxTwitterTweetId(value: string) {
 	try {
 		parsed = new URL(trimmed);
 	} catch {
-		throw new FxTwitterError({
-			message: `Invalid public tweet ID or canonical x.com/Twitter status URL: ${trimmed}`,
-		});
+		throw inputError(
+			`Invalid public tweet ID or canonical x.com/Twitter status URL: ${trimmed}`,
+		);
 	}
 	if (
 		parsed.protocol !== "https:" ||
@@ -117,21 +244,65 @@ export function parseFxTwitterTweetId(value: string) {
 		parsed.hash ||
 		!TWITTER_STATUS_HOSTS.has(parsed.hostname.toLowerCase())
 	) {
-		throw new FxTwitterError({
-			message:
-				"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
-		});
+		throw inputError(
+			"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
+		);
 	}
 	const match = /^\/[A-Za-z0-9_]{1,15}\/status\/(\d{2,20})\/?$/.exec(
 		parsed.pathname,
 	);
 	if (!match?.[1]) {
-		throw new FxTwitterError({
-			message:
-				"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
-		});
+		throw inputError(
+			"FxTwitter accepts only a tweet ID or canonical HTTPS x.com/Twitter status URL",
+		);
 	}
 	return match[1];
+}
+
+export function parseFxTwitterHandle(value: string) {
+	const handle = value.trim().replace(/^@/, "");
+	if (!FXTWITTER_HANDLE_PATTERN.test(handle)) {
+		throw inputError("FxTwitter profile lookup requires a public @handle");
+	}
+	return handle;
+}
+
+export function parseFxTwitterSearchQuery(value: string) {
+	const query = value.trim();
+	if (!query || query.length > 512 || /[\u0000-\u001f\u007f]/u.test(query)) {
+		throw inputError(
+			"FxTwitter search requires a non-empty query of at most 512 characters",
+		);
+	}
+	return query;
+}
+
+function validateLimit(value: number | undefined, fallback: number) {
+	const limit = value ?? fallback;
+	if (
+		!Number.isSafeInteger(limit) ||
+		limit < 1 ||
+		limit > FXTWITTER_MAX_COLLECTION_ITEMS
+	) {
+		throw inputError(
+			`FxTwitter result limit must be between 1 and ${String(FXTWITTER_MAX_COLLECTION_ITEMS)}`,
+		);
+	}
+	return limit;
+}
+
+function validateMaxPages(value: number | undefined) {
+	const maxPages = value ?? 5;
+	if (
+		!Number.isSafeInteger(maxPages) ||
+		maxPages < 1 ||
+		maxPages > FXTWITTER_MAX_PAGES
+	) {
+		throw inputError(
+			`FxTwitter max pages must be between 1 and ${String(FXTWITTER_MAX_PAGES)}`,
+		);
+	}
+	return maxPages;
 }
 
 function safeUrlForHosts(value: unknown, hosts: ReadonlySet<string>) {
@@ -154,14 +325,25 @@ function safeUrlForHosts(value: unknown, hosts: ReadonlySet<string>) {
 	}
 }
 
+function safePublicUrl(value: unknown) {
+	const raw = asString(value);
+	if (!raw) return undefined;
+	try {
+		const parsed = new URL(raw);
+		return parsed.protocol === "https:" && !parsed.username && !parsed.password
+			? parsed.toString()
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function normalizeAuthor(value: unknown): XurlMentionUser {
 	const author = asRecord(value);
 	const id = asString(author?.id);
 	const username = asString(author?.screen_name);
 	if (!author || !id || !TWITTER_ENTITY_ID_PATTERN.test(id) || !username) {
-		throw new FxTwitterError({
-			message: "FxTwitter response is missing a valid tweet author",
-		});
+		throw decodeError("FxTwitter response is missing a valid tweet author");
 	}
 	const verification = asRecord(author.verification);
 	const website = asRecord(author.website);
@@ -173,7 +355,7 @@ function normalizeAuthor(value: unknown): XurlMentionUser {
 		username,
 		description: asString(author.description),
 		location: asString(author.location),
-		url: asString(website?.url),
+		url: safePublicUrl(website?.url),
 		verified: Boolean(verification?.verified),
 		verified_type: asString(verification?.type),
 		profile_image_url: safeUrlForHosts(author.avatar_url, TWITTER_IMAGE_HOSTS),
@@ -248,14 +430,13 @@ function normalizeMedia(tweetId: string, value: unknown) {
 	return normalized;
 }
 
-function normalizeStatusTree(primaryValue: unknown, requestedId: string) {
+function normalizeStatusTree(value: unknown): NormalizedStatusTree {
 	const tweets = new Map<string, XurlTweetData>();
 	const users = new Map<string, XurlMentionUser>();
 	const media = new Map<string, XurlMediaItem>();
-	const provenance = new Map<string, string>();
 
-	const visit = (value: unknown, depth: number): XurlTweetData => {
-		const status = asRecord(value);
+	const visit = (candidate: unknown, depth: number): XurlTweetData => {
+		const status = asRecord(candidate);
 		const id = asString(status?.id);
 		if (
 			!status ||
@@ -263,10 +444,9 @@ function normalizeStatusTree(primaryValue: unknown, requestedId: string) {
 			!id ||
 			!FXTWITTER_TWEET_ID_PATTERN.test(id)
 		) {
-			throw new FxTwitterError({
-				message:
-					"FxTwitter response does not contain an available public tweet",
-			});
+			throw decodeError(
+				"FxTwitter response does not contain an available public tweet",
+			);
 		}
 		const author = normalizeAuthor(status.author);
 		users.set(author.id, author);
@@ -308,32 +488,39 @@ function normalizeStatusTree(primaryValue: unknown, requestedId: string) {
 			},
 		};
 		tweets.set(id, tweet);
-		provenance.set(id, sourceUrlForTweet(requestedId));
 		return tweet;
 	};
 
-	const primary = visit(primaryValue, 0);
-	if (primary.id !== requestedId) {
-		throw new FxTwitterError({
-			message: `FxTwitter returned tweet ${primary.id} for requested tweet ${requestedId}`,
-		});
+	const primary = visit(value, 0);
+	return { primary, tweets, users, media };
+}
+
+function mergeStatusTrees(trees: readonly NormalizedStatusTree[]) {
+	const primary = new Map<string, XurlTweetData>();
+	const tweets = new Map<string, XurlTweetData>();
+	const users = new Map<string, XurlMentionUser>();
+	const media = new Map<string, XurlMediaItem>();
+	for (const tree of trees) {
+		primary.set(tree.primary.id, tree.primary);
+		for (const [id, tweet] of tree.tweets) tweets.set(id, tweet);
+		for (const [id, user] of tree.users) users.set(id, user);
+		for (const [id, item] of tree.media) media.set(id, item);
 	}
-	return {
-		payload: {
-			data: [primary],
-			includes: {
-				users: [...users.values()],
-				tweets: [...tweets.values()].filter((tweet) => tweet.id !== primary.id),
-				media: [...media.values()],
-			},
-			meta: {
-				source: "fxtwitter",
-				endpoint: FXTWITTER_ORIGIN,
-				read_only: true,
-			},
+	const primaryIds = new Set(primary.keys());
+	const payload: XurlTweetsResponse = {
+		data: [...primary.values()],
+		includes: {
+			users: [...users.values()],
+			tweets: [...tweets.values()].filter((tweet) => !primaryIds.has(tweet.id)),
+			media: [...media.values()],
 		},
-		provenance,
+		meta: {
+			source: "fxtwitter",
+			endpoint: FXTWITTER_ORIGIN,
+			read_only: true,
+		},
 	};
+	return { payload, allTweetIds: [...tweets.keys()] };
 }
 
 async function readBoundedJson(response: Response) {
@@ -342,7 +529,10 @@ async function readBoundedJson(response: Response) {
 		Number.isFinite(contentLength) &&
 		contentLength > FXTWITTER_MAX_RESPONSE_BYTES
 	) {
-		throw new FxTwitterError({ message: "FxTwitter response is too large" });
+		throw new FxTwitterError({
+			kind: "response_too_large",
+			message: "FxTwitter response is too large",
+		});
 	}
 	if (!response.body) return null;
 	const reader = response.body.getReader();
@@ -354,33 +544,266 @@ async function readBoundedJson(response: Response) {
 		total += value.byteLength;
 		if (total > FXTWITTER_MAX_RESPONSE_BYTES) {
 			await reader.cancel();
-			throw new FxTwitterError({ message: "FxTwitter response is too large" });
+			throw new FxTwitterError({
+				kind: "response_too_large",
+				message: "FxTwitter response is too large",
+			});
 		}
 		chunks.push(value);
 	}
 	try {
 		return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
 	} catch (cause) {
-		throw new FxTwitterError({
-			message: "FxTwitter returned invalid JSON",
-			cause,
+		throw decodeError("FxTwitter returned invalid JSON", cause);
+	}
+}
+
+function retryAfterMs(response: Response, now: Date) {
+	const value = response.headers.get("retry-after")?.trim();
+	if (!value) return undefined;
+	const seconds = Number(value);
+	if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+	const timestamp = Date.parse(value);
+	return Number.isFinite(timestamp)
+		? Math.max(0, timestamp - now.getTime())
+		: undefined;
+}
+
+function statusError(response: Response, root: JsonRecord | null, now: Date) {
+	const providerCode = asNumber(root?.code);
+	const status = providerCode ?? response.status;
+	const message = asString(root?.message) ?? `status ${String(status)}`;
+	const reason = asString(root?.reason)?.toLowerCase();
+	if (status === 429) {
+		return new FxTwitterError({
+			kind: "rate_limited",
+			message: `FxTwitter rate limited the request: ${message}`,
+			status: response.status,
+			retryAfterMs: retryAfterMs(response, now),
 		});
 	}
+	if (status === 404) {
+		return new FxTwitterError({
+			kind: "not_found",
+			message: `FxTwitter public object was not found: ${message}`,
+			status: response.status,
+		});
+	}
+	if (status === 401 || status === 403 || reason === "protected") {
+		return new FxTwitterError({
+			kind: reason === "protected" ? "protected" : "unavailable",
+			message: `FxTwitter public object is unavailable: ${message}`,
+			status: response.status,
+		});
+	}
+	if (status === 410 || reason === "deleted" || reason === "suspended") {
+		return new FxTwitterError({
+			kind: "unavailable",
+			message: `FxTwitter public object is unavailable: ${message}`,
+			status: response.status,
+		});
+	}
+	return new FxTwitterError({
+		kind: response.ok ? "api_failure" : "http_status",
+		message: `FxTwitter request failed with status ${String(status)}: ${message}`,
+		status: response.status,
+	});
 }
 
 function toFxTwitterError(cause: unknown) {
 	if (cause instanceof FxTwitterError) return cause;
 	if (cause instanceof DOMException && cause.name === "AbortError") {
 		return new FxTwitterError({
+			kind: "timeout",
 			message: "FxTwitter request timed out",
 			cause,
 		});
 	}
 	return new FxTwitterError({
+		kind: "network",
 		message:
 			cause instanceof Error ? cause.message : "FxTwitter request failed",
 		cause,
 	});
+}
+
+function shouldRetry(error: FxTwitterError) {
+	return (
+		error.kind === "rate_limited" ||
+		error.kind === "network" ||
+		error.kind === "timeout" ||
+		(error.kind === "http_status" && (error.status ?? 0) >= 500)
+	);
+}
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function requestFxTwitterJson(
+	url: URL,
+	runtime: RuntimeServices,
+): Promise<JsonRecord> {
+	if (url.origin !== FXTWITTER_ORIGIN || url.username || url.password) {
+		throw new FxTwitterError({
+			kind: "origin_policy",
+			message: "FxTwitter requests must use the fixed public origin",
+		});
+	}
+	const deadline = runtime.now().getTime() + FXTWITTER_TOTAL_DEADLINE_MS;
+	let lastError: FxTwitterError | undefined;
+	for (let attempt = 1; attempt <= FXTWITTER_MAX_ATTEMPTS; attempt += 1) {
+		const remaining = deadline - runtime.now().getTime();
+		if (remaining <= 0) {
+			throw new FxTwitterError({
+				kind: "timeout",
+				message: "FxTwitter request exceeded its total deadline",
+			});
+		}
+		const controller = new AbortController();
+		const timeout = setTimeout(
+			() => controller.abort(),
+			Math.min(FXTWITTER_TIMEOUT_MS, remaining),
+		);
+		try {
+			const response = await runtime.fetch(url, {
+				method: "GET",
+				headers: {
+					Accept: "application/json",
+					"User-Agent": FXTWITTER_USER_AGENT,
+				},
+				redirect: "manual",
+				signal: controller.signal,
+			});
+			if (response.status >= 300 && response.status < 400) {
+				throw new FxTwitterError({
+					kind: "origin_policy",
+					message:
+						"FxTwitter redirects are rejected by the fixed-origin policy",
+					status: response.status,
+				});
+			}
+			const body = await readBoundedJson(response);
+			const root = asRecord(body);
+			const providerCode = asNumber(root?.code);
+			if (!root)
+				throw decodeError("FxTwitter returned an invalid response object");
+			if (!response.ok || providerCode !== 200) {
+				throw statusError(response, root, runtime.now());
+			}
+			return root;
+		} catch (cause) {
+			lastError = toFxTwitterError(cause);
+			if (attempt >= FXTWITTER_MAX_ATTEMPTS || !shouldRetry(lastError)) {
+				throw lastError;
+			}
+			const base =
+				lastError.retryAfterMs ?? Math.min(250 * 2 ** (attempt - 1), 1_000);
+			const jittered = Math.ceil(base + base * 0.25 * runtime.random());
+			const delay = Math.min(FXTWITTER_MAX_BACKOFF_MS, jittered);
+			if (runtime.now().getTime() + delay >= deadline) throw lastError;
+			await sleep(delay);
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+	throw (
+		lastError ??
+		new FxTwitterError({ kind: "network", message: "FxTwitter request failed" })
+	);
+}
+
+function failureSummary(error: FxTwitterError): FxTwitterFailureSummary {
+	return {
+		kind: error.kind,
+		message: error.message,
+		status: error.status,
+		retryAfterMs: error.retryAfterMs,
+	};
+}
+
+function partialReasonForError(error: FxTwitterError): FxTwitterPartialReason {
+	if (error.kind === "timeout") return "timeout";
+	if (error.kind === "rate_limited") return "rate_limited";
+	if (error.kind === "decode_error" || error.kind === "response_too_large") {
+		return "decode_error";
+	}
+	if (error.kind === "cursor_missing_or_malformed") {
+		return "cursor_missing_or_malformed";
+	}
+	if (error.kind === "cursor_repeated") return "cursor_repeated";
+	if (error.kind === "cursor_cycle") return "cursor_cycle";
+	return "upstream_error";
+}
+
+function cursorFromRoot(root: JsonRecord) {
+	const cursor = asRecord(root.cursor);
+	if (!cursor || !Object.hasOwn(cursor, "bottom")) {
+		throw new FxTwitterError({
+			kind: "cursor_missing_or_malformed",
+			message: "FxTwitter search response is missing cursor.bottom",
+		});
+	}
+	if (cursor.bottom === null) return null;
+	const bottom = asString(cursor.bottom);
+	if (!bottom) {
+		throw new FxTwitterError({
+			kind: "cursor_missing_or_malformed",
+			message: "FxTwitter search response has an invalid cursor.bottom",
+		});
+	}
+	return bottom;
+}
+
+function normalizeCollectionValues(values: readonly unknown[]) {
+	const trees: NormalizedStatusTree[] = [];
+	const ids = new Set<string>();
+	let decodeFailure: FxTwitterError | undefined;
+	for (const value of values) {
+		try {
+			const tree = normalizeStatusTree(value);
+			if (ids.has(tree.primary.id)) continue;
+			ids.add(tree.primary.id);
+			trees.push(tree);
+		} catch (cause) {
+			decodeFailure ??= toFxTwitterError(cause);
+		}
+	}
+	return { trees, decodeFailure };
+}
+
+function persistTweetCollection(options: {
+	endpointFamily: "thread" | "conversation" | "search";
+	requestKey: string;
+	sourceUrl: string;
+	trees: readonly NormalizedStatusTree[];
+	collection: FxTwitterCollectionMetadata;
+}) {
+	const { payload, allTweetIds } = mergeStatusTrees(options.trees);
+	const provenance = new Map(
+		allTweetIds.map((tweetId) => [tweetId, sourceUrlForTweet(tweetId)]),
+	);
+	const db = getNativeDb({ seedDemoData: false });
+	let importedIds: string[] = [];
+	db.transaction(() => {
+		importedIds = ingestTweetPayload(db, {
+			accountId: "public",
+			payload,
+			source: "fxtwitter",
+			provenance: { sourceUrlByTweetId: provenance },
+		});
+		recordFxTwitterFetch(db, {
+			endpointFamily: options.endpointFamily,
+			requestKey: options.requestKey,
+			sourceUrl: options.sourceUrl,
+			retrievedAt: options.collection.retrievedAt,
+			pagesFetched: options.collection.pagesFetched,
+			itemsObserved: options.collection.itemsObserved,
+			collection: options.collection,
+			items: allTweetIds.map((id) => ({ kind: "tweet", id })),
+		});
+	})();
+	return importedIds;
 }
 
 export function getTweetByIdViaFxTwitterEffect(
@@ -389,35 +812,23 @@ export function getTweetByIdViaFxTwitterEffect(
 ): Effect.Effect<FxTwitterTweet, FxTwitterError> {
 	return Effect.tryPromise({
 		try: async () => {
+			assertFxTwitterCapability("tweet");
 			const tweetId = parseFxTwitterTweetId(input);
-			const controller = new AbortController();
-			const timeout = setTimeout(
-				() => controller.abort(),
-				FXTWITTER_TIMEOUT_MS,
-			);
-			try {
-				const response = await runtime.fetch(sourceUrlForTweet(tweetId), {
-					method: "GET",
-					headers: {
-						Accept: "application/json",
-						"User-Agent": "birdclaw/fxtwitter-read-only",
-					},
-					redirect: "error",
-					signal: controller.signal,
-				});
-				const body = await readBoundedJson(response);
-				const root = asRecord(body);
-				const providerCode = asNumber(root?.code);
-				if (!response.ok || providerCode !== 200) {
-					throw new FxTwitterError({
-						message: `FxTwitter lookup failed with status ${String(providerCode ?? response.status)}`,
-						status: response.status,
-					});
-				}
-				return normalizeStatusTree(root?.status, tweetId);
-			} finally {
-				clearTimeout(timeout);
+			const url = endpointUrl(`/2/status/${tweetId}`);
+			const root = await requestFxTwitterJson(url, runtime);
+			const tree = normalizeStatusTree(root.status);
+			if (tree.primary.id !== tweetId) {
+				throw decodeError(
+					`FxTwitter returned tweet ${tree.primary.id} for requested tweet ${tweetId}`,
+				);
 			}
+			const merged = mergeStatusTrees([tree]);
+			return {
+				payload: merged.payload,
+				provenance: new Map(
+					merged.allTweetIds.map((id) => [id, sourceUrlForTweet(tweetId)]),
+				),
+			};
 		},
 		catch: toFxTwitterError,
 	});
@@ -434,14 +845,14 @@ export function importTweetsViaFxTwitterEffect(
 		});
 		if (tweetIds.length === 0) {
 			return yield* Effect.fail(
-				new FxTwitterError({ message: "Pass at least one public tweet ID" }),
+				inputError("Pass at least one public tweet ID"),
 			);
 		}
 		if (tweetIds.length > FXTWITTER_MAX_TWEETS_PER_IMPORT) {
 			return yield* Effect.fail(
-				new FxTwitterError({
-					message: `FxTwitter import accepts at most ${String(FXTWITTER_MAX_TWEETS_PER_IMPORT)} tweets per invocation`,
-				}),
+				inputError(
+					`FxTwitter import accepts at most ${String(FXTWITTER_MAX_TWEETS_PER_IMPORT)} tweets per invocation`,
+				),
 			);
 		}
 		const fetched = yield* Effect.forEach(
@@ -482,9 +893,348 @@ export function importTweetsViaFxTwitterEffect(
 	});
 }
 
+async function importThreadCollection(
+	input: string,
+	endpointFamily: "thread" | "conversation",
+	options: FxTwitterCollectionOptions,
+	runtime: RuntimeServices,
+): Promise<FxTwitterCollectionImportResult> {
+	assertFxTwitterCapability(endpointFamily);
+	const tweetId = parseFxTwitterTweetId(input);
+	const limit = validateLimit(options.limit, 500);
+	const url = endpointUrl(`/2/${endpointFamily}/${tweetId}`);
+	const retrievedAt = runtime.now().toISOString();
+	const root = await requestFxTwitterJson(url, runtime);
+	const values = [
+		root.status,
+		...asArray(root.thread),
+		...(endpointFamily === "conversation" ? asArray(root.replies) : []),
+	];
+	const normalized = normalizeCollectionValues(values);
+	if (normalized.trees.length === 0) {
+		throw (
+			normalized.decodeFailure ??
+			decodeError("FxTwitter returned no usable public tweets")
+		);
+	}
+	const selected = normalized.trees.slice(0, limit);
+	const partialReasons: FxTwitterPartialReason[] = [
+		"endpoint_has_no_exhaustion_proof",
+	];
+	if (normalized.trees.length > limit) partialReasons.push("caller_limit");
+	if (normalized.decodeFailure) partialReasons.push("decode_error");
+	const cursor = asRecord(root.cursor);
+	const nextCursor = asString(cursor?.bottom);
+	const focal = asRecord(root.status);
+	const collection: FxTwitterCollectionMetadata = {
+		state: "partial",
+		partialReasons: unique(partialReasons),
+		pagesFetched: 1,
+		itemsObserved: selected.length,
+		retrievedAt,
+		terminalCursor: null,
+		nextCursor,
+		upstreamCount: asNumber(focal?.replies),
+		interruption: normalized.decodeFailure
+			? failureSummary(normalized.decodeFailure)
+			: undefined,
+	};
+	const importedIds = persistTweetCollection({
+		endpointFamily,
+		requestKey: tweetId,
+		sourceUrl: url.toString(),
+		trees: selected,
+		collection,
+	});
+	return {
+		ok: true,
+		readOnlyTransport: true,
+		source: "fxtwitter",
+		endpoint: FXTWITTER_ORIGIN,
+		endpointFamily,
+		request: tweetId,
+		importedCount: importedIds.length,
+		tweetIds: importedIds,
+		collection,
+	};
+}
+
+export function importThreadViaFxTwitterEffect(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return Effect.tryPromise({
+		try: () => importThreadCollection(input, "thread", options, runtime),
+		catch: toFxTwitterError,
+	});
+}
+
+export function importConversationViaFxTwitterEffect(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return Effect.tryPromise({
+		try: () => importThreadCollection(input, "conversation", options, runtime),
+		catch: toFxTwitterError,
+	});
+}
+
+export function importProfileViaFxTwitterEffect(
+	input: string,
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return Effect.tryPromise({
+		try: async (): Promise<FxTwitterProfileImportResult> => {
+			assertFxTwitterCapability("profile");
+			const handle = parseFxTwitterHandle(input);
+			const url = endpointUrl(`/2/profile/${encodeURIComponent(handle)}`);
+			const retrievedAt = runtime.now().toISOString();
+			const root = await requestFxTwitterJson(url, runtime);
+			const user = normalizeAuthor(root.user);
+			if (user.username.toLowerCase() !== handle.toLowerCase()) {
+				throw decodeError(
+					`FxTwitter returned @${user.username} for requested @${handle}`,
+				);
+			}
+			const db = getNativeDb({ seedDemoData: false });
+			let profile: ProfileRecord | undefined;
+			db.transaction(() => {
+				profile = upsertProfileFromXUser(db, user).profile;
+				recordFxTwitterFetch(db, {
+					endpointFamily: "profile",
+					requestKey: handle.toLowerCase(),
+					sourceUrl: url.toString(),
+					retrievedAt,
+					pagesFetched: 1,
+					itemsObserved: 1,
+					items: [{ kind: "profile", id: profile.id }],
+				});
+			})();
+			if (!profile) throw decodeError("FxTwitter profile persistence failed");
+			return {
+				ok: true,
+				readOnlyTransport: true,
+				source: "fxtwitter",
+				endpoint: FXTWITTER_ORIGIN,
+				endpointFamily: "profile",
+				request: handle,
+				retrievedAt,
+				pagesFetched: 1,
+				itemsObserved: 1,
+				profile,
+			};
+		},
+		catch: toFxTwitterError,
+	});
+}
+
+async function importSearchCollection(
+	input: string,
+	options: FxTwitterCollectionOptions,
+	runtime: RuntimeServices,
+): Promise<FxTwitterCollectionImportResult> {
+	assertFxTwitterCapability("search");
+	const query = parseFxTwitterSearchQuery(input);
+	const limit = validateLimit(options.limit, 20);
+	const maxPages = validateMaxPages(options.maxPages);
+	const feed = options.feed ?? "latest";
+	if (feed !== "latest" && feed !== "top" && feed !== "media") {
+		throw inputError("FxTwitter search feed must be latest, top, or media");
+	}
+	const retrievedAt = runtime.now().toISOString();
+	const pageSize = Math.min(100, limit);
+	const sourceUrl = endpointUrl("/2/search", {
+		q: query,
+		feed,
+		count: pageSize,
+	}).toString();
+	const trees: NormalizedStatusTree[] = [];
+	const itemIds = new Set<string>();
+	const partialReasons: FxTwitterPartialReason[] = [];
+	const seenCursors = new Set<string>();
+	let pagesFetched = 0;
+	let currentCursor: string | undefined;
+	let nextCursor: string | undefined;
+	let terminalCursor: string | null = null;
+	let interruption: FxTwitterFailureSummary | undefined;
+	let terminalObserved = false;
+
+	for (;;) {
+		const url = endpointUrl("/2/search", {
+			q: query,
+			feed,
+			count: pageSize,
+			cursor: currentCursor,
+		});
+		let root: JsonRecord;
+		try {
+			root = await requestFxTwitterJson(url, runtime);
+		} catch (cause) {
+			const error = toFxTwitterError(cause);
+			if (trees.length === 0) throw error;
+			partialReasons.push(partialReasonForError(error));
+			interruption = failureSummary(error);
+			nextCursor = currentCursor;
+			break;
+		}
+		pagesFetched += 1;
+		if (!Array.isArray(root.results)) {
+			const error = decodeError("FxTwitter search response is missing results");
+			if (trees.length === 0) throw error;
+			partialReasons.push("decode_error");
+			interruption = failureSummary(error);
+			break;
+		}
+		const normalized = normalizeCollectionValues(root.results);
+		for (const tree of normalized.trees) {
+			if (itemIds.has(tree.primary.id)) continue;
+			if (trees.length >= limit) {
+				partialReasons.push("caller_limit");
+				break;
+			}
+			itemIds.add(tree.primary.id);
+			trees.push(tree);
+		}
+		if (normalized.decodeFailure) {
+			if (trees.length === 0) throw normalized.decodeFailure;
+			partialReasons.push("decode_error");
+			interruption = failureSummary(normalized.decodeFailure);
+			break;
+		}
+
+		let bottom: string | null;
+		try {
+			bottom = cursorFromRoot(root);
+		} catch (cause) {
+			const error = toFxTwitterError(cause);
+			if (trees.length === 0 && root.results.length > 0) throw error;
+			partialReasons.push("cursor_missing_or_malformed");
+			interruption = failureSummary(error);
+			break;
+		}
+		if (bottom === null) {
+			terminalObserved = true;
+			terminalCursor = currentCursor ?? null;
+			break;
+		}
+		nextCursor = bottom;
+		if (trees.length >= limit) {
+			partialReasons.push("caller_limit");
+			break;
+		}
+		if (pagesFetched >= maxPages) {
+			partialReasons.push("max_pages");
+			break;
+		}
+		if (bottom === currentCursor) {
+			const error = new FxTwitterError({
+				kind: "cursor_repeated",
+				message: "FxTwitter search repeated the current cursor",
+			});
+			partialReasons.push("cursor_repeated");
+			interruption = failureSummary(error);
+			break;
+		}
+		if (seenCursors.has(bottom)) {
+			const error = new FxTwitterError({
+				kind: "cursor_cycle",
+				message: "FxTwitter search cursor chain formed a cycle",
+			});
+			partialReasons.push("cursor_cycle");
+			interruption = failureSummary(error);
+			break;
+		}
+		seenCursors.add(bottom);
+		currentCursor = bottom;
+		nextCursor = undefined;
+	}
+
+	const reasons = unique(partialReasons);
+	const collection: FxTwitterCollectionMetadata = {
+		state: terminalObserved && reasons.length === 0 ? "complete" : "partial",
+		partialReasons: reasons,
+		pagesFetched,
+		itemsObserved: trees.length,
+		retrievedAt,
+		terminalCursor,
+		nextCursor,
+		interruption,
+	};
+	const importedIds = persistTweetCollection({
+		endpointFamily: "search",
+		requestKey: JSON.stringify({ query, feed }),
+		sourceUrl,
+		trees,
+		collection,
+	});
+	return {
+		ok: true,
+		readOnlyTransport: true,
+		source: "fxtwitter",
+		endpoint: FXTWITTER_ORIGIN,
+		endpointFamily: "search",
+		request: query,
+		importedCount: importedIds.length,
+		tweetIds: importedIds,
+		collection,
+	};
+}
+
+export function importSearchViaFxTwitterEffect(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return Effect.tryPromise({
+		try: () => importSearchCollection(input, options, runtime),
+		catch: toFxTwitterError,
+	});
+}
+
 export function importTweetsViaFxTwitter(
 	inputs: readonly string[],
 	runtime: RuntimeServices = defaultRuntimeServices,
 ) {
 	return runEffectPromise(importTweetsViaFxTwitterEffect(inputs, runtime));
 }
+
+export function importThreadViaFxTwitter(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return runEffectPromise(
+		importThreadViaFxTwitterEffect(input, options, runtime),
+	);
+}
+
+export function importConversationViaFxTwitter(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return runEffectPromise(
+		importConversationViaFxTwitterEffect(input, options, runtime),
+	);
+}
+
+export function importProfileViaFxTwitter(
+	input: string,
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return runEffectPromise(importProfileViaFxTwitterEffect(input, runtime));
+}
+
+export function importSearchViaFxTwitter(
+	input: string,
+	options: FxTwitterCollectionOptions = {},
+	runtime: RuntimeServices = defaultRuntimeServices,
+) {
+	return runEffectPromise(
+		importSearchViaFxTwitterEffect(input, options, runtime),
+	);
+}
+
+export type { FxTwitterCollectionMetadata, FxTwitterPartialReason };

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -273,7 +273,7 @@ describe("X List sync and local filtering", () => {
 		tempRoots.push(backupRoot);
 		const exported = await exportBackup({ repoPath: backupRoot });
 		expect(exported.manifest).toMatchObject({
-			schemaVersion: 7,
+			schemaVersion: 8,
 			counts: { x_lists: 1, x_list_members: 1 },
 		});
 

--- a/src/test/fixtures/fxtwitter/conversation-truncated.json
+++ b/src/test/fixtures/fxtwitter/conversation-truncated.json
@@ -1,0 +1,57 @@
+{
+	"code": 200,
+	"status": {
+		"type": "status",
+		"id": "100",
+		"text": "conversation root",
+		"created_at": "Tue Mar 21 20:50:14 +0000 2006",
+		"likes": 10,
+		"reposts": 2,
+		"quotes": 1,
+		"replies": 9,
+		"author": {
+			"type": "profile",
+			"id": "12",
+			"screen_name": "example",
+			"name": "Example",
+			"description": "public profile",
+			"followers": 100,
+			"following": 20,
+			"statuses": 50,
+			"joined": "Tue Mar 21 20:50:14 +0000 2006",
+			"protected": false,
+			"website": {}
+		},
+		"media": {}
+	},
+	"thread": [],
+	"replies": [
+		{
+			"type": "status",
+			"id": "102",
+			"text": "one observed reply",
+			"created_at": "Tue Mar 21 20:52:14 +0000 2006",
+			"likes": 1,
+			"reposts": 0,
+			"quotes": 0,
+			"replies": 0,
+			"replying_to": { "status": "100", "user_id": "12" },
+			"author": {
+				"type": "profile",
+				"id": "34",
+				"screen_name": "reply",
+				"name": "Reply",
+				"description": "",
+				"followers": 2,
+				"following": 3,
+				"statuses": 4,
+				"joined": "Wed Mar 22 20:50:14 +0000 2006",
+				"protected": false,
+				"website": {}
+			},
+			"media": {}
+		}
+	],
+	"author": null,
+	"cursor": { "bottom": "conversation-next" }
+}

--- a/src/test/fixtures/fxtwitter/profile.json
+++ b/src/test/fixtures/fxtwitter/profile.json
@@ -1,0 +1,20 @@
+{
+	"code": 200,
+	"message": "OK",
+	"user": {
+		"type": "profile",
+		"id": "12",
+		"screen_name": "example",
+		"name": "Example Person",
+		"description": "Profile from FxTwitter",
+		"location": "Internet",
+		"avatar_url": "https://pbs.twimg.com/profile_images/12/avatar.jpg",
+		"followers": 123,
+		"following": 45,
+		"statuses": 67,
+		"joined": "Tue Mar 21 20:50:14 +0000 2006",
+		"protected": false,
+		"verification": { "verified": true, "type": "individual" },
+		"website": { "url": "https://example.com" }
+	}
+}

--- a/src/test/fixtures/fxtwitter/rate-limit.json
+++ b/src/test/fixtures/fxtwitter/rate-limit.json
@@ -1,0 +1,4 @@
+{
+	"code": 429,
+	"message": "Too Many Requests"
+}

--- a/src/test/fixtures/fxtwitter/search-cursor-cycle.json
+++ b/src/test/fixtures/fxtwitter/search-cursor-cycle.json
@@ -1,0 +1,5 @@
+{
+	"code": 200,
+	"results": [],
+	"cursor": { "top": null, "bottom": "cursor-2" }
+}

--- a/src/test/fixtures/fxtwitter/search-cursor-next.json
+++ b/src/test/fixtures/fxtwitter/search-cursor-next.json
@@ -1,0 +1,5 @@
+{
+	"code": 200,
+	"results": [],
+	"cursor": { "top": null, "bottom": "cursor-3" }
+}

--- a/src/test/fixtures/fxtwitter/search-page-1.json
+++ b/src/test/fixtures/fxtwitter/search-page-1.json
@@ -1,0 +1,54 @@
+{
+	"code": 200,
+	"results": [
+		{
+			"type": "status",
+			"id": "200",
+			"text": "first search result",
+			"created_at": "Tue Mar 21 20:50:14 +0000 2006",
+			"likes": 5,
+			"reposts": 1,
+			"quotes": 0,
+			"replies": 0,
+			"author": {
+				"type": "profile",
+				"id": "40",
+				"screen_name": "searcher",
+				"name": "Searcher",
+				"description": "",
+				"followers": 10,
+				"following": 5,
+				"statuses": 20,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": {}
+			},
+			"media": {}
+		},
+		{
+			"type": "status",
+			"id": "201",
+			"text": "second search result",
+			"created_at": "Tue Mar 21 20:51:14 +0000 2006",
+			"likes": 4,
+			"reposts": 0,
+			"quotes": 0,
+			"replies": 0,
+			"author": {
+				"type": "profile",
+				"id": "41",
+				"screen_name": "finder",
+				"name": "Finder",
+				"description": "",
+				"followers": 11,
+				"following": 6,
+				"statuses": 21,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": {}
+			},
+			"media": {}
+		}
+	],
+	"cursor": { "top": "cursor-top", "bottom": "cursor-2" }
+}

--- a/src/test/fixtures/fxtwitter/search-page-terminal.json
+++ b/src/test/fixtures/fxtwitter/search-page-terminal.json
@@ -1,0 +1,54 @@
+{
+	"code": 200,
+	"results": [
+		{
+			"type": "status",
+			"id": "201",
+			"text": "second search result",
+			"created_at": "Tue Mar 21 20:51:14 +0000 2006",
+			"likes": 4,
+			"reposts": 0,
+			"quotes": 0,
+			"replies": 0,
+			"author": {
+				"type": "profile",
+				"id": "41",
+				"screen_name": "finder",
+				"name": "Finder",
+				"description": "",
+				"followers": 11,
+				"following": 6,
+				"statuses": 21,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": {}
+			},
+			"media": {}
+		},
+		{
+			"type": "status",
+			"id": "202",
+			"text": "terminal search result",
+			"created_at": "Tue Mar 21 20:52:14 +0000 2006",
+			"likes": 3,
+			"reposts": 0,
+			"quotes": 0,
+			"replies": 0,
+			"author": {
+				"type": "profile",
+				"id": "42",
+				"screen_name": "terminal",
+				"name": "Terminal",
+				"description": "",
+				"followers": 12,
+				"following": 7,
+				"statuses": 22,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": {}
+			},
+			"media": {}
+		}
+	],
+	"cursor": { "top": null, "bottom": null }
+}

--- a/src/test/fixtures/fxtwitter/thread-truncated.json
+++ b/src/test/fixtures/fxtwitter/thread-truncated.json
@@ -1,0 +1,88 @@
+{
+	"code": 200,
+	"status": {
+		"type": "status",
+		"id": "100",
+		"url": "https://x.com/example/status/100",
+		"text": "thread root",
+		"created_at": "Tue Mar 21 20:50:14 +0000 2006",
+		"likes": 10,
+		"reposts": 2,
+		"quotes": 1,
+		"replies": 9,
+		"author": {
+			"type": "profile",
+			"id": "12",
+			"screen_name": "example",
+			"name": "Example",
+			"description": "public profile",
+			"location": "Internet",
+			"avatar_url": "https://pbs.twimg.com/profile_images/12/avatar.jpg",
+			"followers": 100,
+			"following": 20,
+			"statuses": 50,
+			"joined": "Tue Mar 21 20:50:14 +0000 2006",
+			"protected": false,
+			"website": { "url": "https://example.com" }
+		},
+		"media": {}
+	},
+	"thread": [
+		{
+			"type": "status",
+			"id": "100",
+			"url": "https://x.com/example/status/100",
+			"text": "thread root",
+			"created_at": "Tue Mar 21 20:50:14 +0000 2006",
+			"likes": 10,
+			"reposts": 2,
+			"quotes": 1,
+			"replies": 9,
+			"author": {
+				"type": "profile",
+				"id": "12",
+				"screen_name": "example",
+				"name": "Example",
+				"description": "public profile",
+				"location": "Internet",
+				"avatar_url": "https://pbs.twimg.com/profile_images/12/avatar.jpg",
+				"followers": 100,
+				"following": 20,
+				"statuses": 50,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": { "url": "https://example.com" }
+			},
+			"media": {}
+		},
+		{
+			"type": "status",
+			"id": "101",
+			"url": "https://x.com/example/status/101",
+			"text": "thread continuation",
+			"created_at": "Tue Mar 21 20:51:14 +0000 2006",
+			"likes": 8,
+			"reposts": 1,
+			"quotes": 0,
+			"replies": 0,
+			"replying_to": { "status": "100", "user_id": "12" },
+			"author": {
+				"type": "profile",
+				"id": "12",
+				"screen_name": "example",
+				"name": "Example",
+				"description": "public profile",
+				"location": "Internet",
+				"avatar_url": "https://pbs.twimg.com/profile_images/12/avatar.jpg",
+				"followers": 100,
+				"following": 20,
+				"statuses": 50,
+				"joined": "Tue Mar 21 20:50:14 +0000 2006",
+				"protected": false,
+				"website": { "url": "https://example.com" }
+			},
+			"media": {}
+		}
+	],
+	"author": null
+}

--- a/src/test/fixtures/fxtwitter/upstream-error.json
+++ b/src/test/fixtures/fxtwitter/upstream-error.json
@@ -1,0 +1,4 @@
+{
+	"code": 500,
+	"message": "Upstream timeline unavailable"
+}


### PR DESCRIPTION
## Summary

- add explicit fixed-origin public thread, conversation, profile, and bounded search reads through the existing `--fxtwitter` opt-in
- fail closed to conservative partial collection metadata, retain typed failures and cursor/rate-limit evidence, and reject account-scoped/private semantics before network access
- persist append-only fetch records plus positive item observations through database schema 8 and portable backup shards
- document disclosure, completeness, durability, and non-goal boundaries from the approved August 2 contract

Closes #99.

## Proof

- `pnpm check`
- `pnpm coverage` — 1,331 tests; 90.55% line coverage
- `pnpm build`
- `pnpm pack:smoke`
- `pnpm e2e` — 12 Chromium tests
- compiled source-blind behavior validation against the approved contract
- live fixed-origin proof: public thread and conversation `2030857479001960633`, profile `@jack`, and bounded `OpenAI` search; no credentials
- autoreview clean on the complete branch against `origin/main`

## Contract notes

Thread and conversation results remain partial even on a clean success because the endpoint cannot prove that no tail was silently truncated. Search claims complete only after explicit bottom-cursor exhaustion; caller/page bounds, rate limits, upstream/decode failures, and cursor anomalies keep imported rows usable with typed partial reasons. Missing items are never deletion evidence.
