### PR TITLE
fix: preserve URL expansion keys in backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Preserve the original spelling of valid HTTP URLs during backup import so non-canonical but distinct URL-expansion keys round-trip instead of collapsing onto one normalized key.
 - Stream portable database fingerprint rows after the import transaction commits and skip recursive topology rewrites for canonical singleton revisions, reducing large Birdclaw backup imports from hour-scale work to seconds while keeping the same deterministic fingerprint contract.
 
 ### Docs

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -127,16 +127,16 @@ function sanitizeImportedTweetRevisions(rows: BackupJsonRecord[]) {
 	}));
 }
 
+function preserveSafeHttpUrl(value: BackupJsonValue | undefined) {
+	if (typeof value !== "string") return null;
+	return safeHttpUrl(value) ? value : null;
+}
+
 function sanitizeImportedUrlExpansions(rows: BackupJsonRecord[]) {
 	return rows.map((row) => {
-		const shortUrl =
-			typeof row.short_url === "string" ? safeHttpUrl(row.short_url) : null;
-		const expandedUrl =
-			typeof row.expanded_url === "string"
-				? safeHttpUrl(row.expanded_url)
-				: null;
-		const finalUrl =
-			typeof row.final_url === "string" ? safeHttpUrl(row.final_url) : null;
+		const shortUrl = preserveSafeHttpUrl(row.short_url);
+		const expandedUrl = preserveSafeHttpUrl(row.expanded_url);
+		const finalUrl = preserveSafeHttpUrl(row.final_url);
 		const safe = Boolean(shortUrl || expandedUrl || finalUrl);
 		return {
 			...row,
@@ -147,7 +147,7 @@ function sanitizeImportedUrlExpansions(rows: BackupJsonRecord[]) {
 			error: safe ? row.error : "unsafe URL stripped from backup import",
 			image_url:
 				typeof row.image_url === "string"
-					? (safeHttpUrl(row.image_url) ?? "")
+					? (preserveSafeHttpUrl(row.image_url) ?? "")
 					: row.image_url,
 		};
 	});

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -219,11 +219,18 @@ function seedBackupFixture() {
     insert into url_expansions (
       short_url, expanded_url, final_url, status, expanded_tweet_id,
       expanded_handle, title, description, error, source, updated_at
-    ) values (
+    ) values
+    (
       'https://t.co/shared', 'https://x.com/friend/status/2039395915421942108',
       'https://x.com/friend/status/2039395915421942108', 'hit',
       '2039395915421942108', 'friend', 'Shared tweet', 'An expanded DM share',
       null, 'network', '2025-01-05T10:01:00.000Z'
+    ),
+    (
+      'https://T.CO/shared', 'https://X.COM/friend/status/2039395915421942108',
+      'https://X.COM/friend/status/2039395915421942108', 'hit',
+      '2039395915421942108', 'friend', 'Shared tweet variant', 'Preserve valid URL spelling',
+      null, 'network', '2025-01-05T10:02:00.000Z'
     );
 
     insert into link_occurrences (
@@ -454,7 +461,7 @@ describe("text backup", () => {
 			collections_likes: 2,
 			dm_conversations: 1,
 			dm_messages: 2,
-			url_expansions: 1,
+			url_expansions: 2,
 			link_occurrences: 1,
 			blocks: 1,
 			mutes: 1,
@@ -557,6 +564,10 @@ describe("text backup", () => {
 				)
 				.all(),
 		).toEqual([
+			{
+				short_url: "https://T.CO/shared",
+				expanded_tweet_id: "2039395915421942108",
+			},
 			{
 				short_url: "https://t.co/shared",
 				expanded_tweet_id: "2039395915421942108",
@@ -1060,7 +1071,7 @@ describe("text backup", () => {
 			collections_likes: 2,
 			dm_conversations: 1,
 			dm_messages: 2,
-			url_expansions: 1,
+			url_expansions: 2,
 			link_occurrences: 1,
 			blocks: 1,
 			mutes: 1,


### PR DESCRIPTION
## Summary

- preserve the original spelling of valid HTTP URLs during backup import
- prevent distinct URL-expansion primary keys from collapsing after URL canonicalization
- add backup round-trip regression coverage for differently cased but valid URL keys

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run check`
- `pnpm test` — 147 files, 1,331 tests passed
- `pnpm run build`
- `pnpm run pack:smoke`
- Codex autoreview — clean, no accepted/actionable findings
- TruffleHog preflight — clean
