### PR TITLE
fix(archive): scope restore cleanup to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Preserve endpoint-routing identity while redacting remote credentials, fail closed for live/cross-host lease owners, and bind recovery journals to repository and Git-directory inode identities.
 - Route authored and profile-analysis live ingestion through the canonical tweet repository so sparse media/profile refreshes, rich video metadata, included context, revisions, and FTS stay consistent across Xurl sources.
 - Make live pagination, cache freshness, account verification, collection saturation, and follow/list completeness conservative across timeline, mentions, authored tweets, saved collections, DMs, and follow graph syncs.
+- Scope full archive restores to archive-owned state for the primary account so other accounts, unrelated local datasets, and their live cursors survive replacement imports.
 
 ### Testing and maintenance
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -89,7 +89,7 @@ Explicit restore:
 
 - clears portable rows owned by the imported full or selected slices before replaying the archive
 - removes destination-only rows in those slices, so use it only when exact replacement is intended
-- remains identity-scoped for selected imports and preserves unselected slices
+- remains identity-scoped for full and selected imports and preserves unselected slices
 
 Typical targeted re-imports:
 

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -945,7 +945,7 @@ describe("archive import", () => {
 
 	it("imports tweets, dms, profiles, and envelope stats from a zip archive", async () => {
 		const archivePath = makeArchive();
-		const staleDb = getNativeDb();
+		const staleDb = getNativeDb({ seedDemoData: false });
 		staleDb.exec(`
       insert into url_expansions (
         short_url, expanded_url, final_url, status, source, updated_at
@@ -960,7 +960,7 @@ describe("archive import", () => {
     `);
 
 		const result = await importArchive(archivePath, { restore: true });
-		const db = getNativeDb();
+		const db = getNativeDb({ seedDemoData: false });
 		const envelope = await getQueryEnvelope({ includeArchives: false });
 		const tweets = listTimelineItems({ resource: "home", limit: 10 });
 		const liked = listTimelineItems({ resource: "home", likedOnly: true });
@@ -1012,6 +1012,252 @@ describe("archive import", () => {
 		expect(archivedTweet?.quotedTweet?.text).toBe("Longer archive note");
 		expect(liked.map((item) => item.text)).toEqual(["liked archive item"]);
 		expect(bookmarked.map((item) => item.text)).toEqual(["saved archive item"]);
+	}, 30000);
+
+	it("scopes a full restore to archive-owned state for the primary account", async () => {
+		await importArchive(makeArchive({ following: ["700"] }));
+		const db = getNativeDb({ seedDemoData: false });
+		insertTestAccount(db, {
+			id: "acct_other",
+			name: "Other",
+			handle: "@other",
+			externalUserId: "other",
+			transport: "xurl",
+			isDefault: 0,
+		});
+		insertTestProfile(db, {
+			id: "profile_other",
+			handle: "other",
+			displayName: "Other",
+		});
+		insertTestDmConversation(db, {
+			id: "dm-other",
+			accountId: "acct_other",
+			participantProfileId: "profile_other",
+			title: "Other account DM",
+		});
+		insertTestDmMessage(db, {
+			id: "m-other",
+			conversationId: "dm-other",
+			senderProfileId: "profile_other",
+			text: "keep other dm",
+			direction: "incoming",
+		});
+		db.exec(`
+			insert into dm_fts (message_id, text) values ('m-other', 'keep other dm');
+			insert into tweet_account_edges (
+				account_id, tweet_id, kind, first_seen_at, last_seen_at, seen_count,
+				source, raw_json, updated_at
+			) values (
+				'acct_other', '100', 'home', '2026-01-01T00:00:00.000Z',
+				'2026-01-01T00:00:00.000Z', 1, 'xurl', '{}', '2026-01-01T00:00:00.000Z'
+			);
+			insert into tweet_collections (
+				account_id, tweet_id, kind, collected_at, source, raw_json, updated_at
+			) values (
+				'acct_other', '100', 'likes', '2026-01-01T00:00:00.000Z',
+				'xurl', '{}', '2026-01-01T00:00:00.000Z'
+			);
+			insert into follow_snapshots (
+				id, account_id, direction, source, status, page_count, result_count,
+				started_at, completed_at, raw_meta_json
+			) values (
+				'follow-other', 'acct_other', 'followers', 'xurl', 'complete', 1, 1,
+				'2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z', '{}'
+			);
+			insert into follow_snapshot_members (snapshot_id, profile_id, external_user_id, position)
+			values ('follow-other', 'profile_other', 'other', 0);
+			insert into follow_edges (
+				account_id, direction, profile_id, external_user_id, source, current,
+				first_seen_at, last_seen_at, ended_at, updated_at
+			) values (
+				'acct_other', 'followers', 'profile_other', 'other', 'xurl', 1,
+				'2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z', null,
+				'2026-01-01T00:00:00.000Z'
+			);
+			insert into follow_events (
+				id, account_id, direction, profile_id, external_user_id, kind, event_at, snapshot_id
+			) values (
+				'follow-event-other', 'acct_other', 'followers', 'profile_other', 'other',
+				'started', '2026-01-01T00:00:00.000Z', 'follow-other'
+			);
+			insert into x_lists (
+				account_id, list_id, name, source, membership_status, lists_synced_at, updated_at
+			) values (
+				'acct_other', 'list-other', 'Other list', 'xurl', 'complete',
+				'2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+			);
+			insert into x_list_members (
+				account_id, list_id, profile_id, external_user_id, source, current,
+				first_seen_at, last_seen_at, updated_at
+			) values (
+				'acct_other', 'list-other', 'profile_other', 'other', 'xurl', 1,
+				'2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z',
+				'2026-01-01T00:00:00.000Z'
+			);
+			insert into blocks (account_id, profile_id, source, created_at) values
+				('acct_primary', 'profile_other', 'local', '2026-01-01T00:00:00.000Z'),
+				('acct_other', 'profile_me', 'xurl', '2026-01-01T00:00:00.000Z');
+			insert into mutes (account_id, profile_id, source, created_at) values
+				('acct_primary', 'profile_other', 'local', '2026-01-01T00:00:00.000Z'),
+				('acct_other', 'profile_me', 'xurl', '2026-01-01T00:00:00.000Z');
+			insert into url_expansions (
+				short_url, expanded_url, final_url, status, source, updated_at
+			) values (
+				'https://t.co/keep', 'https://example.com/keep', 'https://example.com/keep',
+				'hit', 'network', '2026-01-01T00:00:00.000Z'
+			);
+			insert into tweet_sources (tweet_id, source, source_url, observed_at) values
+				('5', 'fxtwitter', 'https://api.fxtwitter.com/status/5', '2026-01-01T00:00:00.000Z');
+			insert into fxtwitter_fetches (
+				id, endpoint_family, request_key, source_url, retrieved_at, partial_reasons_json,
+				pages_fetched, items_observed
+			) values (
+				'fetch-keep', 'search', 'keep', 'https://api.fxtwitter.com/search',
+				'2026-01-01T00:00:00.000Z', '[]', 1, 1
+			);
+			insert into fxtwitter_observations (
+				endpoint_family, request_key, item_kind, item_id, source_url,
+				first_seen_at, last_seen_at, seen_count, last_fetch_id
+			) values (
+				'search', 'keep', 'tweet', '5', 'https://api.fxtwitter.com/status/5',
+				'2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z', 1, 'fetch-keep'
+			);
+			insert into ai_scores (
+				entity_kind, entity_id, model, score, summary, reasoning, updated_at
+			) values (
+				'tweet', '5', 'test', 42, 'keep', 'unrelated', '2026-01-01T00:00:00.000Z'
+			);
+			insert into tweet_actions (id, account_id, tweet_id, kind, body, created_at) values (
+				'action-keep', 'acct_primary', '5', 'reply', 'keep', '2026-01-01T00:00:00.000Z'
+			);
+		`);
+
+		await importArchive(makeRootDataArchive(), { restore: true });
+
+		expect(
+			db.prepare("select id from accounts where id = 'acct_other'").get(),
+		).toEqual({ id: "acct_other" });
+		expect(
+			db.prepare("select id from profiles where id = 'profile_other'").get(),
+		).toEqual({ id: "profile_other" });
+		expect(
+			db
+				.prepare(
+					"select id from dm_conversations where account_id = 'acct_other'",
+				)
+				.all(),
+		).toEqual([{ id: "dm-other" }]);
+		expect(
+			db
+				.prepare("select message_id from dm_fts where message_id = 'm-other'")
+				.get(),
+		).toEqual({ message_id: "m-other" });
+		expect(
+			db
+				.prepare(
+					"select account_id, kind from tweet_account_edges where tweet_id = '100'",
+				)
+				.all(),
+		).toEqual([{ account_id: "acct_other", kind: "home" }]);
+		expect(
+			db
+				.prepare(
+					"select account_id from tweet_collections where tweet_id = '100'",
+				)
+				.all(),
+		).toEqual([{ account_id: "acct_other" }]);
+		expect(
+			db
+				.prepare(
+					"select id from follow_snapshots where account_id = 'acct_other'",
+				)
+				.all(),
+		).toEqual([{ id: "follow-other" }]);
+		expect(
+			db
+				.prepare("select list_id from x_lists where account_id = 'acct_other'")
+				.all(),
+		).toEqual([{ list_id: "list-other" }]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from x_list_members where account_id = 'acct_other'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
+		expect(db.prepare("select count(*) as count from blocks").get()).toEqual({
+			count: 2,
+		});
+		expect(db.prepare("select count(*) as count from mutes").get()).toEqual({
+			count: 2,
+		});
+		for (const table of ["url_expansions", "fxtwitter_fetches"]) {
+			expect(
+				db.prepare(`select count(*) as count from ${table}`).get(),
+			).toEqual({
+				count: 1,
+			});
+		}
+		expect(
+			db
+				.prepare(`
+					select 'tweet_sources' as source, tweet_sources.tweet_id
+					from tweet_sources join tweets on tweets.id = tweet_sources.tweet_id
+					union all
+					select 'fxtwitter_observations', item_id
+					from fxtwitter_observations join tweets on tweets.id = item_id
+					where item_kind = 'tweet'
+					union all
+					select 'ai_scores', entity_id
+					from ai_scores join tweets on tweets.id = entity_id
+					where entity_kind = 'tweet'
+					union all
+					select 'tweet_actions', tweet_actions.tweet_id
+					from tweet_actions join tweets on tweets.id = tweet_actions.tweet_id
+					order by source
+				`)
+				.all(),
+		).toEqual([
+			{ source: "ai_scores", tweet_id: "5" },
+			{ source: "fxtwitter_observations", tweet_id: "5" },
+			{ source: "tweet_actions", tweet_id: "5" },
+			{ source: "tweet_sources", tweet_id: "5" },
+		]);
+		expect(
+			db
+				.prepare(
+					"select id from dm_conversations where account_id = 'acct_primary'",
+				)
+				.all(),
+		).toEqual([{ id: "root-dm" }]);
+		expect(
+			db
+				.prepare(
+					"select tweet_id, kind from tweet_account_edges where account_id = 'acct_primary'",
+				)
+				.all(),
+		).toEqual([
+			{ tweet_id: "root-1", kind: "authored" },
+			{ tweet_id: "root-1", kind: "home" },
+		]);
+		expect(
+			db
+				.prepare(
+					"select tweet_id from tweet_collections where account_id = 'acct_primary'",
+				)
+				.all(),
+		).toEqual([]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from follow_edges where account_id = 'acct_primary' and source = 'archive'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		expect(
+			db.prepare("select id from tweets where id in ('5', '6')").all(),
+		).toEqual([{ id: "5" }]);
 	}, 30000);
 
 	it("extracts archive media files into media originals", async () => {
@@ -1177,26 +1423,32 @@ describe("archive import", () => {
 		});
 	});
 
-	it("clears mention sync state on an explicit full archive restore", async () => {
+	it("clears only primary mention sync state when restoring tweets", async () => {
 		const archivePath = makeArchive();
-		const db = getNativeDb();
-		db.prepare(
-			"insert into sync_cache (cache_key, value_json, updated_at) values (?, ?, ?)",
-		).run(
-			"mentions:sync:high-water:v1:mode=xurl:account=acct_primary",
-			'{"sinceId":"2000"}',
-			"2026-05-01T00:00:00.000Z",
+		const db = getNativeDb({ seedDemoData: false });
+		const insertSyncCache = db.prepare(
+			"insert into sync_cache (cache_key, value_json, updated_at) values (?, '{}', ?)",
 		);
+		for (const accountId of ["acct_primary", "acct_other"]) {
+			insertSyncCache.run(
+				`mentions:sync:high-water:v1:mode=xurl:account=${accountId}`,
+				"2026-05-01T00:00:00.000Z",
+			);
+		}
 
-		await importArchive(archivePath, { restore: true });
+		await importArchive(archivePath, { select: ["tweets"], restore: true });
 
 		expect(
 			db
 				.prepare(
-					"select count(*) as count from sync_cache where cache_key like 'mentions:sync:%'",
+					"select cache_key from sync_cache where cache_key like 'mentions:sync:%' order by cache_key",
 				)
-				.get(),
-		).toEqual({ count: 0 });
+				.all(),
+		).toEqual([
+			{
+				cache_key: "mentions:sync:high-water:v1:mode=xurl:account=acct_other",
+			},
+		]);
 	});
 
 	it("imports only selected archive slices", async () => {
@@ -2828,7 +3080,7 @@ describe("archive import", () => {
 					"select id from profiles where id in ('profile_user_101', 'profile_user_102') order by id",
 				)
 				.all(),
-		).toEqual([]);
+		).toEqual([{ id: "profile_user_101" }, { id: "profile_user_102" }]);
 	});
 
 	it("preserves live follower source when an overlapping archive is later absent", async () => {

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -366,6 +366,14 @@ export function applyArchiveImportPlanEffect({
 				        where referencing_tweet.reply_to_id = tweets.id
 				          or referencing_tweet.quoted_tweet_id = tweets.id
 				      )
+				      and not exists (
+				        select 1 from (
+				          select tweet_id from tweet_sources
+				          union all select item_id from fxtwitter_observations where item_kind = 'tweet'
+				          union all select entity_id from ai_scores where entity_kind = 'tweet'
+				          union all select tweet_id from tweet_actions
+				        ) preserved where preserved.tweet_id = tweets.id
+				      )
 				  `);
 		const deleteOrphanTweetFts = db.prepare(`
 		    delete from tweets_fts
@@ -590,14 +598,10 @@ export function applyArchiveImportPlanEffect({
 			}
 		}
 		yield* databaseWriteEffect(() => {
-			if (restore && !selection) {
-				repository.clearArchiveImport();
-				repository.clearMentionSyncState();
-			}
-
-			if (restore && selection) {
+			if (restore) {
 				if (includeTweets) {
 					repository.clearAuthoredSyncCursors("acct_primary");
+					repository.clearMentionSyncState("acct_primary");
 					clearSelectedArchiveTweetEdges.run("acct_primary", localProfile.id);
 				}
 				if (includeLikes) {

--- a/src/lib/import-repository.test.ts
+++ b/src/lib/import-repository.test.ts
@@ -45,4 +45,31 @@ describe("import repository", () => {
 			{ tweet_id: "one", text: "first" },
 		]);
 	});
+
+	it("clears only account-owned mention sync state", () => {
+		db = new NativeSqliteDatabase(":memory:");
+		db.exec("create table sync_cache (cache_key text primary key)");
+		const keys = [
+			"mentions:sync:cursor:v2:mode=xurl:account=acct_primary:page=100:boundary=auto",
+			"mentions:sync:result:v2:mode=xurl:account=acct_primary:page=100:boundary=auto:single:all-pages",
+			"mentions:sync:result:v2:mode=bird:account=acct_primary:page=100:boundary=auto:all:all-pages",
+			"mentions:sync:high-water:v1:mode=xurl:account=acct_primary",
+			"mentions:sync:cursor:v2:mode=xurl:account=acct_other:page=100:boundary=auto",
+			"mentions:sync:high-water:v1:mode=xurl:account=acct_other",
+			"mentions:export:xurl:acct_primary:100:all:all-pages",
+		];
+		const insert = db.prepare("insert into sync_cache (cache_key) values (?)");
+		for (const key of keys) insert.run(key);
+
+		getImportRepository(db).clearMentionSyncState("acct_primary");
+
+		expect(
+			db.prepare("select cache_key from sync_cache order by cache_key").all(),
+		).toEqual(
+			keys
+				.slice(4)
+				.sort()
+				.map((cache_key) => ({ cache_key })),
+		);
+	});
 });

--- a/src/lib/import-repository.ts
+++ b/src/lib/import-repository.ts
@@ -61,28 +61,6 @@ export class ImportRepository {
 		}
 	}
 
-	clearArchiveImport() {
-		this.db.exec(`
-      delete from ai_scores;
-      delete from tweet_actions;
-      delete from tweet_account_edges;
-      delete from tweet_collections;
-      delete from link_occurrences;
-      delete from url_expansions;
-      delete from dm_fts;
-      delete from tweets_fts;
-      delete from dm_messages;
-      delete from dm_conversations;
-	  delete from tweet_subordinate_tombstones;
-	  delete from tweet_revision_edges;
-	  delete from tweet_revisions;
-      delete from tweets;
-      delete from profiles;
-      delete from accounts;
-    `);
-		this.clearAuthoredSyncCursors();
-	}
-
 	clearAuthoredSyncCursors(accountId?: string) {
 		if (accountId) {
 			this.db
@@ -97,10 +75,23 @@ export class ImportRepository {
 			.run();
 	}
 
-	clearMentionSyncState() {
+	clearMentionSyncState(accountId: string) {
+		const encodedAccountId = encodeURIComponent(accountId);
+		const accountPattern = encodedAccountId.replace(/[\\%_]/g, "\\$&");
 		this.db
-			.prepare("delete from sync_cache where cache_key like 'mentions:sync:%'")
-			.run();
+			.prepare(`
+				delete from sync_cache
+				where cache_key = ?
+				   or cache_key like ? escape '\\'
+				   or cache_key like ? escape '\\'
+				   or cache_key like ? escape '\\'
+			`)
+			.run(
+				`mentions:sync:high-water:v1:mode=xurl:account=${encodedAccountId}`,
+				`mentions:sync:cursor:v2:mode=xurl:account=${accountPattern}:page=%:boundary=%`,
+				`mentions:sync:result:v2:mode=xurl:account=${accountPattern}:page=%:boundary=%`,
+				`mentions:sync:result:v2:mode=bird:account=${accountPattern}:page=%:boundary=%`,
+			);
 	}
 
 	clearBackupImport() {


### PR DESCRIPTION
## Summary

- replace the full-database archive restore wipe with the existing account- and slice-scoped cleanup path
- preserve other accounts, moderation/list/follow state, and unrelated local provenance while replacing archive-owned state for the primary account
- clear authored and mention sync state only for the restored primary account
- retain base tweets still referenced by local provenance, observations, AI scores, or actions, while deleting truly unreferenced stale tweets

## Why

A full archive restore previously deleted every account, profile, tweet, DM, collection, URL expansion, AI score, and tweet action, while leaving several other account-scoped tables behind. In a shared multi-account database this could erase another account’s primary data and retain dangling follow/list/moderation rows.

Full and selected restore now share the same ownership rule: clear only the imported archive slices for `acct_primary`, then replay the archive. Other accounts and unrelated local datasets remain intact.

Handwritten production source drops from 68,030 to 68,025 lines.

## Proof

- format, lint, typecheck, and diff checks
- focused archive/import repository tests: 47 passed
- full pinned-Bun suite: 1,467 tests passed
- structured P2 autoreview and TruffleHog preflight: clean
- actual CLI validation with synthetic archive ZIPs and an isolated Birdclaw home
  - shared tweet survived through another account’s edge
  - locally referenced stale tweet survived with source, observation, AI score, and action rows
  - unreferenced stale primary tweet was deleted
  - new archive tweet replaced the primary archive slice
  - only the primary mention sync state was cleared
  - SQLite integrity remained `ok`

No production, private archive, live transport, release, or deployment access was used.
