### PR TITLE
fix: preserve full Note Tweets across sync and rendering

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -97,6 +97,12 @@ Git operations are rooted at the configured `repoPath`. If that directory sits i
 
 This is what makes birdclaw safe across multiple machines: each machine can sync independently, and the merge step preserves rows that only one side has.
 
+### Schema upgrades
+
+Each Birdclaw release reads its current backup schema and earlier schemas. Schema v9 requires Birdclaw 0.12.2 or newer.
+
+Before the first schema-v9 export or sync, upgrade every Birdclaw installation that shares the backup repository. If an older installation encounters a schema-v9 backup, upgrade it and rerun the import or sync; the last schema-v8 generation remains available in the repository's Git history for recovery.
+
 ## `backup import`
 
 ```bash

--- a/src/components/ConversationThread.tsx
+++ b/src/components/ConversationThread.tsx
@@ -114,6 +114,7 @@ export function ConversationThread({
 								</header>
 								<TweetRichText
 									className="mt-1 whitespace-pre-wrap break-words text-[14px] leading-[1.45] text-[var(--ink)] [overflow-wrap:anywhere]"
+									collapsible={Boolean(tweet.noteTweet)}
 									entities={tweet.entities}
 									text={tweet.text}
 								/>

--- a/src/components/EmbeddedTweetCard.tsx
+++ b/src/components/EmbeddedTweetCard.tsx
@@ -43,6 +43,7 @@ export function EmbeddedTweetCard({
 			</header>
 			<TweetRichText
 				className={embeddedCardCopyClass}
+				collapsible={Boolean(item.noteTweet)}
 				entities={item.entities}
 				text={item.text}
 			/>

--- a/src/components/TimelineCard.tsx
+++ b/src/components/TimelineCard.tsx
@@ -250,6 +250,7 @@ function TweetPresentation({
 		<>
 			<TweetRichText
 				className={feedRowTextClass}
+				collapsible={Boolean(tweet.noteTweet)}
 				entities={tweet.entities}
 				hiddenUrlRanges={hiddenUrlRanges}
 				text={tweet.text}

--- a/src/components/TweetRichText.test.tsx
+++ b/src/components/TweetRichText.test.tsx
@@ -71,6 +71,25 @@ describe("TweetRichText", () => {
 		);
 	});
 
+	it("collapses Note Tweets at a word boundary and expands the full text", () => {
+		const preview = "word ".repeat(55).trimEnd();
+		const text = `${preview} crossingboundary tailmarker`;
+		const { container } = render(
+			<TweetRichText collapsible entities={{}} text={text} />,
+		);
+
+		expect(container.querySelector("p")).toHaveTextContent(preview);
+		expect(container).not.toHaveTextContent("crossingboundary");
+		expect(container).not.toHaveTextContent("tailmarker");
+
+		fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+		expect(container.querySelector("p")).toHaveTextContent(text);
+		expect(
+			screen.queryByRole("button", { name: "Show more" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("can show expanded url labels", () => {
 		const { container } = render(
 			<TweetRichText

--- a/src/components/TweetRichText.tsx
+++ b/src/components/TweetRichText.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import type { ReactNode } from "react";
 import {
 	collectTweetSegmentsForText,
@@ -15,6 +15,47 @@ import {
 } from "#/lib/ui";
 import { safeHttpUrl } from "#/lib/url-safety";
 import { ProfilePreview } from "./ProfilePreview";
+
+const NOTE_TWEET_PREVIEW_LENGTH = 280;
+
+function truncateNoteTweet(text: string) {
+	const characters = Array.from(text);
+	if (characters.length <= NOTE_TWEET_PREVIEW_LENGTH) return text;
+	const preview = characters.slice(0, NOTE_TWEET_PREVIEW_LENGTH).join("");
+	return /\s/u.test(characters[NOTE_TWEET_PREVIEW_LENGTH]!)
+		? preview.trimEnd()
+		: preview.replace(/\s+\S*$/u, "");
+}
+
+function entitiesWithinText(
+	entities: TweetEntities,
+	text: string,
+	visibleText: string,
+) {
+	const segments = collectTweetSegmentsForText(text, entities);
+	const fits = (entry: { end: number }) => entry.end <= visibleText.length;
+	const mentions = segments
+		.filter((entry) => entry.kind === "mention")
+		.filter(fits);
+	const urls = segments.filter((entry) => entry.kind === "url").filter(fits);
+	const hashtags = segments
+		.filter((entry) => entry.kind === "hashtag")
+		.filter(fits);
+	const article = entities.article;
+	const articleUrls = article
+		? segments
+				.filter((entry) => entry.kind === "url")
+				.filter((entry) => isTweetArticleUrlEntity(entry, article))
+		: [];
+	return {
+		...entities,
+		mentions,
+		urls,
+		hashtags,
+		article:
+			articleUrls.length > 0 && !articleUrls.some(fits) ? undefined : article,
+	};
+}
 
 function rangeKey(range: { start: number; end: number }) {
 	return `${range.start}:${range.end}`;
@@ -35,6 +76,7 @@ export function TweetRichText({
 	hiddenUrlRanges = [],
 	urlLabel = "display",
 	as = "p",
+	collapsible = false,
 }: {
 	text: string;
 	entities: TweetEntities;
@@ -42,11 +84,19 @@ export function TweetRichText({
 	hiddenUrlRanges?: Array<{ start: number; end: number }>;
 	urlLabel?: "display" | "expanded";
 	as?: "p" | "span";
+	collapsible?: boolean;
 }) {
-	const richEntities = enrichFallbackUrlEntities(text, entities);
-	const segments = collectTweetSegmentsForText(text, richEntities);
+	const [expanded, setExpanded] = useState(false);
+	const previewText = collapsible ? truncateNoteTweet(text) : text;
+	const collapsed = previewText !== text && !expanded;
+	const visibleText = collapsed ? previewText : text;
+	const visibleEntities = collapsed
+		? entitiesWithinText(entities, text, visibleText)
+		: entities;
+	const richEntities = enrichFallbackUrlEntities(visibleText, visibleEntities);
+	const segments = collectTweetSegmentsForText(visibleText, richEntities);
 	const hiddenRawRangeKeys = new Set(hiddenUrlRanges.map(rangeKey));
-	const article = entities.article;
+	const article = visibleEntities.article;
 	if (article) {
 		const urlEntries = richEntities.urls ?? [];
 		const articleUrlEntries = urlEntries.filter((entry) =>
@@ -69,91 +119,107 @@ export function TweetRichText({
 	for (const entry of richEntities.urls ?? []) {
 		if (!hiddenRawRangeKeys.has(rangeKey(entry))) continue;
 		hiddenRangeKeys.add(
-			rangeKey(normalizeTweetUrlEntityRangeForText(text, entry)),
+			rangeKey(normalizeTweetUrlEntityRangeForText(visibleText, entry)),
 		);
 	}
 	const Wrapper = as;
 	let cursor = 0;
 	const hideArticleTitle =
-		entities.article && text.trim() === entities.article.title.trim();
+		article && visibleText.trim() === article.title.trim();
 	const visibleSegments = hideArticleTitle ? [] : segments;
 
 	return (
-		<Wrapper className={className === "body-copy" ? bodyCopyClass : className}>
-			{visibleSegments.map((segment, index) => {
-				if (
-					segment.start < cursor ||
-					segment.end <= segment.start ||
-					segment.end > text.length
-				) {
-					return null;
-				}
+		<>
+			<Wrapper
+				className={className === "body-copy" ? bodyCopyClass : className}
+			>
+				{visibleSegments.map((segment, index) => {
+					if (
+						segment.start < cursor ||
+						segment.end <= segment.start ||
+						segment.end > visibleText.length
+					) {
+						return null;
+					}
 
-				const prefix = text.slice(cursor, segment.start);
-				cursor = segment.end;
+					const prefix = visibleText.slice(cursor, segment.start);
+					cursor = segment.end;
 
-				let node: ReactNode = (
-					<Fragment key={`segment-${String(index)}`}>
-						{text.slice(segment.start, segment.end)}
-					</Fragment>
-				);
-				if (segment.kind === "url" && hiddenRangeKeys.has(rangeKey(segment))) {
-					node = null;
-				} else if (segment.kind === "mention" && segment.profile) {
-					node = (
-						<ProfilePreview
-							key={`segment-${String(index)}`}
-							profile={segment.profile}
-						>
-							<span className={tweetMentionClass}>@{segment.username}</span>
-						</ProfilePreview>
+					let node: ReactNode = (
+						<Fragment key={`segment-${String(index)}`}>
+							{visibleText.slice(segment.start, segment.end)}
+						</Fragment>
 					);
-				} else if (segment.kind === "mention") {
-					node = (
-						<a
-							key={`segment-${String(index)}`}
-							className={tweetMentionClass}
-							href={`/profiles/${encodeURIComponent(segment.username)}`}
-						>
-							@{segment.username}
-						</a>
-					);
-				} else if (segment.kind === "url") {
-					const href = safeHttpUrl(segment.expandedUrl);
-					if (href) {
+					if (
+						segment.kind === "url" &&
+						hiddenRangeKeys.has(rangeKey(segment))
+					) {
+						node = null;
+					} else if (segment.kind === "mention" && segment.profile) {
+						node = (
+							<ProfilePreview
+								key={`segment-${String(index)}`}
+								profile={segment.profile}
+							>
+								<span className={tweetMentionClass}>@{segment.username}</span>
+							</ProfilePreview>
+						);
+					} else if (segment.kind === "mention") {
 						node = (
 							<a
 								key={`segment-${String(index)}`}
-								className={tweetLinkClass}
-								href={href}
-								rel="noreferrer"
-								target="_blank"
+								className={tweetMentionClass}
+								href={`/profiles/${encodeURIComponent(segment.username)}`}
 							>
-								{urlLabel === "expanded"
-									? segment.expandedUrl
-									: segment.displayUrl}
+								@{segment.username}
 							</a>
 						);
+					} else if (segment.kind === "url") {
+						const href = safeHttpUrl(segment.expandedUrl);
+						if (href) {
+							node = (
+								<a
+									key={`segment-${String(index)}`}
+									className={tweetLinkClass}
+									href={href}
+									rel="noreferrer"
+									target="_blank"
+								>
+									{urlLabel === "expanded"
+										? segment.expandedUrl
+										: segment.displayUrl}
+								</a>
+							);
+						}
+					} else if (segment.kind === "hashtag") {
+						node = (
+							<span
+								className={tweetHashtagClass}
+								key={`segment-${String(index)}`}
+							>
+								#{segment.tag}
+							</span>
+						);
 					}
-				} else if (segment.kind === "hashtag") {
-					node = (
-						<span
-							className={tweetHashtagClass}
-							key={`segment-${String(index)}`}
-						>
-							#{segment.tag}
-						</span>
-					);
-				}
 
-				return (
-					<Fragment key={`piece-${String(index)}`}>
-						{prefix}
-						{node}
-					</Fragment>
-				);
-			})}
-			{hideArticleTitle ? null : text.slice(cursor)}
-		</Wrapper>
+					return (
+						<Fragment key={`piece-${String(index)}`}>
+							{prefix}
+							{node}
+						</Fragment>
+					);
+				})}
+				{hideArticleTitle ? null : visibleText.slice(cursor)}
+			</Wrapper>
+			{collapsed ? (
+				<button
+					className="w-fit border-0 bg-transparent p-0 text-[15px] font-medium text-[var(--accent)] hover:underline"
+					onClick={() => setExpanded(true)}
+					type="button"
+				>
+					Show more
+				</button>
+			) : null}
+		</>
 	);
 }

--- a/src/lib/api-contracts.ts
+++ b/src/lib/api-contracts.ts
@@ -7,6 +7,7 @@ import type {
 	DmSearchMatchItem,
 	EmbeddedTweet,
 	LinkInsightItem,
+	NoteTweet,
 	ProfileAffiliation,
 	ProfileRecord,
 	TimelineItem,
@@ -139,9 +140,15 @@ export const tweetMediaSchema: z.ZodType<TweetMediaItem> = z.object({
 		.optional(),
 });
 
+export const noteTweetSchema: z.ZodType<NoteTweet> = z.object({
+	text: z.string(),
+	entities: tweetEntitiesSchema,
+});
+
 export const embeddedTweetSchema: z.ZodType<EmbeddedTweet> = z.object({
 	id: z.string(),
 	text: z.string(),
+	noteTweet: noteTweetSchema.optional(),
 	createdAt: z.string().default(""),
 	replyToId: z.string().nullable().optional(),
 	isReplied: z.boolean().optional(),
@@ -162,6 +169,7 @@ export const timelineItemSchema: z.ZodType<TimelineItem> = z.object({
 		.enum(["home", "mention", "authored", "search", "like", "bookmark"])
 		.default("home"),
 	text: z.string(),
+	noteTweet: noteTweetSchema.optional(),
 	searchSnippet: z.string().optional(),
 	createdAt: z.string().default(""),
 	replyToId: z.string().nullable().optional(),

--- a/src/lib/archive-import.test.ts
+++ b/src/lib/archive-import.test.ts
@@ -1260,6 +1260,52 @@ describe("archive import", () => {
 		).toEqual([{ id: "5" }]);
 	}, 30000);
 
+	it("preserves Note Tweet content during archive merges", async () => {
+		const archivePath = makeArchive();
+		const db = getNativeDb();
+		const noteEntities = {
+			hashtags: [{ tag: "longform", start: 33, end: 42 }],
+		};
+		const noteText = "full live Note Tweet archiveguardneedle #longform";
+		insertTestProfile(db);
+		insertTestTweet(db, {
+			id: "100",
+			text: noteText,
+			entitiesJson: JSON.stringify(noteEntities),
+		});
+		db.prepare("update tweets set note_tweet_json = ? where id = '100'").run(
+			JSON.stringify({ text: noteText, entities: noteEntities }),
+		);
+		db.prepare("insert into tweets_fts (tweet_id, text) values ('100', ?)").run(
+			noteText,
+		);
+
+		await importArchive(archivePath, { select: ["tweets"] });
+
+		const row = db
+			.prepare(
+				"select text, entities_json, note_tweet_json from tweets where id = '100'",
+			)
+			.get() as {
+			text: string;
+			entities_json: string;
+			note_tweet_json: string;
+		};
+		expect(row.text).toBe(noteText);
+		expect(JSON.parse(row.entities_json)).toEqual(noteEntities);
+		expect(JSON.parse(row.note_tweet_json)).toEqual({
+			text: noteText,
+			entities: noteEntities,
+		});
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweets_fts match 'archiveguardneedle'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
+	});
+
 	it("extracts archive media files into media originals", async () => {
 		const archivePath = makeMediaArchive();
 

--- a/src/lib/archive/apply.ts
+++ b/src/lib/archive/apply.ts
@@ -131,21 +131,25 @@ export function applyArchiveImportPlanEffect({
 		        when tweets.author_profile_id = 'profile_unknown' then excluded.author_profile_id
 		        else tweets.author_profile_id
 		      end,
-			      text = case
-			        when ? = 1 and tweets.text <> ''
-			          then tweets.text
-			        when excluded.text <> '' then excluded.text
-			        else tweets.text
-			      end,
-			      created_at = case
-			        when ? = 1 then tweets.created_at
-			        else excluded.created_at
-			      end,
+		      text = case
+		        when tweets.note_tweet_json is not null then tweets.text
+		        when ? = 1 and tweets.text <> '' then tweets.text
+		        when excluded.text <> '' then excluded.text
+		        else tweets.text
+		      end,
+		      created_at = case
+		        when ? = 1 then tweets.created_at
+		        else excluded.created_at
+		      end,
 		      is_replied = max(tweets.is_replied, excluded.is_replied),
 		      reply_to_id = coalesce(excluded.reply_to_id, tweets.reply_to_id),
 		      like_count = max(tweets.like_count, excluded.like_count),
 		      media_count = max(tweets.media_count, excluded.media_count),
-		      entities_json = case when excluded.entities_json <> '{}' then excluded.entities_json else tweets.entities_json end,
+		      entities_json = case
+		        when tweets.note_tweet_json is not null then tweets.entities_json
+		        when excluded.entities_json <> '{}' then excluded.entities_json
+		        else tweets.entities_json
+		      end,
 		      media_json = case when excluded.media_json <> '[]' then excluded.media_json else tweets.media_json end,
 		      quoted_tweet_id = coalesce(excluded.quoted_tweet_id, tweets.quoted_tweet_id),
 		      deleted_at = case

--- a/src/lib/authored-live.ts
+++ b/src/lib/authored-live.ts
@@ -85,6 +85,7 @@ const AUTHORED_TWEET_FIELDS = [
 	"created_at",
 	"conversation_id",
 	"entities",
+	"note_tweet",
 	"attachments",
 	"public_metrics",
 	"referenced_tweets",

--- a/src/lib/backup-table-codecs.ts
+++ b/src/lib/backup-table-codecs.ts
@@ -110,11 +110,24 @@ function sanitizeJsonTextUrls(
 }
 
 function sanitizeImportedTweets(rows: BackupJsonRecord[]) {
-	return rows.map((row) => ({
-		...row,
-		entities_json: sanitizeJsonTextUrls(row.entities_json, {}),
-		media_json: sanitizeJsonTextUrls(row.media_json, []),
-	}));
+	return rows.map((row) => {
+		const entitiesJson = sanitizeJsonTextUrls(row.entities_json, {});
+		const noteTweetJson = sanitizeJsonTextUrls(row.note_tweet_json, {});
+		const noteTweet =
+			typeof noteTweetJson === "string"
+				? (JSON.parse(noteTweetJson) as BackupJsonRecord)
+				: undefined;
+		const hasNoteTweet = typeof noteTweet?.text === "string";
+		return {
+			...row,
+			text: hasNoteTweet ? noteTweet.text : row.text,
+			entities_json: hasNoteTweet
+				? JSON.stringify(noteTweet.entities ?? {})
+				: entitiesJson,
+			note_tweet_json: hasNoteTweet ? noteTweetJson : null,
+			media_json: sanitizeJsonTextUrls(row.media_json, []),
+		};
+	});
 }
 
 function sanitizeImportedTweetRevisions(rows: BackupJsonRecord[]) {
@@ -482,7 +495,8 @@ const definitions = {
 	tweets: {
 		exportSql: `
       select id, author_profile_id, text, created_at, is_replied, reply_to_id,
-        like_count, media_count, entities_json, media_json, quoted_tweet_id,
+		like_count, media_count, entities_json, note_tweet_json, media_json,
+		quoted_tweet_id,
 		deleted_at, deletion_source, deletion_reason, superseded_at, superseded_by_id
       from tweets
       order by created_at, id
@@ -497,21 +511,29 @@ const definitions = {
 			sql: `
       insert into tweets (
         id, author_profile_id, text, created_at, is_replied, reply_to_id,
-        like_count, media_count, entities_json, media_json, quoted_tweet_id,
+		like_count, media_count, entities_json, note_tweet_json, media_json,
+		quoted_tweet_id,
 		deleted_at, deletion_source, deletion_reason, superseded_at, superseded_by_id
-	  ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	  ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       on conflict(id) do update set
         author_profile_id = coalesce(nullif(excluded.author_profile_id, ''), tweets.author_profile_id),
-        text = coalesce(nullif(excluded.text, ''), tweets.text),
+		text = case
+		  when excluded.note_tweet_json is not null then excluded.text
+		  when tweets.note_tweet_json is not null then tweets.text
+		  else coalesce(nullif(excluded.text, ''), tweets.text)
+		end,
         created_at = min(tweets.created_at, excluded.created_at),
         is_replied = max(tweets.is_replied, excluded.is_replied),
         reply_to_id = coalesce(excluded.reply_to_id, tweets.reply_to_id),
         like_count = max(tweets.like_count, excluded.like_count),
         media_count = max(tweets.media_count, excluded.media_count),
-        entities_json = case
-          when excluded.entities_json not in ('', '{}', 'null') then excluded.entities_json
-          else tweets.entities_json
-        end,
+		entities_json = case
+		  when excluded.note_tweet_json is not null then excluded.entities_json
+		  when tweets.note_tweet_json is not null then tweets.entities_json
+		  when excluded.entities_json not in ('', '{}', 'null') then excluded.entities_json
+		  else tweets.entities_json
+		end,
+		note_tweet_json = coalesce(excluded.note_tweet_json, tweets.note_tweet_json),
         media_json = case
           when excluded.media_json not in ('', '[]', 'null') then excluded.media_json
           else tweets.media_json
@@ -555,6 +577,7 @@ const definitions = {
 				"like_count",
 				"media_count",
 				"entities_json",
+				"note_tweet_json",
 				"media_json",
 				"quoted_tweet_id",
 				"deleted_at",

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -912,7 +912,7 @@ describe("text backup", () => {
 		expect(topologyQueries).toBe(0);
 	});
 
-	it("emits byte-identical schema-v8 data and hashes for the same database", async () => {
+	it("emits byte-identical current-schema data and hashes for the same database", async () => {
 		switchHome("birdclaw-backup-stable-src-");
 		seedBackupFixture();
 		const firstRepoPath = makeTempDir("birdclaw-backup-stable-first-");
@@ -921,7 +921,7 @@ describe("text backup", () => {
 		const first = await exportBackup({ repoPath: firstRepoPath });
 		const second = await exportBackup({ repoPath: secondRepoPath });
 
-		expect(first.manifest.schemaVersion).toBe(8);
+		expect(first.manifest.schemaVersion).toBe(9);
 		expect(second.manifest.files).toEqual(first.manifest.files);
 		expect(second.manifest.counts).toEqual(first.manifest.counts);
 		expect(second.manifest.backupHash).toBe(first.manifest.backupHash);

--- a/src/lib/backup.test.ts
+++ b/src/lib/backup.test.ts
@@ -188,6 +188,23 @@ function clearData() {
 	`);
 }
 
+function setNoteTweet(
+	db: Database,
+	id: string,
+	text: string,
+	entities: object,
+) {
+	const entitiesJson = JSON.stringify(entities);
+	db.prepare(
+		"update tweets set text = ?, entities_json = ?, note_tweet_json = ? where id = ?",
+	).run(text, entitiesJson, JSON.stringify({ text, entities }), id);
+	db.prepare("delete from tweets_fts where tweet_id = ?").run(id);
+	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
+		id,
+		text,
+	);
+}
+
 function writeBackupConfig(
 	home: string,
 	backup: {
@@ -830,6 +847,42 @@ describe("text backup", () => {
 		expect(validation.ok).toBe(true);
 	}, 20000);
 
+	it("round-trips Note Tweets and their FTS content through backups", async () => {
+		switchHome("birdclaw-backup-note-src-");
+		seedBackupFixture();
+		const text = "Full backup Note Tweet backuptailneedle #longform";
+		const entities = {
+			hashtags: [{ tag: "longform", start: 45, end: 54 }],
+		};
+		setNoteTweet(getNativeDb(), "tweet_2024", text, entities);
+		const repoPath = makeTempDir("birdclaw-backup-note-store-");
+		await exportBackup({ repoPath });
+
+		switchHome("birdclaw-backup-note-dst-");
+		await importBackup({ repoPath, mode: "replace" });
+		const db = getNativeDb({ seedDemoData: false });
+		const row = db
+			.prepare(
+				"select text, entities_json, note_tweet_json from tweets where id = 'tweet_2024'",
+			)
+			.get() as {
+			text: string;
+			entities_json: string;
+			note_tweet_json: string;
+		};
+
+		expect(row.text).toBe(text);
+		expect(JSON.parse(row.entities_json)).toEqual(entities);
+		expect(JSON.parse(row.note_tweet_json)).toEqual({ text, entities });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweets_fts match 'backuptailneedle'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
+	}, 20000);
+
 	it("exports and syncs a fresh empty store with a staged data directory", async () => {
 		const remotePath = path.join(
 			makeTempDir("birdclaw-empty-remote-"),
@@ -989,6 +1042,56 @@ describe("text backup", () => {
 				.get(),
 		).toEqual({ inbox_kind: "request" });
 	});
+
+	it("merges backup tweets using the richer Note Tweet representation", async () => {
+		switchHome("birdclaw-backup-note-merge-src-");
+		seedBackupFixture();
+		const incomingText = "Incoming backup Note Tweet incomingnoteneedle";
+		const incomingEntities = {
+			hashtags: [{ tag: "incoming", start: 21, end: 30 }],
+		};
+		setNoteTweet(getNativeDb(), "tweet_2024", incomingText, incomingEntities);
+		const repoPath = makeTempDir("birdclaw-backup-note-merge-store-");
+		await exportBackup({ repoPath });
+
+		switchHome("birdclaw-backup-note-merge-dst-");
+		seedBackupFixture();
+		const db = getNativeDb({ seedDemoData: false });
+		const localText = "Local Note Tweet localnoteneedle";
+		const localEntities = {
+			hashtags: [{ tag: "local", start: 17, end: 23 }],
+		};
+		setNoteTweet(db, "tweet_2025", localText, localEntities);
+
+		await importBackup({ repoPath });
+
+		const rows = db
+			.prepare(
+				"select id, text, entities_json, note_tweet_json from tweets where id in ('tweet_2024', 'tweet_2025') order by id",
+			)
+			.all() as Array<{
+			id: string;
+			text: string;
+			entities_json: string;
+			note_tweet_json: string;
+		}>;
+		expect(rows.map((row) => row.text)).toEqual([incomingText, localText]);
+		expect(rows.map((row) => JSON.parse(row.entities_json))).toEqual([
+			incomingEntities,
+			localEntities,
+		]);
+		expect(rows.map((row) => JSON.parse(row.note_tweet_json))).toEqual([
+			{ text: incomingText, entities: incomingEntities },
+			{ text: localText, entities: localEntities },
+		]);
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweets_fts match 'incomingnoteneedle OR localnoteneedle'",
+				)
+				.get(),
+		).toEqual({ count: 2 });
+	}, 20000);
 
 	it("merges backup rows without deleting local-only tweets", async () => {
 		switchHome("birdclaw-backup-src-");

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -46,7 +46,7 @@ import {
 } from "./profile-identity";
 import { resolveLiveSyncAccount } from "./live-sync-engine";
 
-const BACKUP_SCHEMA_VERSION = 8;
+const BACKUP_SCHEMA_VERSION = 9;
 const MIN_SUPPORTED_BACKUP_SCHEMA_VERSION = 1;
 const DEFAULT_MAX_BACKUP_SHARD_BYTES = 48 * 1024 * 1024;
 const MANIFEST_PATH = "manifest.json";
@@ -3298,6 +3298,10 @@ function importBackupUnlockedEffect({
 				repository.insertRows(codec.merge.sql, rows, codec.merge.columns);
 				const fts = codec.merge.fts;
 				if (!fts) continue;
+				if (fts.target.table === "tweets_fts") {
+					repository.reindexTweets(rows, fts.idKey);
+					continue;
+				}
 				repository.insertFtsRows({
 					target: fts.target,
 					rows,

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -429,7 +429,7 @@ describe("database init", () => {
 			{ name: "fxtwitter_fetches" },
 			{ name: "fxtwitter_observations" },
 		]);
-		expect(db.pragma("user_version", { simple: true })).toBe(9);
+		expect(db.pragma("user_version", { simple: true })).toBe(10);
 	});
 
 	it("adds revision edges without rewriting v6 revision rows", () => {
@@ -452,7 +452,7 @@ describe("database init", () => {
 		resetDatabaseForTests();
 
 		const migrated = getNativeDb({ seedDemoData: false });
-		expect(migrated.pragma("user_version", { simple: true })).toBe(9);
+		expect(migrated.pragma("user_version", { simple: true })).toBe(10);
 		expect(
 			migrated
 				.prepare(
@@ -628,7 +628,7 @@ describe("database init", () => {
 
 	it.each([
 		{ kind: "stale", version: 4 },
-		{ kind: "future", version: 10 },
+		{ kind: "future", version: 11 },
 	])(
 		"rejects a $kind schema and closes its provisional reader",
 		({ version }) => {
@@ -663,10 +663,10 @@ describe("database init", () => {
 
 		const writer = getNativeDb({ seedDemoData: false });
 		getReadDb({ seedDemoData: false });
-		writer.pragma("user_version = 10");
+		writer.pragma("user_version = 11");
 
 		expect(() => getStrictReadDb()).toThrow(
-			/schema 10 is not ready for version 9/,
+			/schema 11 is not ready for version 10/,
 		);
 	});
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -126,6 +126,7 @@ const BASE_SCHEMA_SQL = `
     bookmarked integer not null default 0,
     liked integer not null default 0,
     entities_json text not null default '{}',
+	  note_tweet_json text,
     media_json text not null default '[]',
     quoted_tweet_id text,
     deleted_at text,
@@ -500,6 +501,13 @@ function ensureTweetMetadataColumns(db: Database) {
 	}
 	if (!columnNames.has("quoted_tweet_id")) {
 		db.exec("alter table tweets add column quoted_tweet_id text");
+	}
+}
+
+function ensureTweetNoteColumn(db: Database) {
+	const columnNames = getColumnNames(db, "tweets");
+	if (!columnNames.has("note_tweet_json")) {
+		db.exec("alter table tweets add column note_tweet_json text");
 	}
 }
 
@@ -1169,6 +1177,11 @@ const DATABASE_MIGRATIONS: readonly DatabaseMigration[] = [
 					on profiles(case when json_valid(raw_json) then cast(json_extract(raw_json, '$.legacy.id_str') as text) end);
 			`);
 		},
+	},
+	{
+		version: 10,
+		name: "retain long-form tweet content",
+		up: ensureTweetNoteColumn,
 	},
 ];
 

--- a/src/lib/import-repository.ts
+++ b/src/lib/import-repository.ts
@@ -61,6 +61,20 @@ export class ImportRepository {
 		}
 	}
 
+	reindexTweets(rows: readonly ImportRow[], idKey: string) {
+		const remove = this.db.prepare("delete from tweets_fts where tweet_id = ?");
+		const insert = this.db.prepare(`
+			insert into tweets_fts (tweet_id, text)
+			select id, text from tweets
+			where id = ? and deleted_at is null and superseded_at is null
+		`);
+		for (const row of rows) {
+			const id = row[idKey];
+			if (typeof id !== "string") continue;
+			remove.run(id);
+			insert.run(id);
+		}
+	}
 	clearAuthoredSyncCursors(accountId?: string) {
 		if (accountId) {
 			this.db

--- a/src/lib/mentions-export.test.ts
+++ b/src/lib/mentions-export.test.ts
@@ -107,6 +107,7 @@ describe("mention export", () => {
 	});
 
 	it("serializes local mention items into xurl-compatible payloads", async () => {
+		const hashtag = { tag: "longform", start: 16, end: 25 };
 		listTimelineItemsMock.mockReturnValueOnce([
 			{
 				id: "tweet_live_1",
@@ -114,6 +115,10 @@ describe("mention export", () => {
 				accountHandle: "@steipete",
 				kind: "mentions",
 				text: "Hello @sam https://t.co/demo",
+				noteTweet: {
+					text: "Full Note Tweet #longform",
+					entities: { hashtags: [hashtag] },
+				},
 				createdAt: "2026-03-09T00:00:00.000Z",
 				isReplied: true,
 				likeCount: 7,
@@ -170,6 +175,10 @@ describe("mention export", () => {
 					id: "tweet_live_1",
 					author_id: "42",
 					text: "Hello @sam https://t.co/demo",
+					note_tweet: {
+						text: "Full Note Tweet #longform",
+						entities: { hashtags: [hashtag] },
+					},
 					created_at: "2026-03-09T00:00:00.000Z",
 					conversation_id: "tweet_live_1",
 					entities: {

--- a/src/lib/mentions-export.ts
+++ b/src/lib/mentions-export.ts
@@ -50,14 +50,20 @@ function toXurlEntities(entities: TimelineItem["entities"]) {
 		expanded_url: url.expandedUrl,
 		display_url: url.displayUrl,
 	}));
+	const hashtags = entities.hashtags?.map((hashtag) => ({
+		start: hashtag.start,
+		end: hashtag.end,
+		tag: hashtag.tag,
+	}));
 
-	if (!mentions?.length && !urls?.length) {
+	if (!mentions?.length && !urls?.length && !hashtags?.length) {
 		return undefined;
 	}
 
 	return {
 		...(mentions?.length ? { mentions } : {}),
 		...(urls?.length ? { urls } : {}),
+		...(hashtags?.length ? { hashtags } : {}),
 	};
 }
 

--- a/src/lib/mentions-export.ts
+++ b/src/lib/mentions-export.ts
@@ -1,6 +1,7 @@
 import { listTimelineItems } from "./timeline-read-model";
 import { renderTweetMarkdown, renderTweetPlainText } from "./tweet-render";
 import type {
+	NoteTweet,
 	ReplyFilter,
 	TimelineItem,
 	XurlMentionData,
@@ -17,6 +18,7 @@ export interface MentionExportItem {
 	isReplied: boolean;
 	author: TimelineItem["author"];
 	text: string;
+	noteTweet?: NoteTweet;
 	plainText: string;
 	markdown: string;
 	likeCount: number;
@@ -34,14 +36,14 @@ function toXurlUserId(profileId: string) {
 	return profileId;
 }
 
-function toXurlEntities(item: TimelineItem) {
-	const mentions = item.entities.mentions?.map((mention) => ({
+function toXurlEntities(entities: TimelineItem["entities"]) {
+	const mentions = entities.mentions?.map((mention) => ({
 		start: mention.start,
 		end: mention.end,
 		username: mention.profile?.handle ?? mention.username,
 		...(mention.id ? { id: toXurlUserId(mention.id) } : {}),
 	}));
-	const urls = item.entities.urls?.map((url) => ({
+	const urls = entities.urls?.map((url) => ({
 		start: url.start,
 		end: url.end,
 		url: url.url,
@@ -87,6 +89,7 @@ export function exportMentionItems({
 		isReplied: item.isReplied,
 		author: item.author,
 		text: item.text,
+		noteTweet: item.noteTweet,
 		plainText: renderTweetPlainText(item.text, item.entities),
 		markdown: renderTweetMarkdown(item.text, item.entities),
 		likeCount: item.likeCount,
@@ -123,9 +126,13 @@ export function serializeMentionItemsAsXurlCompatible(
 			id: item.id,
 			author_id: authorId,
 			text: item.text,
+			note_tweet: item.noteTweet && {
+				text: item.noteTweet.text,
+				entities: toXurlEntities(item.noteTweet.entities),
+			},
 			created_at: item.createdAt,
 			conversation_id: item.replyToTweet?.id ?? item.id,
-			entities: toXurlEntities(item),
+			entities: toXurlEntities(item.entities),
 			public_metrics: metrics,
 			edit_history_tweet_ids: [item.id],
 		};

--- a/src/lib/profile-analysis.ts
+++ b/src/lib/profile-analysis.ts
@@ -17,7 +17,6 @@ import {
 } from "./effect-runtime";
 import type { Database } from "./sqlite";
 import { inspectSyncCache, readSyncCache, writeSyncCache } from "./sync-cache";
-import { tweetEntitiesFromXurl } from "./tweet-render";
 import type {
 	ProfileRecord,
 	TweetEntities,
@@ -29,6 +28,7 @@ import { ingestTweetPayload } from "./tweet-repository";
 import { adaptUserTimelinePage, mergeTweetPages } from "./tweet-page";
 import type { TweetAccountEdgeKind } from "./tweet-account-edges";
 import { buildExternalProfileId, upsertProfileFromXUser } from "./x-profile";
+import { tweetContentFromXurl } from "./x-tweet-content";
 import { recordXurlRateLimitEventSafe } from "./xurl-rate-limits";
 import type { XurlJsonCommandAttempt } from "./xurl";
 import {
@@ -321,13 +321,14 @@ function compactProfileTweet(
 	tweet: XurlTweetData,
 	profileHandle: string,
 ): CompactProfileTweet {
+	const content = tweetContentFromXurl(tweet);
 	return {
 		id: tweet.id,
 		url: tweetUrl(profileHandle, tweet.id),
 		author: profileHandle,
 		createdAt: tweet.created_at,
-		text: tweet.text,
-		entities: tweetEntitiesFromXurl(tweet.entities),
+		text: content.text,
+		entities: content.entities,
 		...(tweet.conversation_id ? { conversationId: tweet.conversation_id } : {}),
 		...(tweet.referenced_tweets?.find((item) => item.type === "replied_to")?.id
 			? {
@@ -668,6 +669,7 @@ export function collectProfileAnalysisContextEffect(
 					"created_at",
 					"conversation_id",
 					"entities",
+					"note_tweet",
 					"public_metrics",
 					"referenced_tweets",
 					"in_reply_to_user_id",

--- a/src/lib/profile-replies.test.ts
+++ b/src/lib/profile-replies.test.ts
@@ -121,6 +121,7 @@ describe("profile reply inspection", () => {
 					{
 						id: "tweet_1",
 						text: "@sam one",
+						note_tweet: { text: "@sam complete long-form reply" },
 						created_at: "2026-03-09T00:00:00.000Z",
 						conversation_id: "conv_1",
 						referenced_tweets: [{ type: "replied_to", id: "root_1" }],
@@ -159,7 +160,7 @@ describe("profile reply inspection", () => {
 			items: [
 				{
 					id: "tweet_1",
-					text: "@sam one",
+					text: "@sam complete long-form reply",
 					createdAt: "2026-03-09T00:00:00.000Z",
 					conversationId: "conv_1",
 					replyToTweetId: "root_1",

--- a/src/lib/profile-replies.ts
+++ b/src/lib/profile-replies.ts
@@ -4,6 +4,7 @@ import { resolveOperationAccount } from "./account-selection";
 import { runEffectPromise } from "./effect-runtime";
 import { resolveProfileEffect } from "./moderation-target";
 import type { ProfileRepliesResponse, XurlReferencedTweet } from "./types";
+import { tweetContentFromXurl } from "./x-tweet-content";
 import { listUserTweetsEffect } from "./xurl";
 
 function getReplyTargetId(references?: XurlReferencedTweet[]) {
@@ -53,10 +54,11 @@ export function inspectProfileRepliesEffect(
 				if (!replyToTweetId) {
 					return null;
 				}
+				const content = tweetContentFromXurl(tweet);
 
 				return {
 					id: tweet.id,
-					text: tweet.text,
+					text: content.text,
 					createdAt: tweet.created_at,
 					conversationId: tweet.conversation_id,
 					replyToTweetId,

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -115,6 +115,7 @@ function insertTestTweet(
 		likeCount?: number;
 		mediaCount?: number;
 		entitiesJson?: string;
+		noteTweetJson?: string;
 		mediaJson?: string;
 		quotedTweetId?: string | null;
 	},
@@ -122,8 +123,9 @@ function insertTestTweet(
 	db.prepare(`
 		insert into tweets (
 			id, author_profile_id, text, created_at, is_replied, reply_to_id,
-			like_count, media_count, entities_json, media_json, quoted_tweet_id
-		) values (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)
+			like_count, media_count, entities_json, note_tweet_json, media_json,
+			quoted_tweet_id
+		) values (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
 	`).run(
 		options.id,
 		options.authorProfileId ?? "profile_me",
@@ -133,6 +135,7 @@ function insertTestTweet(
 		options.likeCount ?? 0,
 		options.mediaCount ?? 0,
 		options.entitiesJson ?? "{}",
+		options.noteTweetJson ?? null,
 		options.mediaJson ?? "[]",
 		options.quotedTweetId ?? null,
 	);
@@ -1598,6 +1601,69 @@ describe("query models", () => {
 		expect(quotedItem?.quotedTweet?.id).toBe("tweet_001");
 		expect(quotedItem?.quotedTweet?.text).toContain("local-first");
 		expect(quotedItem?.author.avatarUrl).toMatch(/^data:image\/svg\+xml/);
+	});
+
+	it("hydrates Note Tweets across timeline and conversation contexts", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const noteTweet = (text: string) => JSON.stringify({ text, entities: {} });
+
+		insertTestTweet(db, {
+			id: "note_parent",
+			text: "Full parent Note Tweet",
+			createdAt: "2026-03-10T09:00:00.000Z",
+			noteTweetJson: noteTweet("Full parent Note Tweet"),
+		});
+		insertTestTweet(db, {
+			id: "note_quote",
+			text: "Full quoted Note Tweet",
+			createdAt: "2026-03-10T09:01:00.000Z",
+			noteTweetJson: noteTweet("Full quoted Note Tweet"),
+		});
+		insertTestTweet(db, {
+			id: "note_primary",
+			text: "Full primary Note Tweet",
+			createdAt: "2026-03-10T09:02:00.000Z",
+			replyToId: "note_parent",
+			quotedTweetId: "note_quote",
+			noteTweetJson: noteTweet("Full primary Note Tweet"),
+		});
+		insertTestEdge(db, "note_primary", "2026-03-10T09:02:00.000Z");
+		insertTestTweet(db, {
+			id: "note_retweet",
+			text: "RT @steipete: Full quoted Note Tweet",
+			createdAt: "2026-03-10T09:03:00.000Z",
+		});
+		insertTestEdge(
+			db,
+			"note_retweet",
+			"2026-03-10T09:03:00.000Z",
+			"home",
+			'{"referenced_tweets":[{"type":"retweeted","id":"note_quote"}]}',
+		);
+
+		const items = listTimelineItems({ resource: "home", limit: 20 });
+		const primary = items.find((item) => item.id === "note_primary");
+		const retweet = items.find((item) => item.id === "note_retweet");
+		const conversation = getTweetConversation("note_primary");
+
+		expect(primary?.noteTweet).toEqual({
+			text: "Full primary Note Tweet",
+			entities: { urls: [] },
+		});
+		expect(primary?.replyToTweet?.noteTweet?.text).toBe(
+			"Full parent Note Tweet",
+		);
+		expect(primary?.quotedTweet?.noteTweet?.text).toBe(
+			"Full quoted Note Tweet",
+		);
+		expect(retweet?.retweetedTweet?.noteTweet?.text).toBe(
+			"Full quoted Note Tweet",
+		);
+		expect(
+			conversation?.items.find((item) => item.id === "note_primary")?.noteTweet
+				?.text,
+		).toBe("Full primary Note Tweet");
 	});
 
 	it("returns an archived tweet conversation from the root", () => {

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -7,6 +7,7 @@ import { listTimelineItems } from "./timeline-read-model";
 import { lookupTweetsByIdsEffect } from "./tweet-lookup";
 import { renderTweetMarkdown, renderTweetPlainText } from "./tweet-render";
 import type { TweetEntities, XurlMentionUser } from "./types";
+import { tweetContentFromXurl } from "./x-tweet-content";
 
 type ResearchNodeSource = "local" | "live";
 
@@ -312,7 +313,8 @@ function lookupTweetNodeEffect(
 		if (!tweet) {
 			return null;
 		}
-		const entities = normalizeTweetEntities(tweet.entities);
+		const content = tweetContentFromXurl(tweet);
+		const entities = content.entities;
 
 		const usersById = new Map(
 			(payload.includes?.users ?? []).map((user: XurlMentionUser) => [
@@ -332,9 +334,9 @@ function lookupTweetNodeEffect(
 			authorHandle: author.username,
 			authorName: author.name,
 			createdAt: tweet.created_at,
-			text: tweet.text,
-			plainText: renderTweetPlainText(tweet.text, entities),
-			markdown: renderTweetMarkdown(tweet.text, entities),
+			text: content.text,
+			plainText: renderTweetPlainText(content.text, entities),
+			markdown: renderTweetMarkdown(content.text, entities),
 			likeCount: Number(tweet.public_metrics?.like_count ?? 0),
 			bookmarked: false,
 			liked: false,

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -5,6 +5,7 @@ import type { Database } from "./sqlite";
 import { displayUrlForLink, enrichFallbackUrlEntities } from "./tweet-render";
 import type {
 	EmbeddedTweet,
+	NoteTweet,
 	ProfileRecord,
 	ReplyFilter,
 	TimelineItem,
@@ -164,6 +165,18 @@ type UrlExpansionCache = Map<
 	| null
 >;
 
+function buildNoteTweet(
+	row: Record<string, unknown>,
+	prefix: string,
+	entities: TweetEntities,
+): NoteTweet | undefined {
+	const noteTweet = parseJsonField<NoteTweet | undefined>(
+		row[`${prefix}note_tweet_json`],
+		undefined,
+	);
+	return noteTweet && { text: noteTweet.text, entities };
+}
+
 function getUrlExpansion(
 	db: Database,
 	cache: UrlExpansionCache,
@@ -252,9 +265,19 @@ function buildEmbeddedTweet(
 	});
 
 	const text = String(row[`${prefix}text`] ?? "");
+	const profiles = { [author.id]: author };
+	const entities = enrichTimelineEntities(
+		db,
+		urlExpansionCache,
+		text,
+		parseJsonField<TweetEntities>(row[`${prefix}entities_json`], {}),
+		profiles,
+		resolveProfileByHandle,
+	);
 	return {
 		id: String(row[`${prefix}id`]),
 		text,
+		noteTweet: buildNoteTweet(row, prefix, entities),
 		createdAt: String(row[`${prefix}created_at`] ?? new Date(0).toISOString()),
 		replyToId:
 			typeof row[`${prefix}reply_to_id`] === "string"
@@ -276,16 +299,7 @@ function buildEmbeddedTweet(
 			? {}
 			: { liked: Boolean(row[`${prefix}liked`]) }),
 		author,
-		entities: enrichTimelineEntities(
-			db,
-			urlExpansionCache,
-			text,
-			parseJsonField<TweetEntities>(row[`${prefix}entities_json`], {}),
-			{
-				[author.id]: author,
-			},
-			resolveProfileByHandle,
-		),
+		entities,
 		media: parseJsonField<TweetMediaItem[]>(row[`${prefix}media_json`], []),
 	};
 }
@@ -797,6 +811,7 @@ export function buildTimelineItemsQuery(
         e.kind,
         e.raw_json as edge_raw_json,
         t.text,
+		t.note_tweet_json,
         t.created_at,
         t.reply_to_id,
         t.is_replied,
@@ -838,6 +853,7 @@ export function buildTimelineItemsQuery(
         p.created_at as profile_created_at,
         rt.id as reply_id,
         rt.text as reply_text,
+		rt.note_tweet_json as reply_note_tweet_json,
         rt.created_at as reply_created_at,
         rt.reply_to_id as reply_reply_to_id,
         rt.entities_json as reply_entities_json,
@@ -853,6 +869,7 @@ export function buildTimelineItemsQuery(
         rp.created_at as reply_profile_created_at,
         qt.id as quoted_id,
         qt.text as quoted_text,
+		qt.note_tweet_json as quoted_note_tweet_json,
         qt.created_at as quoted_created_at,
         qt.reply_to_id as quoted_reply_to_id,
         qt.entities_json as quoted_entities_json,
@@ -1100,6 +1117,7 @@ export function listTimelineItems(
 			accountHandle: String(row.account_handle),
 			kind: row.kind as TimelineItem["kind"],
 			text,
+			noteTweet: buildNoteTweet(row, "", entities),
 			...(typeof row.search_snippet === "string"
 				? { searchSnippet: row.search_snippet }
 				: {}),
@@ -1200,6 +1218,7 @@ function conversationTweetSelect(
   select
     t.id,
     t.text,
+	t.note_tweet_json,
     t.created_at,
     t.reply_to_id,
     t.is_replied,

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -98,6 +98,21 @@ it("preserves Note Tweet content when a later payload omits it", () => {
 				{
 					id: "note-1",
 					author_id: "42",
+					text: "initial truncated preview",
+					created_at: "2026-07-01T09:00:00.000Z",
+				},
+			],
+			includes: { users },
+		},
+	});
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "note-1",
+					author_id: "42",
 					text: "truncated preview",
 					note_tweet: {
 						text: "full Note Tweet continuationneedle #longform",

--- a/src/lib/tweet-repository.test.ts
+++ b/src/lib/tweet-repository.test.ts
@@ -79,6 +79,79 @@ it("marks only primary replies as replied", () => {
 	]);
 });
 
+it("preserves Note Tweet content when a later payload omits it", () => {
+	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
+	process.env.BIRDCLAW_HOME = tempRoot;
+	resetBirdclawPathsForTests();
+	resetDatabaseForTests();
+	const db = getNativeDb({ seedDemoData: false });
+	const users = [{ id: "42", username: "sam", name: "Sam" }];
+	const noteEntities = {
+		hashtags: [{ tag: "longform", start: 32, end: 41 }],
+	};
+
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "note-1",
+					author_id: "42",
+					text: "truncated preview",
+					note_tweet: {
+						text: "full Note Tweet continuationneedle #longform",
+						entities: noteEntities,
+					},
+					created_at: "2026-07-01T09:00:00.000Z",
+				},
+			],
+			includes: { users },
+		},
+	});
+	ingestTweetPayload(db, {
+		accountId: "acct_primary",
+		source: "xurl",
+		payload: {
+			data: [
+				{
+					id: "note-1",
+					author_id: "42",
+					text: "later truncated preview",
+					entities: {
+						hashtags: [{ tag: "preview", start: 6, end: 14 }],
+					},
+					created_at: "2026-07-01T09:00:00.000Z",
+				},
+			],
+			includes: { users },
+		},
+	});
+
+	const row = db
+		.prepare(
+			"select text, entities_json, note_tweet_json from tweets where id = 'note-1'",
+		)
+		.get() as {
+		text: string;
+		entities_json: string;
+		note_tweet_json: string;
+	};
+	expect(row.text).toBe("full Note Tweet continuationneedle #longform");
+	expect(JSON.parse(row.entities_json)).toEqual(noteEntities);
+	expect(JSON.parse(row.note_tweet_json)).toEqual({
+		text: row.text,
+		entities: noteEntities,
+	});
+	expect(
+		db
+			.prepare(
+				"select count(*) as count from tweets_fts where tweets_fts match 'continuationneedle'",
+			)
+			.get(),
+	).toEqual({ count: 1 });
+});
+
 it("records observable edit chains without re-indexing a tombstoned tweet", () => {
 	tempRoot = mkdtempSync(path.join(os.tmpdir(), "birdclaw-test-"));
 	process.env.BIRDCLAW_HOME = tempRoot;

--- a/src/lib/tweet-repository.ts
+++ b/src/lib/tweet-repository.ts
@@ -12,6 +12,7 @@ import {
 	upsertTweetAccountEdge,
 } from "./tweet-account-edges";
 import { ensureStubProfileForXUser, upsertProfileFromXUser } from "./x-profile";
+import { tweetContentFromXurl } from "./x-tweet-content";
 
 export interface IngestTweetPayloadOptions {
 	accountId: string;
@@ -43,17 +44,27 @@ function toCanonicalTweets(payload: XurlMentionsResponse) {
 	return tweetsById.values();
 }
 
-export function replaceTweetFts(db: Database, tweetId: string, text: string) {
+function serializeNoteTweet(noteTweet: XurlMentionData["note_tweet"]) {
+	if (!noteTweet) return null;
+	return JSON.stringify({
+		text: noteTweet.text,
+		entities: tweetEntitiesFromXurl(noteTweet.entities),
+	});
+}
+
+function replaceTweetFts(db: Database, tweetId: string) {
 	db.prepare("delete from tweets_fts where tweet_id = ?").run(tweetId);
 	const row = db
-		.prepare("select deleted_at, superseded_at from tweets where id = ?")
-		.get(tweetId) as
-		| { deleted_at: string | null; superseded_at: string | null }
-		| undefined;
-	if (row?.deleted_at || row?.superseded_at) return;
+		.prepare("select text, deleted_at, superseded_at from tweets where id = ?")
+		.get(tweetId) as {
+		text: string;
+		deleted_at: string | null;
+		superseded_at: string | null;
+	};
+	if (row.deleted_at || row.superseded_at) return;
 	db.prepare("insert into tweets_fts (tweet_id, text) values (?, ?)").run(
 		tweetId,
-		text,
+		row.text,
 	);
 }
 
@@ -77,17 +88,25 @@ export function ingestTweetPayload(
 	const upsertTweet = db.prepare(`
     insert into tweets (
       id, author_profile_id, text, created_at, is_replied, reply_to_id,
-      like_count, media_count, entities_json, media_json, quoted_tweet_id
-    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      like_count, media_count, entities_json, note_tweet_json, media_json,
+      quoted_tweet_id
+    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     on conflict(id) do update set
       author_profile_id = excluded.author_profile_id,
-      text = excluded.text,
+      text = case
+        when excluded.note_tweet_json is null and tweets.note_tweet_json is not null then tweets.text
+        else excluded.text
+      end,
       created_at = excluded.created_at,
       is_replied = max(tweets.is_replied, excluded.is_replied),
       reply_to_id = coalesce(tweets.reply_to_id, excluded.reply_to_id),
       like_count = case when ? then tweets.like_count else excluded.like_count end,
       media_count = max(tweets.media_count, excluded.media_count),
-      entities_json = excluded.entities_json,
+      entities_json = case
+        when excluded.note_tweet_json is null and tweets.note_tweet_json is not null then tweets.entities_json
+        else excluded.entities_json
+      end,
+      note_tweet_json = coalesce(excluded.note_tweet_json, tweets.note_tweet_json),
       media_json = case
         when excluded.media_json not in ('', '[]', 'null') then excluded.media_json
         else tweets.media_json
@@ -130,19 +149,21 @@ export function ingestTweetPayload(
 			const replyToId = getReferencedTweetId(tweet, "replied_to");
 			const quotedTweetId = getReferencedTweetId(tweet, "quoted");
 			const media = buildTweetMedia(tweet, mediaByKey);
+			const content = tweetContentFromXurl(tweet);
 			// Included tweets are reference data, not members of the caller's result set.
 			const shouldMarkReplied =
 				isPrimaryTweet && markRepliesAsReplied && Boolean(replyToId);
 			upsertTweet.run(
 				tweet.id,
 				profile.profile.id,
-				tweet.text,
+				content.text,
 				tweet.created_at,
 				shouldMarkReplied ? 1 : 0,
 				replyToId,
 				Number(tweet.public_metrics?.like_count ?? 0),
 				media.count,
-				JSON.stringify(tweetEntitiesFromXurl(tweet.entities)),
+				JSON.stringify(content.entities),
+				serializeNoteTweet(tweet.note_tweet),
 				media.json,
 				quotedTweetId,
 				!isPrimaryTweet && tweet.public_metrics?.like_count === undefined
@@ -183,7 +204,7 @@ export function ingestTweetPayload(
 					observedAt,
 				);
 			}
-			replaceTweetFts(db, tweet.id, tweet.text);
+			replaceTweetFts(db, tweet.id);
 			if (isPrimaryTweet) {
 				tweetIds.push(tweet.id);
 			}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -116,6 +116,11 @@ export interface TweetEntities {
 	article?: TweetArticle;
 }
 
+export interface NoteTweet {
+	text: string;
+	entities: TweetEntities;
+}
+
 export interface TweetMediaItem {
 	url: string;
 	type: "image" | "video" | "gif" | "unknown";
@@ -134,6 +139,7 @@ export interface TweetMediaItem {
 export interface EmbeddedTweet {
 	id: string;
 	text: string;
+	noteTweet?: NoteTweet;
 	createdAt: string;
 	replyToId?: string | null;
 	isReplied?: boolean;
@@ -172,6 +178,7 @@ export interface TimelineItem {
 	accountHandle: string;
 	kind: "home" | "mention" | "authored" | "search" | "like" | "bookmark";
 	text: string;
+	noteTweet?: NoteTweet;
 	searchSnippet?: string;
 	createdAt: string;
 	replyToId?: string | null;
@@ -490,6 +497,7 @@ export interface XurlMentionData {
 	id: string;
 	author_id: string;
 	text: string;
+	note_tweet?: XurlNoteTweet;
 	created_at: string;
 	conversation_id?: string;
 	in_reply_to_user_id?: string;
@@ -509,6 +517,7 @@ export interface XurlUserTweet {
 	id: string;
 	author_id?: string;
 	text: string;
+	note_tweet?: XurlNoteTweet;
 	created_at: string;
 	conversation_id?: string;
 	attachments?: XurlTweetAttachments;
@@ -522,6 +531,7 @@ export interface XurlTweetData {
 	id: string;
 	author_id: string;
 	text: string;
+	note_tweet?: XurlNoteTweet;
 	created_at: string;
 	conversation_id?: string;
 	in_reply_to_user_id?: string;
@@ -530,6 +540,11 @@ export interface XurlTweetData {
 	referenced_tweets?: XurlReferencedTweet[];
 	public_metrics?: XurlPublicMetrics;
 	edit_history_tweet_ids?: string[];
+}
+
+export interface XurlNoteTweet {
+	text: string;
+	entities?: Record<string, unknown>;
 }
 
 export interface XurlTweetAttachments {

--- a/src/lib/x-lists.test.ts
+++ b/src/lib/x-lists.test.ts
@@ -322,7 +322,7 @@ describe("X List sync and local filtering", () => {
 		tempRoots.push(backupRoot);
 		const exported = await exportBackup({ repoPath: backupRoot });
 		expect(exported.manifest).toMatchObject({
-			schemaVersion: 8,
+			schemaVersion: 9,
 			counts: { x_lists: 1, x_list_members: 1 },
 		});
 

--- a/src/lib/x-tweet-content.ts
+++ b/src/lib/x-tweet-content.ts
@@ -1,0 +1,12 @@
+import { tweetEntitiesFromXurl } from "./tweet-render";
+import type { XurlUserTweet } from "./types";
+
+type XurlTweetContent = Pick<XurlUserTweet, "text" | "entities" | "note_tweet">;
+
+export function tweetContentFromXurl(tweet: XurlTweetContent) {
+	const content = tweet.note_tweet ?? tweet;
+	return {
+		text: content.text,
+		entities: tweetEntitiesFromXurl(content.entities),
+	};
+}

--- a/src/lib/xurl.test.ts
+++ b/src/lib/xurl.test.ts
@@ -23,7 +23,7 @@ const MEDIA_EXPANSION = "attachments.media_keys";
 const MEDIA_FIELDS =
 	"variants%2Cpreview_image_url%2Curl%2Cduration_ms%2Calt_text%2Ctype%2Cwidth%2Cheight%2Cpublic_metrics";
 const THREAD_TWEET_FIELDS =
-	"created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets%2Cin_reply_to_user_id%2Cattachments";
+	"created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets%2Cin_reply_to_user_id%2Cattachments";
 const PHOTO_MEDIA = {
 	media_key: "photo_1",
 	type: "photo",
@@ -315,7 +315,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"steipete",
-			`/2/users/25401953/mentions?max_results=5&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/mentions?max_results=5&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -344,7 +344,7 @@ describe("xurl transport", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/mentions?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=next-page`,
+			`/2/users/25401953/mentions?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=next-page`,
 		]);
 	});
 
@@ -373,7 +373,7 @@ describe("xurl transport", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=cursor`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=cursor`,
 		]);
 	});
 
@@ -402,7 +402,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"steipete",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -448,7 +448,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"openclaw-steipete",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -510,7 +510,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"steipete",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -548,7 +548,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"steipete",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, "xurl", [
 			"--app",
@@ -566,7 +566,7 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"openclaw-steipete",
-			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/timelines/reverse_chronological?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -658,7 +658,7 @@ describe("xurl transport", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/42/tweets?max_results=5&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&exclude=retweets`,
+			`/2/users/42/tweets?max_results=5&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&exclude=retweets`,
 		]);
 	});
 
@@ -683,7 +683,7 @@ describe("xurl transport", () => {
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/mentions?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&start_time=2026-03-01T00%3A00%3A00Z`,
+			`/2/users/25401953/mentions?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&start_time=2026-03-01T00%3A00%3A00Z`,
 		]);
 	});
 
@@ -916,7 +916,7 @@ describe("xurl transport", () => {
 			nextToken: "next",
 		});
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
-			`/2/users/42/tweets?max_results=12&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&exclude=retweets`,
+			`/2/users/42/tweets?max_results=12&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&exclude=retweets`,
 		]);
 	});
 
@@ -957,7 +957,7 @@ describe("xurl transport", () => {
 			meta: { result_count: 1 },
 		});
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
-			`/2/tweets?ids=tweet_1&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/tweets?ids=tweet_1&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -1269,12 +1269,12 @@ describe("xurl transport", () => {
 			"oauth2",
 			"--username",
 			"steipete",
-			`/2/users/25401953/liked_tweets?max_results=5&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/liked_tweets?max_results=5&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/bookmarks?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=next`,
+			`/2/users/25401953/bookmarks?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}&pagination_token=next`,
 		]);
 	});
 
@@ -1318,17 +1318,17 @@ describe("xurl transport", () => {
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, "xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/bookmarks?max_results=90&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/bookmarks?max_results=90&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, "xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/bookmarks?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/bookmarks?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 		expect(execFileAsyncMock).toHaveBeenNthCalledWith(3, "xurl", [
 			"--auth",
 			"oauth2",
-			`/2/users/25401953/liked_tweets?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
+			`/2/users/25401953/liked_tweets?max_results=100&expansions=${AUTHOR_MEDIA_EXPANSIONS}&tweet.fields=created_at%2Cconversation_id%2Centities%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&user.fields=${RICH_USER_FIELDS}`,
 		]);
 	});
 
@@ -1511,7 +1511,7 @@ describe("xurl transport", () => {
 			nextToken: null,
 		});
 		expect(execFileAsyncMock).toHaveBeenCalledWith("xurl", [
-			`/2/users/42/tweets?max_results=50&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&pagination_token=next-page`,
+			`/2/users/42/tweets?max_results=50&expansions=${MEDIA_EXPANSION}&tweet.fields=created_at%2Cconversation_id%2Cnote_tweet%2Cpublic_metrics%2Creferenced_tweets&media.fields=${MEDIA_FIELDS}&pagination_token=next-page`,
 		]);
 	});
 

--- a/src/lib/xurl.ts
+++ b/src/lib/xurl.ts
@@ -26,7 +26,7 @@ const RICH_USER_FIELDS =
 const DM_EVENT_FIELDS =
 	"attachments,created_at,dm_conversation_id,entities,event_type,id,participant_ids,referenced_tweets,sender_id,text";
 const THREAD_TWEET_FIELDS =
-	"created_at,conversation_id,entities,public_metrics,referenced_tweets,in_reply_to_user_id,attachments";
+	"created_at,conversation_id,entities,note_tweet,public_metrics,referenced_tweets,in_reply_to_user_id,attachments";
 // X bookmarks pagination truncates above 90 until this bug is fixed:
 // https://devcommunity.x.com/t/bookmarks-api-v2-stops-paginating-after-3-pages-no-next-token-returned/257339
 const BOOKMARKS_MAX_RESULTS_CAP = 90;
@@ -946,7 +946,8 @@ export const listMentionsViaXurlEffect = Effect.fn("xurl.listMentions")(
 		const query = new URLSearchParams({
 			max_results: String(maxResults),
 			expansions: AUTHOR_MEDIA_EXPANSIONS,
-			"tweet.fields": "created_at,conversation_id,entities,public_metrics",
+			"tweet.fields":
+				"created_at,conversation_id,entities,note_tweet,public_metrics",
 			"media.fields": MEDIA_FIELDS,
 			"user.fields":
 				"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
@@ -988,7 +989,7 @@ export const listHomeTimelineViaXurlEffect = Effect.fn("xurl.listHomeTimeline")(
 			max_results: String(maxResults),
 			expansions: AUTHOR_MEDIA_EXPANSIONS,
 			"tweet.fields":
-				"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+				"created_at,conversation_id,entities,note_tweet,public_metrics,referenced_tweets",
 			"media.fields": MEDIA_FIELDS,
 			"user.fields": RICH_USER_FIELDS,
 		});
@@ -1052,7 +1053,7 @@ const listTimelineCollectionViaXurlEffect = Effect.fn(
 		max_results: String(requestMaxResults),
 		expansions: AUTHOR_MEDIA_EXPANSIONS,
 		"tweet.fields":
-			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+			"created_at,conversation_id,entities,note_tweet,public_metrics,referenced_tweets",
 		"media.fields": MEDIA_FIELDS,
 		"user.fields":
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",
@@ -1247,7 +1248,7 @@ export const listUserTweetsEffect = Effect.fn("xurl.listUserTweets")((
 		expansions: MEDIA_EXPANSION,
 		"tweet.fields":
 			tweetFields?.join(",") ??
-			"created_at,conversation_id,public_metrics,referenced_tweets",
+			"created_at,conversation_id,note_tweet,public_metrics,referenced_tweets",
 		"media.fields": MEDIA_FIELDS,
 	});
 	if (expansions && expansions.length > 0) {
@@ -1335,7 +1336,7 @@ export const lookupTweetsByIdsEffect = Effect.fn("xurl.lookupTweetsByIds")((
 		ids: ids.join(","),
 		expansions: AUTHOR_MEDIA_EXPANSIONS,
 		"tweet.fields":
-			"created_at,conversation_id,entities,public_metrics,referenced_tweets",
+			"created_at,conversation_id,entities,note_tweet,public_metrics,referenced_tweets",
 		"media.fields": MEDIA_FIELDS,
 		"user.fields":
 			"description,entities,location,public_metrics,profile_image_url,url,created_at,verified,verified_type",


### PR DESCRIPTION
Xurl's top-level text is only a preview for Note Tweets. Preserve the complete body and matching entities through ingestion, search, archive/backup merges, profile analysis, research, replies, quotes, retweets, and expandable timeline rendering.

A shared content selector reads `note_tweet`; a nullable local marker prevents later preview-only payloads from overwriting the canonical full body. Search indexes rebuild from the final stored text in batches, retaining the recent indexing improvements on main. Read-only rendering and account scoping remain intact.

**Compatibility:** backup output remains schema 8. Full text/entities use the existing fields, and an optional `note_tweet_json` field carries the richer marker. The pre-change main CLI successfully validated and imported new output, then re-exported text/entities that the updated CLI imported again. Older writers omit the optional marker, so they lack the new protection against preview-only refreshes and expandable Note Tweet presentation. SQLite migration 11 adds the local column; prepare existing read-only snapshots with writable initialization before serving the updated application.

Built-CLI proof used fresh synthetic homes and a fake xurl executable that returned one page, then HTTP 402 on page two:

| Result | Before | After |
| --- | ---: | ---: |
| Stored Note Tweet characters | 57 | 572 |
| Search matches for text beyond the preview | 0 | 1 |
| Successful-search cache entries after failure | 0 | 0 |
| Full body retained after later preview payload | — | yes |

```console
birdclaw discuss synthetic --mode xurl --limit 100 --max-pages 2 --refresh --json
# Both versions return exit 1 and retain page one; the updated version keeps full Note content.
birdclaw backup export --repo <synthetic-backup>
# schemaVersion: 8
# Pre-change CLI: validate/import succeeds; full text and entities survive its re-export.
```

Live Chrome proof through the shared relay confirmed the updated card starts collapsed, then “Show more” reveals the complete body and final marker. The attached before/after captures contain only seeded synthetic data. No paid X or OpenAI requests were made.

Validation: format/lint/typecheck, targeted ingestion/read-model/archive/backup/renderer tests, migration and batched-index regressions, production build, full suite (1,699 tests), and isolated Codex P0–P2 review all passed. The subsequent integration with #200 passed 96 focused tests and its own clean P2 review; the final built CLI repeated the same live result. [Exact-head CI passed](https://github.com/steipete/birdclaw/actions/runs/34724333943).

Credit: Emanuel Ferm (@eferm) supplied the Note Tweet ingestion, retention, propagation, and rendering contribution. Maintainer repair rebases it onto current main, keeps schema-8 interoperability, corrects migration guidance, and preserves batch indexing.

![Before: synthetic Note Tweet is truncated to the compatibility preview](https://github.com/user-attachments/assets/104f8a9e-aafc-4c7a-a27f-4386ec750ca2)

![After: Show more reveals the complete retained Note Tweet](https://github.com/user-attachments/assets/eb1be19a-1a2d-4c85-a50a-9b4e92b454db)
