### PR TITLE
refactor: remove duplicate query and account seams

### DIFF
--- a/.agents/skills/birdclaw/SKILL.md
+++ b/.agents/skills/birdclaw/SKILL.md
@@ -188,7 +188,7 @@ Not backed up intentionally: `sync_cache`, `identity_search_index`, FTS tables/s
 After query/filter changes, run focused tests first:
 
 ```bash
-./scripts/bun-canary.sh ./scripts/run-vitest.mjs run src/lib/queries.test.ts src/cli.test.ts src/routes/api/query.test.ts
+./scripts/bun-canary.sh ./scripts/run-vitest.mjs run src/lib/query-models.test.ts src/cli.test.ts src/routes/api/query.test.ts
 ```
 
 After link-index or backup changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Register `archive find` and `db stats` as strict nested CLI commands, reject unknown subcommands, and return a structured HTTP 400 for invalid `/api/query` resources.
+- Apply the shared account-selection policy to follow-graph and network-map reads so IDs, `@handle` selectors, and bare handles resolve consistently.
 - Make numeric X user IDs the durable live-profile identity, preserving history and dependent references across proven legacy rekeys, handle reuse, case-fold collisions, handoffs, and swaps.
 - Serialize backup repositories with renewable token-owned leases and reliable token-checked release, validate NUL-safe fetched and staged generations before checkout mutation, prove Git ownership before finalizing journal recovery, and protect fsynced pending-push receipts from later export generations.
 - Adopt validated non-Git exports into empty backup remotes without weakening inventory checks, and preserve sparse handle-less DM avatar enrichment without fabricating public handles.
@@ -17,6 +19,7 @@
 
 ### Testing and maintenance
 
+- Remove obsolete query compatibility facades and internal Promise transport wrappers in favor of their owning read-model, action, and Effect modules.
 - Add synthetic regressions for profile identity collisions and canonicalization, atomic mention cursor writes, backup lease takeover, fsynced publication recovery, hidden data, large shards, malicious paths, read-only freshness, receipt-owned push retries, corrupt remotes, and diverged histories.
 
 ## 0.12.1 - 2026-08-08

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -137,6 +137,7 @@ vi.mock("#/lib/account-selection", () => ({
 vi.mock("#/lib/dm-read-model", () => ({
 	getConversationThread: (...args: unknown[]) =>
 		getConversationThreadMock(...args),
+	listDmConversations: (...args: unknown[]) => listDmConversationsMock(...args),
 }));
 
 vi.mock("#/lib/archive-finder", () => ({
@@ -304,15 +305,20 @@ vi.mock("#/lib/authored-live", () => ({
 	syncAuthoredTweets: (...args: unknown[]) => syncAuthoredTweetsMock(...args),
 }));
 
-vi.mock("#/lib/queries", () => ({
+vi.mock("#/lib/query-actions", () => ({
 	applyDmRequestMutationToLocalStore: (...args: unknown[]) =>
 		applyDmRequestMutationToLocalStoreMock(...args),
-	getQueryEnvelope: (...args: unknown[]) => getQueryEnvelopeMock(...args),
-	listTimelineItems: (...args: unknown[]) => listTimelineItemsMock(...args),
-	listDmConversations: (...args: unknown[]) => listDmConversationsMock(...args),
 	createPost: (...args: unknown[]) => createPostMock(...args),
 	createTweetReply: (...args: unknown[]) => createTweetReplyMock(...args),
 	createDmReply: (...args: unknown[]) => createDmReplyMock(...args),
+}));
+
+vi.mock("#/lib/query-status", () => ({
+	getQueryEnvelope: (...args: unknown[]) => getQueryEnvelopeMock(...args),
+}));
+
+vi.mock("#/lib/timeline-read-model", () => ({
+	listTimelineItems: (...args: unknown[]) => listTimelineItemsMock(...args),
 }));
 
 vi.mock("#/lib/production-server", () => ({
@@ -729,6 +735,35 @@ describe("cli", () => {
 		});
 		expect(getNativeDbMock).toHaveBeenCalledWith({ seedDemoData: false });
 		expect(seedDemoDataMock).not.toHaveBeenCalled();
+	});
+
+	it("registers archive and db as nested command groups", async () => {
+		const { program } = await loadCli();
+		const archive = program.commands.find(
+			(command) => command.name() === "archive",
+		);
+		const db = program.commands.find((command) => command.name() === "db");
+
+		expect(archive?.description()).toBe("Find and inspect Twitter archives");
+		expect(archive?.commands.map((command) => command.name())).toEqual([
+			"find",
+		]);
+		expect(archive?.commands[0]?.description()).toBe(
+			"Find likely Twitter archives on disk",
+		);
+		expect(db?.description()).toBe("Inspect local storage");
+		expect(db?.commands.map((command) => command.name())).toEqual(["stats"]);
+		expect(db?.commands[0]?.description()).toBe(
+			"Show local storage and dataset stats",
+		);
+
+		for (const command of [archive, db]) {
+			command?.exitOverride();
+			command?.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+			await expect(
+				command?.parseAsync(["nonsense"], { from: "user" }),
+			).rejects.toMatchObject({ code: "commander.unknownCommand" });
+		}
 	});
 
 	it("seeds and explains an offline demo only when requested", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ const packageRoot = findPackageRoot(import.meta.url);
 const packageVersion = JSON.parse(
 	readFileSync(join(packageRoot, "package.json"), "utf8"),
 ) as { version?: string };
-const program = new Command()
+export const program = new Command()
 	.name("birdclaw")
 	.description("Local-first Twitter workspace")
 	.version(packageVersion.version ?? "0.0.0")

--- a/src/cli/dm-command-helpers.ts
+++ b/src/cli/dm-command-helpers.ts
@@ -1,6 +1,6 @@
 import type { DirectMessagesSyncMode } from "#/lib/dms-live";
 import { resolveProfilesForIds } from "#/lib/profile-resolver";
-import { listDmConversations } from "#/lib/queries";
+import { listDmConversations } from "#/lib/dm-read-model";
 import { expandUrlsFromTexts } from "#/lib/url-expansion";
 import { printError } from "./command-context";
 

--- a/src/cli/register-compose.ts
+++ b/src/cli/register-compose.ts
@@ -1,4 +1,8 @@
-import { createDmReply, createPost, createTweetReply } from "#/lib/queries";
+import {
+	createDmReply,
+	createPost,
+	createTweetReply,
+} from "#/lib/query-actions";
 import type { CliCommandContext } from "./command-context";
 
 export function registerComposeCommands({

--- a/src/cli/register-core.ts
+++ b/src/cli/register-core.ts
@@ -17,7 +17,7 @@ import {
 	importTweetsViaFxTwitter,
 } from "#/lib/fxtwitter";
 import { hydrateProfilesFromX } from "#/lib/profile-hydration";
-import { getQueryEnvelope } from "#/lib/queries";
+import { getQueryEnvelope } from "#/lib/query-status";
 import { seedDemoData } from "#/lib/seed";
 import { printError, type CliCommandContext } from "./command-context";
 
@@ -225,8 +225,11 @@ export function registerCoreCommands({
 			if (parsed) print(setActionsTransport(parsed), asJson());
 		});
 
-	program
-		.command("archive find")
+	const archiveCommand = program
+		.command("archive")
+		.description("Find and inspect Twitter archives");
+	archiveCommand
+		.command("find")
 		.description("Find likely Twitter archives on disk")
 		.action(async () => print(await findArchives(), asJson()));
 

--- a/src/cli/register-dms.ts
+++ b/src/cli/register-dms.ts
@@ -6,7 +6,7 @@ import { resolveOperationAccount } from "#/lib/account-selection";
 import { getConversationThread } from "#/lib/dm-read-model";
 import { syncDirectMessagesViaCachedBird } from "#/lib/dms-live";
 import { assertLiveAccountMatches } from "#/lib/live-sync-engine";
-import { applyDmRequestMutationToLocalStore } from "#/lib/queries";
+import { applyDmRequestMutationToLocalStore } from "#/lib/query-actions";
 import type { CliCommandContext } from "./command-context";
 import {
 	enrichDmItems,

--- a/src/cli/register-search.ts
+++ b/src/cli/register-search.ts
@@ -1,7 +1,7 @@
 import { backfillLinkIndex, searchLinks } from "#/lib/link-index";
 import { FxTwitterError, importSearchViaFxTwitter } from "#/lib/fxtwitter";
 import { fetchTweetMedia, formatMediaFetchResult } from "#/lib/media-fetch";
-import { listTimelineItems } from "#/lib/queries";
+import { listTimelineItems } from "#/lib/timeline-read-model";
 import { formatWhois, runWhois } from "#/lib/whois";
 import { resolveStoredXListSelector } from "#/lib/x-lists";
 import type { CliCommandContext } from "./command-context";

--- a/src/cli/register-storage.ts
+++ b/src/cli/register-storage.ts
@@ -6,7 +6,7 @@ import {
 } from "#/lib/backup";
 import { getBirdclawPaths } from "#/lib/config";
 import { getDatabaseRuntimeMetrics } from "#/lib/database-metrics";
-import { getQueryEnvelope } from "#/lib/queries";
+import { getQueryEnvelope } from "#/lib/query-status";
 import type { CliCommandContext } from "./command-context";
 
 export function registerStorageCommands({
@@ -15,8 +15,9 @@ export function registerStorageCommands({
 	asJson,
 	autoUpdateBeforeRead,
 }: CliCommandContext) {
-	program
-		.command("db stats")
+	const dbCommand = program.command("db").description("Inspect local storage");
+	dbCommand
+		.command("stats")
 		.description("Show local storage and dataset stats")
 		.action(async () => {
 			await autoUpdateBeforeRead();

--- a/src/lib/account-selection.test.ts
+++ b/src/lib/account-selection.test.ts
@@ -56,7 +56,30 @@ describe("operation account selection", () => {
 
 	it("accepts ids, usernames, and @usernames without changing storage", () => {
 		const db = getNativeDb({ seedDemoData: false });
+		db.prepare(
+			`insert into accounts
+			 (id, name, handle, external_user_id, transport, is_default, created_at)
+			 values (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"first_user",
+			"ID Owner",
+			"id_owner",
+			"300",
+			"archive",
+			0,
+			"2026-01-03T00:00:00.000Z",
+		);
 		expect(findOperationAccount(db, "acct_first")).toEqual({
+			id: "acct_first",
+			username: "first_user",
+			externalUserId: "100",
+		});
+		expect(findOperationAccount(db, "first_user")).toEqual({
+			id: "first_user",
+			username: "id_owner",
+			externalUserId: "300",
+		});
+		expect(findOperationAccount(db, "@first_user")).toEqual({
 			id: "acct_first",
 			username: "first_user",
 			externalUserId: "100",
@@ -76,7 +99,11 @@ describe("operation account selection", () => {
 		).toEqual([
 			{ id: "acct_default", is_default: 1 },
 			{ id: "acct_first", is_default: 0 },
+			{ id: "first_user", is_default: 0 },
 		]);
+		expect(resolveOperationAccount("@DEFAULT_USER", db)).toMatchObject({
+			id: "acct_default",
+		});
 	});
 
 	it("uses the database default only when no selector is supplied", () => {

--- a/src/lib/account-selection.ts
+++ b/src/lib/account-selection.ts
@@ -15,36 +15,19 @@ export function findOperationAccount(
 	db: Database,
 	selector?: string,
 ): OperationAccount | undefined {
-	const hasSelector = selector !== undefined;
-	const normalized = hasSelector
-		? normalizedAccountSelector(selector)
-		: undefined;
-	if (hasSelector && !normalized) return undefined;
-	const row = hasSelector
-		? (db
-				.prepare(
-					`select id, handle, external_user_id
-					 from accounts
-					 where id = ?
-					    or lower(replace(handle, '@', '')) = lower(?)
-					 order by case when id = ? then 0 else 1 end,
-					          is_default desc,
-					          created_at asc
-					 limit 1`,
-				)
-				.get(selector.trim(), normalized, selector.trim()) as
-				| { id: string; handle: string; external_user_id: string | null }
-				| undefined)
-		: (db
-				.prepare(
-					`select id, handle, external_user_id
+	const row =
+		selector === undefined
+			? (db
+					.prepare(
+						`select id, handle, external_user_id
 					 from accounts
 					 order by is_default desc, created_at asc
 					 limit 1`,
-				)
-				.get() as
-				| { id: string; handle: string; external_user_id: string | null }
-				| undefined);
+					)
+					.get() as
+					| { id: string; handle: string; external_user_id: string | null }
+					| undefined)
+			: findSelectedAccount(db, selector);
 
 	return row
 		? {
@@ -57,8 +40,34 @@ export function findOperationAccount(
 		: undefined;
 }
 
-export function resolveOperationAccount(selector?: string): OperationAccount {
-	const account = findOperationAccount(getNativeDb(), selector);
+function findSelectedAccount(db: Database, selector: string) {
+	const trimmed = selector.trim();
+	const normalized = normalizedAccountSelector(selector);
+	if (!normalized) return undefined;
+	const byId = db
+		.prepare("select id, handle, external_user_id from accounts where id = ?")
+		.get(trimmed) as
+		| { id: string; handle: string; external_user_id: string | null }
+		| undefined;
+	if (byId) return byId;
+	return db
+		.prepare(
+			`select id, handle, external_user_id
+			 from accounts
+			 where lower(replace(handle, '@', '')) = lower(?)
+			 order by is_default desc, created_at asc
+			 limit 1`,
+		)
+		.get(normalized) as
+		| { id: string; handle: string; external_user_id: string | null }
+		| undefined;
+}
+
+export function resolveOperationAccount(
+	selector?: string,
+	db = getNativeDb(),
+): OperationAccount {
+	const account = findOperationAccount(db, selector);
 	if (!account) {
 		throw new Error(`Unknown account: ${selector?.trim() || "default"}`);
 	}

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -8,7 +8,7 @@ import {
 import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { type ActionsTransport, resolveActionsTransport } from "./config";
 import { Effect } from "effect";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { assertLiveAccountMatches } from "./live-sync-engine";
 import { profileHandleKey } from "./profile-row";
 import type {
@@ -38,17 +38,6 @@ export interface ExpectedActionAccount {
 	id: string;
 	handle: string;
 	externalUserId?: string | null;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 function normalizeFailure(transport: ModerationTransportKind, output: string) {

--- a/src/lib/analysis-runtime.ts
+++ b/src/lib/analysis-runtime.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { tryPromise } from "./effect-runtime";
+import { toError, tryPromise } from "./effect-runtime";
 import {
 	readOpenAIResponseStreamEffect,
 	requestOpenAIResponseEffect,
@@ -35,10 +35,6 @@ export interface HybridAnalysisResult<T> {
 	rawText: string;
 	responseId?: string;
 	usage?: unknown;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
 }
 
 export function resolveAnalysisModelSettings(

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -22,12 +22,9 @@ import { __test__, importArchive, importArchiveEffect } from "./archive-import";
 import { getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
 import { listFollowEvents, listUnfollowedSince } from "./follow-graph";
-import {
-	getConversationThread,
-	getQueryEnvelope,
-	listDmConversations,
-	listTimelineItems,
-} from "./queries";
+import { getConversationThread, listDmConversations } from "./dm-read-model";
+import { getQueryEnvelope } from "./query-status";
+import { listTimelineItems } from "./timeline-read-model";
 
 const testHome = useTestHome({ prefix: "birdclaw-home-" });
 

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -7,7 +7,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
 	getTransportStatus: vi.fn(),

--- a/src/lib/avatar-cache.ts
+++ b/src/lib/avatar-cache.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { Effect } from "effect";
 import { getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise, tryPromise, trySync } from "./effect-runtime";
 import { assertSafePreviewUrl } from "./url-safety";
 
 const AVATAR_SIZE_SUFFIX =
@@ -103,17 +103,6 @@ function getAvatarUrlForProfile(profileId: string) {
 		.prepare("select avatar_url from profiles where id = ?")
 		.get(profileId) as { avatar_url: string | null } | undefined;
 	return row?.avatar_url ?? null;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 function assertSafeRemoteAvatarUrl(avatarUrl: string) {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -25,6 +25,7 @@ import { databaseWriteEffect } from "./database-writer";
 import {
 	runEffectBackground,
 	runEffectPromise,
+	trySync,
 	tryPromise,
 } from "./effect-runtime";
 import { getImportRepository } from "./import-repository";
@@ -213,17 +214,6 @@ export class BackupGitCommandError extends Data.TaggedError(
 	readonly stderr?: string;
 	readonly cause?: unknown;
 }> {}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
-}
 
 function openBackupDatabase() {
 	beforeDatabaseOpenForTests?.();

--- a/src/lib/bird-actions.ts
+++ b/src/lib/bird-actions.ts
@@ -3,7 +3,7 @@ import {
 	BirdCommandExecutionError,
 	runBirdCommandEffect,
 } from "./bird-command";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import type { XurlMentionUser } from "./types";
 
 function liveWritesDisabled() {
@@ -53,17 +53,12 @@ function normalizeOutput(stdout?: string, stderr?: string) {
 	return stripAnsi(stdout || stderr || "ok").trim();
 }
 
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
 function runBirdJsonCommandEffect(args: string[]) {
 	return Effect.gen(function* () {
 		const { stdout } = yield* runBirdCommandEffect(args);
-		return yield* Effect.try({
-			try: () => JSON.parse(stripAnsi(stdout)) as Record<string, unknown>,
-			catch: toError,
-		});
+		return yield* trySync(
+			() => JSON.parse(stripAnsi(stdout)) as Record<string, unknown>,
+		);
 	});
 }
 
@@ -80,10 +75,7 @@ function safeBirdProfileArg(query: string) {
 
 export function readBirdStatusViaBirdEffect(query: string) {
 	return Effect.gen(function* () {
-		const safeQuery = yield* Effect.try({
-			try: () => safeBirdProfileArg(query),
-			catch: toError,
-		});
+		const safeQuery = yield* trySync(() => safeBirdProfileArg(query));
 		return yield* runBirdJsonCommandEffect(["status", safeQuery, "--json"]);
 	}).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
@@ -154,10 +146,7 @@ function toBirdLookupUser(payload: Record<string, unknown>): XurlMentionUser {
 
 export function lookupProfileViaBirdEffect(query: string) {
 	return Effect.gen(function* () {
-		const safeQuery = yield* Effect.try({
-			try: () => safeBirdProfileArg(query),
-			catch: toError,
-		});
+		const safeQuery = yield* trySync(() => safeBirdProfileArg(query));
 		const payload = yield* runBirdJsonCommandEffect([
 			"user",
 			safeQuery,
@@ -165,10 +154,7 @@ export function lookupProfileViaBirdEffect(query: string) {
 			"1",
 			"--json",
 		]);
-		return yield* Effect.try({
-			try: () => toBirdLookupUser(payload),
-			catch: toError,
-		});
+		return yield* trySync(() => toBirdLookupUser(payload));
 	}).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 
@@ -188,10 +174,7 @@ function runVerifiedBirdMutationEffect({
 	expectedValue: boolean;
 }) {
 	return Effect.gen(function* () {
-		const safeQuery = yield* Effect.try({
-			try: () => safeBirdProfileArg(query),
-			catch: toError,
-		});
+		const safeQuery = yield* trySync(() => safeBirdProfileArg(query));
 		if (liveWritesDisabled()) {
 			if (e2eFakeLiveWritesEnabled()) {
 				return { ok: true, output: "e2e fake live write" };

--- a/src/lib/bird.test.ts
+++ b/src/lib/bird.test.ts
@@ -7,6 +7,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsyncMock = vi.fn();
 
+async function runBirdEffect<A, E>(
+	build: (bird: typeof import("./bird")) => Effect.Effect<A, E>,
+) {
+	return Effect.runPromise(build(await import("./bird")));
+}
+
 vi.mock("node:child_process", () => ({
 	execFile: Object.assign(vi.fn(), {
 		[Symbol.for("nodejs.util.promisify.custom")]: execFileAsyncMock,
@@ -47,7 +53,7 @@ function expectBirdCommandCall(callNumber: number, args: string[]) {
 	);
 }
 
-describe("bird transport wrapper", () => {
+describe("bird transport", () => {
 	afterEach(() => {
 		vi.resetModules();
 		execFileAsyncMock.mockReset();
@@ -199,11 +205,9 @@ describe("bird transport wrapper", () => {
 				},
 			]),
 		);
-		const { listMentionsViaBird } = await import("./bird");
-
-		const payload = await listMentionsViaBird({
-			maxResults: 12,
-		});
+		const payload = await runBirdEffect((bird) =>
+			bird.listMentionsViaBirdEffect({ maxResults: 12 }),
+		);
 
 		expectBirdCommandCall(1, ["mentions", "-n", "12", "--json-full"]);
 		expect(payload).toEqual({
@@ -282,13 +286,13 @@ describe("bird transport wrapper", () => {
 			}),
 		);
 		mockBirdStdoutOnce("[]");
-		const { listMentionsViaBird } = await import("./bird");
-
-		await expect(listMentionsViaBird({ maxResults: 5 })).resolves.toMatchObject(
-			{
-				data: [],
-			},
-		);
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 5 }),
+			),
+		).resolves.toMatchObject({
+			data: [],
+		});
 		expectBirdCommandCall(1, ["mentions", "-n", "5", "--json-full"]);
 		expectBirdCommandCall(2, ["mentions", "-n", "5", "--json"]);
 	});
@@ -338,10 +342,13 @@ describe("bird transport wrapper", () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce("[]");
 		mockBirdStdoutOnce("[]");
-		const { searchTweetsViaBird } = await import("./bird");
-
 		await expect(
-			searchTweetsViaBird("ChatGPT", { maxResults: 5, maxPages: 1 }),
+			runBirdEffect((bird) =>
+				bird.searchTweetsViaBirdEffect("ChatGPT", {
+					maxResults: 5,
+					maxPages: 1,
+				}),
+			),
 		).resolves.toEqual({
 			data: [],
 			includes: undefined,
@@ -355,11 +362,13 @@ describe("bird transport wrapper", () => {
 		});
 		expectBirdCommandCall(1, ["search", "ChatGPT", "-n", "5", "--json-full"]);
 
-		await searchTweetsViaBird("ChatGPT", {
-			maxResults: 5,
-			all: true,
-			maxPages: 2,
-		});
+		await runBirdEffect((bird) =>
+			bird.searchTweetsViaBirdEffect("ChatGPT", {
+				maxResults: 5,
+				all: true,
+				maxPages: 2,
+			}),
+		);
 		expectBirdCommandCall(2, [
 			"search",
 			"ChatGPT",
@@ -399,9 +408,11 @@ describe("bird transport wrapper", () => {
 		);
 		mockBirdStdoutOnce("[]");
 
-		const { listMentionsViaBird } = await import("./bird");
-
-		await expect(listMentionsViaBird({ maxResults: 2 })).resolves.toEqual({
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 2 }),
+			),
+		).resolves.toEqual({
 			data: [
 				expect.objectContaining({
 					id: "tweet_2",
@@ -453,7 +464,11 @@ describe("bird transport wrapper", () => {
 			},
 		});
 
-		await expect(listMentionsViaBird({ maxResults: 0 })).resolves.toEqual({
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 0 }),
+			),
+		).resolves.toEqual({
 			data: [],
 			includes: undefined,
 			meta: {
@@ -468,11 +483,11 @@ describe("bird transport wrapper", () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce("{}");
 
-		const { listMentionsViaBird } = await import("./bird");
-
-		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"bird mentions returned unexpected JSON",
-		);
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 10 }),
+			),
+		).rejects.toThrow("bird mentions returned unexpected JSON");
 	});
 
 	it("explains how to configure bird when the binary is missing", async () => {
@@ -484,11 +499,11 @@ describe("bird transport wrapper", () => {
 			}),
 		);
 
-		const { listMentionsViaBird } = await import("./bird");
-
-		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"bird command unavailable: /missing/bird",
-		);
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 10 }),
+			),
+		).rejects.toThrow("bird command unavailable: /missing/bird");
 	});
 
 	it("explains how to configure Bash when the wrapper shell is missing", async () => {
@@ -497,11 +512,11 @@ describe("bird transport wrapper", () => {
 			Object.assign(new Error("spawn bash.exe ENOENT"), { code: "ENOENT" }),
 		);
 
-		const { listMentionsViaBird } = await import("./bird");
-
-		await expect(listMentionsViaBird({ maxResults: 10 })).rejects.toThrow(
-			"Bash unavailable:",
-		);
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listMentionsViaBirdEffect({ maxResults: 10 }),
+			),
+		).rejects.toThrow("Bash unavailable:");
 	});
 
 	it("tolerates bird json with raw newlines inside tweet text", async () => {
@@ -509,9 +524,11 @@ describe("bird transport wrapper", () => {
 		mockBirdStdoutOnce(
 			'[{ "id": "tweet_1", "text": "first line\nsecond line", "createdAt": "2026-04-26T13:43:34.000Z", "authorId": "42", "author": { "username": "sam", "name": "Sam" } }]',
 		);
-		const { listLikedTweetsViaBird } = await import("./bird");
-
-		await expect(listLikedTweetsViaBird({ maxResults: 1 })).resolves.toEqual(
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listLikedTweetsViaBirdEffect({ maxResults: 1 }),
+			),
+		).resolves.toEqual(
 			expect.objectContaining({
 				data: [
 					expect.objectContaining({
@@ -538,11 +555,11 @@ describe("bird transport wrapper", () => {
 		};
 		mockBirdStdoutOnce(JSON.stringify(payload));
 
-		const { listDirectMessagesViaBird } = await import("./bird");
-
-		await expect(listDirectMessagesViaBird({ maxResults: 5 })).resolves.toEqual(
-			payload,
-		);
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listDirectMessagesViaBirdEffect({ maxResults: 5 }),
+			),
+		).resolves.toEqual(payload);
 		expectBirdCommandCall(1, ["dms", "-n", "5", "--json"]);
 	});
 
@@ -572,15 +589,15 @@ describe("bird transport wrapper", () => {
 		const payload = { success: true, conversations: [], events: [] };
 		mockBirdStdoutOnce(JSON.stringify(payload));
 
-		const { listDirectMessagesViaBird } = await import("./bird");
-
 		await expect(
-			listDirectMessagesViaBird({
-				maxResults: 50,
-				inbox: "requests",
-				maxPages: 2,
-				pageDelayMs: 750,
-			}),
+			runBirdEffect((bird) =>
+				bird.listDirectMessagesViaBirdEffect({
+					maxResults: 50,
+					inbox: "requests",
+					maxPages: 2,
+					pageDelayMs: 750,
+				}),
+			),
 		).resolves.toEqual(payload);
 		expectBirdCommandCall(1, [
 			"dms",
@@ -679,20 +696,23 @@ describe("bird transport wrapper", () => {
 				},
 			]),
 		);
-		const { listBookmarkedTweetsViaBird, listLikedTweetsViaBird } =
-			await import("./bird");
-
-		await expect(listLikedTweetsViaBird({ maxResults: 5 })).resolves.toEqual({
+		await expect(
+			runBirdEffect((bird) =>
+				bird.listLikedTweetsViaBirdEffect({ maxResults: 5 }),
+			),
+		).resolves.toEqual({
 			data: [expect.objectContaining({ id: "liked_1", author_id: "42" })],
 			includes: { users: [{ id: "42", username: "sam", name: "Sam" }] },
 			meta: expect.objectContaining({ result_count: 1 }),
 		});
 		await expect(
-			listBookmarkedTweetsViaBird({
-				maxResults: 7,
-				all: true,
-				maxPages: 2,
-			}),
+			runBirdEffect((bird) =>
+				bird.listBookmarkedTweetsViaBirdEffect({
+					maxResults: 7,
+					all: true,
+					maxPages: 2,
+				}),
+			),
 		).resolves.toEqual({
 			data: [expect.objectContaining({ id: "bookmark_1", author_id: "43" })],
 			includes: { users: [{ id: "43", username: "amelia", name: "Amelia" }] },
@@ -714,11 +734,12 @@ describe("bird transport wrapper", () => {
 		process.env.BIRDCLAW_BIRD_COMMAND = "/tmp/bird";
 		mockBirdStdoutOnce("[]");
 		mockBirdStdoutOnce("[]");
-		const { listBookmarkedTweetsViaBird, listLikedTweetsViaBird } =
-			await import("./bird");
-
-		await listLikedTweetsViaBird({ maxResults: 5, maxPages: 2 });
-		await listBookmarkedTweetsViaBird({ maxResults: 7, maxPages: 3 });
+		await runBirdEffect((bird) =>
+			bird.listLikedTweetsViaBirdEffect({ maxResults: 5, maxPages: 2 }),
+		);
+		await runBirdEffect((bird) =>
+			bird.listBookmarkedTweetsViaBirdEffect({ maxResults: 7, maxPages: 3 }),
+		);
 
 		expect(execFileAsyncMock).toHaveBeenCalledTimes(2);
 		expectBirdCommandCall(1, ["likes", "-n", "5", "--json-full"]);
@@ -753,11 +774,10 @@ describe("bird transport wrapper", () => {
 				nextCursor: "cursor-next",
 			}),
 		);
-		const { listOwnedXListsViaBird, listXListMembersViaBird } =
-			await import("./bird");
-
 		await expect(
-			listOwnedXListsViaBird({ maxResults: 20 }),
+			runBirdEffect((bird) =>
+				bird.listOwnedXListsViaBirdEffect({ maxResults: 20 }),
+			),
 		).resolves.toMatchObject({
 			data: [
 				{
@@ -770,11 +790,13 @@ describe("bird transport wrapper", () => {
 			],
 		});
 		await expect(
-			listXListMembersViaBird({
-				listId: "list_1",
-				maxResults: 20,
-				maxPages: 3,
-			}),
+			runBirdEffect((bird) =>
+				bird.listXListMembersViaBirdEffect({
+					listId: "list_1",
+					maxResults: 20,
+					maxPages: 3,
+				}),
+			),
 		).resolves.toMatchObject({
 			data: [{ id: "7", username: "member" }],
 			meta: { next_token: "cursor-next", pagination_known_complete: false },
@@ -806,10 +828,13 @@ describe("bird transport wrapper", () => {
 				},
 			]),
 		);
-		const { listHomeTimelineViaBird } = await import("./bird");
-
 		await expect(
-			listHomeTimelineViaBird({ maxResults: 9, following: true }),
+			runBirdEffect((bird) =>
+				bird.listHomeTimelineViaBirdEffect({
+					maxResults: 9,
+					following: true,
+				}),
+			),
 		).resolves.toEqual({
 			data: [expect.objectContaining({ id: "home_1", author_id: "45" })],
 			includes: { users: [{ id: "45", username: "riley", name: "Riley" }] },
@@ -848,16 +873,16 @@ describe("bird transport wrapper", () => {
 				},
 			]),
 		);
-		const { listFollowUsersViaBird } = await import("./bird");
-
 		await expect(
-			listFollowUsersViaBird({
-				direction: "followers",
-				userId: "25401953",
-				maxResults: 100,
-				all: true,
-				maxPages: 2,
-			}),
+			runBirdEffect((bird) =>
+				bird.listFollowUsersViaBirdEffect({
+					direction: "followers",
+					userId: "25401953",
+					maxResults: 100,
+					all: true,
+					maxPages: 2,
+				}),
+			),
 		).resolves.toEqual({
 			data: [
 				expect.objectContaining({
@@ -877,10 +902,12 @@ describe("bird transport wrapper", () => {
 			},
 		});
 		await expect(
-			listFollowUsersViaBird({
-				direction: "following",
-				maxResults: 10,
-			}),
+			runBirdEffect((bird) =>
+				bird.listFollowUsersViaBirdEffect({
+					direction: "following",
+					maxResults: 10,
+				}),
+			),
 		).resolves.toEqual({
 			data: [
 				expect.objectContaining({
@@ -928,10 +955,14 @@ describe("bird transport wrapper", () => {
 				},
 			]),
 		);
-		const { listThreadViaBird } = await import("./bird");
-
 		await expect(
-			listThreadViaBird({ tweetId: "reply_1", maxPages: 2, timeoutMs: 5000 }),
+			runBirdEffect((bird) =>
+				bird.listThreadViaBirdEffect({
+					tweetId: "reply_1",
+					maxPages: 2,
+					timeoutMs: 5000,
+				}),
+			),
 		).resolves.toEqual({
 			data: [
 				expect.objectContaining({
@@ -972,10 +1003,10 @@ describe("bird transport wrapper", () => {
 				nextCursor: null,
 			}),
 		);
-		const { listBookmarkedTweetsViaBird } = await import("./bird");
-
 		await expect(
-			listBookmarkedTweetsViaBird({ maxResults: 5, all: true }),
+			runBirdEffect((bird) =>
+				bird.listBookmarkedTweetsViaBirdEffect({ maxResults: 5, all: true }),
+			),
 		).resolves.toEqual({
 			data: [expect.objectContaining({ id: "bookmark_2", author_id: "44" })],
 			includes: { users: [{ id: "44", username: "jules", name: "Jules" }] },
@@ -998,9 +1029,9 @@ describe("bird transport wrapper", () => {
 				likeCount: 9,
 			}),
 		);
-		const { lookupTweetsByIdsViaBird } = await import("./bird");
-
-		await expect(lookupTweetsByIdsViaBird(["tweet_1"])).resolves.toEqual({
+		await expect(
+			runBirdEffect((bird) => bird.lookupTweetsByIdsViaBirdEffect(["tweet_1"])),
+		).resolves.toEqual({
 			data: [
 				expect.objectContaining({
 					id: "tweet_1",
@@ -1036,9 +1067,9 @@ describe("bird transport wrapper", () => {
 				},
 			}),
 		);
-		const { lookupProfileViaBird } = await import("./bird");
-
-		await expect(lookupProfileViaBird("42")).resolves.toEqual({
+		await expect(
+			runBirdEffect((bird) => bird.lookupProfileViaBirdEffect("42")),
+		).resolves.toEqual({
 			id: "42",
 			username: "sam",
 			name: "Sam",
@@ -1071,9 +1102,9 @@ describe("bird transport wrapper", () => {
 				},
 			}),
 		);
-		const { lookupProfileViaBird } = await import("./bird");
-
-		await expect(lookupProfileViaBird("42")).resolves.toEqual(
+		await expect(
+			runBirdEffect((bird) => bird.lookupProfileViaBirdEffect("42")),
+		).resolves.toEqual(
 			expect.objectContaining({
 				id: "42",
 				username: "sam",
@@ -1101,14 +1132,13 @@ describe("bird transport wrapper", () => {
 			}),
 		);
 
-		const { listDirectMessagesViaBird } = await import("./bird");
-
-		await expect(listDirectMessagesViaBird({ maxResults: 5 })).rejects.toThrow(
-			"bird dms returned unexpected JSON",
-		);
-		await expect(listDirectMessagesViaBird({ maxResults: 5 })).rejects.toThrow(
-			"bird dms returned unexpected JSON",
-		);
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			await expect(
+				runBirdEffect((bird) =>
+					bird.listDirectMessagesViaBirdEffect({ maxResults: 5 }),
+				),
+			).rejects.toThrow("bird dms returned unexpected JSON");
+		}
 	});
 
 	it("uses bird profiles for batch profile hydration", async () => {
@@ -1130,8 +1160,9 @@ describe("bird transport wrapper", () => {
 			}),
 		);
 
-		const { lookupProfilesViaBird } = await import("./bird");
-		const results = await lookupProfilesViaBird(["@github", "missing"]);
+		const results = await runBirdEffect((bird) =>
+			bird.lookupProfilesViaBirdEffect(["@github", "missing"]),
+		);
 
 		expectBirdCommandCall(1, ["profiles", "github", "missing", "--json"]);
 		expect(results).toEqual([
@@ -1165,8 +1196,9 @@ describe("bird transport wrapper", () => {
 			}),
 		);
 
-		const { lookupProfilesViaBird } = await import("./bird");
-		const results = await lookupProfilesViaBird(["github"]);
+		const results = await runBirdEffect((bird) =>
+			bird.lookupProfilesViaBirdEffect(["github"]),
+		);
 
 		expectBirdCommandCall(1, ["profiles", "github", "--json"]);
 		expectBirdCommandCall(2, ["user", "github", "--json", "--profile-only"]);

--- a/src/lib/bird.ts
+++ b/src/lib/bird.ts
@@ -723,12 +723,6 @@ export const listMentionsViaBirdEffect = Effect.fn("bird.listMentions")(
 	},
 );
 
-export function listMentionsViaBird(options: {
-	maxResults: number;
-}): Promise<XurlMentionsResponse> {
-	return runEffectPromise(listMentionsViaBirdEffect(options));
-}
-
 const listTweetsViaBirdCommandEffect = Effect.fn("bird.listTweets")(function* ({
 	command,
 	maxResults,
@@ -763,14 +757,6 @@ export function listLikedTweetsViaBirdEffect(options: {
 	});
 }
 
-export function listLikedTweetsViaBird(options: {
-	maxResults: number;
-	all?: boolean;
-	maxPages?: number;
-}): Promise<XurlMentionsResponse> {
-	return runEffectPromise(listLikedTweetsViaBirdEffect(options));
-}
-
 export function listBookmarkedTweetsViaBirdEffect(options: {
 	maxResults: number;
 	all?: boolean;
@@ -780,14 +766,6 @@ export function listBookmarkedTweetsViaBirdEffect(options: {
 		command: "bookmarks",
 		...options,
 	});
-}
-
-export function listBookmarkedTweetsViaBird(options: {
-	maxResults: number;
-	all?: boolean;
-	maxPages?: number;
-}): Promise<XurlMentionsResponse> {
-	return runEffectPromise(listBookmarkedTweetsViaBirdEffect(options));
 }
 
 export const searchTweetsViaBirdEffect = Effect.fn("bird.searchTweets")(
@@ -812,17 +790,6 @@ export const searchTweetsViaBirdEffect = Effect.fn("bird.searchTweets")(
 	},
 );
 
-export function searchTweetsViaBird(
-	query: string,
-	options: {
-		maxResults: number;
-		all?: boolean;
-		maxPages?: number;
-	},
-): Promise<XurlMentionsResponse> {
-	return runEffectPromise(searchTweetsViaBirdEffect(query, options));
-}
-
 export const lookupTweetsByIdsViaBirdEffect = Effect.fn(
 	"bird.lookupTweetsByIds",
 )(function* (ids: string[]): Effect.fn.Return<XurlTweetsResponse, unknown> {
@@ -842,12 +809,6 @@ export const lookupTweetsByIdsViaBirdEffect = Effect.fn(
 	return normalizeBirdTweets(tweets);
 });
 
-export function lookupTweetsByIdsViaBird(
-	ids: string[],
-): Promise<XurlTweetsResponse> {
-	return runEffectPromise(lookupTweetsByIdsViaBirdEffect(ids));
-}
-
 export const listHomeTimelineViaBirdEffect = Effect.fn("bird.listHomeTimeline")(
 	function* ({
 		maxResults,
@@ -865,13 +826,6 @@ export const listHomeTimelineViaBirdEffect = Effect.fn("bird.listHomeTimeline")(
 		return yield* normalizeBirdTweetsPayloadEffect(payload, "home");
 	},
 );
-
-export function listHomeTimelineViaBird(options: {
-	maxResults: number;
-	following?: boolean;
-}): Promise<XurlMentionsResponse> {
-	return runEffectPromise(listHomeTimelineViaBirdEffect(options));
-}
 
 function normalizeBirdFollowUsers(
 	payload: unknown,
@@ -952,16 +906,6 @@ export const listFollowUsersViaBirdEffect = Effect.fn("bird.listFollowUsers")(
 	},
 );
 
-export function listFollowUsersViaBird(options: {
-	direction: "followers" | "following";
-	userId?: string;
-	maxResults: number;
-	all?: boolean;
-	maxPages?: number;
-}): Promise<XurlFollowUsersResponse> {
-	return runEffectPromise(listFollowUsersViaBirdEffect(options));
-}
-
 function normalizeBirdLists(payload: unknown): XListPage {
 	if (!Array.isArray(payload)) {
 		throw new Error("bird lists returned unexpected JSON");
@@ -1010,10 +954,6 @@ export const listOwnedXListsViaBirdEffect = Effect.fn("bird.listOwnedXLists")(
 	},
 );
 
-export function listOwnedXListsViaBird(options: { maxResults: number }) {
-	return runEffectPromise(listOwnedXListsViaBirdEffect(options));
-}
-
 export const listXListMembersViaBirdEffect = Effect.fn("bird.listXListMembers")(
 	function* ({
 		listId,
@@ -1046,14 +986,6 @@ export const listXListMembersViaBirdEffect = Effect.fn("bird.listXListMembers")(
 	},
 );
 
-export function listXListMembersViaBird(options: {
-	listId: string;
-	maxResults: number;
-	maxPages?: number;
-}) {
-	return runEffectPromise(listXListMembersViaBirdEffect(options));
-}
-
 export const listThreadViaBirdEffect = Effect.fn("bird.listThread")(function* ({
 	tweetId,
 	all,
@@ -1076,15 +1008,6 @@ export const listThreadViaBirdEffect = Effect.fn("bird.listThread")(function* ({
 	const payload = yield* parseBirdJsonEffect(stdout);
 	return yield* normalizeBirdTweetsPayloadEffect(payload, "thread");
 });
-
-export function listThreadViaBird(options: {
-	tweetId: string;
-	all?: boolean;
-	maxPages?: number;
-	timeoutMs?: number;
-}): Promise<XurlMentionsResponse> {
-	return runEffectPromise(listThreadViaBirdEffect(options));
-}
 
 function normalizeBirdDmsPayloadEffect(payload: unknown) {
 	return Effect.try({
@@ -1182,16 +1105,6 @@ export const listDirectMessagesViaBirdEffect = Effect.fn(
 	return yield* normalizeBirdDmsPayloadEffect(payload);
 });
 
-export function listDirectMessagesViaBird(options: {
-	maxResults: number;
-	inbox?: "all" | "accepted" | "requests";
-	maxPages?: number;
-	allPages?: boolean;
-	pageDelayMs?: number;
-}): Promise<BirdDmsResponse> {
-	return runEffectPromise(listDirectMessagesViaBirdEffect(options));
-}
-
 export const runDirectMessageRequestMutationViaBirdEffect = Effect.fn(
 	"bird.runDirectMessageRequestMutation",
 )(function* ({
@@ -1274,12 +1187,6 @@ export const lookupProfileViaBirdEffect = Effect.fn("bird.lookupProfile")(
 		return toXurlMentionUser(payload.user);
 	},
 );
-
-export function lookupProfileViaBird(
-	usernameOrId: string,
-): Promise<XurlMentionUser | null> {
-	return runEffectPromise(lookupProfileViaBirdEffect(usernameOrId));
-}
 
 function toXurlMentionUser(
 	user: BirdUserOverviewPayload["user"],
@@ -1396,14 +1303,6 @@ export const lookupProfilesViaBirdEffect = Effect.fn("bird.lookupProfiles")((
 		}),
 	);
 });
-
-export function lookupProfilesViaBird(
-	usernameOrIds: string[],
-): Promise<
-	Array<{ target: string; user: XurlMentionUser | null; error?: string }>
-> {
-	return runEffectPromise(lookupProfilesViaBirdEffect(usernameOrIds));
-}
 
 export const __test__ = {
 	toIsoTimestamp,

--- a/src/lib/blocks.ts
+++ b/src/lib/blocks.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { getAccountHandle, getDefaultAccountId } from "./moderation-target";
 import {
 	createModerationActions,
@@ -46,17 +46,6 @@ export function removeBlockEffect(
 
 function remoteBlockSyncDisabled() {
 	return process.env.BIRDCLAW_DISABLE_LIVE_WRITES === "1";
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 export function listBlocks({

--- a/src/lib/bookmark-sync-job.ts
+++ b/src/lib/bookmark-sync-job.ts
@@ -7,7 +7,7 @@ import {
 } from "./backup";
 import { ensureBirdclawDirs, getBirdclawPaths } from "./config";
 import { getNativeDb } from "./db";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import {
 	buildLaunchAgent,
 	buildLaunchProgramArguments,
@@ -114,17 +114,6 @@ function countBookmarks(db: Database) {
 		.prepare("select count(*) as count from tweet_collections where kind = ?")
 		.get("bookmarks") as { count: number };
 	return row.count;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 function messageFromError(error: unknown) {

--- a/src/lib/dms-live.test.ts
+++ b/src/lib/dms-live.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
-import { getConversationThread, listDmConversations } from "./queries";
+import { getConversationThread, listDmConversations } from "./dm-read-model";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 
 const listDirectMessagesViaBirdMock = vi.fn();

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -258,6 +258,20 @@ describe("follow graph sync and cache-only queries", () => {
 		);
 	});
 
+	it("applies shared account selection to graph reads", async () => {
+		setupTempHome();
+		const { listTopFollowers } = await import("./follow-graph");
+
+		for (const selector of ["acct_primary", "@STEIPETE", "steipete"]) {
+			expect(listTopFollowers({ account: selector })).toMatchObject({
+				accountId: "acct_primary",
+			});
+		}
+		expect(() => listTopFollowers({ account: "missing" })).toThrow(
+			"Unknown account: missing",
+		);
+	});
+
 	it("reuses fresh cache for duplicate sync requests instead of calling xurl again", async () => {
 		setupTempHome();
 		mocks.listFollowUsersViaXurl.mockResolvedValueOnce({

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
+import { resolveOperationAccount } from "./account-selection";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
 import { liveTransportGateway } from "./live-transport-gateway";
+import {
+	resolveLiveSyncAccount,
+	type LiveSyncAccount,
+} from "./live-sync-engine";
 import type { Database } from "./sqlite";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import { runSyncPlanEffect } from "./sync-plan";
@@ -39,12 +44,6 @@ export interface SyncFollowGraphOptions {
 
 type FollowGraphSyncMode = "auto" | "bird" | "xurl";
 type FollowGraphLiveSource = "bird" | "xurl";
-
-interface ResolvedAccount {
-	accountId: string;
-	username: string;
-	externalUserId?: string;
-}
 
 interface MergedFollowPayload {
 	data: XurlMentionUser[];
@@ -98,43 +97,6 @@ function parseJsonField<T>(value: unknown, fallback: T): T {
 	} catch {
 		return fallback;
 	}
-}
-
-function resolveAccount(db: Database, accountId?: string): ResolvedAccount {
-	const row = accountId
-		? (db
-				.prepare(
-					"select id, handle, external_user_id from accounts where id = ?",
-				)
-				.get(accountId) as
-				| { id: string; handle: string; external_user_id: string | null }
-				| undefined)
-		: (db
-				.prepare(
-					`
-          select id, handle, external_user_id
-          from accounts
-          order by is_default desc, created_at asc
-          limit 1
-          `,
-				)
-				.get() as
-				| { id: string; handle: string; external_user_id: string | null }
-				| undefined);
-
-	if (!row) {
-		throw new Error(`Unknown account: ${accountId ?? "default"}`);
-	}
-
-	return {
-		accountId: row.id,
-		username: row.handle.replace(/^@/, ""),
-		externalUserId:
-			typeof row.external_user_id === "string" &&
-			row.external_user_id.length > 0
-				? row.external_user_id
-				: undefined,
-	};
 }
 
 function buildCacheKey({
@@ -584,7 +546,7 @@ function makeDryRunResponse({
 	cacheTtlMs,
 }: {
 	db: Database;
-	account: ResolvedAccount;
+	account: LiveSyncAccount;
 	direction: FollowDirection;
 	mode: FollowGraphSyncMode;
 	limit: number;
@@ -652,7 +614,9 @@ export function syncFollowGraphEffect(options: SyncFollowGraphOptions) {
 			parseOptionalPositiveInteger("--max-resources", options.maxResources),
 		);
 		const cacheTtlMs = parseCacheTtlMs(options.cacheTtlMs);
-		const account = yield* trySync(() => resolveAccount(db, options.account));
+		const account = yield* trySync(() =>
+			resolveLiveSyncAccount(db, options.account),
+		);
 		const cacheKey = buildCacheKey({
 			direction: options.direction,
 			accountId: account.accountId,
@@ -771,7 +735,7 @@ export function listTopFollowers({
 	limit?: number;
 } = {}) {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
+	const resolved = resolveOperationAccount(account, db);
 	const rows = db
 		.prepare(
 			`
@@ -791,11 +755,9 @@ export function listTopFollowers({
       limit ?
       `,
 		)
-		.all(resolved.accountId, parseRowLimit(limit)) as Array<
-		Record<string, unknown>
-	>;
+		.all(resolved.id, parseRowLimit(limit)) as Array<Record<string, unknown>>;
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		items: rows.map(toGraphProfile),
 	};
 }
@@ -808,7 +770,7 @@ export function listMutuals({
 	limit?: number;
 } = {}) {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
+	const resolved = resolveOperationAccount(account, db);
 	const rows = db
 		.prepare(
 			`
@@ -836,11 +798,9 @@ export function listMutuals({
       limit ?
       `,
 		)
-		.all(resolved.accountId, parseRowLimit(limit)) as Array<
-		Record<string, unknown>
-	>;
+		.all(resolved.id, parseRowLimit(limit)) as Array<Record<string, unknown>>;
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		items: rows.map(toGraphProfile),
 	};
 }
@@ -855,7 +815,7 @@ export function listNonMutualFollowing({
 	limit?: number;
 } = {}) {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
+	const resolved = resolveOperationAccount(account, db);
 	const orderBy =
 		sort === "handle"
 			? "lower(p.handle) asc"
@@ -888,11 +848,9 @@ export function listNonMutualFollowing({
       limit ?
       `,
 		)
-		.all(resolved.accountId, parseRowLimit(limit)) as Array<
-		Record<string, unknown>
-	>;
+		.all(resolved.id, parseRowLimit(limit)) as Array<Record<string, unknown>>;
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		items: rows.map(toGraphProfile),
 	};
 }
@@ -909,7 +867,7 @@ export function listUnfollowedSince({
 	limit?: number;
 }) {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
+	const resolved = resolveOperationAccount(account, db);
 	const since = date.includes("T") ? date : `${date}T00:00:00.000Z`;
 	const rows = db
 		.prepare(
@@ -935,11 +893,11 @@ export function listUnfollowedSince({
       limit ?
       `,
 		)
-		.all(resolved.accountId, direction, since, parseRowLimit(limit)) as Array<
+		.all(resolved.id, direction, since, parseRowLimit(limit)) as Array<
 		Record<string, unknown>
 	>;
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		direction,
 		since,
 		items: rows.map((row) => ({
@@ -965,9 +923,9 @@ export function listFollowEvents({
 	limit?: number;
 } = {}) {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
+	const resolved = resolveOperationAccount(account, db);
 	const where = ["ev.account_id = ?"];
-	const params: unknown[] = [resolved.accountId];
+	const params: unknown[] = [resolved.id];
 
 	if (direction) {
 		where.push("ev.direction = ?");
@@ -1013,7 +971,7 @@ export function listFollowEvents({
 		.all(...params) as Array<Record<string, unknown>>;
 
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		items: rows.map((row): FollowGraphEvent => ({
 			eventAt: String(row.event_at),
 			direction: row.direction as FollowDirection,
@@ -1028,9 +986,9 @@ export function getFollowGraphSummary({
 	account,
 }: { account?: string } = {}): FollowGraphSummary {
 	const db = getNativeDb();
-	const resolved = resolveAccount(db, account);
-	const followers = readCurrentCount(db, resolved.accountId, "followers");
-	const following = readCurrentCount(db, resolved.accountId, "following");
+	const resolved = resolveOperationAccount(account, db);
+	const followers = readCurrentCount(db, resolved.id, "followers");
+	const following = readCurrentCount(db, resolved.id, "following");
 	const mutualsRow = db
 		.prepare(
 			`
@@ -1047,41 +1005,21 @@ export function getFollowGraphSummary({
         and following.current = 1
       `,
 		)
-		.get(resolved.accountId) as { count: number };
+		.get(resolved.id) as { count: number };
 
 	return {
-		accountId: resolved.accountId,
+		accountId: resolved.id,
 		followers,
 		following,
 		mutuals: Number(mutualsRow.count),
 		nonMutualFollowing: following - Number(mutualsRow.count),
 		lastCompleteSnapshots: {
-			followers: getLastSnapshot(
-				db,
-				resolved.accountId,
-				"followers",
-				"complete",
-			),
-			following: getLastSnapshot(
-				db,
-				resolved.accountId,
-				"following",
-				"complete",
-			),
+			followers: getLastSnapshot(db, resolved.id, "followers", "complete"),
+			following: getLastSnapshot(db, resolved.id, "following", "complete"),
 		},
 		lastIncompleteSnapshots: {
-			followers: getLastSnapshot(
-				db,
-				resolved.accountId,
-				"followers",
-				"incomplete",
-			),
-			following: getLastSnapshot(
-				db,
-				resolved.accountId,
-				"following",
-				"incomplete",
-			),
+			followers: getLastSnapshot(db, resolved.id, "followers", "incomplete"),
+			following: getLastSnapshot(db, resolved.id, "following", "incomplete"),
 		},
 	};
 }

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { getNativeDb } from "./db";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { scoreInboxItemWithOpenAIEffect } from "./openai";
 import { listDmConversations } from "./dm-read-model";
 import { listTimelineItems } from "./timeline-read-model";
@@ -156,17 +156,6 @@ export function listInboxItems({
 			heuristic: filtered.filter((item) => item.source === "heuristic").length,
 		},
 	};
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 export function scoreInboxEffect({

--- a/src/lib/mention-threads-live.test.ts
+++ b/src/lib/mention-threads-live.test.ts
@@ -6,7 +6,7 @@ import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
 	listThreadViaBird: vi.fn(),

--- a/src/lib/mentions-live.test.ts
+++ b/src/lib/mentions-live.test.ts
@@ -6,7 +6,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const listMentionsViaBirdMock = vi.fn();
 const listMentionsViaXurlMock = vi.fn();

--- a/src/lib/moderation-state.ts
+++ b/src/lib/moderation-state.ts
@@ -6,7 +6,7 @@ import {
 import type { ActionsTransport } from "./config";
 import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise, tryPromise, trySync } from "./effect-runtime";
 import {
 	getAccountHandle,
 	getDefaultAccountId,
@@ -132,17 +132,6 @@ type ModerationRemoveResult<K extends ModerationKind> =
 		action: RemoveAction<K>;
 		transport: ActionTransportResult;
 	};
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
-}
 
 export function listModerationState<K extends ModerationKind>(
 	kind: K,

--- a/src/lib/moderation-target.ts
+++ b/src/lib/moderation-target.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { lookupProfileViaBirdEffect } from "./bird-actions";
 import { getNativeDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { normalizeProfileHandle, profileFromDbRow } from "./profile-row";
 import type { ProfileRecord, XurlMentionUser } from "./types";
 import { getExternalUserId, upsertProfileFromXUser } from "./x-profile";
@@ -16,17 +16,6 @@ import {
 export interface ResolvedModerationProfile {
 	profile: ProfileRecord;
 	externalUserId: string | null;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 export function normalizeProfileQuery(value: string) {

--- a/src/lib/network-map.test.ts
+++ b/src/lib/network-map.test.ts
@@ -162,6 +162,14 @@ describe("network map", () => {
 		expect(studio.features.map((item) => item.properties.handle)).toEqual([
 			"studiofriend",
 		]);
+		for (const selector of ["@STUDIO", "studio"]) {
+			await expect(
+				getNetworkMap({ account: selector, type: "following", limit: 1 }, db),
+			).resolves.toMatchObject({ meta: { accountId: "acct_studio" } });
+		}
+		await expect(getNetworkMap({ account: "missing" }, db)).rejects.toThrow(
+			"Unknown account: missing",
+		);
 	});
 
 	it("only exposes public Mapbox tokens to the browser config", () => {

--- a/src/lib/network-map.ts
+++ b/src/lib/network-map.ts
@@ -1,4 +1,5 @@
 import { getNativeDb } from "./db";
+import { resolveOperationAccount } from "./account-selection";
 import type { NetworkMapResponse } from "./api-contracts";
 import {
 	geocodeLocation,
@@ -93,22 +94,6 @@ function parseLimit(
 	if (!Number.isFinite(value) || value === undefined || value < min)
 		return fallback;
 	return Math.min(max, Math.floor(value));
-}
-
-function resolveAccountId(db: Database, accountId?: string) {
-	const row = accountId
-		? (db
-				.prepare("select id from accounts where id = ? or handle = ? limit 1")
-				.get(accountId, accountId.replace(/^@/, "")) as
-				| { id: string }
-				| undefined)
-		: (db
-				.prepare(
-					"select id from accounts order by is_default desc, created_at asc limit 1",
-				)
-				.get() as { id: string } | undefined);
-	if (!row) throw new Error(`Unknown account: ${accountId ?? "default"}`);
-	return row.id;
 }
 
 function relationshipForRow(
@@ -310,7 +295,8 @@ export async function getNetworkMap(
 	options: NetworkMapOptions = {},
 	db = getNativeDb(),
 ): Promise<NetworkMapResponse> {
-	const accountId = resolveAccountId(db, options.account);
+	const account = resolveOperationAccount(options.account, db);
+	const accountId = account.id;
 	const type = options.type ?? "all";
 	const limit = parseLimit(options.limit, DEFAULT_LIMIT, MAX_LIMIT);
 	const geocodeLimit = parseLimit(

--- a/src/lib/openai-response-runtime.ts
+++ b/src/lib/openai-response-runtime.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { tryPromise } from "./effect-runtime";
+import { toError, tryPromise } from "./effect-runtime";
 import {
 	defaultRuntimeServices,
 	type RuntimeServices,
@@ -22,10 +22,6 @@ export interface OpenAIStreamResult {
 	rawText: string;
 	responseId?: string;
 	usage?: unknown;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
 }
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,5 +1,10 @@
 import { Effect } from "effect";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import {
+	runEffectPromise,
+	toError,
+	tryPromise,
+	trySync,
+} from "./effect-runtime";
 import { debugLog, resolveOpenAIBaseUrl } from "./openai-response-runtime";
 
 const getEnv = (name: string) => process.env[name];
@@ -26,17 +31,6 @@ export interface OpenAIInboxInput {
 
 function clampScore(value: number) {
 	return Math.max(0, Math.min(100, Math.round(value)));
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 export function scoreInboxItemWithOpenAIEffect(

--- a/src/lib/period-digest.test.ts
+++ b/src/lib/period-digest.test.ts
@@ -13,7 +13,7 @@ import {
 	streamPeriodDigest,
 	streamPeriodDigestEffect,
 } from "./period-digest";
-import { getTweetsByIds } from "./queries";
+import { getTweetsByIds } from "./timeline-read-model";
 
 const tempRoots: string[] = [];
 

--- a/src/lib/period-digest.ts
+++ b/src/lib/period-digest.ts
@@ -10,7 +10,7 @@ import {
 	streamHybridAnalysisEffect,
 } from "./analysis-runtime";
 import { maybeAutoSyncBackupEffect } from "./backup";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { getLinkInsights } from "./link-insights";
 import { syncMentionThreadsEffect } from "./mention-threads-live";
 import { syncMentionsEffect } from "./mentions-live";
@@ -231,17 +231,6 @@ const DEFAULT_LIVE_THREAD_TIMEOUT_MS = 5_000;
 const DEFAULT_DIGEST_FRESHNESS_MS = 5 * 60_000;
 const MAX_PROMPT_DATA_CHARS = 1_200_000;
 const DELIMITER_PATTERN = /\n---\s*\n/;
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function tryDigestSync<T>(try_: () => T): Effect.Effect<T, Error> {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
-}
 
 function localDateStart(date: Date) {
 	return new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -1175,11 +1164,11 @@ function completeOpenAIStreamEffect(
 	handlers: PeriodDigestStreamHandlers,
 ): Effect.Effect<PeriodDigestRunResult, Error> {
 	return Effect.gen(function* () {
-		const enrichedContext = yield* tryDigestSync(() =>
+		const enrichedContext = yield* trySync(() =>
 			enrichContextWithCitedTweets(context, stream.value),
 		);
 		const cacheKey = digestCacheKey(context, options);
-		const updatedAt = yield* tryDigestSync(() =>
+		const updatedAt = yield* trySync(() =>
 			writeSyncCache(cacheKey, {
 				digest: stream.value,
 				markdown: stream.markdown,
@@ -1200,7 +1189,7 @@ function completeOpenAIStreamEffect(
 			cached: false,
 			updatedAt,
 		};
-		yield* tryDigestSync(() =>
+		yield* trySync(() =>
 			writeSyncCache(latestDigestCacheKey(options), {
 				context: result.context,
 				digest: result.digest,
@@ -1249,12 +1238,12 @@ export function streamPeriodDigestEffect(
 	return Effect.gen(function* () {
 		const resolvedOptions = {
 			...options,
-			language: yield* tryDigestSync(() => languageFromOptions(options)),
+			language: yield* trySync(() => languageFromOptions(options)),
 		};
 		const latestCached = resolvedOptions.refresh
 			? null
 			: !resolvedOptions.liveSync
-				? yield* tryDigestSync(() =>
+				? yield* trySync(() =>
 						readSyncCache<CachedPeriodDigestValue>(
 							latestDigestCacheKey(resolvedOptions),
 						),
@@ -1266,7 +1255,7 @@ export function streamPeriodDigestEffect(
 			latestContext &&
 			isFreshDigestCache(latestCached.value.updatedAt ?? latestCached.updatedAt)
 		) {
-			const result = yield* tryDigestSync(() =>
+			const result = yield* trySync(() =>
 				cachedDigestResult(latestCached, latestContext),
 			);
 			emitCachedDigest(result, handlers);
@@ -1278,21 +1267,17 @@ export function streamPeriodDigestEffect(
 			{ threads: false },
 			handlers,
 		).pipe(Effect.catchAll(() => Effect.void));
-		let context = yield* tryDigestSync(() =>
+		let context = yield* trySync(() =>
 			collectPeriodDigestContext(resolvedOptions),
 		);
 		let cacheKey = digestCacheKey(context, resolvedOptions);
 		const cached = resolvedOptions.refresh
 			? null
-			: yield* tryDigestSync(() =>
-					readSyncCache<CachedPeriodDigestValue>(cacheKey),
-				);
+			: yield* trySync(() => readSyncCache<CachedPeriodDigestValue>(cacheKey));
 
 		if (cached) {
-			const result = yield* tryDigestSync(() =>
-				cachedDigestResult(cached, context),
-			);
-			yield* tryDigestSync(() =>
+			const result = yield* trySync(() => cachedDigestResult(cached, context));
+			yield* trySync(() =>
 				writeSyncCache(latestDigestCacheKey(resolvedOptions), {
 					context: result.context,
 					digest: result.digest,
@@ -1319,9 +1304,7 @@ export function streamPeriodDigestEffect(
 			},
 			handlers,
 		).pipe(Effect.catchAll(() => Effect.void));
-		context = yield* tryDigestSync(() =>
-			collectPeriodDigestContext(resolvedOptions),
-		);
+		context = yield* trySync(() => collectPeriodDigestContext(resolvedOptions));
 		cacheKey = digestCacheKey(context, resolvedOptions);
 
 		handlers.onEvent?.({ type: "start", context, cached: false });

--- a/src/lib/profile-affiliation-hydration.ts
+++ b/src/lib/profile-affiliation-hydration.ts
@@ -1,7 +1,7 @@
 import type { Database } from "./sqlite";
 import { Effect } from "effect";
 import { lookupProfileViaBirdEffect } from "./bird";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { syncIdentitySearchIndexForProfileIds } from "./identity-search-index";
 import { syncProfileBioEntitiesForProfileId } from "./profile-bio-entities";
 import { recordProfileSnapshot } from "./profile-history";
@@ -25,17 +25,6 @@ interface SyntheticAffiliationRow {
 	label: string | null;
 	source: string;
 	raw_json: string;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 function replaceSyntheticAffiliation(

--- a/src/lib/profile-analysis.test.ts
+++ b/src/lib/profile-analysis.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { streamProfileAnalysis } from "./profile-analysis";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
 	listUserTweetsEffect: vi.fn(),

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -9,7 +9,12 @@ import {
 	resolveAnalysisModelSettings,
 } from "./analysis-runtime";
 import { getNativeDb } from "./db";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import {
+	runEffectPromise,
+	toError,
+	tryPromise,
+	trySync,
+} from "./effect-runtime";
 import { buildMediaJsonFromIncludes, countTweetMedia } from "./media-includes";
 import type { Database } from "./sqlite";
 import {
@@ -162,10 +167,6 @@ const XURL_PAGE_SIZE = 100;
 const MAX_PROMPT_DATA_CHARS = 1_200_000;
 const DELIMITER_PATTERN = /\n---\s*\n/;
 
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
 function isXurlRateLimitError(error: Error) {
 	// Structured classification from the transport (tag check, so it also works
 	// across module instances); message heuristics stay as a fallback for 429s
@@ -179,10 +180,6 @@ function isXurlRateLimitError(error: Error) {
 		error.message.includes('"status":429') ||
 		/\b429\b/.test(error.message)
 	);
-}
-
-function tryProfileSync<T>(try_: () => T): Effect.Effect<T, Error> {
-	return Effect.try({ try: try_, catch: toError });
 }
 
 function tryProfilePromise<T>(
@@ -693,7 +690,7 @@ function emitStatus(
 }
 
 function abortIfRequestedEffect(signal: AbortSignal | undefined) {
-	return tryProfileSync(() => {
+	return trySync(() => {
 		if (signal?.aborted) {
 			throw new Error("Profile analysis aborted");
 		}
@@ -728,32 +725,30 @@ export function collectProfileAnalysisContextEffect(
 ): Effect.Effect<ProfileAnalysisContext, Error> {
 	return Effect.gen(function* () {
 		const db = getNativeDb();
-		const handle = yield* tryProfileSync(() => normalizeHandle(options.handle));
-		const account = yield* tryProfileSync(() =>
-			resolveAccount(db, options.account),
-		);
-		const maxTweets = yield* tryProfileSync(() =>
+		const handle = yield* trySync(() => normalizeHandle(options.handle));
+		const account = yield* trySync(() => resolveAccount(db, options.account));
+		const maxTweets = yield* trySync(() =>
 			normalizePositiveInteger(
 				options.maxTweets,
 				DEFAULT_MAX_TWEETS,
 				"--max-tweets",
 			),
 		);
-		const maxPages = yield* tryProfileSync(() =>
+		const maxPages = yield* trySync(() =>
 			normalizePositiveInteger(
 				options.maxPages,
 				DEFAULT_MAX_PAGES,
 				"--max-pages",
 			),
 		);
-		const maxConversations = yield* tryProfileSync(() =>
+		const maxConversations = yield* trySync(() =>
 			normalizePositiveInteger(
 				options.maxConversations,
 				DEFAULT_MAX_CONVERSATIONS,
 				"--max-conversations",
 			),
 		);
-		const maxConversationPages = yield* tryProfileSync(() =>
+		const maxConversationPages = yield* trySync(() =>
 			normalizePositiveInteger(
 				options.maxConversationPages,
 				DEFAULT_MAX_CONVERSATION_PAGES,
@@ -772,7 +767,7 @@ export function collectProfileAnalysisContextEffect(
 			maxConversations,
 			maxConversationPages,
 		});
-		const cached = yield* tryProfileSync(() =>
+		const cached = yield* trySync(() =>
 			readSyncCache<ProfileAnalysisContext>(contextKey, db),
 		);
 		const ageMs = cached
@@ -811,9 +806,7 @@ export function collectProfileAnalysisContextEffect(
 		if (!user) {
 			return yield* Effect.fail(new Error(`Could not resolve @${handle}`));
 		}
-		const resolved = yield* tryProfileSync(() =>
-			upsertProfileFromXUser(db, user),
-		);
+		const resolved = yield* trySync(() => upsertProfileFromXUser(db, user));
 
 		const tweetResponses: XurlTweetsResponse[] = [];
 		let nextToken: string | undefined;
@@ -878,7 +871,7 @@ export function collectProfileAnalysisContextEffect(
 			if (!nextToken || limitedResponse.items.length === 0) break;
 		}
 		const profilePayload = mergeResponses(tweetResponses);
-		yield* tryProfileSync(() =>
+		yield* trySync(() =>
 			mergeXurlTweetsIntoLocalStore(
 				db,
 				account.id,
@@ -973,7 +966,7 @@ export function collectProfileAnalysisContextEffect(
 			}
 		}
 		const conversationPayload = mergeResponses(conversationResponses);
-		yield* tryProfileSync(() =>
+		yield* trySync(() =>
 			mergeXurlTweetsIntoLocalStore(
 				db,
 				account.id,
@@ -996,7 +989,7 @@ export function collectProfileAnalysisContextEffect(
 			fetchCached: false,
 		});
 		if (!conversationRateLimited) {
-			yield* tryProfileSync(() => writeSyncCache(contextKey, context, db));
+			yield* trySync(() => writeSyncCache(contextKey, context, db));
 		}
 		return context;
 	});
@@ -1140,7 +1133,7 @@ export function streamProfileAnalysisEffect(
 		);
 		const cached = options.refresh
 			? null
-			: yield* tryProfileSync(() =>
+			: yield* trySync(() =>
 					readSyncCache<{
 						analysis: ProfileAnalysis;
 						markdown: string;
@@ -1150,7 +1143,7 @@ export function streamProfileAnalysisEffect(
 					}>(resultCacheKey(context, options)),
 				);
 		if (cached) {
-			const result: ProfileAnalysisRunResult = yield* tryProfileSync(() => ({
+			const result: ProfileAnalysisRunResult = yield* trySync(() => ({
 				context,
 				analysis: ProfileAnalysisSchema.parse(cached.value.analysis),
 				markdown: cached.value.markdown,
@@ -1176,7 +1169,7 @@ export function streamProfileAnalysisEffect(
 			fallback: (markdown) => fallbackAnalysis(context, markdown),
 			delimiterPattern: DELIMITER_PATTERN,
 		});
-		const updatedAt = yield* tryProfileSync(() =>
+		const updatedAt = yield* trySync(() =>
 			writeSyncCache(resultCacheKey(context, options), {
 				analysis: analysisResponse.value,
 				markdown: analysisResponse.markdown,

--- a/src/lib/profile-hydration.ts
+++ b/src/lib/profile-hydration.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { normalizeAvatarUrl } from "./avatar-cache";
 import { getAuthenticatedBirdAccountEffect } from "./bird";
 import { getNativeDb } from "./db";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import {
 	getProvenSelectedAccountLegacyProfileIds,
 	getProfileRawIdentityEvidence,
@@ -43,17 +43,6 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 function toInt(value: unknown) {
 	const parsed = Number(value);
 	return Number.isFinite(parsed) ? Math.trunc(parsed) : 0;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 const SEEDED_ACCOUNT_HANDLE = "steipete";

--- a/src/lib/profile-resolver.ts
+++ b/src/lib/profile-resolver.ts
@@ -5,7 +5,7 @@ import {
 	lookupProfileViaBirdEffect,
 	lookupProfilesViaBirdEffect,
 } from "./bird";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import {
 	hydrateProfileAffiliationOrganizationsEffect,
@@ -27,17 +27,6 @@ interface CachedProfileLookup {
 	source: Exclude<ProfileLookupSource, "local" | "cache">;
 	user?: XurlMentionUser;
 	error?: string;
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 export interface ResolveProfilesOptions {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,6 +1,0 @@
-// Compatibility facade. New code should import the owned read model or action module.
-export * from "./query-read-models";
-export {
-	applyDmRequestMutationToLocalStore,
-	type DmRequestMutationAction,
-} from "./query-actions";

--- a/src/lib/query-actions.ts
+++ b/src/lib/query-actions.ts
@@ -4,22 +4,14 @@ import type { Database } from "./sqlite";
 import { getReadDb } from "./db";
 import { databaseWriteEffect } from "./database-writer";
 import { getConversationThread } from "./dm-read-model";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import { upsertTweetAccountEdge } from "./tweet-account-edges";
 import {
 	dmViaXurlEffect,
-	lookupAuthenticatedUserFresh,
+	lookupAuthenticatedUserFreshEffect,
 	postViaXurlEffect,
 	replyViaXurlEffect,
 } from "./xurl";
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({ try: try_, catch: toError });
-}
 
 function e2eFakeLiveWritesEnabled() {
 	return (
@@ -48,9 +40,7 @@ function verifySelectedXurlAccountEffect(accountId: string) {
 		if (!account) {
 			return yield* Effect.fail(new Error(`Unknown account: ${accountId}`));
 		}
-		const authenticated = yield* tryPromise(() =>
-			lookupAuthenticatedUserFresh(),
-		);
+		const authenticated = yield* lookupAuthenticatedUserFreshEffect();
 		const authenticatedId =
 			typeof authenticated?.id === "string" ? authenticated.id : "";
 		const authenticatedHandle =

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -7,24 +7,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listInboxItems } from "./inbox";
+import { getConversationThread, listDmConversations } from "./dm-read-model";
 import {
 	applyDmRequestMutationToLocalStore,
-	buildTimelineItemsQuery,
 	createDmReply,
 	createDmReplyEffect,
 	createPost,
 	createPostEffect,
 	createTweetReply,
 	createTweetReplyEffect,
-	getConversationThread,
-	getQueryEnvelope,
-	getQueryEnvelopeEffect,
+} from "./query-actions";
+import { queryResource } from "./query-resource";
+import { getQueryEnvelope, getQueryEnvelopeEffect } from "./query-status";
+import {
+	buildTimelineItemsQuery,
 	getTweetConversation,
-	listDmConversations,
 	listTimelineItems,
-	queryResource,
 	TimelineCandidateLimitError,
-} from "./queries";
+} from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
 	findArchives: vi.fn(),
@@ -56,6 +56,7 @@ vi.mock("./archive-finder", async () => {
 
 vi.mock("./xurl", async () => {
 	const { Effect } = await import("effect");
+	const { effectFromMock } = await import("../test/effect-mocks");
 	const toError = (error: unknown) =>
 		error instanceof Error ? error : new Error(String(error));
 	return {
@@ -85,6 +86,9 @@ vi.mock("./xurl", async () => {
 			}),
 		lookupAuthenticatedUser: mocks.lookupAuthenticatedUser,
 		lookupAuthenticatedUserFresh: mocks.lookupAuthenticatedUser,
+		lookupAuthenticatedUserFreshEffect: effectFromMock(
+			mocks.lookupAuthenticatedUser,
+		),
 	};
 });
 
@@ -181,7 +185,7 @@ afterEach(() => {
 	}
 });
 
-describe("birdclaw queries", () => {
+describe("query models", () => {
 	beforeEach(() => {
 		mocks.findArchives.mockResolvedValue([
 			{

--- a/src/lib/query-read-models.ts
+++ b/src/lib/query-read-models.ts
@@ -1,5 +1,0 @@
-export * from "./dm-read-model";
-export * from "./query-actions";
-export * from "./query-resource";
-export * from "./query-status";
-export * from "./timeline-read-model";

--- a/src/lib/query-status.ts
+++ b/src/lib/query-status.ts
@@ -3,19 +3,11 @@ import type { QueryEnvelope } from "./api-contracts";
 import type { Database } from "./sqlite";
 import { findArchivesCachedEffect } from "./archive-finder";
 import { getReadDb } from "./db";
-import { runEffectPromise } from "./effect-runtime";
+import { runEffectPromise, trySync } from "./effect-runtime";
 import type { AccountRecord } from "./types";
 import { getTransportStatusEffect } from "./xurl";
 
 export type { QueryEnvelope } from "./api-contracts";
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({ try: try_, catch: toError });
-}
 
 function countTimelineEdges(db: Database, kind: "home" | "mention") {
 	const row = db

--- a/src/lib/search-discussion.ts
+++ b/src/lib/search-discussion.ts
@@ -9,7 +9,11 @@ import {
 	streamHybridAnalysisEffect,
 } from "./analysis-runtime";
 import { prefetchCachedAvatarsForProfileIdsEffect } from "./avatar-cache";
-import { runEffectBackground, runEffectPromise } from "./effect-runtime";
+import {
+	runEffectBackground,
+	runEffectPromise,
+	trySync,
+} from "./effect-runtime";
 import { getNativeDb } from "./db";
 import { listDmConversations } from "./dm-read-model";
 import {
@@ -144,17 +148,6 @@ const DEFAULT_LIMIT = 20_000;
 const DEFAULT_MAX_PAGES = 200;
 const MAX_PROMPT_DATA_CHARS = 1_200_000;
 const DELIMITER_PATTERN = /\n---\s*\n/;
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySearchSync<T>(try_: () => T): Effect.Effect<T, Error> {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
-}
 
 function tweetUrl(handle: string, id: string) {
 	return `https://x.com/${handle}/status/${id}`;
@@ -688,7 +681,7 @@ function completeOpenAIStreamEffect(
 	handlers: SearchDiscussionStreamHandlers,
 ): Effect.Effect<SearchDiscussionRunResult, Error> {
 	return Effect.gen(function* () {
-		const updatedAt = yield* trySearchSync(() =>
+		const updatedAt = yield* trySync(() =>
 			writeSyncCache(cacheKey(context, options), {
 				discussion: stream.value,
 				markdown: stream.markdown,
@@ -741,7 +734,7 @@ export function streamSearchDiscussionEffect(
 				),
 			);
 		}
-		const context = yield* trySearchSync(() =>
+		const context = yield* trySync(() =>
 			collectSearchDiscussionContext({
 				...options,
 				source: options.source ?? "search",
@@ -753,7 +746,7 @@ export function streamSearchDiscussionEffect(
 		}
 		const cached = options.refresh
 			? null
-			: yield* trySearchSync(() =>
+			: yield* trySync(() =>
 					readSyncCache<{
 						discussion: SearchDiscussion;
 						markdown: string;
@@ -763,7 +756,7 @@ export function streamSearchDiscussionEffect(
 					}>(cacheKey(context, options)),
 				);
 		if (cached) {
-			const result: SearchDiscussionRunResult = yield* trySearchSync(() => ({
+			const result: SearchDiscussionRunResult = yield* trySync(() => ({
 				context,
 				discussion: SearchDiscussionSchema.parse(cached.value.discussion),
 				markdown: cached.value.markdown,

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -6,7 +6,7 @@ import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
 	listBookmarkedTweetsViaBird: vi.fn(),

--- a/src/lib/timeline-live.test.ts
+++ b/src/lib/timeline-live.test.ts
@@ -6,7 +6,7 @@ import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 
 const listHomeTimelineViaBirdMock = vi.fn();
 const listHomeTimelineViaXurlMock = vi.fn();

--- a/src/lib/url-expansion.ts
+++ b/src/lib/url-expansion.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { getNativeDb } from "./db";
-import { runEffectPromise, tryPromise } from "./effect-runtime";
+import { runEffectPromise, tryPromise, trySync } from "./effect-runtime";
 import {
 	resolvePublicAddresses,
 	safePreviewFetchEffect,
@@ -47,17 +47,6 @@ function isFresh(updatedAt: string, maxAgeMs: number) {
 
 function trimTrailingPunctuation(url: string) {
 	return url.replace(/[.,;:!?]+$/g, "");
-}
-
-function toError(error: unknown) {
-	return error instanceof Error ? error : new Error(String(error));
-}
-
-function trySync<T>(try_: () => T) {
-	return Effect.try({
-		try: try_,
-		catch: toError,
-	});
 }
 
 function cancelBodyEffect(response: Response) {

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { exportBackup, importBackup } from "./backup";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
-import { listTimelineItems } from "./queries";
+import { listTimelineItems } from "./timeline-read-model";
 import { ingestTweetPayload } from "./tweet-repository";
 import type { XurlMentionUser } from "./types";
 

--- a/src/routes/api/query.test.ts
+++ b/src/routes/api/query.test.ts
@@ -115,4 +115,18 @@ describe("api query route", () => {
 			}),
 		);
 	});
+
+	it("rejects invalid resources before querying", async () => {
+		const response = await GET({
+			request: new Request("http://localhost/api/query?resource=unknown"),
+		});
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			ok: false,
+			message: "Invalid query resource",
+		});
+		expect(queryResourceMock).not.toHaveBeenCalled();
+		expect(maybeAutoUpdateBackupMock).not.toHaveBeenCalled();
+	});
 });

--- a/src/routes/api/query.tsx
+++ b/src/routes/api/query.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Effect } from "effect";
 import { queryResponseSchema } from "#/lib/api-contracts";
+import { resourceKindSchema } from "#/lib/api-enums";
 import { requestBackupAutoUpdate } from "#/lib/backup";
 import {
 	jsonResponse,
@@ -9,12 +10,7 @@ import {
 	sensitiveRequestErrorResponse,
 } from "#/lib/http-effect";
 import { queryResource } from "#/lib/query-resource";
-import type {
-	DmQuery,
-	ReplyFilter,
-	ResourceKind,
-	TimelineQualityFilter,
-} from "#/lib/types";
+import type { DmQuery, ReplyFilter, TimelineQualityFilter } from "#/lib/types";
 
 function parseReplyFilter(value: string | null): ReplyFilter {
 	if (value === "replied" || value === "unreplied") {
@@ -54,10 +50,18 @@ export const Route = createFileRoute("/api/query")({
 						const denied = sensitiveRequestErrorResponse(request);
 						if (denied) return denied;
 
-						requestBackupAutoUpdate();
 						const url = new URL(request.url);
-						const resource = (url.searchParams.get("resource") ??
-							"home") as ResourceKind;
+						const parsedResource = resourceKindSchema.safeParse(
+							url.searchParams.get("resource") ?? "home",
+						);
+						if (!parsedResource.success) {
+							return jsonResponse(
+								{ ok: false, message: "Invalid query resource" },
+								{ status: 400 },
+							);
+						}
+						const resource = parsedResource.data;
+						requestBackupAutoUpdate();
 						const baseFilters = {
 							account: url.searchParams.get("account") ?? undefined,
 							search: url.searchParams.get("search") ?? undefined,


### PR DESCRIPTION
## Summary

- make CLI and API query handling strict about invalid or ambiguous inputs
- centralize account resolution so CLI, API, and library call sites share one contract
- remove duplicate query facades, account wrappers, and dead helper seams
- reduce production code from 69,035 to 68,657 lines (net -378)

## Proof

- focused suite: 193/193 passed
- full Bun suite: 1431/1431 passed
- Bun coverage: 79.22%
- Node coverage completed
- Bun and Node builds passed
- Bun and Node checks passed
- isolated live CLI proof passed
- disposable server proof passed
- closeout autoreview and TruffleHog scans were clean

No production deployment was performed or is included in this PR.
