### PR TITLE
refactor(sync): centralize live pagination policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Propagate explicit selected-account identity proof through Bird, Xurl, and local DM hydration, and compare pending-push remotes using credential-free canonical endpoint identity.
 - Preserve endpoint-routing identity while redacting remote credentials, fail closed for live/cross-host lease owners, and bind recovery journals to repository and Git-directory inode identities.
 - Route authored and profile-analysis live ingestion through the canonical tweet repository so sparse media/profile refreshes, rich video metadata, included context, revisions, and FTS stay consistent across Xurl sources.
+- Make live pagination, cache freshness, account verification, collection saturation, and follow/list completeness conservative across timeline, mentions, authored tweets, saved collections, DMs, and follow graph syncs.
 
 ### Testing and maintenance
 

--- a/src/lib/actions-transport.ts
+++ b/src/lib/actions-transport.ts
@@ -5,11 +5,10 @@ import {
 	unblockUserViaBirdEffect,
 	unmuteUserViaBirdEffect,
 } from "./bird-actions";
-import { getAuthenticatedBirdAccountEffect } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import { type ActionsTransport, resolveActionsTransport } from "./config";
 import { Effect } from "effect";
 import { runEffectPromise, trySync } from "./effect-runtime";
-import { assertLiveAccountMatches } from "./live-sync-engine";
 import { profileHandleKey } from "./profile-row";
 import type {
 	ModerationAction,
@@ -93,20 +92,11 @@ function runBirdActionEffect(
 ): Effect.Effect<ActionTransportResult, unknown> {
 	return Effect.gen(function* () {
 		if (expectedAccount && !liveWritesDisabled()) {
-			const authenticated = yield* getAuthenticatedBirdAccountEffect();
-			yield* trySync(() =>
-				assertLiveAccountMatches({
-					source: "bird",
-					account: {
-						accountId: expectedAccount.id,
-						username: profileHandleKey(expectedAccount.handle),
-						externalUserId: expectedAccount.externalUserId ?? undefined,
-						isDefault: false,
-					},
-					liveUsername: authenticated.username,
-					liveExternalUserId: authenticated.id,
-				}),
-			);
+			yield* verifyBirdAccountMatchesEffect({
+				accountId: expectedAccount.id,
+				username: profileHandleKey(expectedAccount.handle),
+				externalUserId: expectedAccount.externalUserId ?? undefined,
+			});
 		}
 		const result = yield* action === "block"
 			? blockUserViaBirdEffect(query)

--- a/src/lib/authored-live.test.ts
+++ b/src/lib/authored-live.test.ts
@@ -207,10 +207,13 @@ describe("live authored tweet sync", () => {
 		const effect = syncAuthoredTweetsEffect({ limit: 4 });
 
 		await expect(Effect.runPromise(effect)).rejects.toThrow(
-			"xurl mode requires --limit between 5 and 100",
+			"--limit must be between 5 and 100",
 		);
 		expect(mocks.getTransportStatus).not.toHaveBeenCalled();
 		expect(mocks.listUserTweets).not.toHaveBeenCalled();
+		await expect(
+			Effect.runPromise(syncAuthoredTweetsEffect({ mode: "auto" as never })),
+		).rejects.toThrow("only supports --mode xurl");
 	});
 
 	it("handles an empty authored response without moving the cursor", async () => {
@@ -663,6 +666,30 @@ describe("live authored tweet sync", () => {
 			nextToken: "page-2",
 		});
 		expect(authoredEdgeCount("250")).toEqual({ count: 1 });
+	});
+
+	it("does not commit a cursor when the first authored fetch fails", async () => {
+		makeTempHome();
+		const savedCursor = {
+			state: "pending-forward",
+			sinceId: "600",
+			token: "saved-page",
+			pendingNewestId: "700",
+		};
+		getNativeDb()
+			.prepare(
+				"insert into sync_cache (cache_key, value_json, updated_at) values (?, ?, ?)",
+			)
+			.run(
+				"authored:xurl:acct_primary:cursor",
+				JSON.stringify(savedCursor),
+				"2026-05-12T12:00:00.000Z",
+			);
+		mocks.listUserTweets.mockRejectedValueOnce(new Error("offline"));
+		const { syncAuthoredTweets } = await import("./authored-live");
+
+		await expect(syncAuthoredTweets({ limit: 5 })).rejects.toThrow("offline");
+		expect(authoredCursor()).toEqual(savedCursor);
 	});
 
 	it("uses an explicit account external id without calling whoami", async () => {
@@ -1154,7 +1181,7 @@ describe("live authored tweet sync", () => {
 		});
 	});
 
-	it("migrates legacy paginationToken cursors to pending-forward on read", async () => {
+	it("ignores legacy paginationToken cursor fields", async () => {
 		makeTempHome();
 		getNativeDb()
 			.prepare(
@@ -1179,9 +1206,29 @@ describe("live authored tweet sync", () => {
 		expect(requestOptions).toEqual(
 			expect.objectContaining({
 				sinceId: "600",
-				paginationToken: "legacy-page",
+				paginationToken: undefined,
 			}),
 		);
+	});
+
+	it("does not persist a repeated authored cursor as resumable", async () => {
+		makeTempHome();
+		mocks.listUserTweets
+			.mockResolvedValueOnce(authoredPage("700", "same-page"))
+			.mockResolvedValueOnce(authoredPage("650", "same-page"));
+		const { syncAuthoredTweets } = await import("./authored-live");
+
+		const result = await syncAuthoredTweets({ limit: 5, sinceId: "600" });
+
+		expect(result).toMatchObject({
+			partial: true,
+			nextToken: null,
+			cursor: { paginationToken: null, pending: false },
+			payload: {
+				meta: { next_token: "same-page" },
+			},
+		});
+		expect(authoredCursor()).toEqual({ state: "committed", sinceId: "600" });
 	});
 
 	it("passes until_id without preserving a stale pending pagination token", async () => {

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -3,19 +3,20 @@ import { Effect } from "effect";
 import { databaseWriteEffect } from "./database-writer";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
-import { resolveLiveSyncAccount } from "./live-sync-engine";
+import {
+	parseOptionalMaxPages,
+	parseLivePageSize,
+	resolveLiveSyncAccount,
+} from "./live-sync-engine";
 import { readSyncCache, writeSyncCache } from "./sync-cache";
 import { runSyncPlanEffect } from "./sync-plan";
-import type {
-	XurlMedia,
-	XurlMentionData,
-	XurlMentionUser,
-	XurlTweetData,
-	XurlTweetIncludes,
-	XurlUserTweet,
-	XurlUserTweetsResponse,
-} from "./types";
+import type { XurlMentionData } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import {
+	adaptUserTimelinePage,
+	mergeTweetPages,
+	type TweetPage,
+} from "./tweet-page";
 import {
 	getTransportStatusEffect,
 	listUserTweetsEffect,
@@ -65,7 +66,7 @@ type AuthoredCursorState =
 
 interface AuthoredPayload {
 	data: XurlMentionData[];
-	includes?: XurlTweetIncludes;
+	includes?: TweetPage["includes"];
 	meta: {
 		result_count: number;
 		page_count: number;
@@ -105,27 +106,6 @@ const AUTHORED_USER_FIELDS = [
 	"verified",
 	"verified_type",
 ];
-function assertXurlLimit(limit: number) {
-	if (
-		!Number.isFinite(limit) ||
-		limit < MIN_XURL_LIMIT ||
-		limit > MAX_XURL_LIMIT
-	) {
-		throw new Error("xurl mode requires --limit between 5 and 100");
-	}
-	return Math.floor(limit);
-}
-
-function parseMaxPages(value?: number) {
-	if (value === undefined) {
-		return null;
-	}
-	if (!Number.isFinite(value) || value < 1) {
-		throw new Error("--max-pages must be at least 1");
-	}
-	return Math.floor(value);
-}
-
 function cursorKey(accountId: string) {
 	return `${AUTHORED_CURSOR_PREFIX}:${accountId}:cursor`;
 }
@@ -164,19 +144,6 @@ function normalizeCursor(value: unknown): AuthoredCursorState {
 			token: record.token,
 			untilId: record.untilId,
 			...(requestedSinceId !== undefined ? { requestedSinceId } : {}),
-		};
-	}
-	const legacyToken =
-		typeof record.paginationToken === "string" ? record.paginationToken : null;
-	if (legacyToken) {
-		return {
-			state: "pending-forward",
-			sinceId,
-			token: legacyToken,
-			pendingNewestId:
-				typeof record.pendingNewestId === "string"
-					? record.pendingNewestId
-					: null,
 		};
 	}
 	return { state: "committed", sinceId };
@@ -434,92 +401,20 @@ function resolveAuthoredIdentityEffect({
 	});
 }
 
-function toMentionData(tweet: XurlUserTweet, fallbackAuthorId: string) {
+function mergePages(pages: readonly TweetPage[]): AuthoredPayload {
+	const merged = mergeTweetPages(pages);
+	const newestId = getNewestTweetId(merged.data);
+	const oldestId = getOldestTweetId(merged.data);
 	return {
-		...tweet,
-		author_id: tweet.author_id ?? fallbackAuthorId,
-	} satisfies XurlMentionData;
-}
-
-function appendUniqueById<T extends { id: string }>(
-	target: T[],
-	seenIds: Set<string>,
-	items: T[] | undefined,
-) {
-	for (const item of items ?? []) {
-		if (seenIds.has(item.id)) {
-			continue;
-		}
-		seenIds.add(item.id);
-		target.push(item);
-	}
-}
-
-function appendUniqueMedia(
-	target: XurlMedia[],
-	seenIds: Set<string>,
-	items: XurlMedia[] | undefined,
-) {
-	for (const item of items ?? []) {
-		if (seenIds.has(item.media_key)) {
-			continue;
-		}
-		seenIds.add(item.media_key);
-		target.push(item);
-	}
-}
-
-function mergePages({
-	pages,
-	userId,
-	nextToken,
-}: {
-	pages: XurlUserTweetsResponse[];
-	userId: string;
-	nextToken: string | null;
-}): AuthoredPayload {
-	const tweets: XurlMentionData[] = [];
-	const users: XurlMentionUser[] = [];
-	const includedTweets: XurlTweetData[] = [];
-	const media: XurlMedia[] = [];
-	const seenTweetIds = new Set<string>();
-	const seenUserIds = new Set<string>();
-	const seenIncludedTweetIds = new Set<string>();
-	const seenMediaKeys = new Set<string>();
-
-	for (const page of pages) {
-		for (const tweet of page.items) {
-			const normalized = toMentionData(tweet, userId);
-			if (seenTweetIds.has(normalized.id)) {
-				continue;
-			}
-			seenTweetIds.add(normalized.id);
-			tweets.push(normalized);
-		}
-		appendUniqueById(users, seenUserIds, page.includes?.users);
-		appendUniqueById(
-			includedTweets,
-			seenIncludedTweetIds,
-			page.includes?.tweets,
-		);
-		appendUniqueMedia(media, seenMediaKeys, page.includes?.media);
-	}
-
-	const newestId = getNewestTweetId(tweets);
-	const oldestId = getOldestTweetId(tweets);
-	const includes = {
-		...(users.length > 0 ? { users } : {}),
-		...(includedTweets.length > 0 ? { tweets: includedTweets } : {}),
-		...(media.length > 0 ? { media } : {}),
-	};
-
-	return {
-		data: tweets,
-		...(Object.keys(includes).length > 0 ? { includes } : {}),
+		...merged,
 		meta: {
-			result_count: tweets.length,
+			...merged.meta,
+			result_count: merged.data.length,
 			page_count: pages.length,
-			next_token: nextToken,
+			next_token:
+				typeof merged.meta?.next_token === "string"
+					? merged.meta.next_token
+					: null,
 			...(newestId ? { newest_id: newestId } : {}),
 			...(oldestId ? { oldest_id: oldestId } : {}),
 		},
@@ -588,8 +483,12 @@ export function syncAuthoredTweetsEffect({
 			);
 		}
 
-		const pageLimit = yield* trySync(() => assertXurlLimit(limit));
-		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const pageLimit = yield* trySync(() =>
+			parseLivePageSize(limit, { min: MIN_XURL_LIMIT, max: MAX_XURL_LIMIT }),
+		);
+		const parsedMaxPages = yield* trySync(() =>
+			parseOptionalMaxPages(maxPages),
+		);
 		const db = yield* trySync(() => getNativeDb());
 		const identity = yield* resolveAuthoredIdentityEffect({ account, db });
 		const cursor = yield* trySync(() =>
@@ -651,77 +550,67 @@ export function syncAuthoredTweetsEffect({
 					userFields: AUTHORED_USER_FIELDS,
 					auth: "oauth2",
 					username: identity.username,
-				}),
+				}).pipe(
+					Effect.map((page) => ({
+						payload: adaptUserTimelinePage(page, identity.userId),
+						nextToken: page.nextToken,
+					})),
+				),
 			getNextCursor: (page) => page.nextToken,
-			persistPage: ({ page, nextCursor: pendingToken }) => {
-				const pagePayload = mergePages({
-					pages: [page],
-					userId: identity.userId,
-					nextToken: page.nextToken,
-				});
+			persistPage: ({ page }) => {
 				return databaseWriteEffect((writeDb) =>
 					ingestTweetPayload(writeDb, {
 						accountId: identity.accountId,
-						payload: pagePayload,
+						payload: page.payload,
 						source: "xurl",
 						edgeKind: "authored",
 						markRepliesAsReplied: true,
 					}),
 				).pipe(
-					Effect.flatMap(() =>
-						trySync(() => {
+					Effect.tap(() =>
+						Effect.sync(() => {
 							newestSeenId = maxTweetId(
 								newestSeenId,
-								pagePayload.meta.newest_id,
+								getNewestTweetId(page.payload.data),
 							);
-							if (pendingToken && untilId) {
-								writePendingUntilCursor(db, identity.accountId, {
-									sinceId: cursor.sinceId,
-									token: pendingToken,
-									untilId,
-									requestedSinceId: effectiveSinceId,
-								});
-							} else if (pendingToken) {
-								writePendingForwardCursor(db, identity.accountId, {
-									sinceId: effectiveSinceId,
-									token: pendingToken,
-									pendingNewestId: newestSeenId,
-								});
-							}
 						}),
 					),
 				);
 			},
 		});
-		const pages = planResult.pages;
+		const pages = planResult.pages.map((page) => page.payload);
 		const pageCount = pages.length;
-		const nextToken = planResult.nextCursor;
-		if (planResult.stopReason === "error") {
-			const payload = mergePages({
-				pages,
-				userId: identity.userId,
-				nextToken: nextToken ?? null,
-			});
-			return buildResult({
-				accountId: identity.accountId,
-				userId: identity.userId,
-				effectiveSinceId,
-				nextSinceId: untilId ? cursor.sinceId : effectiveSinceId,
-				nextToken: nextToken ?? null,
-				pageCount,
-				payload,
-				partial: true,
-				error: formatError(planResult.error),
-			});
-		}
-
-		const capped = Boolean(nextToken);
+		const nextToken =
+			planResult.stopReason === "page-limit" ||
+			planResult.stopReason === "error"
+				? planResult.nextCursor
+				: undefined;
+		const partial = !planResult.complete;
 		const nextSinceId = untilId
 			? cursor.sinceId
-			: capped
+			: partial
 				? effectiveSinceId
 				: maxTweetId(newestSeenId, effectiveSinceId, cursor.sinceId);
-		if (untilId && capped && nextToken) {
+		if (planResult.stopReason === "error") {
+			if (nextToken && untilId) {
+				yield* trySync(() =>
+					writePendingUntilCursor(db, identity.accountId, {
+						sinceId: cursor.sinceId,
+						token: nextToken,
+						untilId,
+						requestedSinceId: effectiveSinceId,
+					}),
+				);
+			} else if (nextToken) {
+				yield* trySync(() =>
+					writePendingForwardCursor(db, identity.accountId, {
+						sinceId: effectiveSinceId,
+						token: nextToken,
+						pendingNewestId: newestSeenId,
+					}),
+				);
+			}
+		} else if (untilId && nextToken) {
 			yield* trySync(() =>
 				writePendingUntilCursor(db, identity.accountId, {
 					sinceId: cursor.sinceId,
@@ -734,7 +623,7 @@ export function syncAuthoredTweetsEffect({
 			yield* trySync(() =>
 				writeCommittedCursor(db, identity.accountId, cursor.sinceId),
 			);
-		} else if (capped && nextToken) {
+		} else if (nextToken) {
 			yield* trySync(() =>
 				writePendingForwardCursor(db, identity.accountId, {
 					sinceId: nextSinceId,
@@ -748,11 +637,7 @@ export function syncAuthoredTweetsEffect({
 			);
 		}
 
-		const payload = mergePages({
-			pages,
-			userId: identity.userId,
-			nextToken: nextToken ?? null,
-		});
+		const payload = mergePages(pages);
 		return buildResult({
 			accountId: identity.accountId,
 			userId: identity.userId,
@@ -761,8 +646,17 @@ export function syncAuthoredTweetsEffect({
 			nextToken: nextToken ?? null,
 			pageCount,
 			payload,
-			partial: capped,
-			...(capped ? { error: "max pages reached before sync completed" } : {}),
+			partial,
+			...(planResult.stopReason === "error"
+				? { error: formatError(planResult.error) }
+				: partial
+					? {
+							error:
+								planResult.stopReason === "repeated-cursor"
+									? "pagination stopped on a repeated cursor"
+									: "max pages reached before sync completed",
+						}
+					: {}),
 		});
 	});
 }

--- a/src/lib/bird-account.ts
+++ b/src/lib/bird-account.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect";
+import { getAuthenticatedBirdAccountEffect } from "./bird";
+import { toError } from "./effect-runtime";
+import {
+	assertLiveAccountMatches,
+	type LiveAccountIdentity,
+} from "./live-sync-engine";
+
+export function verifyBirdAccountMatchesEffect(account: LiveAccountIdentity) {
+	return getAuthenticatedBirdAccountEffect().pipe(
+		Effect.flatMap((authenticated) =>
+			Effect.try({
+				try: () => {
+					assertLiveAccountMatches({
+						source: "bird",
+						account,
+						liveUsername: authenticated.username,
+						liveExternalUserId: authenticated.id,
+					});
+					return authenticated;
+				},
+				catch: toError,
+			}),
+		),
+	);
+}

--- a/src/lib/dms-live.test.ts
+++ b/src/lib/dms-live.test.ts
@@ -46,6 +46,18 @@ function makeTempHome() {
 	return tempDir;
 }
 
+function mockRepeatedXurlDmPages() {
+	listDirectMessageEventsViaXurlMock
+		.mockResolvedValueOnce({
+			data: [{ id: "dm_repeated_1", event_type: "MessageCreate" }],
+			meta: { next_token: "same-page" },
+		})
+		.mockResolvedValueOnce({
+			data: [{ id: "dm_repeated_2", event_type: "MessageCreate" }],
+			meta: { next_token: "same-page" },
+		});
+}
+
 describe("cached live DMs", () => {
 	beforeEach(() => {
 		listDirectMessagesViaBirdMock.mockReset();
@@ -323,6 +335,70 @@ describe("cached live DMs", () => {
 		});
 	});
 
+	it("rejects repeated xurl DM cursors without persisting the partial snapshot", async () => {
+		makeTempHome();
+		mockRepeatedXurlDmPages();
+		const { syncDirectMessagesViaCachedBird } = await import("./dms-live");
+
+		await expect(
+			syncDirectMessagesViaCachedBird({
+				mode: "xurl",
+				limit: 5,
+				maxPages: 1,
+				refresh: true,
+			}),
+		).rejects.toThrow("xurl DM pagination stopped on a repeated cursor");
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from dm_messages where id like 'dm_repeated_%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		expect(
+			getNativeDb()
+				.prepare(
+					"select cache_key from sync_cache where cache_key like 'dms:xurl:%'",
+				)
+				.get(),
+		).toBeUndefined();
+	});
+
+	it("falls back to Bird when xurl DM pagination repeats", async () => {
+		makeTempHome();
+		mockRepeatedXurlDmPages();
+		listDirectMessagesViaBirdMock.mockResolvedValueOnce({
+			success: true,
+			conversations: [],
+			events: [],
+		});
+		const { syncDirectMessagesViaCachedBird } = await import("./dms-live");
+
+		await expect(
+			syncDirectMessagesViaCachedBird({
+				mode: "auto",
+				limit: 5,
+				maxPages: 1,
+				refresh: true,
+			}),
+		).resolves.toMatchObject({ source: "bird", messages: 0 });
+		expect(listDirectMessageEventsViaXurlMock).toHaveBeenCalledTimes(2);
+		expect(listDirectMessagesViaBirdMock).toHaveBeenCalledTimes(1);
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from dm_messages where id like 'dm_repeated_%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		const cache = getNativeDb()
+			.prepare(
+				"select value_json from sync_cache where cache_key like 'dms:auto:%'",
+			)
+			.get() as { value_json: string };
+		expect(cache.value_json).not.toContain("dm_repeated_");
+	});
+
 	it("reuses fresh cache without spending another bird call", async () => {
 		makeTempHome();
 		listDirectMessagesViaBirdMock.mockResolvedValue({
@@ -350,14 +426,14 @@ describe("cached live DMs", () => {
 		const { syncDirectMessagesViaCachedBird } = await import("./dms-live");
 
 		await expect(syncDirectMessagesViaCachedBird({ limit: 0 })).rejects.toThrow(
-			"bird DM mode requires --limit of at least 1",
+			"--limit must be at least 1",
 		);
 		await expect(
 			syncDirectMessagesViaCachedBird({ account: "missing", limit: 1 }),
 		).rejects.toThrow("Unknown account: missing");
 		await expect(
 			syncDirectMessagesViaCachedBird({ mode: "xurl", limit: 101 }),
-		).rejects.toThrow("xurl DM mode requires --limit between 1 and 100");
+		).rejects.toThrow("--limit must be between 1 and 100");
 		await expect(
 			syncDirectMessagesViaCachedBird({
 				mode: "xurl",
@@ -365,6 +441,9 @@ describe("cached live DMs", () => {
 				limit: 5,
 			}),
 		).rejects.toThrow("xurl DM mode cannot read the message-request inbox");
+		await expect(
+			syncDirectMessagesViaCachedBird({ mode: "invalid" as never }),
+		).rejects.toThrow("--mode");
 	});
 
 	it("falls back from xurl to bird in auto mode", async () => {

--- a/src/lib/dms-live.ts
+++ b/src/lib/dms-live.ts
@@ -4,18 +4,23 @@ import {
 	type BirdDmConversation,
 	type BirdDmEvent,
 	type BirdDmUser,
-	getAuthenticatedBirdAccountEffect,
 	listDirectMessagesViaBirdEffect,
 } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import { getProvenSelectedAccountLegacyProfileIds } from "./profile-identity";
 import {
 	assertLiveAccountMatches,
+	parseLiveSyncMode,
+	parseOptionalPageDelayMs,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	type LiveSyncAccount,
+	type LiveSyncMode,
 } from "./live-sync-engine";
-import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { inspectSyncCache, writeSyncCache } from "./sync-cache";
 import { runSyncPlanEffect } from "./sync-plan";
 import type { XurlDmEventsResponse, XurlMentionUser } from "./types";
 import {
@@ -32,7 +37,7 @@ export const DEFAULT_DMS_CACHE_TTL_MS = 2 * 60_000;
 const PREVIEW_MESSAGE_ID_PREFIX = "preview:";
 const XURL_DMS_MAX_RESULTS = 100;
 
-export type DirectMessagesSyncMode = "auto" | "bird" | "xurl";
+export type DirectMessagesSyncMode = LiveSyncMode;
 
 export interface SyncDirectMessagesViaCachedBirdOptions {
 	account?: string;
@@ -44,32 +49,6 @@ export interface SyncDirectMessagesViaCachedBirdOptions {
 	pageDelayMs?: number;
 	refresh?: boolean;
 	cacheTtlMs?: number;
-}
-
-function parseCacheTtlMs(value?: number) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return DEFAULT_DMS_CACHE_TTL_MS;
-	}
-	return Math.floor(value);
-}
-
-function assertBirdLimit(limit: number) {
-	if (!Number.isFinite(limit) || limit < 1) {
-		throw new Error("bird DM mode requires --limit of at least 1");
-	}
-}
-
-function assertXurlLimit(limit: number) {
-	if (!Number.isFinite(limit) || limit < 1 || limit > XURL_DMS_MAX_RESULTS) {
-		throw new Error("xurl DM mode requires --limit between 1 and 100");
-	}
-}
-
-function parseSyncMode(mode: DirectMessagesSyncMode | undefined) {
-	if (!mode || mode === "bird" || mode === "xurl" || mode === "auto") {
-		return mode ?? "bird";
-	}
-	throw new Error("--mode must be auto, bird, or xurl");
 }
 
 function makePreviewMessageId(conversationId: string): string {
@@ -164,25 +143,6 @@ function getLatestEvent(events: BirdDmEvent[]) {
 			new Date(right.createdAt ?? 0).getTime() -
 			new Date(left.createdAt ?? 0).getTime(),
 	)[0];
-}
-
-function assertAuthenticatedBirdAccountMatches({
-	source,
-	account,
-	liveUsername,
-	liveExternalUserId,
-}: {
-	source: "bird" | "xurl";
-	account: LiveSyncAccount;
-	liveUsername: string;
-	liveExternalUserId?: string;
-}) {
-	assertLiveAccountMatches({
-		source,
-		account,
-		liveUsername,
-		liveExternalUserId,
-	});
 }
 
 function getAuthenticatedXurlAccount(payload: Record<string, unknown> | null): {
@@ -677,7 +637,11 @@ function mergeXurlDmPages(pages: XurlDmEventsResponse[]): XurlDmEventsResponse {
 		...(usersById.size > 0
 			? { includes: { users: [...usersById.values()] } }
 			: {}),
-		...(meta ? { meta } : {}),
+		meta: {
+			...meta,
+			result_count: eventsById.size,
+			page_count: pages.length,
+		},
 	};
 }
 
@@ -709,7 +673,15 @@ function fetchDirectMessagesViaXurlEffect({
 			maxPages: pageLimit,
 			pageDelayMs,
 		});
-		return mergeXurlDmPages(result.pages);
+		if (result.stopReason === "repeated-cursor") {
+			return yield* Effect.fail(
+				new Error("xurl DM pagination stopped on a repeated cursor"),
+			);
+		}
+		return {
+			payload: mergeXurlDmPages(result.pages),
+			stopReason: result.stopReason,
+		};
 	});
 }
 
@@ -734,12 +706,15 @@ export function syncDirectMessagesViaCachedBirdEffect({
 	unknown
 > {
 	return Effect.gen(function* () {
-		const parsedMode = parseSyncMode(mode);
-		if (parsedMode === "xurl") {
-			assertXurlLimit(limit);
-		} else {
-			assertBirdLimit(limit);
-		}
+		const parsedMode = parseLiveSyncMode(mode, "bird");
+		const parsedMaxPages = parseOptionalMaxPages(maxPages, { allowZero: true });
+		const parsedPageDelayMs = parseOptionalPageDelayMs(
+			pageDelayMs,
+			"--page-delay-ms",
+		);
+		parseLivePageSize(limit, {
+			max: parsedMode === "xurl" ? XURL_DMS_MAX_RESULTS : undefined,
+		});
 		if (inbox === "requests" && parsedMode === "xurl") {
 			throw new Error(
 				"xurl DM mode cannot read the message-request inbox or accept/reject state; use --mode bird",
@@ -752,16 +727,17 @@ export function syncDirectMessagesViaCachedBirdEffect({
 			: `max-pages:${String(maxPages ?? 0)}`;
 		const cacheMode = parsedMode === "auto" ? "auto" : parsedMode;
 		const cacheKey = `dms:${cacheMode}:${resolvedAccount.accountId}:${String(limit)}:${inbox}:${pageKey}`;
-		const ttlMs = parseCacheTtlMs(cacheTtlMs);
-		const cached = readSyncCache<{
+		const cache = inspectSyncCache<{
 			conversations: BirdDmConversation[];
 			events: BirdDmEvent[];
-		}>(cacheKey, db);
-		const cacheAgeMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
+		}>(
+			cacheKey,
+			{ ttlMs: cacheTtlMs, defaultTtlMs: DEFAULT_DMS_CACHE_TTL_MS },
+			db,
+		);
+		const cached = cache.entry;
 
-		const cacheHit = !refresh && cached && cacheAgeMs <= ttlMs;
+		const cacheHit = !refresh && cached && cache.fresh;
 		let accountExternalUserId = resolvedAccount.externalUserId;
 		let payload:
 			| {
@@ -777,7 +753,7 @@ export function syncDirectMessagesViaCachedBirdEffect({
 				(parsedMode === "xurl" || parsedMode === "auto") &&
 				inbox !== "requests";
 			if (tryXurl) {
-				const xurlPayload = yield* Effect.gen(function* () {
+				const xurlResult = yield* Effect.gen(function* () {
 					const authenticated = getAuthenticatedXurlAccount(
 						yield* lookupAuthenticatedOAuth2UserEffect(
 							resolvedAccount.username,
@@ -788,7 +764,7 @@ export function syncDirectMessagesViaCachedBirdEffect({
 							new Error("xurl authenticated user unavailable"),
 						);
 					}
-					assertAuthenticatedBirdAccountMatches({
+					assertLiveAccountMatches({
 						source: "xurl",
 						account: resolvedAccount,
 						liveUsername: authenticated.username ?? resolvedAccount.username,
@@ -812,9 +788,13 @@ export function syncDirectMessagesViaCachedBirdEffect({
 					return yield* fetchDirectMessagesViaXurlEffect({
 						limit,
 						username: resolvedAccount.username,
-						...(typeof maxPages === "number" ? { maxPages } : {}),
+						...(parsedMaxPages !== undefined
+							? { maxPages: parsedMaxPages }
+							: {}),
 						allPages,
-						...(typeof pageDelayMs === "number" ? { pageDelayMs } : {}),
+						...(parsedPageDelayMs !== undefined
+							? { pageDelayMs: parsedPageDelayMs }
+							: {}),
 					});
 				}).pipe(
 					Effect.catchAll((error) => {
@@ -822,7 +802,7 @@ export function syncDirectMessagesViaCachedBirdEffect({
 						return Effect.succeed(undefined);
 					}),
 				);
-				if (xurlPayload) {
+				if (xurlResult) {
 					const localExternalUserId = accountExternalUserId;
 					if (!localExternalUserId) {
 						throw new Error(
@@ -830,7 +810,7 @@ export function syncDirectMessagesViaCachedBirdEffect({
 						);
 					}
 					payload = adaptXurlDmEventsToBirdPayload({
-						payload: xurlPayload,
+						payload: xurlResult.payload,
 						localExternalUserId,
 						accountUsername: resolvedAccount.username,
 					});
@@ -838,13 +818,8 @@ export function syncDirectMessagesViaCachedBirdEffect({
 				}
 			}
 			if (!payload) {
-				const authenticated = yield* getAuthenticatedBirdAccountEffect();
-				assertAuthenticatedBirdAccountMatches({
-					source: "bird",
-					account: resolvedAccount,
-					liveUsername: authenticated.username,
-					liveExternalUserId: authenticated.id,
-				});
+				const authenticated =
+					yield* verifyBirdAccountMatchesEffect(resolvedAccount);
 				accountExternalUserId ??= authenticated.id;
 				if (!resolvedAccount.externalUserId && accountExternalUserId) {
 					persistAccountExternalUserId(
@@ -856,9 +831,11 @@ export function syncDirectMessagesViaCachedBirdEffect({
 				payload = yield* listDirectMessagesViaBirdEffect({
 					maxResults: limit,
 					...(inbox !== "all" ? { inbox } : {}),
-					...(typeof maxPages === "number" ? { maxPages } : {}),
+					...(parsedMaxPages !== undefined ? { maxPages: parsedMaxPages } : {}),
 					...(allPages ? { allPages } : {}),
-					...(typeof pageDelayMs === "number" ? { pageDelayMs } : {}),
+					...(parsedPageDelayMs !== undefined
+						? { pageDelayMs: parsedPageDelayMs }
+						: {}),
 				});
 				source = "bird";
 			}
@@ -874,7 +851,7 @@ export function syncDirectMessagesViaCachedBirdEffect({
 			accountExternalUserId,
 			payload,
 		);
-		if (!cached || refresh || cacheAgeMs > ttlMs) {
+		if (!cacheHit) {
 			writeSyncCache(cacheKey, payload, db);
 		}
 

--- a/src/lib/follow-graph.test.ts
+++ b/src/lib/follow-graph.test.ts
@@ -330,6 +330,9 @@ describe("follow graph sync and cache-only queries", () => {
 		await expect(
 			syncFollowGraph({ direction: "followers", account: "missing" }),
 		).rejects.toThrow("Unknown account: missing");
+		await expect(
+			syncFollowGraph({ direction: "followers", mode: "invalid" as never }),
+		).rejects.toThrow("--mode");
 		expect(mocks.listFollowUsersViaXurl).not.toHaveBeenCalled();
 	});
 
@@ -462,6 +465,46 @@ describe("follow graph sync and cache-only queries", () => {
 			page_count: 1,
 			truncated_by_max_resources: true,
 		});
+	});
+
+	it("keeps token-bearing Bird snapshots incomplete without ending edges", async () => {
+		setupTempHome();
+		mocks.listFollowUsersViaXurl.mockResolvedValueOnce({
+			data: [user("1", "alice", 100), user("2", "bob", 500)],
+			meta: { pagination_known_complete: true },
+		});
+		const { listTopFollowers, listUnfollowedSince, syncFollowGraph } =
+			await import("./follow-graph");
+		await syncFollowGraph({
+			direction: "followers",
+			mode: "xurl",
+			yes: true,
+			refresh: true,
+		});
+
+		mocks.listFollowUsersViaBird.mockReset();
+		mocks.listFollowUsersViaBird.mockResolvedValueOnce({
+			data: [user("1", "alice", 100)],
+			meta: {
+				result_count: 1,
+				page_count: 1,
+				next_token: "page-two",
+			},
+		});
+		const capped = await syncFollowGraph({
+			direction: "followers",
+			mode: "bird",
+			limit: 1,
+			yes: true,
+			refresh: true,
+		});
+
+		expect(capped).toMatchObject({ status: "incomplete", partial: true });
+		expect(listTopFollowers().items.map((item) => item.handle)).toEqual([
+			"bob",
+			"alice",
+		]);
+		expect(listUnfollowedSince({ date: "2026-01-01" }).items).toEqual([]);
 	});
 
 	it("supports handle sorting and ISO timestamp filters for cache-only queries", async () => {

--- a/src/lib/follow-graph.ts
+++ b/src/lib/follow-graph.ts
@@ -5,11 +5,15 @@ import { listFollowUsersViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
 import {
+	parseLiveSyncMode,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	type LiveSyncAccount,
+	type LiveSyncMode,
 } from "./live-sync-engine";
 import type { Database } from "./sqlite";
-import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { inspectSyncCache, writeSyncCache } from "./sync-cache";
 import { runSyncPlanEffect } from "./sync-plan";
 import type {
 	FollowEventKind,
@@ -43,7 +47,7 @@ export interface SyncFollowGraphOptions {
 	cacheTtlMs?: number;
 }
 
-type FollowGraphSyncMode = "auto" | "bird" | "xurl";
+type FollowGraphSyncMode = LiveSyncMode;
 type FollowGraphLiveSource = "bird" | "xurl";
 
 interface MergedFollowPayload {
@@ -55,14 +59,11 @@ interface MergedFollowPayload {
 }
 
 function parseLimit(value = DEFAULT_FOLLOW_PAGE_LIMIT) {
-	if (
-		!Number.isFinite(value) ||
-		value < MIN_FOLLOW_PAGE_LIMIT ||
-		value > MAX_FOLLOW_PAGE_LIMIT
-	) {
-		throw new Error("--limit must be between 1 and 1000 for follow sync");
-	}
-	return Math.floor(value);
+	return parseLivePageSize(value, {
+		min: MIN_FOLLOW_PAGE_LIMIT,
+		max: MAX_FOLLOW_PAGE_LIMIT,
+		message: "--limit must be between 1 and 1000 for follow sync",
+	});
 }
 
 function parseRowLimit(value: number) {
@@ -72,21 +73,12 @@ function parseRowLimit(value: number) {
 	return value;
 }
 
-function parseOptionalPositiveInteger(name: string, value?: number) {
-	if (value === undefined) {
-		return undefined;
+function parseOptionalResourceCap(value: number | undefined) {
+	if (value === undefined) return undefined;
+	if (!Number.isInteger(value) || value < 1) {
+		throw new Error("--max-resources must be at least 1");
 	}
-	if (!Number.isFinite(value) || value < 1) {
-		throw new Error(`${name} must be at least 1`);
-	}
-	return Math.floor(value);
-}
-
-function parseCacheTtlMs(value?: number) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return DEFAULT_FOLLOW_CACHE_TTL_MS;
-	}
-	return Math.floor(value);
+	return value;
 }
 
 function parseJsonField<T>(value: unknown, fallback: T): T {
@@ -166,7 +158,9 @@ function getLastSnapshot(
 function mergePages(
 	pages: XurlFollowUsersResponse[],
 	nextToken: string | undefined,
+	planComplete: boolean,
 	maxResources?: number,
+	resourceCapped = false,
 ): MergedFollowPayload {
 	const users: XurlMentionUser[] = [];
 	const seen = new Set<string>();
@@ -204,7 +198,12 @@ function mergePages(
 			next_token: nextToken ?? null,
 			truncated_by_max_resources: truncatedByMaxResources,
 		},
-		complete: !nextToken && !truncatedByMaxResources,
+		complete:
+			planComplete &&
+			!nextToken &&
+			lastPage?.meta?.pagination_known_complete !== false &&
+			!truncatedByMaxResources &&
+			!resourceCapped,
 		pageCount,
 		truncatedByMaxResources,
 	};
@@ -244,7 +243,13 @@ function fetchFollowGraphViaXurlEffect({
 			maxPages,
 		});
 
-		return mergePages(result.pages, result.nextCursor, maxResources);
+		return mergePages(
+			result.pages,
+			result.nextCursor,
+			result.complete,
+			maxResources,
+			result.stopReason === "item-limit",
+		);
 	});
 }
 
@@ -282,7 +287,9 @@ function fetchFollowGraphViaBirdEffect({
 			typeof payload.meta?.next_token === "string"
 				? String(payload.meta.next_token)
 				: undefined,
+			true,
 			maxResources,
+			maxResources !== undefined && payload.data.length >= maxResources,
 		);
 	});
 }
@@ -554,13 +561,15 @@ function makeDryRunResponse({
 	maxPages?: number;
 	maxResources?: number;
 	cacheKey: string;
-	cacheTtlMs: number;
+	cacheTtlMs?: number;
 }) {
-	const cached = readSyncCache<MergedFollowPayload>(cacheKey, db);
-	const cacheAgeMs = cached
-		? Date.now() - new Date(cached.updatedAt).getTime()
-		: Number.POSITIVE_INFINITY;
-	const wouldCallLive = !cached || cacheAgeMs > cacheTtlMs;
+	const cache = inspectSyncCache<MergedFollowPayload>(
+		cacheKey,
+		{ ttlMs: cacheTtlMs, defaultTtlMs: DEFAULT_FOLLOW_CACHE_TTL_MS },
+		db,
+	);
+	const cached = cache.entry;
+	const wouldCallLive = !cache.fresh;
 	return {
 		ok: true,
 		dryRun: true,
@@ -574,16 +583,14 @@ function makeDryRunResponse({
 			maxResultsPerPage: limit,
 			maxPages: maxPages ?? null,
 			maxResources: maxResources ?? null,
-			cacheTtlSeconds: Math.floor(cacheTtlMs / 1000),
+			cacheTtlSeconds: Math.floor(cache.ttlMs / 1000),
 		},
 		cache: {
 			key: cacheKey,
 			hit: Boolean(cached),
-			fresh: Boolean(cached && cacheAgeMs <= cacheTtlMs),
+			fresh: cache.fresh,
 			updatedAt: cached?.updatedAt ?? null,
-			ageSeconds: Number.isFinite(cacheAgeMs)
-				? Math.floor(cacheAgeMs / 1000)
-				: null,
+			ageSeconds: cache.ageMs !== null ? Math.floor(cache.ageMs / 1000) : null,
 			count: cached?.value.data.length ?? 0,
 		},
 		currentCount: readCurrentCount(db, account.accountId, direction),
@@ -593,10 +600,7 @@ function makeDryRunResponse({
 }
 
 function parseMode(value?: FollowGraphSyncMode) {
-	if (!value || value === "auto" || value === "bird" || value === "xurl") {
-		return value ?? "auto";
-	}
-	throw new Error("--mode must be auto, bird, or xurl");
+	return parseLiveSyncMode(value, "auto");
 }
 
 function errorMessage(error: unknown) {
@@ -609,12 +613,11 @@ export function syncFollowGraphEffect(options: SyncFollowGraphOptions) {
 		const mode = yield* trySync(() => parseMode(options.mode));
 		const limit = yield* trySync(() => parseLimit(options.limit));
 		const maxPages = yield* trySync(() =>
-			parseOptionalPositiveInteger("--max-pages", options.maxPages),
+			parseOptionalMaxPages(options.maxPages),
 		);
 		const maxResources = yield* trySync(() =>
-			parseOptionalPositiveInteger("--max-resources", options.maxResources),
+			parseOptionalResourceCap(options.maxResources),
 		);
-		const cacheTtlMs = parseCacheTtlMs(options.cacheTtlMs);
 		const account = yield* trySync(() =>
 			resolveLiveSyncAccount(db, options.account),
 		);
@@ -638,20 +641,23 @@ export function syncFollowGraphEffect(options: SyncFollowGraphOptions) {
 					maxPages,
 					maxResources,
 					cacheKey,
-					cacheTtlMs,
+					cacheTtlMs: options.cacheTtlMs,
 				}),
 			);
 		}
 
-		const cached = yield* trySync(() =>
-			readSyncCache<MergedFollowPayload>(cacheKey, db),
+		const cache = yield* trySync(() =>
+			inspectSyncCache<MergedFollowPayload>(
+				cacheKey,
+				{
+					ttlMs: options.cacheTtlMs,
+					defaultTtlMs: DEFAULT_FOLLOW_CACHE_TTL_MS,
+				},
+				db,
+			),
 		);
-		const cacheAgeMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
-		const useCache = Boolean(
-			!options.refresh && cached && cacheAgeMs <= cacheTtlMs,
-		);
+		const cached = cache.entry;
+		const useCache = Boolean(!options.refresh && cached && cache.fresh);
 
 		const liveResult = useCache
 			? undefined

--- a/src/lib/live-sync-engine.test.ts
+++ b/src/lib/live-sync-engine.test.ts
@@ -7,6 +7,10 @@ import {
 	assertLiveAccountMatches,
 	createLiveTransportAdapter,
 	fetchWithTransportFallbackEffect,
+	parseLiveSyncMode,
+	parseOptionalPageDelayMs,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	runCachedLiveSyncEffect,
 } from "./live-sync-engine";
@@ -21,6 +25,20 @@ function setupDatabase() {
 }
 
 describe("live sync engine", () => {
+	it("rejects invalid programmatic sync modes and numeric options", () => {
+		expect(() => parseLiveSyncMode("invalid", "auto")).toThrow("--mode");
+		expect(() =>
+			parseLiveSyncMode("auto", "bird", { allowAuto: false }),
+		).toThrow("--mode must be bird or xurl");
+		for (const value of [Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5]) {
+			expect(() => parseLivePageSize(value)).toThrow("--limit");
+			expect(() => parseOptionalMaxPages(value)).toThrow("--max-pages");
+			expect(() => parseOptionalPageDelayMs(value)).toThrow("--delay-ms");
+		}
+		expect(parseOptionalMaxPages(0, { allowZero: true })).toBe(0);
+		expect(parseOptionalPageDelayMs(0)).toBe(0);
+	});
+
 	it("resolves default and selected accounts", () => {
 		const db = setupDatabase();
 		insertTestAccount(db, {
@@ -111,6 +129,7 @@ describe("live sync engine", () => {
 				cacheKey: "timeline:test",
 				refresh: false,
 				cacheTtlMs: 60_000,
+				defaultCacheTtlMs: 60_000,
 				transports: [{ source: "bird", fetch: Effect.sync(fetch) }],
 				persistLive: () => undefined,
 			}),
@@ -133,6 +152,7 @@ describe("live sync engine", () => {
 					cacheKey: "timeline:test",
 					refresh: true,
 					cacheTtlMs: 0,
+					defaultCacheTtlMs: 0,
 					transports: [
 						{ source: "bird", fetch: Effect.succeed({ value: "live" }) },
 					],

--- a/src/lib/live-sync-engine.ts
+++ b/src/lib/live-sync-engine.ts
@@ -3,7 +3,9 @@ import { findOperationAccount } from "./account-selection";
 import { databaseWriteEffect } from "./database-writer";
 import { toError } from "./effect-runtime";
 import type { Database } from "./sqlite";
-import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { inspectSyncCache, writeSyncCache } from "./sync-cache";
+
+export type LiveSyncMode = "auto" | "bird" | "xurl";
 
 export interface LiveTransportAdapter<Source extends string, Payload> {
 	source: Source;
@@ -17,11 +19,19 @@ export interface LiveSyncAccount {
 	isDefault: boolean;
 }
 
+export interface LiveAccountIdentity {
+	accountId: string;
+	username: string;
+	externalUserId?: string;
+	isDefault?: boolean;
+}
+
 interface CachedLiveSyncOptions<Source extends string, Payload, Persisted> {
 	db: Database;
 	cacheKey: string;
 	refresh: boolean;
-	cacheTtlMs: number;
+	cacheTtlMs?: number;
+	defaultCacheTtlMs: number;
 	transports: readonly LiveTransportAdapter<Source, Payload>[];
 	persistLive: (db: Database, payload: Payload, source: Source) => Persisted;
 	persistCached?: (db: Database, payload: Payload) => Persisted;
@@ -87,7 +97,7 @@ export function assertLiveAccountMatches({
 	liveExternalUserId,
 }: {
 	source: string;
-	account: LiveSyncAccount;
+	account: LiveAccountIdentity;
 	liveUsername: string;
 	liveExternalUserId?: string;
 }) {
@@ -110,14 +120,76 @@ export function assertLiveAccountMatches({
 	}
 }
 
-export function normalizeCacheTtlMs(
-	value: number | undefined,
-	defaultValue: number,
-) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return defaultValue;
+export function parseLiveSyncMode(
+	value: unknown,
+	defaultMode: Exclude<LiveSyncMode, "auto">,
+	options: { allowAuto: false },
+): Exclude<LiveSyncMode, "auto">;
+export function parseLiveSyncMode(
+	value: unknown,
+	defaultMode: LiveSyncMode,
+	options?: { allowAuto?: true },
+): LiveSyncMode;
+export function parseLiveSyncMode(
+	value: unknown,
+	defaultMode: LiveSyncMode,
+	{ allowAuto = true }: { allowAuto?: boolean } = {},
+): LiveSyncMode {
+	if (value === undefined) return defaultMode;
+	if (value === "bird" || value === "xurl" || (allowAuto && value === "auto")) {
+		return value;
 	}
-	return Math.floor(value);
+	throw new Error(
+		allowAuto
+			? "--mode must be auto, bird, or xurl"
+			: "--mode must be bird or xurl",
+	);
+}
+
+export function parseLivePageSize(
+	value: number,
+	{
+		min = 1,
+		max,
+		name = "--limit",
+		message,
+	}: { min?: number; max?: number; name?: string; message?: string } = {},
+) {
+	if (
+		!Number.isInteger(value) ||
+		value < min ||
+		(max !== undefined && value > max)
+	) {
+		if (message) throw new Error(message);
+		throw new Error(
+			max === undefined
+				? `${name} must be at least ${String(min)}`
+				: `${name} must be between ${String(min)} and ${String(max)}`,
+		);
+	}
+	return value;
+}
+
+export function parseOptionalMaxPages(
+	value: number | undefined,
+	{ allowZero = false }: { allowZero?: boolean } = {},
+) {
+	if (value === undefined) return undefined;
+	return parseLivePageSize(value, {
+		min: allowZero ? 0 : 1,
+		name: "--max-pages",
+	});
+}
+
+export function parseOptionalPageDelayMs(
+	value: number | undefined,
+	name = "--delay-ms",
+) {
+	if (value === undefined) return undefined;
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${name} must be a non-negative integer`);
+	}
+	return value;
 }
 
 export function fetchWithTransportFallbackEffect<
@@ -149,6 +221,7 @@ export function runCachedLiveSyncEffect<
 	cacheKey,
 	refresh,
 	cacheTtlMs,
+	defaultCacheTtlMs,
 	transports,
 	persistLive,
 	persistCached,
@@ -157,14 +230,17 @@ export function runCachedLiveSyncEffect<
 	Error
 > {
 	return Effect.gen(function* () {
-		const cached = yield* Effect.try({
-			try: () => readSyncCache<Payload>(cacheKey, db),
+		const cache = yield* Effect.try({
+			try: () =>
+				inspectSyncCache<Payload>(
+					cacheKey,
+					{ ttlMs: cacheTtlMs, defaultTtlMs: defaultCacheTtlMs },
+					db,
+				),
 			catch: toError,
 		});
-		const cacheAgeMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
-		if (!refresh && cached && cacheAgeMs <= cacheTtlMs) {
+		const cached = cache.entry;
+		if (!refresh && cached && cache.fresh) {
 			const persisted = persistCached
 				? yield* databaseWriteEffect((writeDb) =>
 						persistCached(writeDb, cached.value),

--- a/src/lib/mention-threads-live.test.ts
+++ b/src/lib/mention-threads-live.test.ts
@@ -1597,13 +1597,13 @@ describe("mention thread sync", () => {
 			"--limit must be at least 1",
 		);
 		await expect(syncMentionThreads({ delayMs: -1 })).rejects.toThrow(
-			"--delay-ms must be non-negative",
+			"--delay-ms must be a non-negative integer",
 		);
 		await expect(syncMentionThreads({ timeoutMs: 0 })).rejects.toThrow(
 			"--timeout-ms must be at least 1",
 		);
 		await expect(syncMentionThreads({ maxPages: -1 })).rejects.toThrow(
-			"--max-pages must be non-negative",
+			"--max-pages must be at least 0",
 		);
 		await expect(syncMentionThreads({ mode: "auto" })).rejects.toThrow(
 			"--mode must be bird or xurl",

--- a/src/lib/mention-threads-live.ts
+++ b/src/lib/mention-threads-live.ts
@@ -4,13 +4,15 @@ import { listThreadViaBirdEffect } from "./bird";
 import { databaseWriteEffect } from "./database-writer";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
-import { resolveLiveSyncAccount } from "./live-sync-engine";
+import {
+	parseLiveSyncMode,
+	parseOptionalMaxPages,
+	resolveLiveSyncAccount,
+} from "./live-sync-engine";
 import { runSyncPlanEffect } from "./sync-plan";
 import type {
 	XurlMentionData,
 	XurlMentionsResponse,
-	XurlMentionUser,
-	XurlMediaItem,
 	XurlTweetsResponse,
 } from "./types";
 import {
@@ -18,6 +20,7 @@ import {
 	upsertTweetAccountEdge,
 } from "./tweet-account-edges";
 import { ingestTweetPayload } from "./tweet-repository";
+import { mergeTweetPages } from "./tweet-page";
 import { getTweetByIdEffect, searchRecentByConversationIdEffect } from "./xurl";
 
 const DEFAULT_LIMIT = 30;
@@ -63,29 +66,24 @@ interface ThreadFetchResult {
 	warnings: string[];
 }
 
-function assertPositiveInteger(value: number, name: string) {
-	if (!Number.isFinite(value) || value < 1) {
+function positiveInteger(value: number, name: string) {
+	if (!Number.isInteger(value) || value < 1) {
 		throw new Error(`${name} must be at least 1`);
 	}
-	return Math.floor(value);
+	return value;
 }
 
-function parseNonNegativeInteger(value: number | undefined, name: string) {
-	if (value === undefined) {
-		return undefined;
+function nonNegativeInteger(value: number, name: string) {
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${name} must be a non-negative integer`);
 	}
-	if (!Number.isFinite(value) || value < 0) {
-		throw new Error(`${name} must be non-negative`);
-	}
-	return Math.floor(value);
+	return value;
 }
 
 function parseMode(value: string | undefined): MentionThreadsMode {
-	const mode = value ?? DEFAULT_MODE;
-	if (mode !== "bird" && mode !== "xurl") {
-		throw new Error("--mode must be bird or xurl");
-	}
-	return mode;
+	return parseLiveSyncMode(value, DEFAULT_MODE, {
+		allowAuto: false,
+	});
 }
 
 function getRemainingThreadTimeoutMs(
@@ -103,60 +101,6 @@ function getRemainingThreadTimeoutMs(
 function getReplyToId(tweet: XurlMentionData) {
 	return tweet.referenced_tweets?.find((entry) => entry.type === "replied_to")
 		?.id;
-}
-
-function mergePayloads(pages: XurlTweetsResponse[]): XurlMentionsResponse {
-	const tweets: XurlMentionData[] = [];
-	const seenTweetIds = new Set<string>();
-	const users: XurlMentionUser[] = [];
-	const seenUserIds = new Set<string>();
-	const media: XurlMediaItem[] = [];
-	const seenMediaKeys = new Set<string>();
-
-	for (const page of pages) {
-		for (const tweet of page.data) {
-			if (seenTweetIds.has(tweet.id)) {
-				continue;
-			}
-			seenTweetIds.add(tweet.id);
-			tweets.push(tweet);
-		}
-
-		for (const user of page.includes?.users ?? []) {
-			if (seenUserIds.has(user.id)) {
-				continue;
-			}
-			seenUserIds.add(user.id);
-			users.push(user);
-		}
-
-		for (const item of page.includes?.media ?? []) {
-			if (seenMediaKeys.has(item.media_key)) {
-				continue;
-			}
-			seenMediaKeys.add(item.media_key);
-			media.push(item);
-		}
-	}
-
-	const lastMeta = pages.at(-1)?.meta;
-	return {
-		data: tweets,
-		includes:
-			users.length > 0 || media.length > 0
-				? {
-						...(users.length > 0 ? { users } : {}),
-						...(media.length > 0 ? { media } : {}),
-					}
-				: undefined,
-		meta: {
-			...lastMeta,
-			result_count: tweets.length,
-			page_count: pages.length,
-			next_token:
-				typeof lastMeta?.next_token === "string" ? lastMeta.next_token : null,
-		},
-	};
 }
 
 function parseRawTweet(value: string | null | undefined) {
@@ -370,7 +314,7 @@ function fetchConversationViaRecentSearchEffect({
 					: undefined,
 			maxPages: all || maxPages !== undefined ? maxPages : 1,
 		});
-		const payload = mergePayloads(result.pages);
+		const payload = mergeTweetPages(result.pages);
 		const paginationRequested = all || maxPages !== undefined;
 		return {
 			payload,
@@ -460,7 +404,7 @@ function fetchParentChainViaXurlEffect({
 				: undefined;
 		}
 
-		const payload = mergePayloads(pages);
+		const payload = mergeTweetPages(pages);
 		return {
 			payload,
 			fallbackDepth,
@@ -573,7 +517,7 @@ function fetchThreadContextViaXurlEffect({
 					strategy: "conversation_search+parent_walk" as const,
 					pages: search.pages,
 					truncated: search.truncated,
-					payload: mergePayloads([search.payload, fallback.payload]),
+					payload: mergeTweetPages([search.payload, fallback.payload]),
 					fallbackDepth: fallback.fallbackDepth,
 					generalReadTweets:
 						search.generalReadTweets + fallback.generalReadTweets,
@@ -625,17 +569,15 @@ export function syncMentionThreadsEffect({
 }: SyncMentionThreadsOptions) {
 	return Effect.gen(function* () {
 		const parsedMode = yield* trySync(() => parseMode(mode));
-		const parsedLimit = yield* trySync(() =>
-			assertPositiveInteger(limit, "--limit"),
+		const parsedLimit = yield* trySync(() => positiveInteger(limit, "--limit"));
+		const parsedDelayMs = yield* trySync(() =>
+			nonNegativeInteger(delayMs, "--delay-ms"),
 		);
-		const parsedDelayMs =
-			(yield* trySync(() => parseNonNegativeInteger(delayMs, "--delay-ms"))) ??
-			0;
 		const parsedTimeoutMs = yield* trySync(() =>
-			assertPositiveInteger(timeoutMs, "--timeout-ms"),
+			positiveInteger(timeoutMs, "--timeout-ms"),
 		);
 		const parsedMaxPages = yield* trySync(() =>
-			parseNonNegativeInteger(maxPages, "--max-pages"),
+			parseOptionalMaxPages(maxPages, { allowZero: true }),
 		);
 		const db = yield* trySync(() => getNativeDb());
 		const resolvedAccount = yield* trySync(() =>

--- a/src/lib/mentions-live.test.ts
+++ b/src/lib/mentions-live.test.ts
@@ -115,6 +115,27 @@ describe("cached live mentions", () => {
 		}
 	});
 
+	it("rejects a mismatched explicit Bird account before mention persistence", async () => {
+		makeTempHome();
+		getAuthenticatedBirdAccountMock.mockResolvedValue({
+			id: "999",
+			username: "wrong",
+		});
+		const { syncMentions } = await import("./mentions-live");
+
+		await expect(
+			syncMentions({ mode: "bird", limit: 5, refresh: true }),
+		).rejects.toThrow("refusing to sync");
+		expect(listMentionsViaBirdMock).not.toHaveBeenCalled();
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from sync_cache where cache_key like 'mentions:%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+	});
+
 	it("builds mention sync effects lazily", async () => {
 		makeTempHome();
 		insertLocalMentionBaseline();
@@ -160,6 +181,9 @@ describe("cached live mentions", () => {
 			"xurl mode requires --limit between 5 and 100",
 		);
 		expect(listMentionsViaXurlMock).not.toHaveBeenCalled();
+		await expect(
+			Effect.runPromise(syncMentionsEffect({ mode: "invalid" })),
+		).rejects.toThrow("--mode");
 	});
 
 	it("reports bird mention sync progress", async () => {
@@ -631,6 +655,47 @@ describe("cached live mentions", () => {
 		);
 	});
 
+	it("keys automatic result caches by the resolved high-water boundary", async () => {
+		makeTempHome();
+		clearLocalMentionRows();
+		insertLocalMentionBaseline({ tweetId: "1000" });
+		listMentionsViaXurlMock
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "1100",
+						author_id: "42",
+						text: "first page-size result",
+						created_at: "2026-03-09T02:00:00.000Z",
+					},
+				],
+				meta: { result_count: 1 },
+			})
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "1200",
+						author_id: "43",
+						text: "second page-size result",
+						created_at: "2026-03-09T02:01:00.000Z",
+					},
+				],
+				meta: { result_count: 1 },
+			})
+			.mockResolvedValueOnce({ data: [], meta: { result_count: 0 } });
+		const { syncMentions } = await import("./mentions-live");
+
+		await syncMentions({ mode: "xurl", limit: 5 });
+		await syncMentions({ mode: "xurl", limit: 10 });
+		await syncMentions({ mode: "xurl", limit: 5 });
+
+		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(3);
+		expect(listMentionsViaXurlMock).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining({ maxResults: 5, sinceId: "1200" }),
+		);
+	});
+
 	it("rolls back a mention page and high-water together, then retries the same page", async () => {
 		makeTempHome();
 		clearLocalMentionRows();
@@ -1028,7 +1093,7 @@ describe("cached live mentions", () => {
 		).toEqual({ kind: "mention" });
 	});
 
-	it("does not reuse stale scoped partial cache after start_time resume completes", async () => {
+	it("replaces a partial start-time scan with its completed resume result", async () => {
 		makeTempHome();
 		clearLocalMentionRows();
 		listMentionsViaXurlMock
@@ -1084,20 +1149,14 @@ describe("cached live mentions", () => {
 			startTime: "2026-03-01T00:00:00Z",
 		});
 
-		const thirdCall = listMentionsViaXurlMock.mock.calls[2]?.[0] as Record<
-			string,
-			unknown
-		>;
-		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(3);
-		expect(thirdResult.source).toBe("xurl");
-		expect(thirdCall).toMatchObject({
-			paginationToken: undefined,
-			startTime: "2026-03-01T00:00:00Z",
-		});
-		expect(thirdCall).not.toHaveProperty("sinceId");
+		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(2);
+		expect(thirdResult.source).toBe("cache");
+		expect(thirdResult.payload.data.map((tweet) => tweet.id)).toEqual([
+			"partial_start_page_2",
+		]);
 	});
 
-	it("clears completed scoped result cache when refresh writes a cursor", async () => {
+	it("reuses the stable result cache after a refresh cursor completes", async () => {
 		makeTempHome();
 		clearLocalMentionRows();
 		listMentionsViaXurlMock
@@ -1170,78 +1229,63 @@ describe("cached live mentions", () => {
 			startTime: "2026-03-01T00:00:00Z",
 		});
 
-		const fourthCall = listMentionsViaXurlMock.mock.calls[3]?.[0] as Record<
-			string,
-			unknown
-		>;
-		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(4);
-		expect(fourthResult.source).toBe("xurl");
+		expect(listMentionsViaXurlMock).toHaveBeenCalledTimes(3);
+		expect(fourthResult.source).toBe("cache");
 		expect(fourthResult.payload.data.map((tweet) => tweet.id)).toEqual([
-			"fresh_after_refresh_resume",
+			"refreshed_start_page_2",
 		]);
-		expect(fourthCall).toMatchObject({
-			paginationToken: undefined,
-			startTime: "2026-03-01T00:00:00Z",
-		});
-		expect(fourthCall).not.toHaveProperty("sinceId");
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from sync_cache where cache_key like 'mentions:sync:result:v2:%boundary=start%2026-03-01T00%3A00%3A00Z%'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
 	});
 
-	it("resumes legacy mention cursors instead of reseeding from newest local mention", async () => {
+	it("does not persist a repeated mention cursor as resumable", async () => {
 		makeTempHome();
 		clearLocalMentionRows();
-		insertLocalMentionBaseline({ tweetId: "100" });
-		insertLocalMentionBaseline({ tweetId: "250" });
-		const db = getNativeDb();
-		const legacyCursorKey =
-			"mentions:sync:xurl:acct_primary:20:single:all-pages:no-since:no-start";
-		db.prepare(
-			`
-      insert into sync_cache (cache_key, value_json, updated_at)
-      values (?, ?, ?)
-      `,
-		).run(
-			legacyCursorKey,
-			JSON.stringify({
-				data: [],
-				meta: { result_count: 0, next_token: "legacy-page-2" },
-			}),
-			"2026-03-09T02:00:00.000Z",
-		);
-		listMentionsViaXurlMock.mockResolvedValueOnce({
-			data: [
-				{
-					id: "180",
-					author_id: "9",
-					text: "legacy cursor page two mention",
-					created_at: "2026-03-09T01:58:00.000Z",
-				},
-			],
-			meta: { result_count: 1 },
-		});
+		listMentionsViaXurlMock
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "300",
+						author_id: "9",
+						text: "first repeated page",
+						created_at: "2026-03-09T02:00:00.000Z",
+					},
+				],
+				meta: { next_token: "same-page" },
+			})
+			.mockResolvedValueOnce({
+				data: [
+					{
+						id: "250",
+						author_id: "9",
+						text: "second repeated page",
+						created_at: "2026-03-09T01:59:00.000Z",
+					},
+				],
+				meta: { next_token: "same-page" },
+			});
 		const { syncMentions } = await import("./mentions-live");
 
-		await syncMentions({ mode: "xurl" });
+		const result = await syncMentions({ mode: "xurl", sinceId: "100" });
 
-		const call = listMentionsViaXurlMock.mock.calls[0]?.[0] as Record<
-			string,
-			unknown
-		>;
-		expect(call).toMatchObject({
-			paginationToken: "legacy-page-2",
+		expect(result).toMatchObject({
+			partial: true,
+			payload: {
+				meta: { next_token: "same-page" },
+			},
 		});
-		expect(call).not.toHaveProperty("sinceId");
 		expect(
-			db
+			getNativeDb()
 				.prepare(
-					"select kind from tweet_account_edges where tweet_id = ? and kind = 'mention'",
+					"select count(*) as count from sync_cache where cache_key like 'mentions:sync:cursor:v2:%'",
 				)
-				.get("180"),
-		).toEqual({ kind: "mention" });
-		expect(
-			db
-				.prepare("select cache_key from sync_cache where cache_key = ?")
-				.get(legacyCursorKey),
-		).toBeUndefined();
+				.get(),
+		).toEqual({ count: 0 });
 	});
 
 	it("keeps seeded sync mentions cache separate from unseeded exports", async () => {

--- a/src/lib/mentions-live.ts
+++ b/src/lib/mentions-live.ts
@@ -1,37 +1,38 @@
 import type { Database } from "./sqlite";
 import { Effect } from "effect";
-import {
-	getAuthenticatedBirdAccountEffect,
-	listMentionsViaBirdEffect,
-} from "./bird";
+import { listMentionsViaBirdEffect } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import type { MentionsDataSource } from "./config";
 import { databaseWriteEffect } from "./database-writer";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
 import {
-	assertLiveAccountMatches,
+	parseLiveSyncMode,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	type LiveSyncAccount,
+	type LiveSyncMode,
 } from "./live-sync-engine";
 import { serializeMentionItemsAsXurlCompatible } from "./mentions-export";
 import { listTimelineItems } from "./timeline-read-model";
-import { deleteSyncCache, readSyncCache, writeSyncCache } from "./sync-cache";
+import {
+	deleteSyncCache,
+	inspectSyncCache,
+	readSyncCache,
+	writeSyncCache,
+} from "./sync-cache";
 import { runSyncPlanEffect } from "./sync-plan";
-import type {
-	ReplyFilter,
-	XurlMentionData,
-	XurlMentionsResponse,
-	XurlMediaItem,
-	XurlMentionUser,
-} from "./types";
+import type { ReplyFilter, XurlMentionsResponse } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import { mergeTweetPages } from "./tweet-page";
 import { listMentionsViaXurlEffect, lookupUsersByHandlesEffect } from "./xurl";
 
 export const DEFAULT_MENTIONS_CACHE_TTL_MS = 2 * 60_000;
 const MIN_XURL_MENTIONS_LIMIT = 5;
 const MAX_XURL_MENTIONS_LIMIT = 100;
-type MentionSyncMode = Exclude<MentionsDataSource, "birdclaw">;
-type MentionLiveSource = Exclude<MentionSyncMode, "auto">;
+type MentionSyncMode = LiveSyncMode;
+type MentionLiveSource = Exclude<LiveSyncMode, "auto">;
 export interface MentionsProgress {
 	source: "bird" | "xurl" | "cache";
 	fetched: number;
@@ -69,7 +70,6 @@ type MentionScanBoundary =
 	| { kind: "start"; startTime: string }
 	| { kind: "unbounded" };
 interface MentionScanShape {
-	endpoint: "mentions";
 	mode: MentionLiveSource;
 	accountId: string;
 	pageSize: number;
@@ -85,46 +85,20 @@ interface MentionHighWaterValue {
 	sinceId: string;
 }
 
-function getMentionsFetchModeKey({
-	scope,
+function getMentionsExportCacheKey({
 	mode,
 	accountId,
 	pageSize,
 	all,
 	maxPages,
-	sinceId,
-	startTime,
 }: {
-	scope: "sync" | "export";
-	mode: MentionsDataSource;
+	mode: MentionSyncMode;
 	accountId: string;
 	pageSize: number;
 	all: boolean;
 	maxPages: number | null;
-	sinceId: string | null;
-	startTime: string | null;
 }) {
-	return `mentions:${scope}:${mode}:${accountId}:${String(pageSize)}:${all ? "all" : "single"}:${maxPages === null ? "all-pages" : String(maxPages)}:${sinceId ?? "no-since"}:${startTime ?? "no-start"}`;
-}
-
-function getLegacyMentionsFetchModeKeyWithoutStart({
-	scope,
-	mode,
-	accountId,
-	pageSize,
-	all,
-	maxPages,
-	sinceId,
-}: {
-	scope: "sync" | "export";
-	mode: MentionsDataSource;
-	accountId: string;
-	pageSize: number;
-	all: boolean;
-	maxPages: number | null;
-	sinceId: string | null;
-}) {
-	return `mentions:${scope}:${mode}:${accountId}:${String(pageSize)}:${all ? "all" : "single"}:${maxPages === null ? "all-pages" : String(maxPages)}:${sinceId ?? "no-since"}`;
+	return `mentions:export:${mode}:${accountId}:${String(pageSize)}:${all ? "all" : "single"}:${maxPages === null ? "all-pages" : String(maxPages)}`;
 }
 
 function encodeCacheKeyPart(value: string) {
@@ -146,7 +120,6 @@ function getMentionScanBoundaryKey(boundary: MentionScanBoundary) {
 
 function getMentionScanShapeKey(shape: MentionScanShape) {
 	return [
-		`endpoint=${shape.endpoint}`,
 		`mode=${shape.mode}`,
 		`account=${encodeCacheKeyPart(shape.accountId)}`,
 		`page=${String(shape.pageSize)}`,
@@ -212,79 +185,25 @@ function getMentionRequestBoundary({
 	return { kind: "unbounded" };
 }
 
-function getLegacyMentionCursorKeys(shape: MentionScanShape) {
-	const sinceId =
-		shape.boundary.kind === "since" ? shape.boundary.sinceId : null;
-	const startTime =
-		shape.boundary.kind === "start" ? shape.boundary.startTime : null;
-	const keys = [
-		getMentionsFetchModeKey({
-			scope: "sync",
-			mode: shape.mode,
-			accountId: shape.accountId,
-			pageSize: shape.pageSize,
-			all: false,
-			maxPages: null,
-			sinceId,
-			startTime,
-		}),
-	];
-	if (!startTime) {
-		keys.push(
-			getLegacyMentionsFetchModeKeyWithoutStart({
-				scope: "sync",
-				mode: shape.mode,
-				accountId: shape.accountId,
-				pageSize: shape.pageSize,
-				all: false,
-				maxPages: null,
-				sinceId,
-			}),
-		);
-	}
-	return [...new Set(keys)];
-}
-
-function parseCacheTtlMs(value?: number) {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return DEFAULT_MENTIONS_CACHE_TTL_MS;
-	}
-	return Math.floor(value);
-}
-
 function assertXurlLimit(limit: number) {
-	if (limit < MIN_XURL_MENTIONS_LIMIT || limit > MAX_XURL_MENTIONS_LIMIT) {
-		throw new Error("xurl mode requires --limit between 5 and 100");
-	}
+	parseLivePageSize(limit, {
+		min: MIN_XURL_MENTIONS_LIMIT,
+		max: MAX_XURL_MENTIONS_LIMIT,
+		message: "xurl mode requires --limit between 5 and 100",
+	});
 }
 
 function assertBirdLimit(limit: number) {
-	if (!Number.isFinite(limit) || limit < 1) {
-		throw new Error("bird mode requires --limit of at least 1");
-	}
-}
-
-function parseMaxPages(value?: number) {
-	if (value === undefined) {
-		return null;
-	}
-	if (!Number.isFinite(value) || value < 1) {
-		throw new Error("--max-pages must be at least 1");
-	}
-	return Math.floor(value);
+	parseLivePageSize(limit, {
+		message: "bird mode requires --limit of at least 1",
+	});
 }
 
 function parseSyncMode(value?: string): MentionSyncMode {
-	const mode = value ?? "auto";
-	if (mode !== "auto" && mode !== "bird" && mode !== "xurl") {
-		throw new Error("--mode must be auto, bird, or xurl");
-	}
-	return mode;
+	return parseLiveSyncMode(value, "auto");
 }
 
-function getCachedPaginationToken(
-	cached?: { value: XurlMentionsResponse } | null,
-) {
+function getMentionCursorToken(cached?: { value: MentionCursorValue } | null) {
 	return typeof cached?.value.meta?.next_token === "string" &&
 		cached.value.meta.next_token.length > 0
 		? cached.value.meta.next_token
@@ -330,43 +249,18 @@ function addMentionCursorState(
 	};
 }
 
-function readMentionCursor({
-	db,
-	shape,
-	cursorKey,
-	legacyCursorKeys,
-}: {
-	db: Database;
-	shape: MentionScanShape;
-	cursorKey: string;
-	legacyCursorKeys: string[];
-}) {
+function readMentionCursor(db: Database, shape: MentionScanShape) {
+	const cursorKey = getMentionCursorKey(shape);
 	const fallbackBoundary =
 		shape.boundary.kind === "auto" ? undefined : shape.boundary;
 	const current = readSyncCache<MentionCursorValue>(cursorKey, db);
-	const currentToken = getCachedPaginationToken(current);
+	const currentToken = getMentionCursorToken(current);
 	if (current && currentToken) {
 		return {
-			key: cursorKey,
 			token: currentToken,
 			boundary: parseCachedMentionBoundary(current.value, fallbackBoundary),
 			pendingNewestId: getCachedMentionPendingNewestId(current.value),
-			legacyKeys: [] as string[],
 		};
-	}
-
-	for (const legacyKey of legacyCursorKeys) {
-		const legacy = readSyncCache<MentionCursorValue>(legacyKey, db);
-		const legacyToken = getCachedPaginationToken(legacy);
-		if (legacy && legacyToken) {
-			return {
-				key: legacyKey,
-				token: legacyToken,
-				boundary: parseCachedMentionBoundary(legacy.value, fallbackBoundary),
-				pendingNewestId: getCachedMentionPendingNewestId(legacy.value),
-				legacyKeys: [legacyKey],
-			};
-		}
 	}
 
 	return undefined;
@@ -421,23 +315,6 @@ function writeMentionHighWaterId(
 		return;
 	}
 	writeSyncCache(getMentionHighWaterKey({ mode, accountId }), { sinceId }, db);
-}
-
-function verifyBirdAccountMatchesEffect(account: LiveSyncAccount) {
-	return Effect.gen(function* () {
-		const authenticated = yield* getAuthenticatedBirdAccountEffect();
-		return yield* Effect.try({
-			try: () =>
-				assertLiveAccountMatches({
-					source: "bird",
-					account,
-					liveUsername: authenticated.username,
-					liveExternalUserId: authenticated.id,
-				}),
-			catch: (error) =>
-				error instanceof Error ? error : new Error(String(error)),
-		});
-	});
 }
 
 function findNewestArchiveMentionId(db: Database, accountId: string) {
@@ -514,60 +391,6 @@ function readLocalXurlCompatiblePayload({
 	);
 }
 
-function mergeMentionPayloads(
-	pages: XurlMentionsResponse[],
-): XurlMentionsResponse {
-	const tweets: XurlMentionData[] = [];
-	const seenTweetIds = new Set<string>();
-	const users: XurlMentionUser[] = [];
-	const seenUserIds = new Set<string>();
-	const media: XurlMediaItem[] = [];
-	const seenMediaKeys = new Set<string>();
-
-	for (const page of pages) {
-		for (const tweet of page.data) {
-			if (seenTweetIds.has(tweet.id)) {
-				continue;
-			}
-			seenTweetIds.add(tweet.id);
-			tweets.push(tweet);
-		}
-
-		for (const user of page.includes?.users ?? []) {
-			if (seenUserIds.has(user.id)) {
-				continue;
-			}
-			seenUserIds.add(user.id);
-			users.push(user);
-		}
-
-		for (const item of page.includes?.media ?? []) {
-			if (seenMediaKeys.has(item.media_key)) {
-				continue;
-			}
-			seenMediaKeys.add(item.media_key);
-			media.push(item);
-		}
-	}
-
-	const lastMeta = pages.at(-1)?.meta;
-	const includes = {
-		...(users.length > 0 ? { users } : {}),
-		...(media.length > 0 ? { media } : {}),
-	};
-	return {
-		data: tweets,
-		includes: users.length > 0 || media.length > 0 ? includes : undefined,
-		meta: {
-			...lastMeta,
-			result_count: tweets.length,
-			page_count: pages.length,
-			next_token:
-				typeof lastMeta?.next_token === "string" ? lastMeta.next_token : null,
-		},
-	};
-}
-
 function fetchMentionsViaXurlEffect({
 	resolvedAccount,
 	limit,
@@ -630,25 +453,24 @@ function fetchMentionsViaXurlEffect({
 				}),
 		});
 
-		return mergeMentionPayloads(result.pages);
+		return {
+			payload: mergeTweetPages(result.pages),
+			stopReason: result.stopReason,
+			nextCursor: result.nextCursor,
+			complete: result.complete,
+		};
 	});
 }
 
-function fetchMentionsViaBirdEffect({ limit }: { limit: number }) {
-	return listMentionsViaBirdEffect({ maxResults: limit });
-}
-
-function isMaxPagesPartial({
-	payload,
-	maxPages,
+function fetchMentionsViaBirdEffect({
+	account,
+	limit,
 }: {
-	payload: XurlMentionsResponse;
-	maxPages: number | null;
+	account: LiveSyncAccount;
+	limit: number;
 }) {
-	return (
-		maxPages !== null &&
-		typeof payload.meta?.next_token === "string" &&
-		payload.meta.next_token.length > 0
+	return verifyBirdAccountMatchesEffect(account).pipe(
+		Effect.flatMap(() => listMentionsViaBirdEffect({ maxResults: limit })),
 	);
 }
 
@@ -679,7 +501,8 @@ export function syncMentionsEffect({
 		} else {
 			yield* trySync(() => assertBirdLimit(limit));
 		}
-		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const parsedMaxPages =
+			(yield* trySync(() => parseOptionalMaxPages(maxPages))) ?? null;
 		const fetchAll =
 			primaryMode === "xurl" &&
 			(parsedMaxPages !== null ||
@@ -689,7 +512,6 @@ export function syncMentionsEffect({
 			resolveLiveSyncAccount(db, account),
 		);
 		const cursorShape: MentionScanShape = {
-			endpoint: "mentions",
 			mode: primaryMode,
 			accountId: resolvedAccount.accountId,
 			pageSize: limit,
@@ -699,17 +521,9 @@ export function syncMentionsEffect({
 			}),
 		};
 		const cursorKey = getMentionCursorKey(cursorShape);
-		const legacyCursorKeys = getLegacyMentionCursorKeys(cursorShape);
 		const cursor =
 			primaryMode === "xurl"
-				? yield* trySync(() =>
-						readMentionCursor({
-							db,
-							shape: cursorShape,
-							cursorKey,
-							legacyCursorKeys,
-						}),
-					)
+				? yield* trySync(() => readMentionCursor(db, cursorShape))
 				: undefined;
 		const startPaginationToken = cursor?.token;
 		const cursorSinceId =
@@ -744,39 +558,34 @@ export function syncMentionsEffect({
 			: !resolvedSinceId
 				? explicitStartTime
 				: undefined;
+		const resolvedBoundary = getMentionRequestBoundary({
+			sinceId: resolvedSinceId,
+			startTime: resolvedStartTime,
+		});
 		const resultShape: MentionScanShape = {
-			endpoint: "mentions",
-			mode: primaryMode,
-			accountId: resolvedAccount.accountId,
-			pageSize: limit,
-			boundary: getMentionRequestBoundary({
-				sinceId: resolvedSinceId,
-				startTime: resolvedStartTime,
-			}),
+			...cursorShape,
+			boundary: resolvedBoundary,
 		};
 		const resultCacheKey = getMentionResultCacheKey({
 			shape: resultShape,
 			all: fetchAll,
 			maxPages: parsedMaxPages,
 		});
-		const ttlMs = parseCacheTtlMs(cacheTtlMs);
-		const cached = startPaginationToken
-			? null
+		const cache = startPaginationToken
+			? { entry: null, fresh: false }
 			: yield* trySync(() =>
-					readSyncCache<XurlMentionsResponse>(resultCacheKey, db),
+					inspectSyncCache<XurlMentionsResponse>(
+						resultCacheKey,
+						{
+							ttlMs: cacheTtlMs,
+							defaultTtlMs: DEFAULT_MENTIONS_CACHE_TTL_MS,
+						},
+						db,
+					),
 				);
-		const cachedPaginationToken = getCachedPaginationToken(cached);
-		const cacheAgeMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
+		const cached = cache.entry;
 
-		if (
-			!startPaginationToken &&
-			!cachedPaginationToken &&
-			!refresh &&
-			cached &&
-			cacheAgeMs <= ttlMs
-		) {
+		if (!startPaginationToken && !refresh && cached && cache.fresh) {
 			yield* databaseWriteEffect((writeDb) =>
 				mergeMentionsIntoLocalStore(
 					writeDb,
@@ -799,10 +608,7 @@ export function syncMentionsEffect({
 				kind: "mentions",
 				accountId: resolvedAccount.accountId,
 				count: cached.value.data.length,
-				partial: isMaxPagesPartial({
-					payload: cached.value,
-					maxPages: parsedMaxPages,
-				}),
+				partial: false,
 				payload: cached.value,
 			};
 		}
@@ -826,9 +632,17 @@ export function syncMentionsEffect({
 			!explicitSinceId &&
 			!explicitStartTime &&
 			!startPaginationToken;
-		const payload =
+		const fetched =
 			primaryMode === "bird"
-				? yield* fetchMentionsViaBirdEffect({ limit })
+				? {
+						payload: yield* fetchMentionsViaBirdEffect({
+							account: resolvedAccount,
+							limit,
+						}),
+						complete: true,
+						stopReason: "exhausted" as const,
+						nextCursor: undefined,
+					}
 				: yield* fetchMentionsViaXurlEffect({
 						resolvedAccount,
 						limit,
@@ -842,11 +656,20 @@ export function syncMentionsEffect({
 						Effect.catchAll((error) => {
 							if (!canFallbackToBird) return Effect.fail(error);
 							source = "bird";
-							return verifyBirdAccountMatchesEffect(resolvedAccount).pipe(
-								Effect.flatMap(() => fetchMentionsViaBirdEffect({ limit })),
+							return fetchMentionsViaBirdEffect({
+								account: resolvedAccount,
+								limit,
+							}).pipe(
+								Effect.map((payload) => ({
+									payload,
+									complete: true,
+									stopReason: "exhausted" as const,
+									nextCursor: undefined,
+								})),
 							);
 						}),
 					);
+		const { payload } = fetched;
 		if (source === "bird") {
 			yield* Effect.sync(() =>
 				onProgress?.({
@@ -857,7 +680,9 @@ export function syncMentionsEffect({
 				}),
 			);
 		}
-		const payloadPaginationToken = getCachedPaginationToken({ value: payload });
+		const resumeToken =
+			fetched.stopReason === "page-limit" ? fetched.nextCursor : undefined;
+		const newestMentionId = getNewestMentionId(payload);
 		yield* databaseWriteEffect((writeDb) => {
 			mergeMentionsIntoLocalStore(
 				writeDb,
@@ -866,37 +691,23 @@ export function syncMentionsEffect({
 				source,
 			);
 			if (source === "xurl") {
-				if (payloadPaginationToken) {
+				if (resumeToken) {
+					deleteSyncCache(resultCacheKey, writeDb);
 					writeSyncCache(
 						cursorKey,
 						addMentionCursorState(
-							payload,
-							getMentionRequestBoundary({
-								sinceId: resolvedSinceId,
-								startTime: resolvedStartTime,
-							}),
-							maxNumericTweetId(resolvedSinceId, getNewestMentionId(payload)),
+							{
+								...payload,
+								meta: { ...payload.meta, next_token: resumeToken },
+							},
+							resolvedBoundary,
+							maxNumericTweetId(resolvedSinceId, newestMentionId),
 						),
 						writeDb,
 					);
-					deleteSyncCache(resultCacheKey, writeDb);
-					deleteSyncCache(
-						getMentionResultCacheKey({
-							shape: cursorShape,
-							all: fetchAll,
-							maxPages: parsedMaxPages,
-						}),
-						writeDb,
-					);
-					for (const legacyKey of cursor?.legacyKeys ?? []) {
-						deleteSyncCache(legacyKey, writeDb);
-					}
 				} else {
 					deleteSyncCache(cursorKey, writeDb);
-					for (const legacyKey of legacyCursorKeys) {
-						deleteSyncCache(legacyKey, writeDb);
-					}
-					if (cursorShape.boundary.kind === "auto") {
+					if (fetched.complete && cursorShape.boundary.kind === "auto") {
 						writeMentionHighWaterId(
 							writeDb,
 							source,
@@ -904,13 +715,13 @@ export function syncMentionsEffect({
 							maxNumericTweetId(
 								resolvedSinceId,
 								cursor?.pendingNewestId,
-								getNewestMentionId(payload),
+								newestMentionId,
 							),
 						);
 					}
 				}
 			}
-			if (!payloadPaginationToken && !startPaginationToken) {
+			if (fetched.complete) {
 				const writeCacheKey =
 					source === primaryMode
 						? resultCacheKey
@@ -932,7 +743,7 @@ export function syncMentionsEffect({
 			kind: "mentions",
 			accountId: resolvedAccount.accountId,
 			count: payload.data.length,
-			partial: isMaxPagesPartial({ payload, maxPages: parsedMaxPages }),
+			partial: !fetched.complete,
 			payload,
 		};
 	});
@@ -960,30 +771,32 @@ function exportMentionsViaCachedLiveSourceEffect({
 		} else {
 			yield* trySync(() => assertBirdLimit(limit));
 		}
-		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const parsedMaxPages =
+			(yield* trySync(() => parseOptionalMaxPages(maxPages))) ?? null;
 		const fetchAll = primaryMode === "xurl" && (all || parsedMaxPages !== null);
 
 		const db = yield* trySync(() => getNativeDb());
 		const resolvedAccount = yield* trySync(() =>
 			resolveLiveSyncAccount(db, account),
 		);
-		const cacheKey = getMentionsFetchModeKey({
-			scope: "export",
+		const cacheKey = getMentionsExportCacheKey({
 			mode,
 			accountId: resolvedAccount.accountId,
 			pageSize: limit,
 			all: fetchAll,
 			maxPages: parsedMaxPages,
-			sinceId: null,
-			startTime: null,
 		});
-		const ttlMs = parseCacheTtlMs(cacheTtlMs);
-		const cached = yield* trySync(() =>
-			readSyncCache<XurlMentionsResponse>(cacheKey, db),
+		const cache = yield* trySync(() =>
+			inspectSyncCache<XurlMentionsResponse>(
+				cacheKey,
+				{
+					ttlMs: cacheTtlMs,
+					defaultTtlMs: DEFAULT_MENTIONS_CACHE_TTL_MS,
+				},
+				db,
+			),
 		);
-		const cacheAgeMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
+		const cached = cache.entry;
 		const readFilteredOrRaw = (payload: XurlMentionsResponse) => {
 			if (
 				shouldReturnFilteredLocalPayload({
@@ -1001,14 +814,17 @@ function exportMentionsViaCachedLiveSourceEffect({
 			return payload;
 		};
 
-		if (!refresh && cached && cacheAgeMs <= ttlMs) {
+		if (!refresh && cached && cache.fresh) {
 			return yield* trySync(() => readFilteredOrRaw(cached.value));
 		}
 
 		let source: MentionLiveSource = primaryMode;
 		const liveResult = yield* (
 			primaryMode === "bird"
-				? fetchMentionsViaBirdEffect({ limit })
+				? fetchMentionsViaBirdEffect({
+						account: resolvedAccount,
+						limit,
+					}).pipe(Effect.map((payload) => ({ payload })))
 				: fetchMentionsViaXurlEffect({
 						resolvedAccount,
 						limit,
@@ -1019,11 +835,12 @@ function exportMentionsViaCachedLiveSourceEffect({
 			Effect.catchAll((error) => {
 				if (mode !== "auto" || fetchAll) return Effect.fail(error);
 				source = "bird";
-				return verifyBirdAccountMatchesEffect(resolvedAccount).pipe(
-					Effect.flatMap(() => fetchMentionsViaBirdEffect({ limit })),
-				);
+				return fetchMentionsViaBirdEffect({
+					account: resolvedAccount,
+					limit,
+				}).pipe(Effect.map((payload) => ({ payload })));
 			}),
-			Effect.flatMap((payload) =>
+			Effect.flatMap(({ payload }) =>
 				databaseWriteEffect((writeDb) => {
 					mergeMentionsIntoLocalStore(
 						writeDb,

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -16,18 +16,17 @@ import {
 	trySync,
 } from "./effect-runtime";
 import type { Database } from "./sqlite";
-import { readSyncCache, writeSyncCache } from "./sync-cache";
+import { inspectSyncCache, readSyncCache, writeSyncCache } from "./sync-cache";
 import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	ProfileRecord,
 	TweetEntities,
-	XurlMediaItem,
 	XurlMentionUser,
 	XurlTweetData,
 	XurlTweetsResponse,
-	XurlUserTweetsResponse,
 } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import { adaptUserTimelinePage, mergeTweetPages } from "./tweet-page";
 import type { TweetAccountEdgeKind } from "./tweet-account-edges";
 import { buildExternalProfileId, upsertProfileFromXUser } from "./x-profile";
 import { recordXurlRateLimitEventSafe } from "./xurl-rate-limits";
@@ -204,14 +203,6 @@ function normalizePositiveInteger(
 	return Math.floor(value);
 }
 
-function normalizeCacheTtlMs(value: number | undefined) {
-	if (value === undefined) return DEFAULT_CACHE_TTL_MS;
-	if (!Number.isFinite(value) || value < 0) {
-		return DEFAULT_CACHE_TTL_MS;
-	}
-	return Math.floor(value);
-}
-
 function normalizeNonNegativeInteger(
 	value: number | undefined,
 	defaultValue: number,
@@ -324,51 +315,6 @@ function ingestProfileAnalysisPayload(
 		edgeKind,
 		source: "xurl",
 	});
-}
-
-function userTimelineToTweetsResponse(
-	response: XurlUserTweetsResponse,
-	fallbackAuthorId: string,
-): XurlTweetsResponse {
-	return {
-		data: response.items.map((tweet) => ({
-			...tweet,
-			author_id: tweet.author_id ?? fallbackAuthorId,
-		})),
-		includes: response.includes,
-		meta: {
-			result_count: response.items.length,
-			...(response.nextToken ? { next_token: response.nextToken } : {}),
-		},
-	};
-}
-
-function mergeResponses(responses: XurlTweetsResponse[]): XurlTweetsResponse {
-	const seenTweetIds = new Set<string>();
-	const usersById = new Map<string, XurlMentionUser>();
-	const mediaByKey = new Map<string, XurlMediaItem>();
-	const data: XurlTweetData[] = [];
-	for (const response of responses) {
-		for (const user of response.includes?.users ?? []) {
-			usersById.set(user.id, user);
-		}
-		for (const media of response.includes?.media ?? []) {
-			mediaByKey.set(media.media_key, media);
-		}
-		for (const tweet of response.data) {
-			if (seenTweetIds.has(tweet.id)) continue;
-			seenTweetIds.add(tweet.id);
-			data.push(tweet);
-		}
-	}
-	return {
-		data,
-		includes: {
-			users: [...usersById.values()],
-			media: [...mediaByKey.values()],
-		},
-		meta: { result_count: data.length },
-	};
 }
 
 function compactProfileTweet(
@@ -520,8 +466,8 @@ function buildContextFromPayloads({
 	conversationPages: number;
 	fetchCached: boolean;
 }): ProfileAnalysisContext {
-	const tweetPayload = mergeResponses(tweetResponses);
-	const conversationPayload = mergeResponses(conversationResponses);
+	const tweetPayload = mergeTweetPages(tweetResponses);
+	const conversationPayload = mergeTweetPages(conversationResponses);
 	const profileTweets = tweetPayload.data
 		.map((tweet) => compactProfileTweet(tweet, handle))
 		.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
@@ -643,7 +589,6 @@ export function collectProfileAnalysisContextEffect(
 		const conversationDelayMs = conversationDelayMsFromOptions(options);
 		const rateLimitRetryMs = rateLimitRetryMsFromOptions(options);
 		const rateLimitMaxRetries = rateLimitMaxRetriesFromOptions(options);
-		const cacheTtlMs = normalizeCacheTtlMs(options.cacheTtlMs);
 		const contextKey = contextCacheKey({
 			accountId: account.id,
 			handle,
@@ -652,13 +597,18 @@ export function collectProfileAnalysisContextEffect(
 			maxConversations,
 			maxConversationPages,
 		});
-		const cached = yield* trySync(() =>
-			readSyncCache<ProfileAnalysisContext>(contextKey, db),
+		const cache = yield* trySync(() =>
+			inspectSyncCache<ProfileAnalysisContext>(
+				contextKey,
+				{
+					ttlMs: options.cacheTtlMs,
+					defaultTtlMs: DEFAULT_CACHE_TTL_MS,
+				},
+				db,
+			),
 		);
-		const ageMs = cached
-			? Date.now() - new Date(cached.updatedAt).getTime()
-			: Number.POSITIVE_INFINITY;
-		if (!options.refresh && cached && ageMs <= cacheTtlMs) {
+		const cached = cache.entry;
+		if (!options.refresh && cached && cache.fresh) {
 			emitStatus(handlers, "Using cached profile backfill", `@${handle}`);
 			return { ...cached.value, fetchCached: true };
 		}
@@ -747,7 +697,7 @@ export function collectProfileAnalysisContextEffect(
 			tweetPages += 1;
 			fetchedTweets += limitedResponse.items.length;
 			tweetResponses.push(
-				userTimelineToTweetsResponse(limitedResponse, resolved.externalUserId),
+				adaptUserTimelinePage(limitedResponse, resolved.externalUserId),
 			);
 			nextToken =
 				fetchedTweets < maxTweets
@@ -755,7 +705,7 @@ export function collectProfileAnalysisContextEffect(
 					: undefined;
 			if (!nextToken || limitedResponse.items.length === 0) break;
 		}
-		const profilePayload = mergeResponses(tweetResponses);
+		const profilePayload = mergeTweetPages(tweetResponses);
 		yield* trySync(() =>
 			ingestProfileAnalysisPayload(db, account.id, profilePayload, "profile"),
 		);
@@ -844,7 +794,7 @@ export function collectProfileAnalysisContextEffect(
 				if (!conversationNextToken || response.data.length === 0) break;
 			}
 		}
-		const conversationPayload = mergeResponses(conversationResponses);
+		const conversationPayload = mergeTweetPages(conversationResponses);
 		yield* trySync(() =>
 			ingestProfileAnalysisPayload(
 				db,

--- a/src/lib/scheduled-job.test.ts
+++ b/src/lib/scheduled-job.test.ts
@@ -248,11 +248,20 @@ describe("scheduled job runtime", () => {
 		const observed = new Promise<void>((resolve) => {
 			markerObserved = resolve;
 		});
-		let markerHolders = 0;
+		let activeMarkerHolders = 0;
+		let maxConcurrentMarkerHolders = 0;
 		__test__.setAfterGuardReclaimMarker(async () => {
-			markerHolders += 1;
-			markerObserved();
-			await resumed;
+			activeMarkerHolders += 1;
+			maxConcurrentMarkerHolders = Math.max(
+				maxConcurrentMarkerHolders,
+				activeMarkerHolders,
+			);
+			try {
+				markerObserved();
+				await resumed;
+			} finally {
+				activeMarkerHolders -= 1;
+			}
 		});
 
 		const contenders = [
@@ -277,7 +286,7 @@ describe("scheduled job runtime", () => {
 			undefined,
 			undefined,
 		]);
-		expect(markerHolders).toBe(1);
+		expect(maxConcurrentMarkerHolders).toBe(1);
 		expect(
 			(JSON.parse(readFileSync(ownerPath, "utf8")) as { token: string }).token,
 		).toBe("fresh-guard");

--- a/src/lib/sync-cache.test.ts
+++ b/src/lib/sync-cache.test.ts
@@ -2,7 +2,12 @@
 import { describe, expect, it } from "vitest";
 import { useTestHome } from "../test/test-home";
 import { createServerRuntimeServices } from "./server-runtime-services";
-import { deleteSyncCache, readSyncCache, writeSyncCache } from "./sync-cache";
+import {
+	deleteSyncCache,
+	inspectSyncCache,
+	readSyncCache,
+	writeSyncCache,
+} from "./sync-cache";
 
 const testHome = useTestHome({ prefix: "birdclaw-sync-cache-" });
 
@@ -41,5 +46,42 @@ describe("sync cache", () => {
 		).run("mentions:bad", "{not-json", "2026-03-09T00:00:00.000Z");
 
 		expect(readSyncCache("mentions:bad", db)).toBeNull();
+	});
+
+	it("treats the TTL boundary as fresh but stale, invalid, and future timestamps as unusable", () => {
+		const { db } = testHome();
+		const runtime = createServerRuntimeServices({
+			now: () => new Date("2026-06-15T12:00:10.000Z"),
+		});
+		const insert = db.prepare(
+			"insert into sync_cache (cache_key, value_json, updated_at) values (?, '{}', ?)",
+		);
+		insert.run("boundary", "2026-06-15T12:00:00.000Z");
+		insert.run("stale", "2026-06-15T11:59:59.999Z");
+		insert.run("invalid", "not-a-date");
+		insert.run("future", "2026-06-15T12:00:10.001Z");
+
+		const policy = { ttlMs: 10_000, defaultTtlMs: 60_000 };
+		expect(inspectSyncCache("boundary", policy, db, runtime)).toMatchObject({
+			ageMs: 10_000,
+			fresh: true,
+			ttlMs: 10_000,
+		});
+		expect(inspectSyncCache("stale", policy, db, runtime).fresh).toBe(false);
+		expect(inspectSyncCache("invalid", policy, db, runtime)).toMatchObject({
+			ageMs: null,
+			fresh: false,
+		});
+		expect(inspectSyncCache("future", policy, db, runtime)).toMatchObject({
+			ageMs: -1,
+			fresh: false,
+		});
+	});
+
+	it("normalizes optional TTL values during inspection", () => {
+		const { db } = testHome();
+		expect(
+			inspectSyncCache("missing", { ttlMs: Number.NaN, defaultTtlMs: 42 }, db),
+		).toMatchObject({ ttlMs: 42, fresh: false });
 	});
 });

--- a/src/lib/sync-cache.ts
+++ b/src/lib/sync-cache.ts
@@ -9,6 +9,18 @@ export interface SyncCacheEntry<T> {
 	updatedAt: string;
 }
 
+export interface SyncCacheInspection<T> {
+	entry: SyncCacheEntry<T> | null;
+	ageMs: number | null;
+	fresh: boolean;
+	ttlMs: number;
+}
+
+export interface SyncCachePolicy {
+	ttlMs?: number;
+	defaultTtlMs: number;
+}
+
 function readSyncCacheRow(cacheKey: string, db = getNativeDb()) {
 	return db
 		.prepare(
@@ -43,6 +55,30 @@ export function readSyncCache<T>(
 	} catch {
 		return null;
 	}
+}
+
+export function inspectSyncCache<T>(
+	cacheKey: string,
+	{ ttlMs, defaultTtlMs }: SyncCachePolicy,
+	db = getNativeDb(),
+	runtime: ServerRuntimeServices = defaultServerRuntimeServices,
+): SyncCacheInspection<T> {
+	const effectiveTtlMs =
+		typeof ttlMs === "number" && Number.isFinite(ttlMs) && ttlMs >= 0
+			? Math.floor(ttlMs)
+			: defaultTtlMs;
+	const entry = readSyncCache<T>(cacheKey, db);
+	if (!entry) {
+		return { entry: null, ageMs: null, fresh: false, ttlMs: effectiveTtlMs };
+	}
+	const updatedAtMs = new Date(entry.updatedAt).getTime();
+	const ageMs = runtime.now().getTime() - updatedAtMs;
+	return {
+		entry,
+		ageMs: Number.isFinite(ageMs) ? ageMs : null,
+		fresh: Number.isFinite(ageMs) && ageMs >= 0 && ageMs <= effectiveTtlMs,
+		ttlMs: effectiveTtlMs,
+	};
 }
 
 export function writeSyncCache(

--- a/src/lib/sync-plan.test.ts
+++ b/src/lib/sync-plan.test.ts
@@ -42,6 +42,20 @@ describe("runSyncPlanEffect", () => {
 		expect(result.pages).toHaveLength(2);
 	});
 
+	it("reports a repeated cursor before a coincident page limit", async () => {
+		const result = await runEffectPromise(
+			runSyncPlanEffect({
+				initialCursor: "same",
+				maxPages: 1,
+				fetchPage: () => Effect.succeed({ next: "same" }),
+				getNextCursor: (page) => page.next,
+			}),
+		);
+
+		expect(result.stopReason).toBe("repeated-cursor");
+		expect(result.nextCursor).toBe("same");
+	});
+
 	it("persists each page and reports page-limit cursors", async () => {
 		type Page = { items: Array<string | undefined>; next: string };
 		const persistPage = vi.fn(

--- a/src/lib/sync-plan.ts
+++ b/src/lib/sync-plan.ts
@@ -127,10 +127,10 @@ export function runSyncPlanEffect<Page, FetchError, PageError = never>({
 				stopReason = "boundary";
 			} else if (fetched >= itemLimit) {
 				stopReason = "item-limit";
-			} else if (pages.length >= pageLimit) {
-				stopReason = "page-limit";
 			} else if (seenCursors.has(nextCursor)) {
 				stopReason = "repeated-cursor";
+			} else if (pages.length >= pageLimit) {
+				stopReason = "page-limit";
 			}
 
 			const context: SyncPlanPageContext<Page> = {

--- a/src/lib/timeline-collections-live.test.ts
+++ b/src/lib/timeline-collections-live.test.ts
@@ -4,11 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { birdAccountForTest } from "../test/bird-account";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listTimelineItems } from "./timeline-read-model";
 
 const mocks = vi.hoisted(() => ({
+	getAuthenticatedBirdAccount: vi.fn(),
 	listBookmarkedTweetsViaBird: vi.fn(),
 	listHomeTimelineViaBird: vi.fn(),
 	listLikedTweetsViaBird: vi.fn(),
@@ -20,6 +22,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./bird", async () => {
 	const { effectFromMock } = await import("../test/effect-mocks");
 	return {
+		getAuthenticatedBirdAccountEffect: effectFromMock(
+			mocks.getAuthenticatedBirdAccount,
+		),
 		listBookmarkedTweetsViaBirdEffect: effectFromMock(
 			mocks.listBookmarkedTweetsViaBird,
 		),
@@ -91,6 +96,10 @@ function setupTempHome() {
 	process.env.BIRDCLAW_HOME = tempRoot;
 	resetBirdclawPathsForTests();
 	resetDatabaseForTests();
+	mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+		id: "25401953",
+		username: "steipete",
+	});
 }
 
 afterEach(() => {
@@ -106,6 +115,34 @@ afterEach(() => {
 });
 
 describe("live timeline collection sync", () => {
+	it("rejects a mismatched Bird account before collection persistence", async () => {
+		setupTempHome();
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue({
+			id: "999",
+			username: "wrong",
+		});
+		const before = getNativeDb()
+			.prepare("select count(*) as count from tweet_collections")
+			.get();
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		await expect(
+			syncTimelineCollection({
+				kind: "likes",
+				mode: "bird",
+				limit: 5,
+				refresh: true,
+			}),
+		).rejects.toThrow("refusing to sync");
+		expect(mocks.listLikedTweetsViaBird).not.toHaveBeenCalled();
+		expect(
+			getNativeDb()
+				.prepare("select count(*) as count from tweet_collections")
+				.get(),
+		).toEqual(before);
+	});
+
 	it("builds collection sync effects lazily", async () => {
 		setupTempHome();
 		const { syncTimelineCollectionEffect } =
@@ -438,7 +475,7 @@ describe("live timeline collection sync", () => {
 						expect.objectContaining({ id: "43" }),
 					]),
 				},
-				meta: { page_count: 2, oldest_id: "liked_2", newest_id: "liked_1" },
+				meta: { page_count: 2 },
 			},
 		});
 		expect(mocks.lookupUsersByHandles).toHaveBeenCalledWith(["steipete"]);
@@ -499,8 +536,11 @@ describe("live timeline collection sync", () => {
 			.spyOn(console, "error")
 			.mockImplementation(() => {});
 		mocks.listLikedTweetsViaXurl.mockResolvedValue({
-			data: [makeTweet("liked_existing", "already local")],
-			includes: { users: [makeUser()] },
+			data: [makeTweet("liked_existing", "canonical payload refreshed")],
+			includes: {
+				users: [makeUser(), makeUser("43", "quoted")],
+				tweets: [makeTweet("quoted_context", "quoted context", "43")],
+			},
 			meta: { result_count: 1, next_token: "wasteful-next-page" },
 		});
 		const { syncTimelineCollection } =
@@ -519,9 +559,27 @@ describe("live timeline collection sync", () => {
 			source: "xurl",
 			count: 0,
 			saturated_at_page: 1,
-			payload: { meta: { page_count: 1, saturated_at_page: 1 } },
+			payload: {
+				data: [expect.objectContaining({ id: "liked_existing" })],
+				includes: {
+					tweets: [expect.objectContaining({ id: "quoted_context" })],
+				},
+				meta: { page_count: 1, saturated_at_page: 1, next_token: null },
+			},
 		});
 		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(1);
+		expect(
+			getNativeDb()
+				.prepare("select text from tweets where id = ?")
+				.get("liked_existing"),
+		).toEqual({ text: "canonical payload refreshed" });
+		expect(
+			getNativeDb()
+				.prepare(
+					"select source, updated_at from tweet_collections where tweet_id = ? and kind = 'likes'",
+				)
+				.get("liked_existing"),
+		).toEqual({ source: "archive", updated_at: "2026-01-01T00:00:00.000Z" });
 		expect(consoleError).toHaveBeenCalledWith(
 			"likes saturated at page 1 (100% existing rows)",
 		);
@@ -781,6 +839,9 @@ describe("live timeline collection sync", () => {
 
 	it("keeps live saved-state scoped to the syncing account", async () => {
 		setupTempHome();
+		mocks.getAuthenticatedBirdAccount.mockResolvedValue(
+			birdAccountForTest(getNativeDb(), "acct_studio"),
+		);
 		mocks.listLikedTweetsViaBird.mockResolvedValue({
 			data: [
 				{
@@ -834,6 +895,42 @@ describe("live timeline collection sync", () => {
 				)
 				.all("tweet_003"),
 		).toEqual([{ account_id: "acct_studio", kind: "likes" }]);
+	});
+
+	it("ignores legacy raw collection cache rows after the envelope change", async () => {
+		setupTempHome();
+		getNativeDb()
+			.prepare(
+				"insert into sync_cache (cache_key, value_json, updated_at) values (?, ?, ?)",
+			)
+			.run(
+				"likes:xurl:acct_primary:5:single:all-pages",
+				JSON.stringify({
+					data: [makeTweet("legacy_cached_like")],
+					meta: { result_count: 1 },
+				}),
+				new Date().toISOString(),
+			);
+		mocks.listLikedTweetsViaXurl.mockResolvedValue({
+			data: [makeTweet("fresh_like")],
+			includes: { users: [makeUser()] },
+			meta: { result_count: 1 },
+		});
+		const { syncTimelineCollection } =
+			await import("./timeline-collections-live");
+
+		const result = await syncTimelineCollection({
+			kind: "likes",
+			mode: "xurl",
+			limit: 5,
+		});
+
+		expect(result).toMatchObject({
+			source: "xurl",
+			count: 1,
+			payload: { data: [expect.objectContaining({ id: "fresh_like" })] },
+		});
+		expect(mocks.listLikedTweetsViaXurl).toHaveBeenCalledTimes(1);
 	});
 
 	it("uses bird directly for liked collections and caches the payload", async () => {
@@ -916,7 +1013,7 @@ describe("live timeline collection sync", () => {
 		).rejects.toThrow("--limit must be at least 1");
 		await expect(
 			syncTimelineCollection({ kind: "likes", mode: "xurl", limit: 4 }),
-		).rejects.toThrow("xurl mode requires --limit between 5 and 100");
+		).rejects.toThrow("--limit must be between 5 and 100");
 		await expect(
 			syncTimelineCollection({
 				kind: "likes",
@@ -925,6 +1022,9 @@ describe("live timeline collection sync", () => {
 				maxPages: 0,
 			}),
 		).rejects.toThrow("--max-pages must be at least 1");
+		await expect(
+			syncTimelineCollection({ kind: "likes", mode: "invalid" as never }),
+		).rejects.toThrow("--mode");
 	});
 
 	it("does not fall back when xurl mode fails", async () => {
@@ -1041,6 +1141,12 @@ describe("live timeline collection sync", () => {
 		await expect(syncHomeTimeline({ limit: 0 })).rejects.toThrow(
 			"--limit must be at least 1",
 		);
+		await expect(syncHomeTimeline({ maxPages: 0 })).rejects.toThrow(
+			"--max-pages",
+		);
+		await expect(
+			syncHomeTimeline({ mode: "invalid" as never }),
+		).rejects.toThrow("--mode");
 		await expect(syncHomeTimeline({ account: "missing" })).rejects.toThrow(
 			"Unknown account: missing",
 		);

--- a/src/lib/timeline-collections-live.ts
+++ b/src/lib/timeline-collections-live.ts
@@ -4,22 +4,22 @@ import {
 	listBookmarkedTweetsViaBirdEffect,
 	listLikedTweetsViaBirdEffect,
 } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import { getNativeDb } from "./db";
 import { runEffectPromise, trySync } from "./effect-runtime";
 import {
 	createLiveTransportAdapter,
-	normalizeCacheTtlMs,
+	parseLiveSyncMode,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	runCachedLiveSyncEffect,
+	type LiveSyncMode,
 } from "./live-sync-engine";
 import { runSyncPlanEffect } from "./sync-plan";
-import type {
-	XurlMentionData,
-	XurlMentionsResponse,
-	XurlMediaItem,
-	XurlMentionUser,
-} from "./types";
+import type { XurlMentionsResponse } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import { mergeTweetPages } from "./tweet-page";
 import {
 	listBookmarkedTweetsViaXurlEffect,
 	listLikedTweetsViaXurlEffect,
@@ -28,7 +28,7 @@ import {
 
 import type { TimelineCollectionKind } from "./api-enums";
 export type { TimelineCollectionKind } from "./api-enums";
-export type TimelineCollectionMode = "auto" | "xurl" | "bird";
+export type TimelineCollectionMode = LiveSyncMode;
 export interface SyncTimelineCollectionOptions {
 	kind: TimelineCollectionKind;
 	account?: string;
@@ -45,80 +45,6 @@ const DEFAULT_COLLECTION_CACHE_TTL_MS = 2 * 60_000;
 const DEFAULT_EARLY_STOP_MAX_PAGES = 10;
 const MIN_XURL_LIMIT = 5;
 const MAX_XURL_LIMIT = 100;
-
-function parseMaxPages(value?: number) {
-	if (value === undefined) {
-		return null;
-	}
-	if (!Number.isFinite(value) || value < 1) {
-		throw new Error("--max-pages must be at least 1");
-	}
-	return Math.floor(value);
-}
-
-function assertLimit(limit: number) {
-	if (!Number.isFinite(limit) || limit < 1) {
-		throw new Error("--limit must be at least 1");
-	}
-}
-
-function assertXurlLimit(limit: number) {
-	if (limit < MIN_XURL_LIMIT || limit > MAX_XURL_LIMIT) {
-		throw new Error("xurl mode requires --limit between 5 and 100");
-	}
-}
-
-function mergePayloads(pages: XurlMentionsResponse[]): XurlMentionsResponse {
-	const tweets: XurlMentionData[] = [];
-	const seenTweetIds = new Set<string>();
-	const users: XurlMentionUser[] = [];
-	const seenUserIds = new Set<string>();
-	const media: XurlMediaItem[] = [];
-	const seenMediaKeys = new Set<string>();
-
-	for (const page of pages) {
-		for (const tweet of page.data) {
-			if (seenTweetIds.has(tweet.id)) {
-				continue;
-			}
-			seenTweetIds.add(tweet.id);
-			tweets.push(tweet);
-		}
-
-		for (const user of page.includes?.users ?? []) {
-			if (seenUserIds.has(user.id)) {
-				continue;
-			}
-			seenUserIds.add(user.id);
-			users.push(user);
-		}
-
-		for (const item of page.includes?.media ?? []) {
-			if (seenMediaKeys.has(item.media_key)) {
-				continue;
-			}
-			seenMediaKeys.add(item.media_key);
-			media.push(item);
-		}
-	}
-
-	const lastPage = pages.at(-1);
-	const includes = {
-		...(users.length > 0 ? { users } : {}),
-		...(media.length > 0 ? { media } : {}),
-	};
-	return {
-		data: tweets,
-		includes: users.length > 0 || media.length > 0 ? includes : undefined,
-		meta: {
-			result_count: tweets.length,
-			page_count: pages.length,
-			next_token: lastPage?.meta?.next_token ?? null,
-			...(tweets[0] ? { newest_id: tweets[0].id } : {}),
-			...(tweets.at(-1) ? { oldest_id: tweets.at(-1)?.id } : {}),
-		},
-	};
-}
 
 function getCollectionPageDedupe(
 	db: Database,
@@ -148,19 +74,6 @@ function getCollectionPageDedupe(
 	};
 }
 
-function filterExistingCollectionTweets(
-	payload: XurlMentionsResponse,
-	existingTweetIds: Set<string>,
-) {
-	if (existingTweetIds.size === 0) {
-		return payload;
-	}
-	return {
-		...payload,
-		data: payload.data.filter((tweet) => !existingTweetIds.has(tweet.id)),
-	};
-}
-
 function readSaturatedAtPage(payload: XurlMentionsResponse) {
 	const value = payload.meta?.saturated_at_page;
 	return typeof value === "number" ? value : undefined;
@@ -171,12 +84,14 @@ function mergeTimelineCollectionIntoLocalStore(
 	accountId: string,
 	kind: TimelineCollectionKind,
 	payload: XurlMentionsResponse,
+	collectionTweetIds: readonly string[],
 	source: "xurl" | "bird",
 ) {
 	ingestTweetPayload(db, {
 		accountId,
 		payload,
 		collectionKind: kind,
+		collectionTweetIds: new Set(collectionTweetIds),
 		markRepliesAsReplied: true,
 		source,
 	});
@@ -234,7 +149,11 @@ function fetchXurlCollectionEffect({
 								paginationToken: cursor,
 							});
 					if (!earlyStop) {
-						return { payload, persistedPayload: payload, saturated: false };
+						return {
+							payload,
+							collectionTweetIds: payload.data.map((tweet) => tweet.id),
+							saturated: false,
+						};
 					}
 					const tweetIds = payload.data.map((tweet) => tweet.id);
 					const { existingTweetIds, uniqueTweetCount } = yield* trySync(() =>
@@ -245,9 +164,8 @@ function fetchXurlCollectionEffect({
 					if (saturated) saturatedAtPage = pageIndex + 1;
 					return {
 						payload,
-						persistedPayload: filterExistingCollectionTweets(
-							payload,
-							existingTweetIds,
+						collectionTweetIds: tweetIds.filter(
+							(tweetId) => !existingTweetIds.has(tweetId),
 						),
 						saturated,
 					};
@@ -268,47 +186,60 @@ function fetchXurlCollectionEffect({
 			},
 		});
 
-		const merged = mergePayloads(
-			result.pages
-				.filter((page) => !page.saturated)
-				.map((page) => page.persistedPayload),
+		const merged = mergeTweetPages(result.pages.map((page) => page.payload));
+		const eligibleIds = new Set(
+			result.pages.flatMap((page) => page.collectionTweetIds),
 		);
-		// A saturated page may expose another token, but our walk is complete.
+		const collectionTweetIds = merged.data
+			.filter((tweet) => eligibleIds.has(tweet.id))
+			.map((tweet) => tweet.id);
 		const saturationMeta =
 			saturatedAtPage === undefined
 				? {}
 				: { saturated_at_page: saturatedAtPage, next_token: null };
 		merged.meta = {
 			...merged.meta,
-			page_count: result.pages.length,
 			...saturationMeta,
 		};
-		return merged;
+		return {
+			payload: merged,
+			collectionTweetIds,
+		};
 	});
 }
 
 function fetchBirdCollectionEffect({
+	account,
 	kind,
 	limit,
 	all,
 	maxPages,
 }: {
+	account: ReturnType<typeof resolveLiveSyncAccount>;
 	kind: TimelineCollectionKind;
 	limit: number;
 	all: boolean;
 	maxPages: number | null;
 }) {
-	return kind === "likes"
-		? listLikedTweetsViaBirdEffect({
-				maxResults: limit,
-				all,
-				maxPages: maxPages ?? undefined,
-			})
-		: listBookmarkedTweetsViaBirdEffect({
-				maxResults: limit,
-				all,
-				maxPages: maxPages ?? undefined,
-			});
+	return verifyBirdAccountMatchesEffect(account).pipe(
+		Effect.flatMap(() =>
+			kind === "likes"
+				? listLikedTweetsViaBirdEffect({
+						maxResults: limit,
+						all,
+						maxPages: maxPages ?? undefined,
+					})
+				: listBookmarkedTweetsViaBirdEffect({
+						maxResults: limit,
+						all,
+						maxPages: maxPages ?? undefined,
+					}),
+		),
+		Effect.map((payload) => ({
+			payload,
+			collectionTweetIds: payload.data.map((tweet) => tweet.id),
+		})),
+	);
 }
 
 export function syncTimelineCollectionEffect({
@@ -323,23 +254,30 @@ export function syncTimelineCollectionEffect({
 	earlyStop = false,
 }: SyncTimelineCollectionOptions) {
 	return Effect.gen(function* () {
-		yield* trySync(() => assertLimit(limit));
-		const parsedMaxPages = yield* trySync(() => parseMaxPages(maxPages));
+		const parsedMode = yield* trySync(() => parseLiveSyncMode(mode, "auto"));
+		yield* trySync(() => parseLivePageSize(limit));
+		const parsedMaxPages =
+			(yield* trySync(() => parseOptionalMaxPages(maxPages))) ?? null;
 		const shouldApplyEarlyStopCap =
-			earlyStop && !all && parsedMaxPages === null && mode !== "bird";
+			earlyStop && !all && parsedMaxPages === null && parsedMode !== "bird";
 		const xurlMaxPages = shouldApplyEarlyStopCap
 			? DEFAULT_EARLY_STOP_MAX_PAGES
 			: parsedMaxPages;
-		if (mode === "xurl" || mode === "auto") {
-			yield* trySync(() => assertXurlLimit(limit));
+		if (parsedMode === "xurl" || parsedMode === "auto") {
+			yield* trySync(() =>
+				parseLivePageSize(limit, {
+					min: MIN_XURL_LIMIT,
+					max: MAX_XURL_LIMIT,
+				}),
+			);
 		}
 
 		const db = yield* trySync(() => getNativeDb());
 		const resolvedAccount = yield* trySync(() =>
 			resolveLiveSyncAccount(db, account),
 		);
-		const cacheMaxPages = mode === "bird" ? parsedMaxPages : xurlMaxPages;
-		const cacheKey = `${kind}:${mode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${cacheMaxPages === null ? "all-pages" : String(cacheMaxPages)}${earlyStop ? ":early-stop" : ""}`;
+		const cacheMaxPages = parsedMode === "bird" ? parsedMaxPages : xurlMaxPages;
+		const cacheKey = `timeline-collection:v2:${kind}:${parsedMode}:${resolvedAccount.accountId}:${String(limit)}:${all ? "all" : "single"}:${cacheMaxPages === null ? "all-pages" : String(cacheMaxPages)}${earlyStop ? ":early-stop" : ""}`;
 
 		if (shouldApplyEarlyStopCap) {
 			console.error(
@@ -359,15 +297,16 @@ export function syncTimelineCollectionEffect({
 			earlyStop,
 		});
 		const birdFetch = fetchBirdCollectionEffect({
+			account: resolvedAccount,
 			kind,
 			limit,
 			all,
 			maxPages: parsedMaxPages,
 		});
 		const transports =
-			mode === "bird"
+			parsedMode === "bird"
 				? [createLiveTransportAdapter("bird", birdFetch)]
-				: mode === "xurl"
+				: parsedMode === "xurl"
 					? [createLiveTransportAdapter("xurl", xurlFetch)]
 					: [
 							createLiveTransportAdapter("xurl", xurlFetch),
@@ -377,21 +316,21 @@ export function syncTimelineCollectionEffect({
 			db,
 			cacheKey,
 			refresh,
-			cacheTtlMs: normalizeCacheTtlMs(
-				cacheTtlMs,
-				DEFAULT_COLLECTION_CACHE_TTL_MS,
-			),
+			cacheTtlMs,
+			defaultCacheTtlMs: DEFAULT_COLLECTION_CACHE_TTL_MS,
 			transports,
-			persistLive: (writeDb, livePayload, liveSource) =>
+			persistLive: (writeDb, liveResult, liveSource) =>
 				mergeTimelineCollectionIntoLocalStore(
 					writeDb,
 					resolvedAccount.accountId,
 					kind,
-					livePayload,
+					liveResult.payload,
+					liveResult.collectionTweetIds,
 					liveSource,
 				),
 		});
-		const { source, payload } = syncResult;
+		const { source } = syncResult;
+		const { payload, collectionTweetIds } = syncResult.payload;
 		const saturatedAtPage = readSaturatedAtPage(payload);
 
 		return {
@@ -399,7 +338,7 @@ export function syncTimelineCollectionEffect({
 			source,
 			kind,
 			accountId: resolvedAccount.accountId,
-			count: payload.data.length,
+			count: collectionTweetIds.length,
 			payload,
 			...(saturatedAtPage === undefined
 				? {}

--- a/src/lib/timeline-live.test.ts
+++ b/src/lib/timeline-live.test.ts
@@ -4,16 +4,21 @@ import os from "node:os";
 import path from "node:path";
 import { Effect } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { birdAccountForTest } from "../test/bird-account";
 import { resetBirdclawPathsForTests } from "./config";
 import { getNativeDb, resetDatabaseForTests } from "./db";
 import { listTimelineItems } from "./timeline-read-model";
 
 const listHomeTimelineViaBirdMock = vi.fn();
 const listHomeTimelineViaXurlMock = vi.fn();
+const getAuthenticatedBirdAccountMock = vi.fn();
 
 vi.mock("./bird", async () => {
 	const { effectFromMock } = await import("../test/effect-mocks");
 	return {
+		getAuthenticatedBirdAccountEffect: effectFromMock(
+			getAuthenticatedBirdAccountMock,
+		),
 		listHomeTimelineViaBirdEffect: effectFromMock(listHomeTimelineViaBirdMock),
 	};
 });
@@ -33,6 +38,10 @@ function makeTempHome() {
 	);
 	tempDirs.push(tempDir);
 	process.env.BIRDCLAW_HOME = tempDir;
+	getAuthenticatedBirdAccountMock.mockResolvedValue({
+		id: "25401953",
+		username: "steipete",
+	});
 	return tempDir;
 }
 
@@ -42,6 +51,7 @@ afterEach(() => {
 	delete process.env.BIRDCLAW_HOME;
 	listHomeTimelineViaBirdMock.mockReset();
 	listHomeTimelineViaXurlMock.mockReset();
+	getAuthenticatedBirdAccountMock.mockReset();
 
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -49,6 +59,27 @@ afterEach(() => {
 });
 
 describe("live home timeline sync", () => {
+	it("rejects a mismatched Bird account before timeline persistence", async () => {
+		makeTempHome();
+		getAuthenticatedBirdAccountMock.mockResolvedValue({
+			id: "999",
+			username: "wrong",
+		});
+		const { syncHomeTimeline } = await import("./timeline-live");
+
+		await expect(
+			syncHomeTimeline({ mode: "bird", limit: 5, refresh: true }),
+		).rejects.toThrow("refusing to sync");
+		expect(listHomeTimelineViaBirdMock).not.toHaveBeenCalled();
+		expect(
+			getNativeDb()
+				.prepare(
+					"select count(*) as count from sync_cache where cache_key like 'timeline:%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+	});
+
 	it("keeps home timeline sync effects lazy", async () => {
 		makeTempHome();
 		listHomeTimelineViaBirdMock.mockResolvedValueOnce({
@@ -84,6 +115,9 @@ describe("live home timeline sync", () => {
 	it("stores account-scoped home timeline edges without moving canonical tweets", async () => {
 		makeTempHome();
 		const db = getNativeDb();
+		getAuthenticatedBirdAccountMock.mockResolvedValue(
+			birdAccountForTest(db, "acct_studio"),
+		);
 		listHomeTimelineViaBirdMock.mockResolvedValueOnce({
 			data: [
 				{

--- a/src/lib/timeline-live.ts
+++ b/src/lib/timeline-live.ts
@@ -1,27 +1,28 @@
 import { Effect } from "effect";
 import type { Database } from "./sqlite";
 import { listHomeTimelineViaBirdEffect } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import { getNativeDb } from "./db";
 import { runEffectPromise } from "./effect-runtime";
 import {
 	createLiveTransportAdapter,
-	normalizeCacheTtlMs,
+	parseLiveSyncMode,
+	parseOptionalMaxPages,
+	parseLivePageSize,
 	resolveLiveSyncAccount,
 	runCachedLiveSyncEffect,
+	type LiveSyncMode,
 } from "./live-sync-engine";
 import { runSyncPlanEffect } from "./sync-plan";
-import type {
-	XurlMediaItem,
-	XurlMentionUser,
-	XurlMentionsResponse,
-} from "./types";
+import type { XurlMentionsResponse } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import { mergeTweetPages } from "./tweet-page";
 import { listHomeTimelineViaXurlEffect } from "./xurl";
 
 const DEFAULT_TIMELINE_CACHE_TTL_MS = 2 * 60_000;
 const MAX_XURL_TIMELINE_PAGE_SIZE = 100;
 
-export type HomeTimelineMode = "bird" | "xurl" | "auto";
+export type HomeTimelineMode = LiveSyncMode;
 export interface HomeTimelineProgress {
 	source: "bird" | "xurl" | "cache";
 	fetched: number;
@@ -44,28 +45,6 @@ export interface SyncHomeTimelineOptions {
 	onProgress?: (progress: HomeTimelineProgress) => void;
 }
 
-function assertLimit(limit: number) {
-	if ((!Number.isFinite(limit) && limit !== Infinity) || limit < 1) {
-		throw new Error("--limit must be at least 1");
-	}
-}
-
-function parseMode(mode: HomeTimelineMode | undefined) {
-	const parsed = mode ?? "bird";
-	if (parsed !== "bird" && parsed !== "xurl" && parsed !== "auto") {
-		throw new Error("--mode must be bird, xurl, or auto");
-	}
-	return parsed;
-}
-
-function parseMaxPages(maxPages: number | undefined) {
-	if (maxPages === undefined) return 1;
-	if (!Number.isFinite(maxPages) || maxPages < 1) {
-		throw new Error("--max-pages must be at least 1");
-	}
-	return Math.floor(maxPages);
-}
-
 function parseStartTime(value: string | undefined) {
 	if (!value?.trim()) return undefined;
 	const time = new Date(value).getTime();
@@ -84,46 +63,6 @@ function reachedStartTimeBoundary(
 		const createdAt = new Date(tweet.created_at).getTime();
 		return Number.isFinite(createdAt) && createdAt <= startTimeMs;
 	});
-}
-
-function mergeTimelinePayloads(
-	payloads: XurlMentionsResponse[],
-	limit: number,
-) {
-	const data: XurlMentionsResponse["data"] = [];
-	const usersById = new Map<string, XurlMentionUser>();
-	const tweetsById = new Map<string, XurlMentionsResponse["data"][number]>();
-	const mediaByKey = new Map<string, XurlMediaItem>();
-	let meta: XurlMentionsResponse["meta"] | undefined;
-
-	for (const payload of payloads) {
-		meta = payload.meta;
-		for (const tweet of payload.data) {
-			if (data.some((existing) => existing.id === tweet.id)) continue;
-			data.push(tweet);
-			if (data.length >= limit) break;
-		}
-		for (const user of payload.includes?.users ?? []) {
-			usersById.set(user.id, user);
-		}
-		for (const tweet of payload.includes?.tweets ?? []) {
-			tweetsById.set(tweet.id, tweet);
-		}
-		for (const media of payload.includes?.media ?? []) {
-			mediaByKey.set(media.media_key, media);
-		}
-		if (data.length >= limit) break;
-	}
-
-	return {
-		data,
-		includes: {
-			users: [...usersById.values()],
-			tweets: [...tweetsById.values()],
-			media: [...mediaByKey.values()],
-		},
-		meta,
-	} satisfies XurlMentionsResponse;
 }
 
 function mergeHomeTimelineIntoLocalStore(
@@ -168,18 +107,19 @@ export function syncHomeTimelineEffect({
 			try: () => parseStartTime(startTime),
 			catch: (error) => error,
 		});
-		const parsedMode = parseMode(mode);
+		const parsedMode = parseLiveSyncMode(mode, "bird");
+		if (limit !== undefined) parseLivePageSize(limit);
+		const requestedMaxPages = parseOptionalMaxPages(maxPages);
 		const finiteFallbackLimit = limit ?? (parsedStartTime ? 300 : 100);
 		const effectiveLimit =
 			limit ??
 			(parsedStartTime && (parsedMode === "xurl" || parsedMode === "auto")
 				? Infinity
 				: finiteFallbackLimit);
-		assertLimit(effectiveLimit);
 		const parsedMaxPages =
 			maxPages === undefined && parsedStartTime
 				? Infinity
-				: parseMaxPages(maxPages);
+				: (requestedMaxPages ?? 1);
 		const db = getNativeDb();
 		const resolvedAccount = resolveLiveSyncAccount(db, account);
 		const accountId = resolvedAccount.accountId;
@@ -237,12 +177,16 @@ export function syncHomeTimelineEffect({
 						done,
 					}),
 			});
-			return mergeTimelinePayloads(result.pages, effectiveLimit);
+			return mergeTweetPages(result.pages, { itemLimit: effectiveLimit });
 		});
-		const fetchViaBird = listHomeTimelineViaBirdEffect({
-			maxResults: finiteFallbackLimit,
-			following,
-		});
+		const fetchViaBird = verifyBirdAccountMatchesEffect(resolvedAccount).pipe(
+			Effect.flatMap(() =>
+				listHomeTimelineViaBirdEffect({
+					maxResults: finiteFallbackLimit,
+					following,
+				}),
+			),
+		);
 		const transports =
 			effectiveMode === "xurl"
 				? [createLiveTransportAdapter("xurl", fetchViaXurl)]
@@ -256,10 +200,8 @@ export function syncHomeTimelineEffect({
 			db,
 			cacheKey,
 			refresh,
-			cacheTtlMs: normalizeCacheTtlMs(
-				cacheTtlMs,
-				DEFAULT_TIMELINE_CACHE_TTL_MS,
-			),
+			cacheTtlMs,
+			defaultCacheTtlMs: DEFAULT_TIMELINE_CACHE_TTL_MS,
 			transports,
 			persistLive: (writeDb, livePayload, liveSource) =>
 				mergeHomeTimelineIntoLocalStore(

--- a/src/lib/tweet-page.test.ts
+++ b/src/lib/tweet-page.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	adaptUserTimelinePage,
+	mergeTweetPages,
+	type TweetPage,
+} from "./tweet-page";
+
+function tweet(id: string, text = id) {
+	return { id, author_id: `author-${id}`, text, created_at: "2026-01-01" };
+}
+
+describe("mergeTweetPages", () => {
+	it("normalizes user timeline pages at the transport boundary", () => {
+		expect(
+			adaptUserTimelinePage(
+				{
+					items: [{ id: "1", text: "one", created_at: "2026-01-01" }],
+					nextToken: "next",
+				},
+				"author",
+			),
+		).toMatchObject({
+			data: [{ id: "1", author_id: "author" }],
+			meta: { next_token: "next" },
+		});
+	});
+
+	it("deduplicates tweets, merges every include, and preserves page metadata", () => {
+		const pages: TweetPage[] = [
+			{
+				data: [tweet("1", "first"), tweet("2")],
+				includes: {
+					users: [{ id: "u1", name: "Old", username: "one" }],
+					tweets: [tweet("quoted", "old")],
+					media: [{ media_key: "m1", type: "photo", url: "old" }],
+				},
+			},
+			{
+				data: [tweet("1", "second"), tweet("3")],
+				includes: {
+					users: [
+						{ id: "u1", name: "New", username: "one" },
+						{ id: "u2", name: "Two", username: "two" },
+					],
+					tweets: [tweet("quoted", "new"), tweet("late")],
+					media: [
+						{ media_key: "m1", type: "photo", url: "new" },
+						{ media_key: "m2", type: "video" },
+					],
+				},
+				meta: { next_token: "raw-next", result_count: 99 },
+			},
+		];
+
+		const merged = mergeTweetPages(pages, { itemLimit: 2 });
+
+		expect(merged.data.map(({ id, text }) => ({ id, text }))).toEqual([
+			{ id: "1", text: "first" },
+			{ id: "2", text: "2" },
+		]);
+		expect(
+			merged.includes?.users?.map(({ id, name }) => ({ id, name })),
+		).toEqual([
+			{ id: "u1", name: "New" },
+			{ id: "u2", name: "Two" },
+		]);
+		expect(
+			merged.includes?.tweets?.map(({ id, text }) => ({ id, text })),
+		).toEqual([
+			{ id: "quoted", text: "new" },
+			{ id: "late", text: "late" },
+		]);
+		expect(
+			merged.includes?.media?.map(({ media_key, url }) => ({ media_key, url })),
+		).toEqual([
+			{ media_key: "m1", url: "new" },
+			{ media_key: "m2", url: undefined },
+		]);
+		expect(merged.meta).toMatchObject({
+			result_count: 2,
+			page_count: 2,
+			next_token: "raw-next",
+		});
+	});
+});

--- a/src/lib/tweet-page.ts
+++ b/src/lib/tweet-page.ts
@@ -1,0 +1,70 @@
+import type {
+	XurlMediaItem,
+	XurlMentionData,
+	XurlMentionUser,
+	XurlMentionsResponse,
+	XurlTweetData,
+	XurlUserTweetsResponse,
+} from "./types";
+
+export type TweetPage = XurlMentionsResponse;
+
+interface MergeTweetPageOptions {
+	itemLimit?: number;
+}
+
+export function adaptUserTimelinePage(
+	page: XurlUserTweetsResponse,
+	fallbackAuthorId: string,
+): TweetPage {
+	return {
+		data: page.items.map((tweet) => ({
+			...tweet,
+			author_id: tweet.author_id ?? fallbackAuthorId,
+		})),
+		includes: page.includes,
+		meta: {
+			result_count: page.items.length,
+			next_token: page.nextToken,
+		},
+	};
+}
+
+export function mergeTweetPages(
+	pages: readonly TweetPage[],
+	{ itemLimit }: MergeTweetPageOptions = {},
+): TweetPage {
+	const dataById = new Map<string, XurlMentionData>();
+	const usersById = new Map<string, XurlMentionUser>();
+	const tweetsById = new Map<string, XurlTweetData>();
+	const mediaByKey = new Map<string, XurlMediaItem>();
+	for (const page of pages) {
+		for (const item of page.data) {
+			if (!dataById.has(item.id)) dataById.set(item.id, item);
+		}
+		for (const user of page.includes?.users ?? []) usersById.set(user.id, user);
+		for (const tweet of page.includes?.tweets ?? [])
+			tweetsById.set(tweet.id, tweet);
+		for (const media of page.includes?.media ?? [])
+			mediaByKey.set(media.media_key, media);
+	}
+
+	const data = [...dataById.values()].slice(0, itemLimit);
+	const lastMeta = pages.at(-1)?.meta;
+	const includes = {
+		...(usersById.size ? { users: [...usersById.values()] } : {}),
+		...(tweetsById.size ? { tweets: [...tweetsById.values()] } : {}),
+		...(mediaByKey.size ? { media: [...mediaByKey.values()] } : {}),
+	};
+	return {
+		data,
+		...(Object.keys(includes).length ? { includes } : {}),
+		meta: {
+			...lastMeta,
+			result_count: data.length,
+			page_count: pages.length,
+			next_token:
+				lastMeta && "next_token" in lastMeta ? lastMeta.next_token : null,
+		},
+	};
+}

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -19,6 +19,7 @@ export interface IngestTweetPayloadOptions {
 	source: string;
 	edgeKind?: TweetAccountEdgeKind;
 	collectionKind?: "likes" | "bookmarks";
+	collectionTweetIds?: ReadonlySet<string>;
 	markRepliesAsReplied?: boolean;
 	provenance?: {
 		sourceUrlByTweetId: ReadonlyMap<string, string>;
@@ -64,6 +65,7 @@ export function ingestTweetPayload(
 		source,
 		edgeKind,
 		collectionKind,
+		collectionTweetIds,
 		markRepliesAsReplied = false,
 		provenance,
 	}: IngestTweetPayloadOptions,
@@ -168,7 +170,10 @@ export function ingestTweetPayload(
 					rawJson: JSON.stringify(tweet),
 				});
 			}
-			if (isPrimaryTweet) {
+			if (
+				isPrimaryTweet &&
+				(!collectionTweetIds || collectionTweetIds.has(tweet.id))
+			) {
 				upsertCollection?.run(
 					accountId,
 					tweet.id,

--- a/src/lib/tweet-search-live.ts
+++ b/src/lib/tweet-search-live.ts
@@ -4,16 +4,17 @@ import { searchTweetsViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
 import { runEffectPromise, toError, trySync } from "./effect-runtime";
 import {
-	normalizeCacheTtlMs,
 	resolveLiveSyncAccount,
 	runCachedLiveSyncEffect,
+	type LiveSyncMode,
 } from "./live-sync-engine";
 import { runSyncPlanEffect } from "./sync-plan";
-import type { XurlMentionsResponse, XurlTweetsResponse } from "./types";
+import type { XurlMentionsResponse } from "./types";
 import { ingestTweetPayload } from "./tweet-repository";
+import { mergeTweetPages } from "./tweet-page";
 import { searchRecentTweetsEffect } from "./xurl";
 
-export type TweetSearchMode = "auto" | "bird" | "xurl" | "local";
+export type TweetSearchMode = LiveSyncMode | "local";
 
 export interface SyncTweetSearchOptions {
 	query: string;
@@ -88,51 +89,6 @@ function mergeTweetSearchIntoLocalStore(
 		edgeKind: "search",
 		source,
 	});
-}
-
-function toMentionsResponse(payload: XurlTweetsResponse): XurlMentionsResponse {
-	return {
-		data: payload.data,
-		includes: payload.includes,
-		meta: payload.meta,
-	};
-}
-
-function mergeResponses(
-	responses: XurlMentionsResponse[],
-): XurlMentionsResponse {
-	const seenTweetIds = new Set<string>();
-	const data = [];
-	const usersById = new Map();
-	const mediaByKey = new Map();
-	let pageCount = 0;
-
-	for (const response of responses) {
-		pageCount += Number(response.meta?.page_count ?? 1);
-		for (const user of response.includes?.users ?? []) {
-			usersById.set(user.id, user);
-		}
-		for (const media of response.includes?.media ?? []) {
-			mediaByKey.set(media.media_key, media);
-		}
-		for (const tweet of response.data) {
-			if (seenTweetIds.has(tweet.id)) continue;
-			seenTweetIds.add(tweet.id);
-			data.push(tweet);
-		}
-	}
-
-	return {
-		data,
-		includes: {
-			users: [...usersById.values()],
-			media: [...mediaByKey.values()],
-		},
-		meta: {
-			result_count: data.length,
-			page_count: pageCount,
-		},
-	};
 }
 
 function limitResponse(
@@ -213,7 +169,7 @@ function fetchXurlSearchEffect({
 					startTime: since,
 					endTime: until,
 					timeoutMs,
-				}).pipe(Effect.map(toMentionsResponse));
+				});
 			},
 			getItemCount: (page) => page.data.length,
 			getNextCursor: (page) =>
@@ -223,7 +179,7 @@ function fetchXurlSearchEffect({
 			maxItems: limit,
 			maxPages,
 		});
-		return mergeResponses(result.pages);
+		return mergeTweetPages(result.pages);
 	});
 }
 
@@ -238,7 +194,7 @@ function runModeEffect(
 		since?: string;
 		until?: string;
 		refresh: boolean;
-		cacheTtlMs: number;
+		cacheTtlMs?: number;
 		timeoutMs?: number;
 	},
 ): Effect.Effect<SyncTweetSearchResult, Error> {
@@ -254,6 +210,7 @@ function runModeEffect(
 			cacheKey: key,
 			refresh: options.refresh,
 			cacheTtlMs: options.cacheTtlMs,
+			defaultCacheTtlMs: DEFAULT_CACHE_TTL_MS,
 			transports: [
 				{
 					source: mode,
@@ -358,7 +315,6 @@ export function syncTweetSearchEffect({
 		const normalizedUntil = yield* trySync(() =>
 			normalizeTime(until, "--until"),
 		);
-		const ttlMs = normalizeCacheTtlMs(cacheTtlMs, DEFAULT_CACHE_TTL_MS);
 		const db = getNativeDb();
 		const resolvedAccount = yield* trySync(() =>
 			resolveLiveSyncAccount(db, account),
@@ -385,7 +341,7 @@ export function syncTweetSearchEffect({
 			since: normalizedSince,
 			until: normalizedUntil,
 			refresh,
-			cacheTtlMs: ttlMs,
+			cacheTtlMs,
 			timeoutMs,
 		};
 		if (mode === "bird" || mode === "xurl") {

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -122,6 +122,22 @@ afterEach(() => {
 });
 
 describe("X List sync and local filtering", () => {
+	it("validates list-specific sync option boundaries", async () => {
+		setupAccount();
+		const { syncXLists } = await import("./x-lists");
+		await expect(syncXLists({ maxLists: 0 })).rejects.toThrow("--max-lists");
+		await expect(syncXLists({ memberLimit: 0 })).rejects.toThrow(
+			"--member-limit",
+		);
+		await expect(syncXLists({ maxMemberPages: 0 })).rejects.toThrow(
+			"--max-member-pages",
+		);
+		await expect(syncXLists({ delayMs: -1 })).rejects.toThrow("--delay-ms");
+		await expect(syncXLists({ mode: "invalid" as never })).rejects.toThrow(
+			"--mode",
+		);
+	});
+
 	it("syncs complete Bird membership and filters lexical search locally", async () => {
 		const { db, account } = setupAccount();
 		mocks.listOwnedXListsViaBird.mockResolvedValue(ownedList());
@@ -255,6 +271,39 @@ describe("X List sync and local filtering", () => {
 			["bob", false],
 			["alice", true],
 		]);
+	});
+
+	it("marks repeated xurl member cursors partial without looping", async () => {
+		setupAccount();
+		mocks.lookupAuthenticatedOAuth2User.mockResolvedValue({
+			id: "25401953",
+			username: "steipete",
+		});
+		mocks.listOwnedXListsViaXurl.mockResolvedValue(ownedList());
+		mocks.listXListMembersViaXurl
+			.mockResolvedValueOnce({
+				data: [member("1", "alice")],
+				meta: { next_token: "same-page" },
+			})
+			.mockResolvedValueOnce({
+				data: [member("2", "bob")],
+				meta: { next_token: "same-page" },
+			});
+		const { listStoredXLists, syncXLists } = await import("./x-lists");
+
+		const result = await syncXLists({
+			mode: "xurl",
+			maxLists: 1,
+			maxMemberPages: 10,
+			delayMs: 0,
+		});
+
+		expect(result).toMatchObject({ membershipPartialCount: 1 });
+		expect(mocks.listXListMembersViaXurl).toHaveBeenCalledTimes(2);
+		expect(listStoredXLists()[0]).toMatchObject({
+			membershipStatus: "partial",
+			memberPageCount: 2,
+		});
 	});
 
 	it("round-trips List metadata and membership through current-schema backup", async () => {

--- a/src/lib/x-lists.ts
+++ b/src/lib/x-lists.ts
@@ -1,9 +1,9 @@
 import { Effect } from "effect";
 import {
-	getAuthenticatedBirdAccountEffect,
 	listOwnedXListsViaBirdEffect,
 	listXListMembersViaBirdEffect,
 } from "./bird";
+import { verifyBirdAccountMatchesEffect } from "./bird-account";
 import { databaseWriteEffect } from "./database-writer";
 import { getNativeDb, getReadDb } from "./db";
 import { runEffectPromise, toError, trySync } from "./effect-runtime";
@@ -11,9 +11,12 @@ import {
 	assertLiveAccountMatches,
 	createLiveTransportAdapter,
 	fetchWithTransportFallbackEffect,
+	parseLiveSyncMode,
+	type LiveSyncMode,
 	type LiveTransportAdapter,
 	resolveLiveSyncAccount,
 } from "./live-sync-engine";
+import type { PaginationStopReason } from "./sync-plan";
 import type { Database } from "./sqlite";
 import type {
 	XListPage,
@@ -28,7 +31,7 @@ import {
 	lookupAuthenticatedOAuth2UserEffect,
 } from "./xurl";
 
-export type XListSyncMode = "auto" | "bird" | "xurl";
+export type XListSyncMode = LiveSyncMode;
 export type XListMembershipStatus =
 	| "not_synced"
 	| "partial"
@@ -91,23 +94,21 @@ const MAX_MEMBER_LIMIT = 100;
 const MAX_MEMBER_PAGES = 100;
 
 function positiveInteger(name: string, value: number, maximum: number) {
-	if (!Number.isFinite(value) || value < 1 || value > maximum) {
+	if (!Number.isInteger(value) || value < 1 || value > maximum) {
 		throw new Error(`${name} must be between 1 and ${String(maximum)}`);
 	}
-	return Math.floor(value);
+	return value;
 }
 
 function nonNegativeInteger(name: string, value: number) {
-	if (!Number.isFinite(value) || value < 0) {
+	if (!Number.isInteger(value) || value < 0) {
 		throw new Error(`${name} must be a non-negative integer`);
 	}
-	return Math.floor(value);
+	return value;
 }
 
 function normalizedMode(value: XListSyncMode | undefined): XListSyncMode {
-	if (value === undefined) return "auto";
-	if (value === "auto" || value === "bird" || value === "xurl") return value;
-	throw new Error("--mode must be auto, bird, or xurl");
+	return parseLiveSyncMode(value, "auto");
 }
 
 function metaString(meta: Record<string, unknown> | undefined, key: string) {
@@ -144,18 +145,11 @@ function fetchOwnedListsEffect({
 	maxLists: number;
 }): Effect.Effect<XListPage, unknown> {
 	if (source === "bird") {
-		return Effect.gen(function* () {
-			const authenticated = yield* getAuthenticatedBirdAccountEffect();
-			yield* trySync(() =>
-				assertLiveAccountMatches({
-					source: "bird",
-					account,
-					liveUsername: authenticated.username,
-					liveExternalUserId: authenticated.id,
-				}),
-			);
-			return yield* listOwnedXListsViaBirdEffect({ maxResults: maxLists });
-		});
+		return verifyBirdAccountMatchesEffect(account).pipe(
+			Effect.flatMap(() =>
+				listOwnedXListsViaBirdEffect({ maxResults: maxLists }),
+			),
+		);
 	}
 
 	return Effect.gen(function* () {
@@ -203,55 +197,84 @@ function fetchListMembersEffect({
 	username: string;
 	memberLimit: number;
 	maxMemberPages: number;
-}): Effect.Effect<XurlFollowUsersResponse, unknown> {
+}): Effect.Effect<
+	{ payload: XurlFollowUsersResponse; stopReason: PaginationStopReason },
+	unknown
+> {
 	if (source === "bird") {
 		return listXListMembersViaBirdEffect({
 			listId: list.id,
 			maxResults: memberLimit,
 			maxPages: maxMemberPages,
-		});
+		}).pipe(
+			Effect.map((payload) => ({
+				payload,
+				stopReason:
+					payload.meta?.pagination_known_complete === true
+						? ("exhausted" as const)
+						: ("page-limit" as const),
+			})),
+		);
 	}
 
 	return Effect.gen(function* () {
 		const data: XurlMentionUser[] = [];
-		const seen = new Set<string>();
-		let paginationToken: string | undefined;
+		const seenUsers = new Set<string>();
+		const seenCursors = new Set<string>();
+		let cursor: string | undefined;
 		let pageCount = 0;
-		do {
+		let stopReason: PaginationStopReason = "page-limit";
+		while (pageCount < maxMemberPages) {
 			const page = yield* listXListMembersViaXurlEffect({
 				listId: list.id,
 				username,
 				maxResults: memberLimit,
-				paginationToken,
+				paginationToken: cursor,
 			});
 			pageCount += 1;
 			for (const user of page.data) {
-				if (seen.has(user.id)) continue;
-				seen.add(user.id);
+				if (seenUsers.has(user.id)) continue;
+				seenUsers.add(user.id);
 				data.push(user);
 			}
-			paginationToken = metaString(page.meta, "next_token");
-		} while (paginationToken && pageCount < maxMemberPages);
+			const nextCursor = metaString(page.meta, "next_token");
+			cursor = nextCursor;
+			if (!nextCursor) {
+				stopReason = "exhausted";
+				break;
+			}
+			if (seenCursors.has(nextCursor)) {
+				stopReason = "repeated-cursor";
+				break;
+			}
+			seenCursors.add(nextCursor);
+		}
 
 		return {
-			data,
-			meta: {
-				result_count: data.length,
-				page_count: pageCount,
-				next_token: paginationToken ?? null,
-				pagination_known_complete: !paginationToken,
+			payload: {
+				data,
+				meta: {
+					result_count: data.length,
+					page_count: pageCount,
+					next_token: cursor ?? null,
+					pagination_known_complete: stopReason === "exhausted",
+				},
 			},
-		} satisfies XurlFollowUsersResponse;
+			stopReason,
+		};
 	});
 }
 
 function membershipStatus({
 	list,
 	payload,
+	stopReason,
 }: {
 	list: XListRecord;
 	payload: XurlFollowUsersResponse;
+	stopReason: PaginationStopReason;
 }) {
+	if (stopReason === "repeated-cursor") return "partial";
 	if (payload.meta?.pagination_known_complete === true) return "complete";
 	if (payload.meta?.pagination_inferred_complete === true) return "inferred";
 	if (
@@ -415,7 +438,7 @@ export function syncXListsEffect(options: SyncXListsOptions = {}) {
 		const sources =
 			mode === "auto"
 				? (["bird", "xurl"] as const)
-				: ([mode] as readonly ("bird" | "xurl")[]);
+				: ([mode] as readonly Exclude<LiveSyncMode, "auto">[]);
 		const transports: Array<LiveTransportAdapter<"bird" | "xurl", XListPage>> =
 			sources.map((source) =>
 				createLiveTransportAdapter(
@@ -445,12 +468,13 @@ export function syncXListsEffect(options: SyncXListsOptions = {}) {
 					),
 				);
 				const now = new Date().toISOString();
+				const memberPayload = fetched.ok ? fetched.payload.payload : undefined;
 				const rateLimit = {
 					memberLimit,
 					maxMemberPages,
 					delayMs,
 					nextCursorStored: fetched.ok
-						? Boolean(metaString(fetched.payload.meta, "next_token"))
+						? Boolean(metaString(memberPayload?.meta, "next_token"))
 						: false,
 				};
 
@@ -475,14 +499,18 @@ export function syncXListsEffect(options: SyncXListsOptions = {}) {
 					continue;
 				}
 
-				const status = membershipStatus({ list, payload: fetched.payload });
+				const status = membershipStatus({
+					list,
+					payload: fetched.payload.payload,
+					stopReason: fetched.payload.stopReason,
+				});
 				yield* databaseWriteEffect((writeDb) =>
 					persistListResult({
 						db: writeDb,
 						accountId: account.accountId,
 						list,
 						source,
-						payload: fetched.payload,
+						payload: fetched.payload.payload,
 						status,
 						now,
 						rateLimit,
@@ -492,8 +520,8 @@ export function syncXListsEffect(options: SyncXListsOptions = {}) {
 					listId: list.id,
 					name: list.name,
 					status,
-					members: fetched.payload.data.length,
-					pages: metaNumber(fetched.payload.meta, "page_count") ?? 1,
+					members: fetched.payload.payload.data.length,
+					pages: metaNumber(fetched.payload.payload.meta, "page_count") ?? 1,
 				});
 			}
 

--- a/src/test/bird-account.ts
+++ b/src/test/bird-account.ts
@@ -1,0 +1,11 @@
+import type { Database } from "../lib/sqlite";
+
+export function birdAccountForTest(db: Database, accountId: string) {
+	const account = db
+		.prepare("select handle, external_user_id from accounts where id = ?")
+		.get(accountId) as { handle: string; external_user_id: string | null };
+	return {
+		username: account.handle.replace(/^@/, ""),
+		...(account.external_user_id ? { id: account.external_user_id } : {}),
+	};
+}


### PR DESCRIPTION
## Summary

- centralize live pagination, cursor-stop, cache freshness, and account-verification policy without introducing a universal sync DSL
- reuse canonical tweet-page adaptation and merging across authored tweets, mentions, mention threads, timelines, collections, search, and profile analysis
- make collection membership explicit while preserving canonical hydration, reject incomplete repeated-cursor snapshots, and keep follow/mention high-water state safe
- simplify X List member pagination and fix the scheduled-job concurrency test to assert exclusive ownership rather than total sequential entrants

## Architecture

The generic sync plan now reports mechanical pagination facts only. Feature modules continue to own cursor commitment and completion semantics. Bird account verification lives at the Bird boundary, cache TTL interpretation lives with cache inspection, and collection edges are selected explicitly rather than encoded by reshaping transport payloads.

Handwritten production source drops from 67,966 to 67,620 lines, a net reduction of 346 lines for this slice.

## Correctness fixes

- ignore incompatible legacy collection-cache envelopes via a versioned key
- clear collection continuation tokens when early-stop saturation completes the logical walk
- reject repeated Xurl DM cursors before persistence or caching, with Bird fallback in auto mode
- key automatic mention result caches by their resolved high-water boundary
- keep token-bearing follow snapshots incomplete so omitted edges cannot be ended
- preserve stable collection membership while still refreshing canonical tweets and included context

## Proof

- format, lint, typecheck, and diff checks
- 1,454 tests under pinned Bun, 90.62% line coverage
- 1,454 tests under Node 26.5.1, 90.75% line coverage
- Bun and Node production builds
- npm package smoke: 116 files
- Playwright: 12 tests
- structured P2 autoreview and TruffleHog preflight: clean
- isolated CLI/server validation with temporary Birdclaw homes only
  - invalid modes, page counts, limits, and unknown accounts rejected before live transport access
  - synthetic numeric-ID handle handoff survived backup export, validation, local bare-remote sync, concurrent retry, and fresh import
  - SQLite integrity remained clean
  - valid query returned HTTP 200 and invalid resource returned HTTP 400

No production deployment or real Bird/Xurl fetch was performed.
