### PR TITLE
fix: bound Bun FTS timeline searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Move source installs, dependency locking, builds, tests, CI, Pages, and source-backed launchd jobs to the checksum-pinned Bun `1.4.0-canary.1+f972c287f` Rust-port runtime while retaining the public Node 26 npm/Homebrew contract.
 
+### Fixed
+
+- Keep common-term FTS timeline searches bounded under Bun's SQLite 3.51 planner by pinning the dense index and join order and capping match preflight work.
+
 ### Testing and maintenance
 
 - Add Bun/Istanbul and Node/V8 coverage lanes, dual-runtime installed-package smoke, Playwright against the built Bun production server, and explicit runtime performance metadata.

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -592,6 +592,17 @@ describe("birdclaw queries", () => {
 				detail: string;
 			}>;
 			const parentById = new Map(planRows.map((row) => [row.id, row.parent]));
+			const hasAncestor = (
+				row: (typeof planRows)[number],
+				ids: Set<number>,
+			) => {
+				let ancestor: number | undefined = row.parent;
+				while (ancestor !== undefined && ancestor !== 0) {
+					if (ids.has(ancestor)) return true;
+					ancestor = parentById.get(ancestor);
+				}
+				return false;
+			};
 			const materializeIds = new Set(
 				planRows
 					.filter((row) => row.detail.startsWith("MATERIALIZE fts_matches"))
@@ -606,18 +617,74 @@ describe("birdclaw queries", () => {
 			);
 			expect(ftsAccesses.length).toBeGreaterThan(0);
 			for (const access of ftsAccesses) {
-				let ancestor: number | undefined = access.parent;
-				let insideMaterialize = false;
-				while (ancestor !== undefined && ancestor !== 0) {
-					if (materializeIds.has(ancestor)) {
-						insideMaterialize = true;
-						break;
-					}
-					ancestor = parentById.get(ancestor);
-				}
-				expect(insideMaterialize).toBe(true);
+				expect(hasAncestor(access, materializeIds)).toBe(true);
 			}
+			expect(
+				planRows.some((row) =>
+					row.detail.includes("idx_tweet_account_edges_kind_tweet"),
+				),
+			).toBe(true);
 		}
+	});
+
+	it("pins dense timeline searches to the created-time index and bounded hydration", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const plan = buildTimelineItemsQuery(
+			{ resource: "home", search: "Agents", limit: 5 },
+			1_000_000,
+		);
+		const planRows = db
+			.prepare(`explain query plan ${plan.sql}`)
+			.all(...plan.params) as Array<{
+			id: number;
+			parent: number;
+			detail: string;
+		}>;
+		const parentById = new Map(planRows.map((row) => [row.id, row.parent]));
+		const searchSelectionIds = new Set(
+			planRows
+				.filter((row) => row.detail.startsWith("MATERIALIZE search_selection"))
+				.map((row) => row.id),
+		);
+		const hasSearchSelectionAncestor = (row: (typeof planRows)[number]) => {
+			let ancestor: number | undefined = row.parent;
+			while (ancestor !== undefined && ancestor !== 0) {
+				if (searchSelectionIds.has(ancestor)) return true;
+				ancestor = parentById.get(ancestor);
+			}
+			return false;
+		};
+		const selectionRows = planRows.filter(hasSearchSelectionAncestor);
+		const outerRows = planRows.filter(
+			(row) =>
+				!searchSelectionIds.has(row.id) && !hasSearchSelectionAncestor(row),
+		);
+
+		expect(searchSelectionIds.size).toBe(1);
+		expect(
+			selectionRows.some((row) =>
+				row.detail.includes("SCAN t USING INDEX idx_tweets_created"),
+			),
+		).toBe(true);
+		expect(
+			selectionRows.some(
+				(row) =>
+					row.detail.includes("idx_tweets_deleted") ||
+					row.detail.includes("idx_tweets_superseded"),
+			),
+		).toBe(false);
+		expect(outerRows.some((row) => row.detail === "SCAN e")).toBe(true);
+		expect(
+			outerRows.some(
+				(row) =>
+					row.detail.startsWith("SEARCH t USING") &&
+					row.detail.includes("(id=?)"),
+			),
+		).toBe(true);
+		expect(outerRows.some((row) => row.detail.startsWith("SCAN t"))).toBe(
+			false,
+		);
 	});
 
 	it("returns identical timeline search results for both FTS drive strategies", () => {
@@ -638,7 +705,37 @@ describe("birdclaw queries", () => {
 		expect(results[0]).toEqual(results[1]);
 	});
 
-	it("uses a supplied FTS match-count hint without an uncapped count query", () => {
+	it("bounds FTS match counting at the dense-strategy threshold", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		let countSql = "";
+		let countParams: Array<string | number> = [];
+		const boundedDb = {
+			prepare(sql: string) {
+				const statement = db.prepare(sql);
+				const normalizedSql = sql.replace(/\s+/gu, " ").trim().toLowerCase();
+				if (!normalizedSql.includes(" as match_count")) return statement;
+				countSql = normalizedSql;
+				return {
+					get(...params: Array<string | number>) {
+						countParams = params;
+						return statement.get(...params);
+					},
+				} as ReturnType<TestDatabase["prepare"]>;
+			},
+		} as unknown as TestDatabase;
+
+		listTimelineItems(
+			{ resource: "home", search: "Agents", limit: 5 },
+			boundedDb,
+		);
+
+		expect(countSql).toContain("select distinct tweet_id from tweets_fts");
+		expect(countSql).toContain("limit ?");
+		expect(countParams.at(-1)).toBe(10_001);
+	});
+
+	it("uses a supplied FTS match-count hint without a count query", () => {
 		setupTempHome();
 		const db = getNativeDb();
 		const preparedSql: string[] = [];
@@ -656,11 +753,9 @@ describe("birdclaw queries", () => {
 		);
 
 		expect(items.map((item) => item.id)).toContain("tweet_001");
-		expect(
-			preparedSql.some((sql) =>
-				/select count\s*\([^)]*\)\s+as match_count from tweets_fts/u.test(sql),
-			),
-		).toBe(false);
+		expect(preparedSql.some((sql) => sql.includes(" as match_count"))).toBe(
+			false,
+		);
 	});
 
 	it("keeps timeline membership account-scoped for the same canonical tweet", () => {

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -520,6 +520,7 @@ export class TimelineCandidateLimitError extends Error {
 // dedupe subquery) costs more than walking the created_at index newest-first
 // and probing the match set until the limit fills.
 const FTS_DRIVE_FROM_MATCHES_MAX = 10_000;
+const FTS_MATCH_COUNT_LIMIT = FTS_DRIVE_FROM_MATCHES_MAX + 1;
 
 // Exported so tests can EXPLAIN the generated SQL with bound parameters and
 // guard the query plan (see the fts_matches comment below).
@@ -553,17 +554,20 @@ export function buildTimelineItemsQuery(
 	const effectiveAccountId = hasLiteralAccountId ? literalAccountId : account;
 	const shouldDedupeAcrossAccounts =
 		!hasLiteralAccountId && (!account || account === "all");
+	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
+	const timelineEdgeIndexHint = ftsSearch
+		? " indexed by idx_tweet_account_edges_kind_tweet"
+		: "";
 	let timelineEdgesCte = `
 	      with timeline_edges as (
 	        select account_id, tweet_id, kind, raw_json
-	        from tweet_account_edges
+	        from tweet_account_edges${timelineEdgeIndexHint}
 	        where kind = ?
 	      )
 	    `;
 	const unwindowedTimelineEdgesCte = timelineEdgesCte;
 	let usedRecentEdgeWindow = false;
 	let where = "where e.kind = ?";
-	const ftsSearch = search?.trim() ? toFtsSearchQuery(search) : "";
 
 	const canUseRecentEdgeWindow =
 		!likedOnly &&
@@ -757,7 +761,7 @@ export function buildTimelineItemsQuery(
 	}
 	const searchDrivenFrom =
 		ftsMatchCountHint > FTS_DRIVE_FROM_MATCHES_MAX
-			? `tweets t
+			? `tweets t indexed by idx_tweets_created
         cross join fts_matches on fts_matches.tweet_id = t.id
         cross join timeline_edges e on e.tweet_id = t.id`
 			: `fts_matches
@@ -783,6 +787,7 @@ export function buildTimelineItemsQuery(
       )`
 		: "";
 
+	const hydrationJoin = ftsSearch ? "cross join" : "join";
 	const buildTimelineSelectSql = (timelineEdgesSql: string) => `
       ${timelineEdgesSql}${ftsMatchesCte}${searchSelectionCte}
       select
@@ -862,9 +867,9 @@ export function buildTimelineItemsQuery(
         qp.avatar_url as quoted_avatar_url,
         qp.created_at as quoted_profile_created_at
       from ${ftsSearch ? "search_selection e" : "timeline_edges e"}
-      join tweets t on t.id = e.tweet_id
-      join accounts a on a.id = e.account_id
-      join profiles p on p.id = t.author_profile_id
+      ${hydrationJoin} tweets t on t.id = e.tweet_id
+      ${hydrationJoin} accounts a on a.id = e.account_id
+      ${hydrationJoin} profiles p on p.id = t.author_profile_id
       left join tweets rt on rt.id = t.reply_to_id and rt.deleted_at is null and rt.superseded_at is null
       left join profiles rp on rp.id = rt.author_profile_id
       left join tweets qt on qt.id = t.quoted_tweet_id and qt.deleted_at is null and qt.superseded_at is null
@@ -982,9 +987,15 @@ export function listTimelineItems(
 				(
 					db
 						.prepare(
-							"select count(distinct tweet_id) as match_count from tweets_fts where tweets_fts.text match ?",
+							`select count(*) as match_count
+							 from (
+							   select distinct tweet_id
+							   from tweets_fts
+							   where tweets_fts.text match ?
+							   limit ?
+							 )`,
 						)
-						.get(ftsSearch) as { match_count: number }
+						.get(ftsSearch, FTS_MATCH_COUNT_LIMIT) as { match_count: number }
 				).match_count,
 			))
 		: 0;


### PR DESCRIPTION
## Summary

Fix common-term cached timeline searches under the pinned Bun canary by making the intended dense-query plan explicit:

- stop FTS match counting after the 10,001st distinct tweet, which is enough to choose the sparse/dense strategy
- force dense searches to walk `idx_tweets_created` newest-first rather than a low-selectivity deletion index
- pin the bounded search selection ahead of wide tweet/account/profile hydration
- pin FTS timeline membership to the tweet lookup index
- add plan-shape, result-parity, and bounded-count regression coverage

## Root cause

The production-sized shadow gate found that the same landed artifact completed `search tweets the --resource home --limit 20` in 3.70 seconds on Node 26.7 but exceeded 60 seconds on the exact Bun canary; an earlier Bun process ran for more than ten minutes.

The query spent its time in `sqlite3_step`. Node uses SQLite 3.53.4 with STAT4, while the canary exposes SQLite 3.51.0 without STAT4. On the unanalyzed archive, SQLite 3.51 chose `idx_tweets_superseded`, scanned the active tweet set, and sorted before applying the limit. Running `ANALYZE` on a copy restored performance, confirming a planner/cardinality issue, but relying on mutable database statistics would leave fresh imports and query-only readers exposed.

This patch instead makes the already-intended adaptive plan deterministic without changing result semantics or schema.

## Proof

On the same isolated, transactionally copied 1.47 GB database, with live writes/profile lookups/backup auto-sync disabled:

- before: Node 3.70s; Bun >60s
- after: Node 1.53s; Bun 1.26s
- ordered 20-row result and snippets: identical
- Bun plan: `idx_tweets_created` selected; no deleted/superseded index; bounded selection hydrated by tweet ID
- shadow database SHA-256: unchanged

Local gates:

- format, lint, and TypeScript checks
- Bun: 148 files, 1,347 tests; Istanbul thresholds passed
- Node: 148 files, 1,347 tests; V8 thresholds passed
- Bun and Node builds
- focused planner tests under both runtimes
- Codex autoreview

This PR does not publish npm, update Homebrew, create a tag, or create a GitHub Release.
