### PR TITLE
fix: fail account sync when backup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Register `archive find` and `db stats` as strict nested CLI commands, reject unknown subcommands, and return a structured HTTP 400 for invalid `/api/query` resources.
 - Apply the shared account-selection policy to follow-graph and network-map reads so IDs, `@handle` selectors, and bare handles resolve consistently.
+- Report scheduled account syncs as failed when their configured backup export fails, so launchd records a nonzero exit.
 - Make numeric X user IDs the durable live-profile identity, preserving history and dependent references across proven legacy rekeys, handle reuse, case-fold collisions, handoffs, and swaps.
 - Serialize backup repositories with renewable token-owned leases and reliable token-checked release, validate NUL-safe fetched and staged generations before checkout mutation, prove Git ownership before finalizing journal recovery, and protect fsynced pending-push receipts from later export generations.
 - Adopt validated non-Git exports into empty backup remotes without weakening inventory checks, and preserve sparse handle-less DM avatar enrichment without fabricating public handles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Register `archive find` and `db stats` as strict nested CLI commands, reject unknown subcommands, and return a structured HTTP 400 for invalid `/api/query` resources.
 - Apply the shared account-selection policy to follow-graph and network-map reads so IDs, `@handle` selectors, and bare handles resolve consistently.
+- Preserve newer numeric profile identities and handle ownership when backup sync merges a prior valid generation after live profile updates.
 - Report scheduled account syncs as failed when their configured backup export fails, so launchd records a nonzero exit.
 - Make numeric X user IDs the durable live-profile identity, preserving history and dependent references across proven legacy rekeys, handle reuse, case-fold collisions, handoffs, and swaps.
 - Serialize backup repositories with renewable token-owned leases and reliable token-checked release, validate NUL-safe fetched and staged generations before checkout mutation, prove Git ownership before finalizing journal recovery, and protect fsynced pending-push receipts from later export generations.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureBirdclawDirsMock = vi.fn();
@@ -763,6 +765,82 @@ describe("cli", () => {
 			await expect(
 				command?.parseAsync(["nonsense"], { from: "user" }),
 			).rejects.toMatchObject({ code: "commander.unknownCommand" });
+		}
+	});
+
+	it("exits nonzero when account sync backup returns a failure", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-cli-job-"));
+		try {
+			getBirdclawPathsMock.mockReturnValue({
+				rootDir: tempDir,
+				dbPath: path.join(tempDir, "birdclaw.sqlite"),
+			});
+			syncMentionsMock.mockResolvedValueOnce({ source: "xurl", count: 1 });
+			maybeAutoSyncBackupMock.mockResolvedValueOnce({
+				ok: false,
+				enabled: true,
+				skipped: false,
+				error: "backup export failed",
+			});
+			const { runCli } = await loadCli();
+
+			await runCli([
+				"node",
+				"birdclaw",
+				"--json",
+				"jobs",
+				"sync-account",
+				"--steps",
+				"mentions",
+			]);
+
+			expect(process.exitCode).toBe(1);
+			expect(
+				JSON.parse(consoleLogMock.mock.lastCall?.[0] as string),
+			).toMatchObject({
+				ok: false,
+				backup: { ok: false, error: "backup export failed" },
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("exits zero when account sync backup is successfully skipped", async () => {
+		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-cli-job-"));
+		try {
+			getBirdclawPathsMock.mockReturnValue({
+				rootDir: tempDir,
+				dbPath: path.join(tempDir, "birdclaw.sqlite"),
+			});
+			syncMentionsMock.mockResolvedValueOnce({ source: "xurl", count: 1 });
+			maybeAutoSyncBackupMock.mockResolvedValueOnce({
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "backup auto-sync is not configured",
+			});
+			const { runCli } = await loadCli();
+
+			await runCli([
+				"node",
+				"birdclaw",
+				"--json",
+				"jobs",
+				"sync-account",
+				"--steps",
+				"mentions",
+			]);
+
+			expect(process.exitCode).toBe(0);
+			expect(
+				JSON.parse(consoleLogMock.mock.lastCall?.[0] as string),
+			).toMatchObject({
+				ok: true,
+				backup: { ok: true, enabled: false, skipped: true },
+			});
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
 

--- a/src/lib/account-sync-job.test.ts
+++ b/src/lib/account-sync-job.test.ts
@@ -190,6 +190,110 @@ describe("account sync job", () => {
 		});
 	});
 
+	it("fails when all sync steps succeed but backup returns a failure", async () => {
+		tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-account-job-"));
+		const logPath = path.join(tempDir, "audit.jsonl");
+		const lockPath = path.join(tempDir, "sync.lock");
+		syncMentionsMock.mockResolvedValue({
+			source: "xurl",
+			count: 3,
+		});
+		maybeAutoSyncBackupMock.mockResolvedValue({
+			ok: false,
+			enabled: true,
+			skipped: false,
+			repoPath: "/tmp/backup-birdclaw",
+			error: "backup export failed",
+		});
+
+		const result = await runAccountSyncJob({
+			steps: ["mentions"],
+			logPath,
+			lockPath,
+			db: {} as never,
+		});
+
+		expect(result).toMatchObject({
+			ok: false,
+			steps: [{ kind: "mentions", ok: true, count: 3, source: "xurl" }],
+			backup: {
+				ok: false,
+				enabled: true,
+				skipped: false,
+				repoPath: "/tmp/backup-birdclaw",
+				error: "backup export failed",
+			},
+		});
+		const entry = JSON.parse(readFileSync(logPath, "utf8").trim()) as unknown;
+		expect(entry).toMatchObject(result);
+	});
+
+	it("succeeds when all sync steps and a disabled backup skip succeed", async () => {
+		tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-account-job-"));
+		const logPath = path.join(tempDir, "audit.jsonl");
+		const lockPath = path.join(tempDir, "sync.lock");
+		syncMentionsMock.mockResolvedValue({
+			source: "xurl",
+			count: 3,
+		});
+		maybeAutoSyncBackupMock.mockResolvedValue({
+			ok: true,
+			enabled: false,
+			skipped: true,
+			reason: "backup auto-sync is not configured",
+		});
+
+		const result = await runAccountSyncJob({
+			steps: ["mentions"],
+			logPath,
+			lockPath,
+			db: {} as never,
+		});
+
+		expect(result).toMatchObject({
+			ok: true,
+			steps: [{ kind: "mentions", ok: true, count: 3, source: "xurl" }],
+			backup: {
+				ok: true,
+				enabled: false,
+				skipped: true,
+				reason: "backup auto-sync is not configured",
+			},
+		});
+	});
+
+	it("fails when a sync step fails even though backup succeeds", async () => {
+		tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-account-job-"));
+		const logPath = path.join(tempDir, "audit.jsonl");
+		const lockPath = path.join(tempDir, "sync.lock");
+		syncMentionsMock.mockRejectedValue(new Error("mentions failed"));
+		maybeAutoSyncBackupMock.mockResolvedValue({
+			ok: true,
+			enabled: true,
+			skipped: false,
+		});
+
+		const result = await runAccountSyncJob({
+			steps: ["mentions"],
+			logPath,
+			lockPath,
+			db: {} as never,
+		});
+
+		expect(result).toMatchObject({
+			ok: false,
+			steps: [
+				{
+					kind: "mentions",
+					ok: false,
+					count: 0,
+					error: "mentions failed",
+				},
+			],
+			backup: { ok: true, enabled: true, skipped: false },
+		});
+	});
+
 	it("refuses Bird-backed non-default account sync without an assertion", async () => {
 		tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-account-job-"));
 		const logPath = path.join(tempDir, "audit.jsonl");

--- a/src/lib/account-sync-job.ts
+++ b/src/lib/account-sync-job.ts
@@ -391,7 +391,7 @@ export async function runAccountSyncJob({
 		const backup = await maybeAutoSyncBackup(database);
 		const entry: AccountSyncAuditEntry = {
 			job: "account-sync",
-			ok: stepResults.every((step) => step.ok),
+			ok: stepResults.every((step) => step.ok) && backup.ok,
 			...run.finish(),
 			options,
 			steps: stepResults,

--- a/src/lib/backup-table-codecs.test.ts
+++ b/src/lib/backup-table-codecs.test.ts
@@ -49,6 +49,15 @@ describe("backup table codecs", () => {
 				(left, right) => left - right,
 			),
 		).toEqual(Array.from({ length: 28 }, (_, index) => index));
+		const mergeOrder = new Map(
+			BACKUP_TABLE_CODECS.map((codec) => [codec.name, codec.merge.order]),
+		);
+		expect(mergeOrder.get("profiles")).toBeLessThan(
+			mergeOrder.get("profile_snapshots")!,
+		);
+		expect(mergeOrder.get("profiles")).toBeLessThan(
+			mergeOrder.get("profile_bio_entities")!,
+		);
 
 		const sample = { created_at: "2026-01-02T00:00:00.000Z", kind: "likes" };
 		for (const codec of BACKUP_TABLE_CODECS) {

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -195,7 +195,7 @@ const definitions = {
     `,
 		...fixedShard("data/profiles.jsonl", "profiles"),
 		merge: {
-			order: 3,
+			order: 1,
 			sql: `
       insert into profiles (
         id, handle, display_name, bio, followers_count, following_count,
@@ -264,19 +264,17 @@ const definitions = {
         first_seen_at, last_seen_at, raw_json, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?, coalesce(?, 'backup'), coalesce(?, 1), ?, ?, coalesce(?, '{}'), ?)
       on conflict(subject_profile_id, organization_profile_id) do update set
-        organization_name = coalesce(excluded.organization_name, profile_affiliations.organization_name),
-        organization_handle = coalesce(excluded.organization_handle, profile_affiliations.organization_handle),
-        badge_url = coalesce(excluded.badge_url, profile_affiliations.badge_url),
-        url = coalesce(excluded.url, profile_affiliations.url),
-        label = coalesce(excluded.label, profile_affiliations.label),
-        source = excluded.source,
-        is_active = excluded.is_active,
+        organization_name = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.organization_name else profile_affiliations.organization_name end, ''), profile_affiliations.organization_name, excluded.organization_name),
+        organization_handle = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.organization_handle else profile_affiliations.organization_handle end, ''), profile_affiliations.organization_handle, excluded.organization_handle),
+        badge_url = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.badge_url else profile_affiliations.badge_url end, ''), profile_affiliations.badge_url, excluded.badge_url),
+        url = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.url else profile_affiliations.url end, ''), profile_affiliations.url, excluded.url),
+        label = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.label else profile_affiliations.label end, ''), profile_affiliations.label, excluded.label),
+        source = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.source else profile_affiliations.source end, ''), profile_affiliations.source, excluded.source),
+        is_active = case when excluded.updated_at > profile_affiliations.updated_at then excluded.is_active else profile_affiliations.is_active end,
+        first_seen_at = min(profile_affiliations.first_seen_at, excluded.first_seen_at),
         last_seen_at = max(profile_affiliations.last_seen_at, excluded.last_seen_at),
-        raw_json = case
-          when excluded.raw_json not in ('', '{}', 'null') then excluded.raw_json
-          else profile_affiliations.raw_json
-        end,
-        updated_at = excluded.updated_at
+        raw_json = coalesce(nullif(case when excluded.updated_at > profile_affiliations.updated_at then excluded.raw_json else profile_affiliations.raw_json end, '{}'), nullif(profile_affiliations.raw_json, '{}'), nullif(excluded.raw_json, '{}'), '{}'),
+        updated_at = max(profile_affiliations.updated_at, excluded.updated_at)
       `,
 			columns: [
 				"subject_profile_id",
@@ -305,7 +303,7 @@ const definitions = {
     `,
 		...fixedShard("data/profile_snapshots.jsonl", "profile_snapshots"),
 		merge: {
-			order: 1,
+			order: 2,
 			sql: `
       insert into profile_snapshots (
         profile_id, snapshot_hash, observed_at, last_seen_at, source, handle,
@@ -313,12 +311,20 @@ const definitions = {
         following_count, affiliations_json, raw_json
       ) values (?, ?, ?, ?, coalesce(?, 'backup'), ?, ?, ?, ?, ?, ?, coalesce(?, 0), coalesce(?, 0), coalesce(?, '[]'), coalesce(?, '{}'))
       on conflict(profile_id, snapshot_hash) do update set
+        observed_at = min(profile_snapshots.observed_at, excluded.observed_at),
         last_seen_at = max(profile_snapshots.last_seen_at, excluded.last_seen_at),
-        source = excluded.source,
+        source = case
+          when excluded.last_seen_at > profile_snapshots.last_seen_at
+            or (excluded.last_seen_at = profile_snapshots.last_seen_at
+              and (excluded.source || char(0) || excluded.raw_json) >
+                (profile_snapshots.source || char(0) || profile_snapshots.raw_json))
+          then excluded.source else profile_snapshots.source end,
         raw_json = case
-          when excluded.raw_json not in ('', '{}', 'null') then excluded.raw_json
-          else profile_snapshots.raw_json
-        end
+          when excluded.last_seen_at > profile_snapshots.last_seen_at
+            or (excluded.last_seen_at = profile_snapshots.last_seen_at
+              and (excluded.source || char(0) || excluded.raw_json) >
+                (profile_snapshots.source || char(0) || profile_snapshots.raw_json))
+          then excluded.raw_json else profile_snapshots.raw_json end
       `,
 			columns: [
 				"profile_id",
@@ -348,19 +354,17 @@ const definitions = {
     `,
 		...fixedShard("data/profile_bio_entities.jsonl", "profile_bio_entities"),
 		merge: {
-			order: 2,
+			order: 3,
 			sql: `
       insert into profile_bio_entities (
         profile_id, kind, value, source, is_active, first_seen_at, last_seen_at, raw_json
       ) values (?, ?, ?, coalesce(?, 'backup'), coalesce(?, 1), ?, ?, coalesce(?, '{}'))
       on conflict(profile_id, kind, value) do update set
-        source = excluded.source,
-        is_active = excluded.is_active,
+        source = coalesce(nullif(case when excluded.last_seen_at > profile_bio_entities.last_seen_at then excluded.source else profile_bio_entities.source end, ''), profile_bio_entities.source, excluded.source),
+        is_active = case when excluded.last_seen_at > profile_bio_entities.last_seen_at then excluded.is_active else profile_bio_entities.is_active end,
+        first_seen_at = min(profile_bio_entities.first_seen_at, excluded.first_seen_at),
         last_seen_at = max(profile_bio_entities.last_seen_at, excluded.last_seen_at),
-        raw_json = case
-          when excluded.raw_json not in ('', '{}', 'null') then excluded.raw_json
-          else profile_bio_entities.raw_json
-        end
+        raw_json = coalesce(nullif(case when excluded.last_seen_at > profile_bio_entities.last_seen_at then excluded.raw_json else profile_bio_entities.raw_json end, '{}'), nullif(profile_bio_entities.raw_json, '{}'), nullif(excluded.raw_json, '{}'), '{}')
       `,
 			columns: [
 				"profile_id",

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -43,6 +43,7 @@ import { getBirdclawPaths, resetBirdclawPathsForTests } from "./config";
 import { getNativeDb } from "./db";
 import NativeSqliteDatabase, { type Database } from "./sqlite";
 import { acquireScheduledJobLock } from "./scheduled-job";
+import { upsertProfileFromXUser } from "./x-profile";
 
 const testHome = useTestHome({ prefix: "birdclaw-backup-home-" });
 
@@ -1032,6 +1033,295 @@ describe("text backup", () => {
 				.prepare("select count(*) from tweets where id = 'tweet_2025'")
 				.get() as { "count(*)": number },
 		).toEqual({ "count(*)": 1 });
+	}, 20000);
+
+	it("keeps newer numeric profile identities when syncing a prior handle generation", async () => {
+		switchHome("birdclaw-backup-profile-handoff-");
+		const db = getNativeDb({ seedDemoData: false });
+		clearData();
+		insertTestAccount(db, {
+			id: "acct_primary",
+			handle: "@owner",
+			externalUserId: "9000",
+		});
+		const repoPath = makeTempDir("birdclaw-profile-handoff-store-");
+		const remotePath = path.join(
+			makeTempDir("birdclaw-profile-handoff-remote-"),
+			"remote.git",
+		);
+		execFileSync("git", ["init", "--bare", remotePath]);
+		vi.useFakeTimers({ toFake: ["Date"] });
+		try {
+			vi.setSystemTime(new Date("2026-08-18T10:00:00.000Z"));
+			upsertProfileFromXUser(db, {
+				id: "1001",
+				username: "alpha",
+				name: "Alpha",
+				description: "Founder at @oldco",
+				affiliation: {
+					organizationIds: ["profile_org_1"],
+					label: "Old Org",
+					organizationHandle: "oldorg",
+				},
+				public_metrics: { followers_count: 10, following_count: 5 },
+			});
+			upsertProfileFromXUser(db, {
+				id: "1002",
+				username: "beta",
+				name: "Beta",
+				description: "Original beta",
+				public_metrics: { followers_count: 20, following_count: 6 },
+			});
+			insertTestTweet(db, {
+				id: "tweet_profile_handoff",
+				authorProfileId: "profile_user_1001",
+				text: "Numeric identity stays put",
+			});
+			const prior = await exportBackup({ repoPath, db });
+
+			vi.setSystemTime(new Date("2026-08-18T11:00:00.000Z"));
+			db.transaction(() => {
+				upsertProfileFromXUser(db, {
+					id: "1001",
+					username: "beta",
+					name: "Alpha Current",
+					description: "Founder at @newco",
+					affiliation: {
+						organizationIds: ["profile_org_1"],
+						label: "Current Org",
+						organizationHandle: "currentorg",
+					},
+					public_metrics: { followers_count: 11, following_count: 5 },
+				});
+				upsertProfileFromXUser(db, {
+					id: "1002",
+					username: "alpha",
+					name: "Beta Current",
+					description: "Current alpha owner",
+					public_metrics: { followers_count: 21, following_count: 6 },
+				});
+			})();
+
+			const synced = await syncBackup({ repoPath, remote: remotePath, db });
+			const reexported = await exportBackup({ repoPath, db });
+
+			expect(synced.imported).toBe(true);
+			expect(synced.exportResult.validation.ok).toBe(true);
+			expect(reexported.validation.ok).toBe(true);
+			expect(reexported.manifest.backupHash).toBe(
+				synced.exportResult.manifest.backupHash,
+			);
+			expect(reexported.manifest.backupHash).not.toBe(
+				prior.manifest.backupHash,
+			);
+			expect(
+				db
+					.prepare(
+						"select id, handle, display_name, bio, raw_json from profiles where id in (?, ?) order by id",
+					)
+					.all("profile_user_1001", "profile_user_1002"),
+			).toEqual([
+				expect.objectContaining({
+					id: "profile_user_1001",
+					handle: "beta",
+					display_name: "Alpha Current",
+					bio: "Founder at @newco",
+					raw_json: expect.stringContaining('"id":"1001"'),
+				}),
+				expect.objectContaining({
+					id: "profile_user_1002",
+					handle: "alpha",
+					display_name: "Beta Current",
+					bio: "Current alpha owner",
+					raw_json: expect.stringContaining('"id":"1002"'),
+				}),
+			]);
+			expect(
+				db
+					.prepare(
+						"select author_profile_id from tweets where id = 'tweet_profile_handoff'",
+					)
+					.get(),
+			).toEqual({ author_profile_id: "profile_user_1001" });
+			expect(
+				db
+					.prepare(
+						"select handle from profile_snapshots where profile_id = ? and handle in ('alpha', 'beta') order by handle",
+					)
+					.all("profile_user_1001"),
+			).toEqual([{ handle: "alpha" }, { handle: "beta" }]);
+			expect(
+				db
+					.prepare(
+						"select value, is_active from profile_bio_entities where profile_id = ? and value in ('@newco', '@oldco') order by value",
+					)
+					.all("profile_user_1001"),
+			).toEqual([
+				{ value: "@newco", is_active: 1 },
+				{ value: "@oldco", is_active: 0 },
+			]);
+			expect(
+				db
+					.prepare(
+						"select organization_name, organization_handle, is_active from profile_affiliations where subject_profile_id = ? and organization_profile_id = ?",
+					)
+					.get("profile_user_1001", "profile_org_1"),
+			).toEqual({
+				organization_name: "Current Org",
+				organization_handle: "currentorg",
+				is_active: 1,
+			});
+			const exportedProfiles = readFileSync(
+				path.join(repoPath, "data/profiles.jsonl"),
+				"utf8",
+			);
+			expect(exportedProfiles).toContain(
+				'"handle":"beta","id":"profile_user_1001"',
+			);
+			expect(exportedProfiles).toContain(
+				'"handle":"alpha","id":"profile_user_1002"',
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	}, 20000);
+
+	it("adopts a newer backup profile generation into an older live database", async () => {
+		switchHome("birdclaw-backup-newer-profile-source-");
+		const sourceDb = getNativeDb({ seedDemoData: false });
+		clearData();
+		insertTestAccount(sourceDb, {
+			id: "acct_primary",
+			handle: "@owner",
+			externalUserId: "9000",
+		});
+		const repoPath = makeTempDir("birdclaw-newer-profile-store-");
+		vi.useFakeTimers({ toFake: ["Date"] });
+		try {
+			vi.setSystemTime(new Date("2026-08-18T10:00:00.000Z"));
+			upsertProfileFromXUser(sourceDb, {
+				id: "2001",
+				username: "north",
+				name: "North",
+				description: "Founder at @oldco",
+				public_metrics: { followers_count: 10, following_count: 5 },
+			});
+			upsertProfileFromXUser(sourceDb, {
+				id: "2002",
+				username: "south",
+				name: "South",
+				description: "Original south",
+				public_metrics: { followers_count: 20, following_count: 6 },
+			});
+			vi.setSystemTime(new Date("2026-08-18T11:00:00.000Z"));
+			sourceDb.transaction(() => {
+				upsertProfileFromXUser(sourceDb, {
+					id: "2001",
+					username: "south",
+					name: "North Current",
+					description: "Founder at @newco",
+					public_metrics: { followers_count: 11, following_count: 5 },
+				});
+				upsertProfileFromXUser(sourceDb, {
+					id: "2002",
+					username: "north",
+					name: "South Current",
+					description: "Current north owner",
+					public_metrics: { followers_count: 21, following_count: 6 },
+				});
+			})();
+			const newer = await exportBackup({ repoPath, db: sourceDb });
+
+			switchHome("birdclaw-backup-older-profile-destination-");
+			const destinationDb = getNativeDb({ seedDemoData: false });
+			clearData();
+			insertTestAccount(destinationDb, {
+				id: "acct_primary",
+				handle: "@owner",
+				externalUserId: "9000",
+			});
+			vi.setSystemTime(new Date("2026-08-18T10:00:00.000Z"));
+			upsertProfileFromXUser(destinationDb, {
+				id: "2001",
+				username: "north",
+				name: "North",
+				description: "Founder at @oldco",
+				public_metrics: { followers_count: 10, following_count: 5 },
+			});
+			upsertProfileFromXUser(destinationDb, {
+				id: "2002",
+				username: "south",
+				name: "South",
+				description: "Original south",
+				public_metrics: { followers_count: 20, following_count: 6 },
+			});
+			insertTestTweet(destinationDb, {
+				id: "tweet_older_profile_reference",
+				authorProfileId: "profile_user_2002",
+				text: "Keep this destination-only reference",
+			});
+
+			const imported = await importBackup({
+				repoPath,
+				db: destinationDb,
+			});
+			const reexported = await exportBackup({ repoPath, db: destinationDb });
+
+			expect(imported.ok).toBe(true);
+			expect(imported.mode).toBe("merge");
+			expect(newer.validation.ok).toBe(true);
+			expect(reexported.validation.ok).toBe(true);
+			expect(
+				destinationDb
+					.prepare(
+						"select id, handle, display_name, bio, followers_count, raw_json from profiles where id in (?, ?) order by id",
+					)
+					.all("profile_user_2001", "profile_user_2002"),
+			).toEqual([
+				expect.objectContaining({
+					id: "profile_user_2001",
+					handle: "south",
+					display_name: "North Current",
+					bio: "Founder at @newco",
+					followers_count: 11,
+					raw_json: expect.stringContaining('"id":"2001"'),
+				}),
+				expect.objectContaining({
+					id: "profile_user_2002",
+					handle: "north",
+					display_name: "South Current",
+					bio: "Current north owner",
+					followers_count: 21,
+					raw_json: expect.stringContaining('"id":"2002"'),
+				}),
+			]);
+			expect(
+				destinationDb
+					.prepare(
+						"select author_profile_id from tweets where id = 'tweet_older_profile_reference'",
+					)
+					.get(),
+			).toEqual({ author_profile_id: "profile_user_2002" });
+			expect(
+				destinationDb
+					.prepare(
+						"select handle from profile_snapshots where profile_id = ? and handle in ('north', 'south') order by handle",
+					)
+					.all("profile_user_2001"),
+			).toEqual([{ handle: "north" }, { handle: "south" }]);
+			expect(
+				destinationDb
+					.prepare(
+						"select value, is_active from profile_bio_entities where profile_id = ? and value in ('@newco', '@oldco') order by value",
+					)
+					.all("profile_user_2001"),
+			).toEqual([
+				{ value: "@newco", is_active: 1 },
+				{ value: "@oldco", is_active: 0 },
+			]);
+		} finally {
+			vi.useRealTimers();
+		}
 	}, 20000);
 
 	it("round-trips tweet tombstones, subordinate deletions, and edit revisions", async () => {

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -41,6 +41,7 @@ import {
 import { BACKUP_TABLE_CODECS } from "./backup-table-codecs";
 import { getBirdclawPaths, resetBirdclawPathsForTests } from "./config";
 import { getNativeDb } from "./db";
+import { syncIdentitySearchIndexForProfileIds } from "./identity-search-index";
 import NativeSqliteDatabase, { type Database } from "./sqlite";
 import { acquireScheduledJobLock } from "./scheduled-job";
 import { upsertProfileFromXUser } from "./x-profile";
@@ -1034,6 +1035,394 @@ describe("text backup", () => {
 				.get() as { "count(*)": number },
 		).toEqual({ "count(*)": 1 });
 	}, 20000);
+
+	it("adopts a proven legacy selected-account backup after importing all references", async () => {
+		switchHome("birdclaw-backup-legacy-account-source-");
+		const sourceDb = getNativeDb({ seedDemoData: false });
+		clearData();
+		insertTestAccount(sourceDb, {
+			id: "acct_primary",
+			handle: "@selected_owner",
+			externalUserId: "25401953",
+			createdAt: "2009-03-19T22:54:05.000Z",
+		});
+		insertTestProfile(sourceDb, {
+			id: "profile_me",
+			handle: "selected_owner",
+			displayName: "Legacy Selected Owner",
+			bio: "Legacy bio at @legacyco",
+			followersCount: 20_000,
+			followingCount: 500,
+			publicMetricsJson: '{"followers_count":20000,"following_count":500}',
+			rawJson: '{"id":"profile_me","username":"selected_owner"}',
+			createdAt: "2009-03-19T22:54:05.000Z",
+		});
+		insertTestProfile(sourceDb, {
+			id: "profile_user_25401953",
+			handle: "birdclaw_stub_25401953",
+			displayName: "Numeric Stub",
+			bio: "",
+			followersCount: 0,
+			followingCount: 0,
+			publicMetricsJson: "{}",
+			rawJson: '{"id":"25401953"}',
+			createdAt: "2009-03-19T22:54:05.000Z",
+		});
+		insertTestProfile(sourceDb, {
+			id: "profile_org_legacy",
+			handle: "legacyco",
+			displayName: "Legacy Co",
+		});
+		sourceDb.exec(`
+			insert into profile_snapshots (
+				profile_id, snapshot_hash, observed_at, last_seen_at, source,
+				handle, display_name, bio, followers_count, following_count,
+				affiliations_json, raw_json
+			) values
+				('profile_me', 'legacy-selected-state',
+				 '2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z',
+				 'backup-test', 'selected_owner', 'Legacy Selected Owner',
+				 'Legacy bio at @legacyco', 20000, 500,
+				 '[{"organizationHandle":"legacyco"}]', '{"id":"profile_me"}'),
+				('profile_user_25401953', 'legacy-numeric-stub',
+				 '2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z',
+				 'backup-test', 'birdclaw_stub_25401953', 'Numeric Stub', '',
+				 0, 0, '[]', '{"id":"25401953"}');
+
+			insert into profile_bio_entities (
+				profile_id, kind, value, source, is_active, first_seen_at,
+				last_seen_at, raw_json
+			) values (
+				'profile_me', 'handle', '@legacyco', 'backup-test', 1,
+				'2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z', '{}'
+			);
+
+			insert into profile_affiliations (
+				subject_profile_id, organization_profile_id, organization_name,
+				organization_handle, label, source, is_active, first_seen_at,
+				last_seen_at, raw_json, updated_at
+			) values (
+				'profile_me', 'profile_org_legacy', 'Legacy Co', 'legacyco',
+				'Legacy affiliation', 'backup-test', 1,
+				'2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z',
+				'{}', '2026-08-18T06:18:12.256Z'
+			);
+
+			insert into tweets (
+				id, author_profile_id, text, created_at, is_replied, like_count,
+				media_count, entities_json, media_json
+			) values (
+				'legacy-selected-tweet', 'profile_me', 'legacy reference',
+				'2026-08-18T06:18:12.256Z', 0, 0, 0, '{}', '[]'
+			);
+
+			insert into dm_conversations (
+				id, account_id, participant_profile_id, title, inbox_kind,
+				last_message_at, unread_count, needs_reply
+			) values (
+				'legacy-selected-dm', 'acct_primary', 'profile_me', 'Selected owner',
+				'accepted', '2026-08-18T06:18:12.256Z', 0, 0
+			);
+			insert into dm_messages (
+				id, conversation_id, sender_profile_id, text, created_at, direction,
+				is_replied, media_count
+			) values (
+				'legacy-selected-message', 'legacy-selected-dm', 'profile_me',
+				'legacy dm reference', '2026-08-18T06:18:12.256Z', 'outbound', 1, 0
+			);
+
+			insert into follow_snapshots (
+				id, account_id, direction, source, status, page_count, result_count,
+				started_at, completed_at, raw_meta_json
+			) values (
+				'legacy-follow-snapshot', 'acct_primary', 'following', 'backup-test',
+				'complete', 1, 1, '2026-08-18T06:18:12.256Z',
+				'2026-08-18T06:18:12.256Z', '{}'
+			);
+			insert into follow_snapshot_members (
+				snapshot_id, profile_id, external_user_id, position
+			) values ('legacy-follow-snapshot', 'profile_me', '25401953', 0);
+			insert into follow_edges (
+				account_id, direction, profile_id, external_user_id, source, current,
+				first_seen_at, last_seen_at, ended_at, updated_at
+			) values (
+				'acct_primary', 'following', 'profile_me', '25401953', 'backup-test',
+				1, '2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z', null,
+				'2026-08-18T06:18:12.256Z'
+			);
+			insert into follow_events (
+				id, account_id, direction, profile_id, external_user_id, kind,
+				event_at, snapshot_id
+			) values (
+				'legacy-follow-event', 'acct_primary', 'following', 'profile_me',
+				'25401953', 'started', '2026-08-18T06:18:12.256Z',
+				'legacy-follow-snapshot'
+			);
+
+			insert into x_lists (
+				account_id, list_id, name, owner_profile_id, owner_external_user_id,
+				is_private, source, membership_status, lists_synced_at,
+				member_page_count, member_result_count, rate_limit_json, raw_json,
+				updated_at
+			) values (
+				'acct_primary', 'legacy-list', 'Legacy list', 'profile_me', '25401953',
+				0, 'backup-test', 'complete', '2026-08-18T06:18:12.256Z', 1, 1,
+				'{}', '{}', '2026-08-18T06:18:12.256Z'
+			);
+			insert into x_list_members (
+				account_id, list_id, profile_id, external_user_id, source, current,
+				first_seen_at, last_seen_at, raw_json, updated_at
+			) values (
+				'acct_primary', 'legacy-list', 'profile_me', '25401953', 'backup-test',
+				1, '2026-08-18T06:18:12.256Z', '2026-08-18T06:18:12.256Z', '{}',
+				'2026-08-18T06:18:12.256Z'
+			);
+			insert into blocks (account_id, profile_id, source, created_at)
+			values ('acct_primary', 'profile_me', 'backup-test', '2026-08-18T06:18:12.256Z');
+			insert into mutes (account_id, profile_id, source, created_at)
+			values ('acct_primary', 'profile_me', 'backup-test', '2026-08-18T06:18:12.256Z');
+		`);
+		const repoPath = makeTempDir("birdclaw-legacy-account-store-");
+		const prior = await exportBackup({ repoPath, db: sourceDb });
+		expect(prior.validation.ok).toBe(true);
+
+		switchHome("birdclaw-backup-legacy-account-destination-");
+		const destinationDb = getNativeDb({ seedDemoData: false });
+		clearData();
+		insertTestAccount(destinationDb, {
+			id: "acct_primary",
+			handle: "@selected_owner",
+			externalUserId: "25401953",
+			createdAt: "2009-03-19T22:54:05.000Z",
+		});
+		insertTestProfile(destinationDb, {
+			id: "profile_user_25401953",
+			handle: "selected_owner",
+			displayName: "Current Selected Owner",
+			bio: "Current live bio",
+			followersCount: 15_000,
+			followingCount: 400,
+			publicMetricsJson: '{"followers_count":15000,"following_count":400}',
+			avatarUrl: "https://images.example/current.jpg",
+			rawJson: '{"id":"25401953","username":"selected_owner"}',
+			createdAt: "2009-03-19T22:54:05.000Z",
+		});
+		destinationDb
+			.prepare(
+				`insert into profile_snapshots (
+				profile_id, snapshot_hash, observed_at, last_seen_at, source,
+				handle, display_name, bio, followers_count, following_count,
+				affiliations_json, raw_json
+			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				"profile_user_25401953",
+				"current-selected-state",
+				"2026-08-18T23:04:16.635Z",
+				"2026-08-18T23:04:16.635Z",
+				"live-test",
+				"selected_owner",
+				"Current Selected Owner",
+				"Current live bio",
+				15_000,
+				400,
+				"[]",
+				'{"id":"25401953"}',
+			);
+		syncIdentitySearchIndexForProfileIds(destinationDb, [
+			"profile_user_25401953",
+		]);
+
+		const imported = await importBackup({ repoPath, db: destinationDb });
+		const reexported = await exportBackup({ repoPath, db: destinationDb });
+
+		expect(imported.ok).toBe(true);
+		expect(imported.mode).toBe("merge");
+		expect(reexported.validation.ok).toBe(true);
+		expect(
+			destinationDb
+				.prepare(
+					"select id, handle, display_name, bio, followers_count, following_count, avatar_url from profiles where id in ('profile_me', 'profile_user_25401953') order by id",
+				)
+				.all(),
+		).toEqual([
+			{
+				id: "profile_user_25401953",
+				handle: "selected_owner",
+				display_name: "Current Selected Owner",
+				bio: "Current live bio",
+				followers_count: 15_000,
+				following_count: 400,
+				avatar_url: "https://images.example/current.jpg",
+			},
+		]);
+		for (const [table, column] of [
+			["tweets", "author_profile_id"],
+			["dm_conversations", "participant_profile_id"],
+			["dm_messages", "sender_profile_id"],
+			["profile_snapshots", "profile_id"],
+			["profile_bio_entities", "profile_id"],
+			["profile_affiliations", "subject_profile_id"],
+			["follow_snapshot_members", "profile_id"],
+			["follow_edges", "profile_id"],
+			["follow_events", "profile_id"],
+			["x_lists", "owner_profile_id"],
+			["x_list_members", "profile_id"],
+			["blocks", "profile_id"],
+			["mutes", "profile_id"],
+			["identity_search_index", "profile_id"],
+		] as const) {
+			expect(
+				destinationDb
+					.prepare(
+						`select count(*) as count from ${table} where ${column} = 'profile_me'`,
+					)
+					.get(),
+			).toEqual({ count: 0 });
+		}
+		expect(
+			destinationDb
+				.prepare(
+					"select author_profile_id from tweets where id = 'legacy-selected-tweet'",
+				)
+				.get(),
+		).toEqual({ author_profile_id: "profile_user_25401953" });
+		expect(
+			destinationDb
+				.prepare(
+					"select participant_profile_id from dm_conversations where id = 'legacy-selected-dm'",
+				)
+				.get(),
+		).toEqual({ participant_profile_id: "profile_user_25401953" });
+		expect(
+			destinationDb
+				.prepare(
+					"select profile_id, external_user_id from follow_edges where account_id = 'acct_primary' and direction = 'following'",
+				)
+				.get(),
+		).toEqual({
+			profile_id: "profile_user_25401953",
+			external_user_id: "25401953",
+		});
+		expect(
+			destinationDb
+				.prepare(
+					"select owner_profile_id, owner_external_user_id from x_lists where list_id = 'legacy-list'",
+				)
+				.get(),
+		).toEqual({
+			owner_profile_id: "profile_user_25401953",
+			owner_external_user_id: "25401953",
+		});
+		expect(
+			destinationDb
+				.prepare(
+					"select handle, bio, last_seen_at from profile_snapshots where profile_id = 'profile_user_25401953' and handle = 'selected_owner' and last_seen_at in ('2026-08-18T06:18:12.256Z', '2026-08-18T23:04:16.635Z') order by last_seen_at",
+				)
+				.all(),
+		).toEqual([
+			{
+				handle: "selected_owner",
+				bio: "Legacy bio at @legacyco",
+				last_seen_at: "2026-08-18T06:18:12.256Z",
+			},
+			{
+				handle: "selected_owner",
+				bio: "Current live bio",
+				last_seen_at: "2026-08-18T23:04:16.635Z",
+			},
+		]);
+		expect(
+			destinationDb
+				.prepare(
+					"select organization_handle from profile_affiliations where subject_profile_id = 'profile_user_25401953'",
+				)
+				.get(),
+		).toEqual({ organization_handle: "legacyco" });
+		expect(
+			destinationDb
+				.prepare(
+					"select value from identity_search_index where profile_id = 'profile_user_25401953' and value = 'selected_owner'",
+				)
+				.get(),
+		).toEqual({ value: "selected_owner" });
+		expect(
+			destinationDb
+				.prepare(
+					"select count(*) as count from identity_search_index where value like 'birdclaw_stale_%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+	}, 20000);
+
+	it.each([
+		{
+			name: "contradictory raw identity",
+			accountHandle: "@selected_owner",
+			rawJson: '{"id":"999999","username":"selected_owner"}',
+		},
+		{
+			name: "selected account handle mismatch",
+			accountHandle: "@different_owner",
+			rawJson: "{}",
+		},
+	])(
+		"keeps unproven legacy profile_me separate for $name",
+		async ({ accountHandle, rawJson }) => {
+			switchHome("birdclaw-backup-unproven-legacy-source-");
+			const sourceDb = getNativeDb({ seedDemoData: false });
+			clearData();
+			insertTestAccount(sourceDb, {
+				id: "acct_primary",
+				handle: accountHandle,
+				externalUserId: "25401953",
+			});
+			insertTestProfile(sourceDb, {
+				id: "profile_me",
+				handle: "selected_owner",
+				displayName: "Unproven Legacy",
+				rawJson,
+			});
+			const repoPath = makeTempDir("birdclaw-unproven-legacy-store-");
+			await exportBackup({ repoPath, db: sourceDb });
+
+			switchHome("birdclaw-backup-unproven-legacy-destination-");
+			const destinationDb = getNativeDb({ seedDemoData: false });
+			clearData();
+			insertTestAccount(destinationDb, {
+				id: "acct_primary",
+				handle: "@selected_owner",
+				externalUserId: "25401953",
+			});
+			insertTestProfile(destinationDb, {
+				id: "profile_user_25401953",
+				handle: "selected_owner",
+				displayName: "Current Numeric Owner",
+				rawJson: '{"id":"25401953"}',
+			});
+
+			const imported = await importBackup({ repoPath, db: destinationDb });
+
+			expect(imported.ok).toBe(true);
+			expect(
+				destinationDb
+					.prepare(
+						"select id, handle from profiles where id in ('profile_me', 'profile_user_25401953') order by id",
+					)
+					.all(),
+			).toEqual([
+				expect.objectContaining({
+					id: "profile_me",
+					handle: expect.stringMatching(/^birdclaw_stale_/u),
+				}),
+				{
+					id: "profile_user_25401953",
+					handle: "selected_owner",
+				},
+			]);
+		},
+		20000,
+	);
 
 	it("keeps newer numeric profile identities when syncing a prior handle generation", async () => {
 		switchHome("birdclaw-backup-profile-handoff-");

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -39,6 +39,7 @@ import {
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 import { acquireScheduledJobLockEffect } from "./scheduled-job";
+import { reconcileBackupProfileRows } from "./profile-identity";
 
 const BACKUP_SCHEMA_VERSION = 8;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
@@ -3272,7 +3273,14 @@ function importBackupUnlockedEffect({
 				(left, right) => left.merge.order - right.merge.order,
 			);
 			for (const codec of mergeCodecs) {
-				const rows = importRows[codec.name];
+				const rows =
+					mode === "merge" && codec.name === "profiles"
+						? reconcileBackupProfileRows({
+								db: writeDb,
+								profileRows: importRows.profiles,
+								profileSnapshotRows: importRows.profile_snapshots,
+							})
+						: importRows[codec.name];
 				repository.insertRows(codec.merge.sql, rows, codec.merge.columns);
 				const fts = codec.merge.fts;
 				if (!fts) continue;

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -39,7 +39,12 @@ import {
 } from "./streaming-ingestion";
 import { runSubprocessEffect, SubprocessError } from "./subprocess";
 import { acquireScheduledJobLockEffect } from "./scheduled-job";
-import { reconcileBackupProfileRows } from "./profile-identity";
+import {
+	finalizeBackupProfileRows,
+	reconcileBackupProfileRows,
+	type BackupLegacyProfileMergePlan,
+} from "./profile-identity";
+import { resolveLiveSyncAccount } from "./live-sync-engine";
 
 const BACKUP_SCHEMA_VERSION = 8;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
@@ -3272,15 +3277,24 @@ function importBackupUnlockedEffect({
 			const mergeCodecs = [...BACKUP_TABLE_CODECS].sort(
 				(left, right) => left.merge.order - right.merge.order,
 			);
+			let legacyProfileMergePlans: BackupLegacyProfileMergePlan[] = [];
 			for (const codec of mergeCodecs) {
-				const rows =
-					mode === "merge" && codec.name === "profiles"
-						? reconcileBackupProfileRows({
-								db: writeDb,
-								profileRows: importRows.profiles,
-								profileSnapshotRows: importRows.profile_snapshots,
-							})
-						: importRows[codec.name];
+				let rows = importRows[codec.name];
+				if (mode === "merge" && codec.name === "profiles") {
+					const selectedAccount = writeDb
+						.prepare("select 1 from accounts limit 1")
+						.get()
+						? resolveLiveSyncAccount(writeDb)
+						: undefined;
+					const reconciled = reconcileBackupProfileRows({
+						db: writeDb,
+						profileRows: importRows.profiles,
+						profileSnapshotRows: importRows.profile_snapshots,
+						selectedAccount,
+					});
+					rows = reconciled.rows;
+					legacyProfileMergePlans = reconciled.legacyProfileMergePlans;
+				}
 				repository.insertRows(codec.merge.sql, rows, codec.merge.columns);
 				const fts = codec.merge.fts;
 				if (!fts) continue;
@@ -3290,6 +3304,12 @@ function importBackupUnlockedEffect({
 					idKey: fts.idKey,
 					textKey: fts.textKey,
 					existingIds: existingFtsIds.get(codec.name),
+				});
+			}
+			if (mode === "merge") {
+				finalizeBackupProfileRows({
+					db: writeDb,
+					legacyProfileMergePlans,
 				});
 			}
 			const importedRevisionChains = new Map<

--- a/src/lib/profile-identity.ts
+++ b/src/lib/profile-identity.ts
@@ -26,6 +26,24 @@ type ProfileRow = {
 	created_at: string;
 };
 
+type ProfileIdentityCollision = Pick<ProfileRow, "id" | "handle" | "raw_json">;
+
+const PROFILE_MUTABLE_COLUMNS = [
+	"handle",
+	"display_name",
+	"bio",
+	"followers_count",
+	"following_count",
+	"public_metrics_json",
+	"avatar_hue",
+	"avatar_url",
+	"location",
+	"url",
+	"verified_type",
+	"entities_json",
+	"raw_json",
+] as const satisfies readonly (keyof ProfileRow)[];
+
 let observeProfileIdentityCandidateCountForTests:
 	| ((count: number) => void)
 	| undefined;
@@ -193,6 +211,170 @@ function isReservedPlaceholderHandle(handle: string, externalUserId: string) {
 		handle === `user_${externalUserId}` ||
 		handle === `id${externalUserId}`
 	);
+}
+
+function isReservedBackupMergeHandle(handle: string, externalUserId: string) {
+	return (
+		isReservedPlaceholderHandle(handle, externalUserId) ||
+		handle.startsWith("birdclaw_stale_")
+	);
+}
+
+function normalizeProfileSnapshotState(row: Record<string, unknown>) {
+	return {
+		handle: String(row.handle ?? ""),
+		displayName: String(row.display_name ?? ""),
+		bio: String(row.bio ?? ""),
+		location: row.location ?? null,
+		url: row.url ?? null,
+		verifiedType: row.verified_type ?? null,
+		followersCount: Number(row.followers_count ?? 0),
+		followingCount: Number(row.following_count ?? 0),
+	};
+}
+
+function profileSnapshotStateKey(row: Record<string, unknown>) {
+	return JSON.stringify(normalizeProfileSnapshotState(row));
+}
+
+function liveProfileStateLastSeenAt(
+	db: Database,
+	profileId: string,
+	row: Record<string, unknown>,
+) {
+	const state = normalizeProfileSnapshotState(row);
+	const match = db
+		.prepare(
+			`select max(last_seen_at) as last_seen_at
+			 from profile_snapshots
+			 where profile_id = ?
+			   and handle = ?
+			   and display_name = ?
+			   and bio = ?
+			   and location is ?
+			   and url is ?
+			   and verified_type is ?
+			   and followers_count = ?
+			   and following_count = ?`,
+		)
+		.get(
+			profileId,
+			state.handle,
+			state.displayName,
+			state.bio,
+			state.location,
+			state.url,
+			state.verifiedType,
+			state.followersCount,
+			state.followingCount,
+		) as { last_seen_at: string | null } | undefined;
+	return match?.last_seen_at ?? null;
+}
+
+function indexImportedProfileSnapshotRecency(
+	rows: readonly Record<string, unknown>[],
+) {
+	const recency = new Map<string, string>();
+	for (const row of rows) {
+		if (
+			typeof row.profile_id !== "string" ||
+			typeof row.last_seen_at !== "string"
+		) {
+			continue;
+		}
+		const key = `${row.profile_id}\0${profileSnapshotStateKey(row)}`;
+		const current = recency.get(key);
+		if (!current || row.last_seen_at > current) {
+			recency.set(key, row.last_seen_at);
+		}
+	}
+	return recency;
+}
+
+function currentProfileRow(db: Database, profileId: string) {
+	return db.prepare("select * from profiles where id = ?").get(profileId) as
+		| ProfileRow
+		| undefined;
+}
+
+function preserveCurrentProfileState(
+	incoming: Record<string, unknown>,
+	current: ProfileRow,
+) {
+	const preserved = { ...incoming };
+	for (const column of PROFILE_MUTABLE_COLUMNS) {
+		preserved[column] = current[column];
+	}
+	return preserved;
+}
+
+export function reconcileBackupProfileRows({
+	db,
+	profileRows,
+	profileSnapshotRows,
+}: {
+	db: Database;
+	profileRows: readonly Record<string, unknown>[];
+	profileSnapshotRows: readonly Record<string, unknown>[];
+}) {
+	const importedSnapshotRecency =
+		indexImportedProfileSnapshotRecency(profileSnapshotRows);
+	return profileRows.map((input) => {
+		const incoming = { ...input };
+		const profileId = typeof incoming.id === "string" ? incoming.id : "";
+		const externalUserId = canonicalExternalUserId(profileId);
+		const incomingHandle =
+			typeof incoming.handle === "string" ? incoming.handle : "";
+		if (!externalUserId || !incomingHandle) return incoming;
+
+		const current = currentProfileRow(db, profileId);
+		const incomingLastSeenAt = importedSnapshotRecency.get(
+			`${profileId}\0${profileSnapshotStateKey(incoming)}`,
+		);
+		const currentLastSeenAt = current
+			? liveProfileStateLastSeenAt(db, profileId, current)
+			: null;
+		const currentIsPlaceholder = Boolean(
+			current && isReservedBackupMergeHandle(current.handle, externalUserId),
+		);
+		const incomingIsNewer = Boolean(
+			!current ||
+			currentIsPlaceholder ||
+			(incomingLastSeenAt &&
+				(!currentLastSeenAt || incomingLastSeenAt > currentLastSeenAt)),
+		);
+		if (!incomingIsNewer && current) {
+			return preserveCurrentProfileState(incoming, current);
+		}
+
+		const reconciliation = reconcileCanonicalXProfileIdentity({
+			db,
+			externalUserId,
+			canonicalProfileId: profileId,
+			incomingHandle,
+			canReassignHandleCollision: (collision) => {
+				const collisionRow = currentProfileRow(db, collision.id);
+				const collisionLastSeenAt = collisionRow
+					? liveProfileStateLastSeenAt(db, collision.id, collisionRow)
+					: null;
+				return Boolean(
+					incomingLastSeenAt &&
+					(!collisionLastSeenAt || incomingLastSeenAt > collisionLastSeenAt),
+				);
+			},
+		});
+		const handle =
+			reconciliation.blockedHandleProfileIds.length === 0
+				? incomingHandle
+				: (current?.handle ?? allocateReservedProfileHandle(db, profileId));
+		incoming.handle = handle;
+		incoming.raw_json = repairRawIdentity(
+			typeof incoming.raw_json === "string" ? incoming.raw_json : "{}",
+			externalUserId,
+			handle,
+		);
+		return incoming;
+	});
 }
 
 function repairRawIdentity(
@@ -620,12 +802,14 @@ export function reconcileCanonicalXProfileIdentity({
 	canonicalProfileId,
 	incomingHandle,
 	provenLegacyProfileIds = new Set<string>(),
+	canReassignHandleCollision,
 }: {
 	db: Database;
 	externalUserId: string;
 	canonicalProfileId: string;
 	incomingHandle: string;
 	provenLegacyProfileIds?: ReadonlySet<string>;
+	canReassignHandleCollision?: (collision: ProfileIdentityCollision) => boolean;
 }) {
 	const explicitLegacyIds = [...provenLegacyProfileIds];
 	const explicitClause =
@@ -712,12 +896,13 @@ export function reconcileCanonicalXProfileIdentity({
 	const blockedHandleProfileIds: string[] = [];
 	for (const collision of collisions) {
 		if (
-			collision.id === "profile_me" &&
-			(profileRawIdentityVetoesExternalUserId(
-				collision.raw_json,
-				externalUserId,
-			) ||
-				profileIdentityHasConflict(collision.raw_json, externalUserId))
+			(collision.id === "profile_me" &&
+				(profileRawIdentityVetoesExternalUserId(
+					collision.raw_json,
+					externalUserId,
+				) ||
+					profileIdentityHasConflict(collision.raw_json, externalUserId))) ||
+			(canReassignHandleCollision && !canReassignHandleCollision(collision))
 		) {
 			blockedHandleProfileIds.push(collision.id);
 			continue;

--- a/src/lib/profile-identity.ts
+++ b/src/lib/profile-identity.ts
@@ -28,6 +28,33 @@ type ProfileRow = {
 
 type ProfileIdentityCollision = Pick<ProfileRow, "id" | "handle" | "raw_json">;
 
+type PortableProfileValue =
+	| null
+	| boolean
+	| number
+	| string
+	| PortableProfileValue[]
+	| { [key: string]: PortableProfileValue };
+type PortableProfileRow = Record<string, PortableProfileValue>;
+
+interface SelectedAccountIdentity {
+	accountId: string;
+	username: string;
+	externalUserId?: string;
+	isDefault: boolean;
+}
+
+export interface BackupLegacyProfileMergePlan {
+	profileId: string;
+	incomingHandle: string;
+	incomingRawJson: string;
+	existingRawJson?: string;
+	incomingLastSeenAt: string | null;
+	selectedAccount?: SelectedAccountIdentity;
+	canonicalProfileId?: string;
+	externalUserId?: string;
+}
+
 const PROFILE_MUTABLE_COLUMNS = [
 	"handle",
 	"display_name",
@@ -120,12 +147,7 @@ export function profileIdentityHasConflict(
 
 export function getProvenSelectedAccountLegacyProfileIds(
 	db: Database,
-	account: {
-		accountId: string;
-		username: string;
-		externalUserId?: string;
-		isDefault: boolean;
-	},
+	account: SelectedAccountIdentity,
 	incomingExternalUserId: string,
 ) {
 	const proven = new Set<string>();
@@ -298,9 +320,9 @@ function currentProfileRow(db: Database, profileId: string) {
 }
 
 function preserveCurrentProfileState(
-	incoming: Record<string, unknown>,
+	incoming: PortableProfileRow,
 	current: ProfileRow,
-) {
+): PortableProfileRow {
 	const preserved = { ...incoming };
 	for (const column of PROFILE_MUTABLE_COLUMNS) {
 		preserved[column] = current[column];
@@ -312,19 +334,95 @@ export function reconcileBackupProfileRows({
 	db,
 	profileRows,
 	profileSnapshotRows,
+	selectedAccount,
 }: {
 	db: Database;
-	profileRows: readonly Record<string, unknown>[];
-	profileSnapshotRows: readonly Record<string, unknown>[];
+	profileRows: readonly PortableProfileRow[];
+	profileSnapshotRows: readonly PortableProfileRow[];
+	selectedAccount?: SelectedAccountIdentity;
 }) {
 	const importedSnapshotRecency =
 		indexImportedProfileSnapshotRecency(profileSnapshotRows);
-	return profileRows.map((input) => {
+	const unavailableHandleKeys = new Set(
+		profileRows
+			.filter((row) => row.id !== "profile_me")
+			.map((row) =>
+				typeof row.handle === "string" ? profileHandleKey(row.handle) : "",
+			)
+			.filter(Boolean),
+	);
+	const legacyProfileMergePlans: BackupLegacyProfileMergePlan[] = [];
+	const rows = profileRows.map((input) => {
 		const incoming = { ...input };
 		const profileId = typeof incoming.id === "string" ? incoming.id : "";
-		const externalUserId = canonicalExternalUserId(profileId);
 		const incomingHandle =
 			typeof incoming.handle === "string" ? incoming.handle : "";
+		if (profileId === "profile_me" && incomingHandle) {
+			const existingLegacyProfile = currentProfileRow(db, profileId);
+			const externalUserId = selectedAccount?.externalUserId;
+			const canonicalProfileId = externalUserId
+				? `profile_user_${externalUserId}`
+				: undefined;
+			const canonicalProfileExists = Boolean(
+				canonicalProfileId &&
+				(profileRows.some((row) => row.id === canonicalProfileId) ||
+					db
+						.prepare("select 1 from profiles where id = ?")
+						.get(canonicalProfileId)),
+			);
+			const canProveSelectedAccount = Boolean(
+				selectedAccount?.isDefault &&
+				externalUserId &&
+				/^[0-9]+$/u.test(externalUserId) &&
+				canonicalProfileExists &&
+				profileHandleKey(selectedAccount.username) ===
+					profileHandleKey(incomingHandle),
+			);
+			legacyProfileMergePlans.push({
+				profileId,
+				incomingHandle,
+				incomingRawJson:
+					typeof incoming.raw_json === "string" ? incoming.raw_json : "{}",
+				...(existingLegacyProfile
+					? { existingRawJson: existingLegacyProfile.raw_json }
+					: {}),
+				incomingLastSeenAt:
+					importedSnapshotRecency.get(
+						`${profileId}\0${profileSnapshotStateKey(incoming)}`,
+					) ?? null,
+				...(canProveSelectedAccount &&
+				selectedAccount &&
+				externalUserId &&
+				canonicalProfileId
+					? {
+							selectedAccount,
+							externalUserId,
+							canonicalProfileId,
+						}
+					: {}),
+			});
+
+			const handleCollision = Boolean(
+				unavailableHandleKeys.has(profileHandleKey(incomingHandle)) ||
+				db
+					.prepare(
+						"select 1 from profiles where lower(handle) = lower(?) and id <> ?",
+					)
+					.get(incomingHandle, profileId),
+			);
+			if (handleCollision) {
+				incoming["handle"] = allocateReservedProfileHandle(
+					db,
+					profileId,
+					"stale",
+					unavailableHandleKeys,
+				);
+			}
+			unavailableHandleKeys.add(profileHandleKey(String(incoming["handle"])));
+			return incoming;
+		}
+
+		const externalUserId = canonicalExternalUserId(profileId);
 		if (!externalUserId || !incomingHandle) return incoming;
 
 		const current = currentProfileRow(db, profileId);
@@ -367,14 +465,77 @@ export function reconcileBackupProfileRows({
 			reconciliation.blockedHandleProfileIds.length === 0
 				? incomingHandle
 				: (current?.handle ?? allocateReservedProfileHandle(db, profileId));
-		incoming.handle = handle;
-		incoming.raw_json = repairRawIdentity(
+		incoming["handle"] = handle;
+		incoming["raw_json"] = repairRawIdentity(
 			typeof incoming.raw_json === "string" ? incoming.raw_json : "{}",
 			externalUserId,
 			handle,
 		);
 		return incoming;
 	});
+	return { rows, legacyProfileMergePlans };
+}
+
+export function finalizeBackupProfileRows({
+	db,
+	legacyProfileMergePlans,
+}: {
+	db: Database;
+	legacyProfileMergePlans: readonly BackupLegacyProfileMergePlan[];
+}) {
+	for (const plan of legacyProfileMergePlans) {
+		const { selectedAccount, externalUserId, canonicalProfileId, profileId } =
+			plan;
+		const proven = Boolean(
+			selectedAccount &&
+			externalUserId &&
+			canonicalProfileId &&
+			!profileRawIdentityVetoesExternalUserId(
+				plan.incomingRawJson,
+				externalUserId,
+			) &&
+			(!plan.existingRawJson ||
+				!profileRawIdentityVetoesExternalUserId(
+					plan.existingRawJson,
+					externalUserId,
+				)) &&
+			getProvenSelectedAccountLegacyProfileIds(
+				db,
+				selectedAccount,
+				externalUserId,
+			).has(profileId),
+		);
+		if (!proven || !selectedAccount || !externalUserId || !canonicalProfileId) {
+			if (db.prepare("select 1 from profiles where id = ?").get(profileId)) {
+				syncIdentitySearchIndexForProfileIds(db, [profileId]);
+			}
+			continue;
+		}
+
+		const current = currentProfileRow(db, canonicalProfileId);
+		const currentLastSeenAt = current
+			? liveProfileStateLastSeenAt(db, canonicalProfileId, current)
+			: null;
+		const preserveCanonicalMutableState = Boolean(
+			current &&
+			!isReservedBackupMergeHandle(current.handle, externalUserId) &&
+			plan.incomingLastSeenAt &&
+			currentLastSeenAt &&
+			plan.incomingLastSeenAt <= currentLastSeenAt,
+		);
+		reconcileCanonicalXProfileIdentity({
+			db,
+			externalUserId,
+			canonicalProfileId,
+			incomingHandle: selectedAccount.username,
+			provenLegacyProfileIds: new Set([profileId]),
+			preserveCanonicalMutableStateForLegacyProfileIds:
+				preserveCanonicalMutableState ? new Set([profileId]) : undefined,
+			skipIdentityMergeSnapshotForLegacyProfileIds: plan.incomingLastSeenAt
+				? new Set([profileId])
+				: undefined,
+		});
+	}
 }
 
 function repairRawIdentity(
@@ -412,7 +573,12 @@ export function repairCanonicalProfileRawIdentity(
 	return true;
 }
 
-function collisionHandle(db: Database, profileId: string, prefix: string) {
+function collisionHandle(
+	db: Database,
+	profileId: string,
+	prefix: string,
+	unavailableHandleKeys: ReadonlySet<string> = new Set(),
+) {
 	const digest = createHash("sha1")
 		.update(profileId)
 		.digest("hex")
@@ -421,6 +587,7 @@ function collisionHandle(db: Database, profileId: string, prefix: string) {
 	let candidate = base;
 	let suffix = 1;
 	while (
+		unavailableHandleKeys.has(profileHandleKey(candidate)) ||
 		db
 			.prepare(
 				"select 1 from profiles where lower(handle) = lower(?) and id <> ?",
@@ -436,8 +603,14 @@ export function allocateReservedProfileHandle(
 	db: Database,
 	profileId: string,
 	kind: "stub" | "stale" = "stub",
+	unavailableHandleKeys: ReadonlySet<string> = new Set(),
 ) {
-	return collisionHandle(db, profileId, `birdclaw_${kind}`);
+	return collisionHandle(
+		db,
+		profileId,
+		`birdclaw_${kind}`,
+		unavailableHandleKeys,
+	);
 }
 
 function mergeCurrentProfile(
@@ -446,6 +619,8 @@ function mergeCurrentProfile(
 	newProfileId: string,
 	externalUserId: string,
 	incomingHandle: string,
+	preserveTargetMutableState: boolean,
+	skipSourceSnapshot: boolean,
 ) {
 	const source = db
 		.prepare("select * from profiles where id = ?")
@@ -492,7 +667,15 @@ function mergeCurrentProfile(
 	}
 
 	recordProfileSnapshot(db, newProfileId, "pre_identity_merge");
-	recordProfileSnapshot(db, oldProfileId, "identity_merge");
+	if (!skipSourceSnapshot) {
+		recordProfileSnapshot(db, oldProfileId, "identity_merge");
+	}
+	if (preserveTargetMutableState) {
+		db.prepare(
+			"update profiles set created_at = min(created_at, ?) where id = ?",
+		).run(source.created_at, newProfileId);
+		return;
+	}
 	const targetHandleIsPlaceholder =
 		isReservedPlaceholderHandle(target.handle, externalUserId) ||
 		(target.display_name === target.handle &&
@@ -764,6 +947,8 @@ function mergeOrRekeyProfile(
 	newProfileId: string,
 	externalUserId: string,
 	incomingHandle: string,
+	preserveTargetMutableState = false,
+	skipSourceSnapshot = false,
 ) {
 	if (oldProfileId === newProfileId) return new Set([newProfileId]);
 	mergeCurrentProfile(
@@ -772,6 +957,8 @@ function mergeOrRekeyProfile(
 		newProfileId,
 		externalUserId,
 		incomingHandle,
+		preserveTargetMutableState,
+		skipSourceSnapshot,
 	);
 	const affectedSubjects = mergeProfileReferences(
 		db,
@@ -802,6 +989,8 @@ export function reconcileCanonicalXProfileIdentity({
 	canonicalProfileId,
 	incomingHandle,
 	provenLegacyProfileIds = new Set<string>(),
+	preserveCanonicalMutableStateForLegacyProfileIds = new Set<string>(),
+	skipIdentityMergeSnapshotForLegacyProfileIds = new Set<string>(),
 	canReassignHandleCollision,
 }: {
 	db: Database;
@@ -809,6 +998,8 @@ export function reconcileCanonicalXProfileIdentity({
 	canonicalProfileId: string;
 	incomingHandle: string;
 	provenLegacyProfileIds?: ReadonlySet<string>;
+	preserveCanonicalMutableStateForLegacyProfileIds?: ReadonlySet<string>;
+	skipIdentityMergeSnapshotForLegacyProfileIds?: ReadonlySet<string>;
 	canReassignHandleCollision?: (collision: ProfileIdentityCollision) => boolean;
 }) {
 	const explicitLegacyIds = [...provenLegacyProfileIds];
@@ -865,6 +1056,8 @@ export function reconcileCanonicalXProfileIdentity({
 			canonicalProfileId,
 			externalUserId,
 			incomingHandle,
+			preserveCanonicalMutableStateForLegacyProfileIds.has(profileId),
+			skipIdentityMergeSnapshotForLegacyProfileIds.has(profileId),
 		)) {
 			affectedSubjects.add(subjectId);
 		}

--- a/src/lib/x-profile.test.ts
+++ b/src/lib/x-profile.test.ts
@@ -206,7 +206,7 @@ describe("x profile sync helpers", () => {
 				},
 			],
 			profileSnapshotRows: [],
-		});
+		}).rows;
 
 		expect(prepared).toMatchObject({
 			id: "profile_user_4242",

--- a/src/lib/x-profile.test.ts
+++ b/src/lib/x-profile.test.ts
@@ -11,6 +11,7 @@ import {
 	getProvenSelectedAccountLegacyProfileIds,
 	markProfileIdentityConflict,
 	profileIdentityHasConflict,
+	reconcileBackupProfileRows,
 	repairCanonicalProfileRawIdentity,
 } from "./profile-identity";
 import {
@@ -171,6 +172,50 @@ describe("x profile sync helpers", () => {
 				followingCount: 44,
 			}),
 		);
+	});
+
+	it("preserves a non-placeholder current profile without matching imported snapshot evidence", () => {
+		const db = makeTempHome();
+		upsertProfileFromXUser(db, {
+			id: "4242",
+			username: "current_handle",
+			name: "Current Name",
+			description: "Current bio",
+			public_metrics: { followers_count: 42, following_count: 7 },
+		});
+
+		const [prepared] = reconcileBackupProfileRows({
+			db,
+			profileRows: [
+				{
+					id: "profile_user_4242",
+					handle: "stale_handle",
+					display_name: "Stale Name",
+					bio: "Stale bio",
+					followers_count: 10,
+					following_count: 2,
+					public_metrics_json: "{}",
+					avatar_hue: 1,
+					avatar_url: null,
+					location: null,
+					url: null,
+					verified_type: null,
+					entities_json: "{}",
+					raw_json: '{"id":"4242","username":"stale_handle"}',
+					created_at: "2025-01-01T00:00:00.000Z",
+				},
+			],
+			profileSnapshotRows: [],
+		});
+
+		expect(prepared).toMatchObject({
+			id: "profile_user_4242",
+			handle: "current_handle",
+			display_name: "Current Name",
+			bio: "Current bio",
+			followers_count: 42,
+			following_count: 7,
+		});
 	});
 
 	it("preserves an existing avatar when a later payload omits one", () => {


### PR DESCRIPTION
## Summary

- make scheduled account sync fail when its configured backup sync returns a failure
- preserve newer numeric profile identity and handle ownership when backup sync merges a prior valid generation after live updates
- use imported profile snapshots to let genuinely newer backup state update an older live database
- safely adopt proven legacy selected-account `profile_me` rows into the canonical numeric profile after imported references exist
- make related profile snapshot, bio-entity, and affiliation conflict merges timestamp-aware

## Proof

- 1,442 tests passed
- format, lint, typecheck, client/SSR/CLI builds passed
- stale-backup, newer-backup, and production-shaped legacy-profile regressions pass
- contradictory and account-mismatch legacy aliases remain separate
- Codex autoreview reported no actionable findings

## Live discovery

Production rehearsals completed all six data steps and correctly exited 1 while surfacing two backup-import bugs: stale handle ownership and a legacy `profile_me` collision with the canonical numeric selected account. In both cases the scheduler stayed unloaded, no lock remained, and the clean backup checkout was unchanged. This PR fixes the status propagation and both import paths before scheduling is re-enabled.
