### PR TITLE
perf: make web reads local-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Serve web/API reads from the current local snapshot while backup freshness runs in the background, skip unchanged manifest imports, recycle readers after bulk imports, and avoid the duplicate unscoped Home request before account selection resolves.
 - Preserve the original spelling of valid HTTP URLs during backup import so non-canonical but distinct URL-expansion keys round-trip instead of collapsing onto one normalized key.
 - Stream portable database fingerprint rows after the import transaction commits and skip recursive topology rewrites for canonical singleton revisions, reducing large Birdclaw backup imports from hour-scale work to seconds while keeping the same deterministic fingerprint contract.
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -145,9 +145,12 @@ Exits non-zero on validation failure. Run it in CI before publishing a backup, o
 
 When `autoSync` is enabled:
 
-- read paths (CLI search, inbox, API status/query, web startup) pull + merge from Git **only** when the last backup check is older than `staleAfterSeconds`
+- CLI read paths pull + merge from Git before returning when the last backup check is older than `staleAfterSeconds`
+- web startup and API reads serve the current local SQLite snapshot immediately and request the stale backup check in the background
+- stale checks compare the manifest `backupHash` and skip validation/import when the already-applied backup is unchanged
+- after a changed backup import, Birdclaw reopens its read pool and requests a passive WAL checkpoint
 - data-changing commands (compose, sync, blocks, mutes, etc.) run a full backup sync afterward
-- the freshness window is per-process; nothing pings Git on every command
+- a changed import still uses synchronous SQLite work in the server process, so concurrent requests may briefly pause while that import commits; use a separate scheduled updater when strict isolation is required
 
 Set `BIRDCLAW_BACKUP_AUTO_SYNC=0` to disable auto-sync for one process — useful for local debugging.
 

--- a/scripts/browser-perf.mjs
+++ b/scripts/browser-perf.mjs
@@ -209,6 +209,11 @@ function apiBucket(rawUrl) {
 	if (url.pathname === "/api/link-insights") {
 		return `${url.pathname}:${url.searchParams.get("kind") ?? "unknown"}`;
 	}
+	if (url.pathname === "/api/query") {
+		const resource = url.searchParams.get("resource") ?? "home";
+		const scope = url.searchParams.has("account") ? "scoped" : "unscoped";
+		return `${url.pathname}:${resource}:${scope}`;
+	}
 	return url.pathname;
 }
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -177,6 +177,9 @@ vi.mock("#/lib/backup", async (importOriginal) => {
 		exportBackup: (...args: unknown[]) => exportBackupMock(...args),
 		importBackup: (...args: unknown[]) => importBackupMock(...args),
 		maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
+		requestBackupAutoUpdate: () => {
+			void maybeAutoUpdateBackupMock();
+		},
 		maybeAutoSyncBackup: () => maybeAutoSyncBackupMock(),
 		syncBackup: (...args: unknown[]) => syncBackupMock(...args),
 		validateBackup: (...args: unknown[]) => validateBackupMock(...args),
@@ -722,6 +725,7 @@ describe("cli", () => {
 			host: "127.0.0.1",
 			port: 3000,
 			serverVersion: packageVersion,
+			onListening: expect.any(Function),
 		});
 		expect(getNativeDbMock).toHaveBeenCalledWith({ seedDemoData: false });
 		expect(seedDemoDataMock).not.toHaveBeenCalled();

--- a/src/cli/register-serve.ts
+++ b/src/cli/register-serve.ts
@@ -1,12 +1,9 @@
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import { runProductionServer } from "#/lib/production-server";
 import { printError, type CliCommandContext } from "./command-context";
 
 export function registerServeCommand(
-	{
-		program,
-		autoUpdateBeforeRead,
-		parseNonNegativeIntegerOption,
-	}: CliCommandContext,
+	{ program, parseNonNegativeIntegerOption }: CliCommandContext,
 	packageRoot: string,
 	serverVersion: string,
 ) {
@@ -32,12 +29,12 @@ export function registerServeCommand(
 			}
 			const port = parseNonNegativeIntegerOption(options.port, "--port");
 			if (port === undefined) return;
-			await autoUpdateBeforeRead();
 			await runProductionServer({
 				packageRoot,
 				host,
 				port,
 				serverVersion,
+				onListening: () => requestBackupAutoUpdate(),
 			});
 		});
 }

--- a/src/components/SavedTimelineView.test.tsx
+++ b/src/components/SavedTimelineView.test.tsx
@@ -25,6 +25,7 @@ vi.mock("#/components/TimelineCard", () => ({
 describe("SavedTimelineView", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
+		window.localStorage.clear();
 	});
 
 	afterEach(() => {
@@ -119,21 +120,21 @@ describe("SavedTimelineView", () => {
 		expect(queryUrl?.searchParams.get("liked")).toBeNull();
 	});
 
-	it("shows item count before status metadata arrives and trims search params", async () => {
+	it("waits for the default account before querying and trims search params", async () => {
 		const queryUrls: URL[] = [];
+		let resolveStatus!: (response: Response) => void;
+		const statusResponse = new Promise<Response>((resolve) => {
+			resolveStatus = resolve;
+		});
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);
-			if (url.endsWith("/api/status")) {
-				return new Promise<Response>(() => {});
-			}
+			if (url.endsWith("/api/status")) return statusResponse;
 			if (url.includes("/api/query")) {
 				queryUrls.push(new URL(url));
-				return new Response(
-					JSON.stringify({
-						resource: "home",
-						items: [{ id: "liked_2", text: "searchable thing" }],
-					}),
-				);
+				return Response.json({
+					resource: "home",
+					items: [{ id: "liked_2", text: "searchable thing" }],
+				});
 			}
 			throw new Error(`Unexpected fetch ${url}`);
 		});
@@ -149,8 +150,28 @@ describe("SavedTimelineView", () => {
 			/>,
 		);
 
+		expect(queryUrls).toHaveLength(0);
+		resolveStatus(
+			Response.json({
+				stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+				transport: { statusText: "local" },
+				accounts: [
+					{
+						id: "acct_primary",
+						name: "Primary",
+						handle: "steipete",
+						transport: "archive",
+						isDefault: 1,
+						createdAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+				archives: [],
+			}),
+		);
+
 		expect(await screen.findByText("searchable thing")).toBeInTheDocument();
-		expect(await screen.findByText("1 visible")).toBeInTheDocument();
+		expect(queryUrls).toHaveLength(1);
+		expect(queryUrls[0]?.searchParams.get("account")).toBe("acct_primary");
 		fireEvent.change(screen.getByPlaceholderText("Search likes"), {
 			target: { value: "  launch  " },
 		});
@@ -158,6 +179,91 @@ describe("SavedTimelineView", () => {
 		await waitFor(() => {
 			expect(queryUrls.at(-1)?.searchParams.get("search")).toBe("launch");
 		});
+	});
+
+	it("uses a stored account immediately while status is pending", async () => {
+		window.localStorage.setItem("birdclaw:selected-account-id", "acct_primary");
+		const queryUrls: URL[] = [];
+		let resolveStatus!: (response: Response) => void;
+		const statusResponse = new Promise<Response>((resolve) => {
+			resolveStatus = resolve;
+		});
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) return statusResponse;
+			if (url.includes("/api/query")) {
+				queryUrls.push(new URL(url));
+				return Response.json({
+					resource: "home",
+					items: [{ id: "liked_stored", text: "stored account item" }],
+				});
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SavedTimelineView
+				eyebrow="liked posts"
+				filter="liked"
+				loadingLabel="Loading liked posts..."
+				searchPlaceholder="Search likes"
+				title="Liked"
+			/>,
+		);
+
+		expect(await screen.findByText("stored account item")).toBeInTheDocument();
+		expect(queryUrls).toHaveLength(1);
+		expect(queryUrls[0]?.searchParams.get("account")).toBe("acct_primary");
+		resolveStatus(
+			Response.json({
+				stats: { home: 3, mentions: 1, dms: 4, needsReply: 2, inbox: 3 },
+				transport: { statusText: "local" },
+				accounts: [
+					{
+						id: "acct_primary",
+						name: "Primary",
+						handle: "steipete",
+						transport: "archive",
+						isDefault: 1,
+						createdAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+				archives: [],
+			}),
+		);
+		await waitFor(() => expect(queryUrls).toHaveLength(1));
+	});
+
+	it("falls back to one unscoped query when status fails", async () => {
+		const queryUrls: URL[] = [];
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith("/api/status")) throw new Error("status unavailable");
+			if (url.includes("/api/query")) {
+				queryUrls.push(new URL(url));
+				return Response.json({
+					resource: "home",
+					items: [{ id: "liked_fallback", text: "fallback item" }],
+				});
+			}
+			throw new Error(`Unexpected fetch ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(
+			<SavedTimelineView
+				eyebrow="liked posts"
+				filter="liked"
+				loadingLabel="Loading liked posts..."
+				searchPlaceholder="Search likes"
+				title="Liked"
+			/>,
+		);
+
+		expect(await screen.findByText("fallback item")).toBeInTheDocument();
+		expect(queryUrls).toHaveLength(1);
+		expect(queryUrls[0]?.searchParams.has("account")).toBe(false);
 	});
 
 	it("syncs the matching saved collection and reloads local data", async () => {

--- a/src/components/account-selection.ts
+++ b/src/components/account-selection.ts
@@ -24,7 +24,10 @@ export function setStoredAccountId(accountId: string) {
 	);
 }
 
-export function useSelectedAccountId(accounts: AccountRecord[] | undefined) {
+export function useSelectedAccountId(
+	accounts: AccountRecord[] | undefined,
+	options: { allowStoredBeforeAccounts?: boolean } = {},
+) {
 	const fallbackAccountId = useMemo(
 		() => defaultAccountId(accounts),
 		[accounts],
@@ -57,6 +60,7 @@ export function useSelectedAccountId(accounts: AccountRecord[] | undefined) {
 		}
 	}, [accounts, fallbackAccountId]);
 
+	if (!accounts && options.allowStoredBeforeAccounts) return selectedAccountId;
 	return selectedAccountId &&
 		accounts?.some((account) => account.id === selectedAccountId)
 		? selectedAccountId

--- a/src/components/useTimelineRouteData.ts
+++ b/src/components/useTimelineRouteData.ts
@@ -84,7 +84,11 @@ export function useTimelineRouteData({
 		queryFn: ({ signal }) => fetchQueryEnvelope({ signal }),
 	});
 	const meta = statusQuery.data ?? null;
-	const selectedAccountId = useSelectedAccountId(meta?.accounts);
+	const selectedAccountId = useSelectedAccountId(meta?.accounts, {
+		allowStoredBeforeAccounts: true,
+	});
+	const accountSelectionSettled =
+		Boolean(selectedAccountId) || statusQuery.isSuccess || statusQuery.isError;
 	const debouncedSearch = useDebouncedValue(search, 180);
 	const timelineQueryKey = [
 		...queryKeys.timelines,
@@ -99,6 +103,7 @@ export function useTimelineRouteData({
 	] as const;
 	const timelineQuery = useInfiniteQuery({
 		queryKey: timelineQueryKey,
+		enabled: accountSelectionSettled,
 		initialPageParam: undefined as TimelinePageParam | undefined,
 		queryFn: ({ pageParam, signal }) =>
 			fetchQueryResponse(

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	insertTestAccount,
 	insertTestProfile,
@@ -27,6 +27,7 @@ import {
 	importBackupEffect,
 	maybeAutoSyncBackup,
 	maybeAutoUpdateBackup,
+	requestBackupAutoUpdate,
 	syncBackup,
 	updateBackupFromGitEffect,
 	validateBackup,
@@ -1265,7 +1266,7 @@ describe("text backup", () => {
 		);
 	}, 20000);
 
-	it("auto-updates from the configured backup repo only when stale", async () => {
+	it("imports a changed automatic backup once and skips an unchanged manifest", async () => {
 		const previousAutoSyncEnv = process.env.BIRDCLAW_BACKUP_AUTO_SYNC;
 		process.env.BIRDCLAW_BACKUP_AUTO_SYNC = "1";
 		const remotePath = path.join(makeTempDir("birdclaw-remote-"), "remote.git");
@@ -1289,7 +1290,7 @@ describe("text backup", () => {
 						repoPath,
 						remote: remotePath,
 						autoSync: true,
-						staleAfterSeconds: 900,
+						staleAfterSeconds: 0,
 					},
 				}),
 			);
@@ -1301,6 +1302,7 @@ describe("text backup", () => {
 				enabled: true,
 				skipped: false,
 				imported: true,
+				backupHash: expect.any(String),
 			});
 			expect(
 				getNativeDb()
@@ -1316,7 +1318,9 @@ describe("text backup", () => {
 				ok: true,
 				enabled: true,
 				skipped: true,
-				reason: "backup auto-sync is fresh",
+				reason: "backup auto-sync manifest is unchanged",
+				imported: false,
+				backupHash: first.backupHash,
 			});
 		} finally {
 			if (previousAutoSyncEnv === undefined) {
@@ -1326,6 +1330,36 @@ describe("text backup", () => {
 			}
 		}
 	}, 20000);
+
+	it("requests web backup updates without blocking or rejecting the caller", async () => {
+		const previousAutoSyncEnv = process.env.BIRDCLAW_BACKUP_AUTO_SYNC;
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.useFakeTimers();
+		try {
+			process.env.BIRDCLAW_BACKUP_AUTO_SYNC = "1";
+			switchHome("birdclaw-auto-background-");
+			writeFileSync(path.join(testHome().root, "config.json"), "{bad");
+			resetBirdclawPathsForTests();
+
+			expect(requestBackupAutoUpdate()).toBeUndefined();
+			expect(requestBackupAutoUpdate()).toBeUndefined();
+			expect(errorSpy).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(5_000);
+			await Promise.resolve();
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("birdclaw backup auto-sync failed"),
+			);
+		} finally {
+			vi.useRealTimers();
+			errorSpy.mockRestore();
+			if (previousAutoSyncEnv === undefined) {
+				delete process.env.BIRDCLAW_BACKUP_AUTO_SYNC;
+			} else {
+				process.env.BIRDCLAW_BACKUP_AUTO_SYNC = previousAutoSyncEnv;
+			}
+		}
+	});
 
 	it("skips automatic backup work when disabled or unconfigured", async () => {
 		const previousAutoSyncEnv = process.env.BIRDCLAW_BACKUP_AUTO_SYNC;

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -17,9 +17,13 @@ import {
 	type BackupJsonValue as JsonValue,
 } from "./backup-table-codecs";
 import { getBirdclawConfig } from "./config";
-import { getNativeDb } from "./db";
+import { getNativeDb, refreshReadDatabasePoolAfterBulkWrite } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import {
+	runEffectBackground,
+	runEffectPromise,
+	tryPromise,
+} from "./effect-runtime";
 import { getImportRepository } from "./import-repository";
 import {
 	mergeTweetRevisionChain,
@@ -39,7 +43,9 @@ const DATA_DIR = "data";
 const GITATTRIBUTES_PATH = ".gitattributes";
 const AUTO_SYNC_CACHE_KEY = "backup:auto-sync";
 const DEFAULT_STALE_AFTER_SECONDS = 15 * 60;
+const BACKGROUND_AUTO_UPDATE_DELAY_MS = 5_000;
 let autoUpdateInFlight: Promise<BackupAutoUpdateResult> | null = null;
+let autoUpdateBackgroundScheduled = false;
 
 export interface BackupFileManifest {
 	path: string;
@@ -97,7 +103,15 @@ export interface BackupAutoUpdateResult {
 	remote?: string;
 	pulled?: boolean;
 	imported?: boolean;
+	backupHash?: string;
 	error?: string;
+}
+
+interface BackupAutoSyncState {
+	checkedAt?: string;
+	ok?: boolean;
+	error?: string;
+	backupHash?: string;
 }
 
 export interface BackupValidationResult {
@@ -1223,6 +1237,7 @@ export function importBackupEffect({
 			}
 			reconcileTweetTombstones(writeDb);
 		}, db);
+		yield* trySync(() => refreshReadDatabasePoolAfterBulkWrite(db));
 		const fingerprint = yield* trySync(() =>
 			db.readTransaction(() => getBackupDatabaseFingerprint(db))(),
 		);
@@ -1303,6 +1318,7 @@ export interface UpdateBackupFromGitOptions {
 	repoPath: string;
 	remote?: string;
 	db?: Database;
+	appliedBackupHash?: string;
 }
 
 export interface UpdateBackupFromGitResult {
@@ -1311,6 +1327,7 @@ export interface UpdateBackupFromGitResult {
 	remote?: string;
 	pulled: boolean;
 	imported: boolean;
+	backupHash?: string;
 	importResult?: BackupImportResult;
 }
 
@@ -1318,6 +1335,7 @@ export function updateBackupFromGitEffect({
 	repoPath,
 	remote,
 	db,
+	appliedBackupHash,
 }: UpdateBackupFromGitOptions): Effect.Effect<
 	UpdateBackupFromGitResult,
 	unknown
@@ -1331,13 +1349,17 @@ export function updateBackupFromGitEffect({
 		const manifestExists = yield* trySync(() =>
 			existsSync(path.join(resolvedRepoPath, MANIFEST_PATH)),
 		);
-		const importResult = manifestExists
-			? yield* importBackupEffect({
-					repoPath: resolvedRepoPath,
-					db: database,
-					mode: "merge",
-				})
+		const manifest = manifestExists
+			? yield* readManifestEffect(resolvedRepoPath)
 			: undefined;
+		const importResult =
+			manifest && manifest.backupHash !== appliedBackupHash
+				? yield* importBackupEffect({
+						repoPath: resolvedRepoPath,
+						db: database,
+						mode: "merge",
+					})
+				: undefined;
 
 		return {
 			ok: true,
@@ -1345,6 +1367,7 @@ export function updateBackupFromGitEffect({
 			...(remote ? { remote: redactSecretUrl(remote) } : {}),
 			pulled,
 			imported: Boolean(importResult),
+			...(manifest ? { backupHash: manifest.backupHash } : {}),
 			...(importResult ? { importResult } : {}),
 		};
 	});
@@ -1358,11 +1381,7 @@ function readAutoSyncState(db: Database) {
 		return null;
 	}
 	try {
-		return JSON.parse(row.value_json) as {
-			checkedAt?: string;
-			ok?: boolean;
-			error?: string;
-		};
+		return JSON.parse(row.value_json) as BackupAutoSyncState;
 	} catch {
 		return null;
 	}
@@ -1370,7 +1389,7 @@ function readAutoSyncState(db: Database) {
 
 function writeAutoSyncState(
 	db: Database,
-	value: { checkedAt: string; ok: boolean; error?: string },
+	value: BackupAutoSyncState & { checkedAt: string; ok: boolean },
 ) {
 	db.prepare(
 		`
@@ -1471,6 +1490,7 @@ function runMaybeAutoUpdateBackupEffect(
 			repoPath: config.repoPath,
 			remote: config.remote,
 			db: database,
+			appliedBackupHash: state?.backupHash,
 		}).pipe(
 			Effect.map((value) => ({ ok: true as const, value })),
 			Effect.catchAll((error) => Effect.succeed({ ok: false as const, error })),
@@ -1478,18 +1498,32 @@ function runMaybeAutoUpdateBackupEffect(
 
 		if (result.ok) {
 			yield* trySync(() =>
-				writeAutoSyncState(database, { checkedAt: now, ok: true }),
+				writeAutoSyncState(database, {
+					checkedAt: now,
+					ok: true,
+					...(result.value.backupHash
+						? { backupHash: result.value.backupHash }
+						: state?.backupHash
+							? { backupHash: state.backupHash }
+							: {}),
+				}),
 			).pipe(Effect.orDie);
 			return {
 				ok: true,
 				enabled: true,
-				skipped: false,
+				skipped: Boolean(result.value.backupHash) && !result.value.imported,
+				...(result.value.backupHash && !result.value.imported
+					? { reason: "backup auto-sync manifest is unchanged" }
+					: {}),
 				repoPath: result.value.repoPath,
 				...(result.value.remote
 					? { remote: redactSecretUrl(result.value.remote) }
 					: {}),
 				pulled: result.value.pulled,
 				imported: result.value.imported,
+				...(result.value.backupHash
+					? { backupHash: result.value.backupHash }
+					: {}),
 			};
 		}
 
@@ -1502,6 +1536,7 @@ function runMaybeAutoUpdateBackupEffect(
 				checkedAt: now,
 				ok: false,
 				error: message,
+				...(state?.backupHash ? { backupHash: state.backupHash } : {}),
 			}),
 		).pipe(Effect.orDie);
 		return {
@@ -1541,6 +1576,29 @@ export function maybeAutoUpdateBackup(
 	return runEffectPromise(maybeAutoUpdateBackupEffect(db));
 }
 
+export function requestBackupAutoUpdate(db?: Database) {
+	if (autoUpdateBackgroundScheduled || autoUpdateInFlight) return;
+	autoUpdateBackgroundScheduled = true;
+	const timer = setTimeout(() => {
+		autoUpdateBackgroundScheduled = false;
+		runEffectBackground(maybeAutoUpdateBackupEffect(db), {
+			onSuccess: (result) => {
+				if (!result.ok) {
+					console.error(`birdclaw backup auto-sync failed: ${result.error}`);
+				}
+			},
+			onFailure: (error) => {
+				console.error(
+					`birdclaw backup auto-sync failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			},
+		});
+	}, BACKGROUND_AUTO_UPDATE_DELAY_MS);
+	timer.unref();
+}
+
 export function maybeAutoSyncBackupEffect(
 	db?: Database,
 ): Effect.Effect<BackupAutoUpdateResult, never> {
@@ -1570,6 +1628,9 @@ export function maybeAutoSyncBackupEffect(
 		const database = yield* trySync(
 			() => db ?? getNativeDb({ seedDemoData: false }),
 		).pipe(Effect.orDie);
+		const state = yield* trySync(() => readAutoSyncState(database)).pipe(
+			Effect.catchAll(() => Effect.succeed(null)),
+		);
 		const now = new Date().toISOString();
 		const result = yield* syncBackupEffect({
 			repoPath: config.repoPath,
@@ -1582,7 +1643,11 @@ export function maybeAutoSyncBackupEffect(
 
 		if (result.ok) {
 			yield* trySync(() =>
-				writeAutoSyncState(database, { checkedAt: now, ok: true }),
+				writeAutoSyncState(database, {
+					checkedAt: now,
+					ok: true,
+					backupHash: result.value.exportResult.manifest.backupHash,
+				}),
 			).pipe(Effect.orDie);
 			return {
 				ok: true,
@@ -1604,6 +1669,7 @@ export function maybeAutoSyncBackupEffect(
 				checkedAt: now,
 				ok: false,
 				error: message,
+				...(state?.backupHash ? { backupHash: state.backupHash } : {}),
 			}),
 		).pipe(Effect.orDie);
 		return {

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -9,6 +9,7 @@ import {
 	getNativeDb,
 	getReadDb,
 	getStrictReadDb,
+	refreshReadDatabasePoolAfterBulkWrite,
 	resetDatabaseForTests,
 } from "./db";
 import { seedDemoData } from "./seed";
@@ -526,6 +527,74 @@ describe("database init", () => {
 		} finally {
 			writer.exec("rollback");
 		}
+	});
+
+	it("refreshes managed readers after a bulk write without closing the writer", () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-db-refresh-"));
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const writer = getNativeDb({ seedDemoData: false });
+		writer.exec("create table refresh_probe (value text)");
+		const firstReader = getReadDb({ seedDemoData: false });
+		const secondReader = getReadDb({ seedDemoData: false });
+		const closeSpy = vi.spyOn(NativeSqliteDatabase.prototype, "close");
+
+		writer.prepare("insert into refresh_probe (value) values ('ready')").run();
+		expect(refreshReadDatabasePoolAfterBulkWrite(writer)).toBe(true);
+		expect(closeSpy).toHaveBeenCalledTimes(2);
+		expect(new Set(closeSpy.mock.instances)).toEqual(
+			new Set([firstReader, secondReader]),
+		);
+		expect(writer.prepare("select value from refresh_probe").get()).toEqual({
+			value: "ready",
+		});
+
+		const refreshedReader = getReadDb({ seedDemoData: false });
+		expect(refreshedReader === firstReader).toBe(false);
+		expect(refreshedReader === secondReader).toBe(false);
+		expect(refreshedReader.pragma("query_only", { simple: true })).toBe(1);
+		expect(
+			refreshedReader.prepare("select value from refresh_probe").get(),
+		).toEqual({ value: "ready" });
+	});
+
+	it("ignores reader refresh for an unmanaged writer", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "birdclaw-db-refresh-other-"),
+		);
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		getNativeDb({ seedDemoData: false });
+		const reader = getReadDb({ seedDemoData: false });
+		const other = new NativeSqliteDatabase(path.join(tempDir, "other.sqlite"));
+		try {
+			expect(refreshReadDatabasePoolAfterBulkWrite(other)).toBe(false);
+			expect(reader.pragma("query_only", { simple: true })).toBe(1);
+		} finally {
+			other.close();
+		}
+	});
+
+	it("keeps imports successful when the passive checkpoint is unavailable", () => {
+		const tempDir = mkdtempSync(
+			path.join(os.tmpdir(), "birdclaw-db-refresh-checkpoint-"),
+		);
+		tempDirs.push(tempDir);
+		process.env.BIRDCLAW_HOME = tempDir;
+
+		const writer = getNativeDb({ seedDemoData: false });
+		getReadDb({ seedDemoData: false });
+		const originalExec = writer.exec.bind(writer);
+		const execSpy = vi.spyOn(writer, "exec").mockImplementation((sql) => {
+			if (sql.includes("wal_checkpoint")) throw new Error("checkpoint busy");
+			return originalExec(sql);
+		});
+
+		expect(refreshReadDatabasePoolAfterBulkWrite(writer)).toBe(true);
+		expect(execSpy).toHaveBeenCalledWith("pragma wal_checkpoint(passive)");
+		expect(getReadDb().pragma("query_only", { simple: true })).toBe(1);
 	});
 
 	it("opens strict readers without initialization and rejects writes", () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1274,6 +1274,22 @@ export function getReadDb(options: InitDatabaseOptions = {}) {
 	return nextReadDb();
 }
 
+export function refreshReadDatabasePoolAfterBulkWrite(db: Database) {
+	if (db !== nativeDb) return false;
+
+	const readers = readDbs;
+	readDbs = [];
+	readDbIndex = 0;
+	for (const reader of readers) closeDatabaseIgnoringErrors(reader);
+
+	try {
+		db.exec("pragma wal_checkpoint(passive)");
+	} catch {
+		// The import is already committed; a busy external reader may delay cleanup.
+	}
+	return true;
+}
+
 export function getStrictReadDb() {
 	if (readDbs.length > 0) {
 		assertCurrentDatabaseSchema(readDbs[0] as Database);

--- a/src/lib/production-server.ts
+++ b/src/lib/production-server.ts
@@ -31,6 +31,7 @@ export interface ProductionServerOptions {
 	requestTimeoutMs?: number;
 	headersTimeoutMs?: number;
 	mcpResponseTimeoutMs?: number;
+	onListening?: (address: { host: string; port: number }) => void;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 35_000;
@@ -413,9 +414,9 @@ export async function runProductionServer(options: ProductionServerOptions) {
 	if (!address || typeof address === "string") {
 		throw new Error("Production server did not bind a TCP address");
 	}
-	console.log(
-		`Birdclaw listening on http://${options.host ?? "127.0.0.1"}:${String(address.port)}`,
-	);
+	const host = options.host ?? "127.0.0.1";
+	console.log(`Birdclaw listening on http://${host}:${String(address.port)}`);
+	options.onListening?.({ host, port: address.port });
 
 	await new Promise<never>((_, reject) => {
 		const signals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"] as const;

--- a/src/lib/query-status.ts
+++ b/src/lib/query-status.ts
@@ -22,14 +22,14 @@ function countTimelineEdges(db: Database, kind: "home" | "mention") {
 		.prepare(
 			`
       select count(distinct tweet_id) as count
-		from tweet_account_edges edge
-		where edge.kind = ?
-		  and exists (
-			select 1 from tweets t
-			where t.id = edge.tweet_id
-			  and t.deleted_at is null
-			  and t.superseded_at is null
-		  )
+			from tweet_account_edges edge
+			where edge.kind = ?
+			  and exists (
+				select 1 from tweets t
+				where t.id = edge.tweet_id
+				  and t.deleted_at is null
+				  and t.superseded_at is null
+			  )
       `,
 		)
 		.get(kind) as { count: number | bigint } | undefined;
@@ -64,48 +64,68 @@ function getAccountProfileMeta(
 		| undefined;
 }
 
+function readLocalQueryEnvelope(db: Database) {
+	return db.readTransaction(() => {
+		const homeCount = countTimelineEdges(db, "home");
+		const mentionCount = countTimelineEdges(db, "mention");
+		const dms = db
+			.prepare("select count(*) as count from dm_conversations")
+			.get() as { count: number };
+		const needsReply = db
+			.prepare(
+				"select count(*) as count from dm_conversations where needs_reply = 1",
+			)
+			.get() as { count: number };
+		const accountRows = db
+			.prepare("select * from accounts order by is_default desc, name asc")
+			.all() as Array<{
+			id: string;
+			name: string;
+			handle: string;
+			external_user_id: string | null;
+			transport: string;
+			is_default: number;
+			created_at: string;
+		}>;
+		const accounts = accountRows.map((row) => {
+			const profile = getAccountProfileMeta(db, row);
+			return {
+				id: row.id,
+				name: row.name,
+				handle: row.handle,
+				externalUserId: row.external_user_id,
+				...(profile
+					? {
+							profileId: profile.id,
+							avatarHue: Number(profile.avatar_hue),
+							...(profile.avatar_url ? { avatarUrl: profile.avatar_url } : {}),
+						}
+					: {}),
+				transport: row.transport,
+				isDefault: row.is_default,
+				createdAt: row.created_at,
+			};
+		}) satisfies AccountRecord[];
+
+		return {
+			stats: {
+				home: homeCount,
+				mentions: mentionCount,
+				dms: Number(dms.count),
+				needsReply: Number(needsReply.count),
+				inbox: mentionCount + Number(needsReply.count),
+			},
+			accounts,
+		};
+	})();
+}
+
 export function getQueryEnvelopeEffect({
 	includeArchives = true,
 }: { includeArchives?: boolean } = {}): Effect.Effect<QueryEnvelope, unknown> {
 	return Effect.gen(function* () {
-		const nativeDb = yield* trySync(() => getReadDb());
-		const homeCount = yield* trySync(() =>
-			countTimelineEdges(nativeDb, "home"),
-		);
-		const mentionCount = yield* trySync(() =>
-			countTimelineEdges(nativeDb, "mention"),
-		);
-		const counts = yield* Effect.all({
-			dms: trySync(
-				() =>
-					nativeDb
-						.prepare("select count(*) as count from dm_conversations")
-						.get() as { count: number },
-			),
-			needsReply: trySync(
-				() =>
-					nativeDb
-						.prepare(
-							"select count(*) as count from dm_conversations where needs_reply = 1",
-						)
-						.get() as { count: number },
-			),
-			accounts: trySync(
-				() =>
-					nativeDb
-						.prepare(
-							"select * from accounts order by is_default desc, name asc",
-						)
-						.all() as Array<{
-						id: string;
-						name: string;
-						handle: string;
-						external_user_id: string | null;
-						transport: string;
-						is_default: number;
-						created_at: string;
-					}>,
-			),
+		const local = yield* trySync(() => readLocalQueryEnvelope(getReadDb()));
+		const external = yield* Effect.all({
 			archives: includeArchives
 				? findArchivesCachedEffect()
 				: Effect.succeed([]),
@@ -113,36 +133,9 @@ export function getQueryEnvelopeEffect({
 		});
 
 		return {
-			stats: {
-				home: homeCount,
-				mentions: mentionCount,
-				dms: Number(counts.dms.count),
-				needsReply: Number(counts.needsReply.count),
-				inbox: mentionCount + Number(counts.needsReply.count),
-			},
-			accounts: counts.accounts.map((row) => {
-				const profile = getAccountProfileMeta(nativeDb, row);
-				return {
-					id: row.id,
-					name: row.name,
-					handle: row.handle,
-					externalUserId: row.external_user_id,
-					...(profile
-						? {
-								profileId: profile.id,
-								avatarHue: Number(profile.avatar_hue),
-								...(profile.avatar_url
-									? { avatarUrl: profile.avatar_url }
-									: {}),
-							}
-						: {}),
-					transport: row.transport,
-					isDefault: row.is_default,
-					createdAt: row.created_at,
-				};
-			}) satisfies AccountRecord[],
-			archives: counts.archives,
-			transport: counts.transport,
+			...local,
+			archives: external.archives,
+			transport: external.transport,
 		};
 	});
 }

--- a/src/routes/api/conversation.test.ts
+++ b/src/routes/api/conversation.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
@@ -11,9 +10,7 @@ vi.mock("#/lib/timeline-read-model", () => ({
 		getTweetConversationMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 
 import { Route } from "./conversation";

--- a/src/routes/api/conversation.tsx
+++ b/src/routes/api/conversation.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { tweetConversationResponseSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	runRouteEffect,
 	sensitiveRequestErrorResponse,
@@ -22,11 +22,11 @@ export const Route = createFileRoute("/api/conversation")({
 		handlers: {
 			GET: ({ request }) =>
 				runRouteEffect(
-					Effect.gen(function* () {
+					Effect.sync(() => {
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const tweetId = url.searchParams.get("tweetId")?.trim();
 						if (!tweetId) {

--- a/src/routes/api/inbox.test.ts
+++ b/src/routes/api/inbox.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
@@ -10,9 +9,7 @@ vi.mock("#/lib/inbox", () => ({
 	listInboxItems: (...args: unknown[]) => listInboxItemsMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 
 import { Route } from "./inbox";

--- a/src/routes/api/inbox.tsx
+++ b/src/routes/api/inbox.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { inboxResponseSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
 	runRouteEffect,
@@ -21,11 +21,11 @@ export const Route = createFileRoute("/api/inbox")({
 		handlers: {
 			GET: ({ request }) =>
 				runRouteEffect(
-					Effect.gen(function* () {
+					Effect.sync(() => {
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const kind = (url.searchParams.get("kind") ?? "mixed") as InboxKind;
 						return jsonResponse(

--- a/src/routes/api/link-insights.test.ts
+++ b/src/routes/api/link-insights.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
@@ -11,9 +10,7 @@ vi.mock("#/lib/link-insights", () => ({
 	getLinkInsights: (...args: unknown[]) => getLinkInsightsMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 vi.mock("#/lib/db", () => ({
 	getNativeDb: () => getNativeDbMock(),

--- a/src/routes/api/link-insights.tsx
+++ b/src/routes/api/link-insights.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { linkInsightResponseSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import { getNativeDb } from "#/lib/db";
 import {
 	jsonResponse,
@@ -58,11 +58,11 @@ export const Route = createFileRoute("/api/link-insights")({
 		handlers: {
 			GET: ({ request }) =>
 				runRouteEffect(
-					Effect.gen(function* () {
+					Effect.sync(() => {
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						getNativeDb();
 						const url = new URL(request.url);
 						return jsonResponse(

--- a/src/routes/api/network-map.tsx
+++ b/src/routes/api/network-map.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { networkMapResponseSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
 	parseBoundedInteger,
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/api/network-map")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const response = yield* Effect.promise(() =>
 							getNetworkMap({

--- a/src/routes/api/period-digest.test.ts
+++ b/src/routes/api/period-digest.test.ts
@@ -7,9 +7,7 @@ const maybeAutoUpdateBackupMock = vi.fn();
 const streamPeriodDigestMock = vi.fn();
 
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 vi.mock("#/lib/period-digest", () => ({
 	normalizeDigestLanguage: (value: string | undefined) => {
@@ -132,7 +130,8 @@ describe("api period digest route", () => {
 		const text = new TextDecoder().decode(first.value);
 		expect(text).toContain('"type":"status"');
 		expect(text).toContain("Preparing local archive");
-		expect(streamPeriodDigestMock).not.toHaveBeenCalled();
+		await vi.waitFor(() => expect(streamPeriodDigestMock).toHaveBeenCalled());
+		expect(maybeAutoUpdateBackupMock).toHaveBeenCalled();
 
 		resolveBackup?.({ skipped: true });
 		await reader!.cancel();

--- a/src/routes/api/period-digest.tsx
+++ b/src/routes/api/period-digest.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { periodDigestStreamEventSchema } from "#/lib/client-stream-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
 	parseBoundedInteger,
@@ -73,6 +73,7 @@ export const Route = createFileRoute("/api/period-digest")({
 								{ status: 400 },
 							);
 						}
+						requestBackupAutoUpdate();
 						return createEffectNdjsonResponse<PeriodDigestStreamEvent>({
 							request,
 							schema: periodDigestStreamEventSchema,
@@ -80,17 +81,14 @@ export const Route = createFileRoute("/api/period-digest")({
 								{
 									type: "status",
 									label: "Preparing local archive",
-									detail: "Checking for backup updates.",
+									detail: "Using local data while checking for updates.",
 								},
 							],
 							run: ({ signal, emit }) =>
-								Effect.gen(function* () {
-									yield* maybeAutoUpdateBackupEffect();
-									return yield* streamPeriodDigestEffect(
-										{ ...options, signal },
-										{ onEvent: emit },
-									);
-								}),
+								streamPeriodDigestEffect(
+									{ ...options, signal },
+									{ onEvent: emit },
+								),
 							errorEvent: (error) => ({
 								type: "error",
 								error: error instanceof Error ? error.message : "Digest failed",

--- a/src/routes/api/profile-analysis.test.ts
+++ b/src/routes/api/profile-analysis.test.ts
@@ -7,9 +7,7 @@ const maybeAutoUpdateBackupMock = vi.fn();
 const streamProfileAnalysisMock = vi.fn();
 
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 vi.mock("#/lib/profile-analysis", () => ({
 	streamProfileAnalysisEffect: (...args: unknown[]) =>
@@ -124,7 +122,10 @@ describe("api profile analysis route", () => {
 		const text = new TextDecoder().decode(first.value);
 		expect(text).toContain('"type":"status"');
 		expect(text).toContain("Starting profile analysis");
-		expect(streamProfileAnalysisMock).not.toHaveBeenCalled();
+		await vi.waitFor(() =>
+			expect(streamProfileAnalysisMock).toHaveBeenCalled(),
+		);
+		expect(maybeAutoUpdateBackupMock).toHaveBeenCalled();
 
 		resolveBackup?.({ skipped: true });
 		await reader!.cancel();

--- a/src/routes/api/profile-analysis.tsx
+++ b/src/routes/api/profile-analysis.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { profileAnalysisStreamEventSchema } from "#/lib/client-stream-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	parseBoundedInteger,
 	runRouteEffect,
@@ -65,6 +65,7 @@ export const Route = createFileRoute("/api/profile-analysis")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const options = parseOptions(url);
 						return createEffectNdjsonResponse<ProfileAnalysisStreamEvent>({
@@ -77,13 +78,10 @@ export const Route = createFileRoute("/api/profile-analysis")({
 								},
 							],
 							run: ({ signal, emit }) =>
-								Effect.gen(function* () {
-									yield* maybeAutoUpdateBackupEffect();
-									return yield* streamProfileAnalysisEffect(
-										{ ...options, signal },
-										{ onEvent: emit },
-									);
-								}),
+								streamProfileAnalysisEffect(
+									{ ...options, signal },
+									{ onEvent: emit },
+								),
 							errorEvent: (error) => ({
 								type: "error",
 								error:

--- a/src/routes/api/query.test.ts
+++ b/src/routes/api/query.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment node
-import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRouteHandler } from "#/test/route-handlers";
 
@@ -10,9 +9,7 @@ vi.mock("#/lib/query-resource", () => ({
 	queryResource: (...args: unknown[]) => queryResourceMock(...args),
 }));
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 
 import { Route } from "./query";

--- a/src/routes/api/query.tsx
+++ b/src/routes/api/query.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { queryResponseSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
 	parseBoundedInteger,
@@ -50,11 +50,11 @@ export const Route = createFileRoute("/api/query")({
 		handlers: {
 			GET: ({ request }) =>
 				runRouteEffect(
-					Effect.gen(function* () {
+					Effect.sync(() => {
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const resource = (url.searchParams.get("resource") ??
 							"home") as ResourceKind;

--- a/src/routes/api/search-discussion.test.ts
+++ b/src/routes/api/search-discussion.test.ts
@@ -7,9 +7,7 @@ const maybeAutoUpdateBackupMock = vi.fn();
 const streamSearchDiscussionMock = vi.fn();
 
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: () => maybeAutoUpdateBackupMock(),
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(maybeAutoUpdateBackupMock())),
+	requestBackupAutoUpdate: () => maybeAutoUpdateBackupMock(),
 }));
 vi.mock("#/lib/search-discussion", () => ({
 	streamSearchDiscussionEffect: (...args: unknown[]) =>

--- a/src/routes/api/search-discussion.tsx
+++ b/src/routes/api/search-discussion.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { searchDiscussionStreamEventSchema } from "#/lib/client-stream-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	parseBoundedInteger,
 	runRouteEffect,
@@ -82,26 +82,23 @@ export const Route = createFileRoute("/api/search-discussion")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
+						requestBackupAutoUpdate();
 						const url = new URL(request.url);
 						const options = parseOptions(url);
 						return createEffectNdjsonResponse<SearchDiscussionStreamEvent>({
 							request,
 							schema: searchDiscussionStreamEventSchema,
 							run: ({ signal, emit }) =>
-								maybeAutoUpdateBackupEffect().pipe(
-									Effect.flatMap(() =>
-										signal.aborted
-											? Effect.succeed(undefined)
-											: streamSearchDiscussionEffect(
-													{
-														...options,
-														signal,
-														prefetchAvatars: true,
-													},
-													{ onEvent: emit },
-												),
-									),
-								),
+								signal.aborted
+									? Effect.succeed(undefined)
+									: streamSearchDiscussionEffect(
+											{
+												...options,
+												signal,
+												prefetchAvatars: true,
+											},
+											{ onEvent: emit },
+										),
 							errorEvent: (error) => ({
 								type: "error",
 								error:

--- a/src/routes/api/status.test.tsx
+++ b/src/routes/api/status.test.tsx
@@ -8,9 +8,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("#/lib/backup", () => ({
-	maybeAutoUpdateBackup: mocks.maybeAutoUpdateBackup,
-	maybeAutoUpdateBackupEffect: () =>
-		Effect.promise(() => Promise.resolve(mocks.maybeAutoUpdateBackup())),
+	requestBackupAutoUpdate: mocks.maybeAutoUpdateBackup,
 }));
 
 vi.mock("#/lib/query-status", () => ({

--- a/src/routes/api/status.tsx
+++ b/src/routes/api/status.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { queryEnvelopeSchema } from "#/lib/api-contracts";
-import { maybeAutoUpdateBackupEffect } from "#/lib/backup";
+import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
 	runRouteEffect,
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/api/status")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						yield* maybeAutoUpdateBackupEffect();
+						requestBackupAutoUpdate();
 						const envelope = yield* getQueryEnvelopeEffect({
 							includeArchives: false,
 						});


### PR DESCRIPTION
## Summary

Birdclaw’s web startup and read APIs were serializing local reads behind a backup freshness check. On a warm local database that made the current SQLite snapshot feel remote: the server did not bind until Git/backup work finished, and the first timeline could issue an unnecessary unscoped request before account selection settled.

This change makes the web path local-first. The production server binds immediately, schedules one delayed/deduplicated background backup update, skips re-importing an unchanged manifest, refreshes managed SQLite readers after a real bulk import, and groups status reads into one read transaction. The timeline now waits for account selection to settle, while returning users can use their stored account immediately.

## Behavioral boundaries

- Backup auto-sync remains enabled and freshness-controlled; it moves off the request critical path rather than being removed.
- Changed backups still import and refresh readers. Unchanged manifest hashes skip validation/import work.
- Background failures remain visible in logs without failing local read requests.
- Returning to Home still reuses the cached scoped query, and initial account resolution no longer creates an unscoped duplicate.

## Proof

- `pnpm check`
- `pnpm coverage` — 147 files, 1,337 tests; 90.52% lines / 80.18% branches / 89.99% functions / 88.86% statements
- `pnpm build`
- `pnpm pack:smoke` — 126 packaged files; installed CLI/server/MCP/SIGTERM smoke passed
- `pnpm e2e`
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings
