### PR TITLE
docs(skill): update Birdclaw production URL

### DIFF
--- a/.agents/skills/birdclaw/SKILL.md
+++ b/.agents/skills/birdclaw/SKILL.md
@@ -14,7 +14,7 @@ ssh -o RequestTTY=no -o RemoteCommand=none steipete@clawstudio \
   'zsh -lc "birdclaw --json db stats"'
 ```
 
-Use the same SSH/login-shell shape for searches. If `clawstudio` is unavailable, report that before falling back to a local archive because coverage may differ. Production web UI: `https://app.birdclaw.sh`.
+Use the same SSH/login-shell shape for searches. If `clawstudio` is unavailable, report that before falling back to a local archive because coverage may differ. Production web UI: `https://bird.steipete.dev/`.
 
 ## Data
 


### PR DESCRIPTION
## Summary

Update the Birdclaw agent skill to use the current production UI at https://bird.steipete.dev/ instead of the retired `app.birdclaw.sh` hostname.

## Proof

- `https://bird.steipete.dev/` returns HTTP 200 and serves the Birdclaw UI directly.
- No tracked `app.birdclaw.sh` references remain after this change.
- The change is documentation-only and does not alter runtime behavior or publish a package/release.
