### PR TITLE
Validate --interval-seconds before writing the launch agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Reject invalid account and bookmark LaunchAgent intervals before writing a plist while preserving existing numeric spellings. (#137 — thanks @devYRPauli)
 - Reject non-finite DM follower filters and inbox scores before reading or scoring, and validate inbox limits while preserving existing numeric spellings and fractional thresholds. (#133 — thanks @devYRPauli)
 - Reject invalid local tweet-search, DM-search, and `whois` limits before reading the archive while preserving zero, legacy numeric spellings, and link-search coercion. (#132 — thanks @devYRPauli)
 - Register `archive find` and `db stats` as strict nested CLI commands, reject unknown subcommands, and return a structured HTTP 400 for invalid `/api/query` resources.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -385,6 +385,7 @@ tail -n 20 ~/.birdclaw/audit/account-sync.jsonl | jq .
 
 - writes `~/Library/LaunchAgents/com.steipete.birdclaw.account-sync.plist`
 - runs `jobs sync-account` every 30 minutes by default
+- `--interval-seconds <seconds>` requires a positive safe integer; invalid values exit nonzero before writing a plist
 - uses `launchctl load -w` unless `--no-load` is passed
 - `--steps <steps>` narrows the scheduled surfaces
 - `--env-path <path>` sources account-specific `bird` cookies for launchd
@@ -420,6 +421,7 @@ tail -n 20 ~/.birdclaw/audit/bookmarks-sync.jsonl | jq .
 
 - writes `~/Library/LaunchAgents/com.steipete.birdclaw.bookmarks-sync.plist`
 - runs `jobs sync-bookmarks` every 3 hours by default
+- `--interval-seconds <seconds>` requires a positive safe integer; invalid values exit nonzero before writing a plist
 - uses `launchctl load -w` unless `--no-load` is passed
 - writes launchd stdout/stderr to `~/.birdclaw/logs/bookmarks-sync.*.log`
 - `--env-path <path>` sources an export-only shell env file inside the scheduled process, useful when `bird` needs `AUTH_TOKEN`/`CT0` outside an interactive browser session

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -7,6 +7,8 @@ description: "Scheduler-friendly bookmark sync with launchd integration, audit l
 
 `birdclaw jobs` is the scheduler-friendly subset of sync: short defaults, JSONL audit logs, lock files to prevent overlap, and launchd installers for macOS.
 
+Both LaunchAgent installers accept `--interval-seconds <seconds>` as a positive safe integer. Zero, negative, fractional, non-numeric, and unsafe values exit nonzero before writing a plist. Existing numeric spellings such as `1e3` (1,000 seconds) and `0x10` (16 seconds) remain accepted.
+
 ## `jobs sync-account`
 
 ```bash

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -72,6 +72,8 @@ const removeBlockMock = vi.fn();
 const removeMuteMock = vi.fn();
 const maybeAutoUpdateBackupMock = vi.fn();
 const maybeAutoSyncBackupMock = vi.fn();
+const installAccountSyncLaunchAgentMock = vi.fn();
+const installBookmarkSyncLaunchAgentMock = vi.fn();
 const exportBackupMock = vi.fn();
 const importBackupMock = vi.fn();
 const syncBackupMock = vi.fn();
@@ -186,6 +188,24 @@ vi.mock("#/lib/backup", async (importOriginal) => {
 		maybeAutoSyncBackup: () => maybeAutoSyncBackupMock(),
 		syncBackup: (...args: unknown[]) => syncBackupMock(...args),
 		validateBackup: (...args: unknown[]) => validateBackupMock(...args),
+	};
+});
+
+vi.mock("#/lib/account-sync-job", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("#/lib/account-sync-job")>();
+	return {
+		...actual,
+		installAccountSyncLaunchAgent: (...args: unknown[]) =>
+			installAccountSyncLaunchAgentMock(...args),
+	};
+});
+
+vi.mock("#/lib/bookmark-sync-job", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("#/lib/bookmark-sync-job")>();
+	return {
+		...actual,
+		installBookmarkSyncLaunchAgent: (...args: unknown[]) =>
+			installBookmarkSyncLaunchAgentMock(...args),
 	};
 });
 
@@ -429,6 +449,8 @@ describe("cli", () => {
 		removeMuteMock.mockReset();
 		maybeAutoUpdateBackupMock.mockReset();
 		maybeAutoSyncBackupMock.mockReset();
+		installAccountSyncLaunchAgentMock.mockReset();
+		installBookmarkSyncLaunchAgentMock.mockReset();
 		exportBackupMock.mockReset();
 		importBackupMock.mockReset();
 		syncBackupMock.mockReset();
@@ -767,6 +789,75 @@ describe("cli", () => {
 			).rejects.toMatchObject({ code: "commander.unknownCommand" });
 		}
 	});
+
+	it.each([
+		[
+			"account",
+			["jobs", "install-account-launchd"],
+			installAccountSyncLaunchAgentMock,
+		],
+		[
+			"bookmark",
+			["jobs", "install-bookmarks-launchd"],
+			installBookmarkSyncLaunchAgentMock,
+		],
+	])(
+		"rejects an invalid %s sync interval before installing a plist",
+		async (_name, args, installerMock) => {
+			const consoleErrorMock = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const { runCli } = await loadCli();
+
+			await runCli([
+				"node",
+				"birdclaw",
+				...args,
+				"--interval-seconds",
+				"abc",
+			]);
+
+			expect(consoleErrorMock).toHaveBeenCalledWith(
+				JSON.stringify({
+					error: "--interval-seconds must be a non-negative integer",
+				}),
+			);
+			expect(process.exitCode).toBe(1);
+			expect(installerMock).not.toHaveBeenCalled();
+			consoleErrorMock.mockRestore();
+		},
+	);
+
+	it.each([
+		[
+			"account",
+			["jobs", "install-account-launchd"],
+			installAccountSyncLaunchAgentMock,
+		],
+		[
+			"bookmark",
+			["jobs", "install-bookmarks-launchd"],
+			installBookmarkSyncLaunchAgentMock,
+		],
+	])(
+		"passes a valid %s sync interval to the installer",
+		async (_name, args, installerMock) => {
+			const { runCli } = await loadCli();
+
+			await runCli([
+				"node",
+				"birdclaw",
+				...args,
+				"--interval-seconds",
+				"7200",
+			]);
+
+			expect(process.exitCode).toBe(0);
+			expect(installerMock).toHaveBeenCalledWith(
+				expect.objectContaining({ intervalSeconds: 7200 }),
+			);
+		},
+	);
 
 	it("exits nonzero when account sync backup returns a failure", async () => {
 		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-cli-job-"));

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -192,7 +192,8 @@ vi.mock("#/lib/backup", async (importOriginal) => {
 });
 
 vi.mock("#/lib/account-sync-job", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("#/lib/account-sync-job")>();
+	const actual =
+		await importOriginal<typeof import("#/lib/account-sync-job")>();
 	return {
 		...actual,
 		installAccountSyncLaunchAgent: (...args: unknown[]) =>
@@ -201,7 +202,8 @@ vi.mock("#/lib/account-sync-job", async (importOriginal) => {
 });
 
 vi.mock("#/lib/bookmark-sync-job", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("#/lib/bookmark-sync-job")>();
+	const actual =
+		await importOriginal<typeof import("#/lib/bookmark-sync-job")>();
 	return {
 		...actual,
 		installBookmarkSyncLaunchAgent: (...args: unknown[]) =>
@@ -809,13 +811,7 @@ describe("cli", () => {
 				.mockImplementation(() => {});
 			const { runCli } = await loadCli();
 
-			await runCli([
-				"node",
-				"birdclaw",
-				...args,
-				"--interval-seconds",
-				"abc",
-			]);
+			await runCli(["node", "birdclaw", ...args, "--interval-seconds", "abc"]);
 
 			expect(consoleErrorMock).toHaveBeenCalledWith(
 				JSON.stringify({
@@ -844,13 +840,7 @@ describe("cli", () => {
 		async (_name, args, installerMock) => {
 			const { runCli } = await loadCli();
 
-			await runCli([
-				"node",
-				"birdclaw",
-				...args,
-				"--interval-seconds",
-				"7200",
-			]);
+			await runCli(["node", "birdclaw", ...args, "--interval-seconds", "7200"]);
 
 			expect(process.exitCode).toBe(0);
 			expect(installerMock).toHaveBeenCalledWith(

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -849,6 +849,31 @@ describe("cli", () => {
 		},
 	);
 
+	it.each([
+		[
+			"account",
+			["jobs", "install-account-launchd"],
+			installAccountSyncLaunchAgentMock,
+		],
+		[
+			"bookmark",
+			["jobs", "install-bookmarks-launchd"],
+			installBookmarkSyncLaunchAgentMock,
+		],
+	])(
+		"keeps Number-compatible %s sync interval spellings",
+		async (_name, args, installerMock) => {
+			const { runCli } = await loadCli();
+
+			await runCli(["node", "birdclaw", ...args, "--interval-seconds", "1e3"]);
+
+			expect(process.exitCode).toBe(0);
+			expect(installerMock).toHaveBeenCalledWith(
+				expect.objectContaining({ intervalSeconds: 1000 }),
+			);
+		},
+	);
+
 	it("exits nonzero when account sync backup returns a failure", async () => {
 		const tempDir = mkdtempSync(path.join(os.tmpdir(), "birdclaw-cli-job-"));
 		try {

--- a/src/cli/command-context.ts
+++ b/src/cli/command-context.ts
@@ -24,6 +24,10 @@ export interface CliCommandContext {
 		value: string | undefined,
 		option: string,
 	) => number | undefined;
+	parsePositiveLimitOption: (
+		value: string | undefined,
+		option: string,
+	) => number | undefined;
 	parsePositiveIntegerOption: (
 		value: string | undefined,
 		option: string,
@@ -148,6 +152,22 @@ export function parseLimitOption(value: string | undefined, option: string) {
 	return parsed;
 }
 
+export function parsePositiveLimitOption(
+	value: string | undefined,
+	option: string,
+) {
+	// Mirrors parsePositiveIntegerOption but keeps the Number() grammar that
+	// parseLimitOption preserves, so spellings such as 1e3 and 0x10 still work.
+	const parsed = parseLimitOption(value, option);
+	if (parsed === undefined) return undefined;
+	if (parsed < 1) {
+		printError(`${option} must be at least 1`);
+		process.exitCode = 1;
+		return undefined;
+	}
+	return parsed;
+}
+
 export function parsePositiveIntegerOption(
 	value: string | undefined,
 	option: string,
@@ -194,6 +214,7 @@ export function createCommandContext(program: Command): CliCommandContext {
 		parseNonNegativeIntegerOption,
 		parseFiniteNumberOption,
 		parseLimitOption,
+		parsePositiveLimitOption,
 		parsePositiveIntegerOption,
 	};
 }

--- a/src/cli/register-jobs.ts
+++ b/src/cli/register-jobs.ts
@@ -14,7 +14,11 @@ function collectRuntimeArg(value: string, previous: string[]) {
 	return [...previous, value];
 }
 
-export function registerJobCommands({ program, print }: CliCommandContext) {
+export function registerJobCommands({
+	program,
+	print,
+	parsePositiveIntegerOption,
+}: CliCommandContext) {
 	const jobsCommand = program
 		.command("jobs")
 		.description("Run and install background Birdclaw jobs");
@@ -94,9 +98,14 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 		.option("--launch-agents-dir <path>", "LaunchAgents directory")
 		.option("--no-load", "Write plist without loading it")
 		.action(async (options) => {
+			const intervalSeconds = parsePositiveIntegerOption(
+				options.intervalSeconds,
+				"--interval-seconds",
+			);
+			if (intervalSeconds === undefined) return;
 			const result = await installAccountSyncLaunchAgent({
 				label: options.label,
-				intervalSeconds: Number(options.intervalSeconds),
+				intervalSeconds,
 				program: options.program,
 				runtime: options.runtime,
 				runtimeArgs: options.runtimeArg,
@@ -176,10 +185,15 @@ export function registerJobCommands({ program, print }: CliCommandContext) {
 		.option("--launch-agents-dir <path>", "LaunchAgents directory")
 		.option("--no-load", "Write plist without loading it")
 		.action(async (options) => {
+			const intervalSeconds = parsePositiveIntegerOption(
+				options.intervalSeconds,
+				"--interval-seconds",
+			);
+			if (intervalSeconds === undefined) return;
 			const result = await installBookmarkSyncLaunchAgent({
 				account: options.account,
 				label: options.label,
-				intervalSeconds: Number(options.intervalSeconds),
+				intervalSeconds,
 				program: options.program,
 				runtime: options.runtime,
 				runtimeArgs: options.runtimeArg,

--- a/src/cli/register-jobs.ts
+++ b/src/cli/register-jobs.ts
@@ -17,7 +17,7 @@ function collectRuntimeArg(value: string, previous: string[]) {
 export function registerJobCommands({
 	program,
 	print,
-	parsePositiveIntegerOption,
+	parsePositiveLimitOption,
 }: CliCommandContext) {
 	const jobsCommand = program
 		.command("jobs")
@@ -98,7 +98,7 @@ export function registerJobCommands({
 		.option("--launch-agents-dir <path>", "LaunchAgents directory")
 		.option("--no-load", "Write plist without loading it")
 		.action(async (options) => {
-			const intervalSeconds = parsePositiveIntegerOption(
+			const intervalSeconds = parsePositiveLimitOption(
 				options.intervalSeconds,
 				"--interval-seconds",
 			);
@@ -185,7 +185,7 @@ export function registerJobCommands({
 		.option("--launch-agents-dir <path>", "LaunchAgents directory")
 		.option("--no-load", "Write plist without loading it")
 		.action(async (options) => {
-			const intervalSeconds = parsePositiveIntegerOption(
+			const intervalSeconds = parsePositiveLimitOption(
 				options.intervalSeconds,
 				"--interval-seconds",
 			);


### PR DESCRIPTION
Follow-up to #133, which added the numeric option helpers this uses.

## Problem

`jobs account-sync install` and `jobs bookmark-sync install` both take `--interval-seconds` and pass it through unchecked:

```ts
intervalSeconds: Number(options.intervalSeconds),
```

The library default cannot catch a bad value. `src/lib/account-sync-job.ts:475` and `src/lib/bookmark-sync-job.ts:298` use:

```ts
options.intervalSeconds ?? DEFAULT_ACCOUNT_SYNC_INTERVAL_SECONDS
```

`??` replaces only `null` and `undefined`. `NaN` is neither, so it passes through to `src/lib/launchd.ts:141`:

```ts
<integer>${String(intervalSeconds)}</integer>
```

`birdclaw jobs account-sync install --interval-seconds abc` therefore writes `<integer>NaN</integer>`. macOS rejects that plist:

```
$ plutil -lint nan.plist
nan.plist: (Unknown character 'N' (0x4e) in <integer> on line 8)
```

The command reports success and the agent is written, but it never runs on a schedule.

## Change

Both actions now parse the option first with `parsePositiveIntegerOption`, the helper added in #133, and return before any install work when it is invalid. An interval must be at least 1, which matches what `StartInterval` accepts.

`src/lib/launchd.ts`, `account-sync-job.ts` and `bookmark-sync-job.ts` are unchanged. The validation sits at the CLI boundary, the same place as #132 and #133. No flag name, default value or help text changes.

## Tests

Two tests in `src/cli.test.ts`, one per command. Each asserts that an invalid interval exits 1 and that no plist is installed, and that a valid interval still reaches the installer with the right number.

```
node ./node_modules/vitest/vitest.mjs run src/cli.test.ts
Tests  95 passed (95)

npx tsc --noEmit
exit 0
```

Reverting only the source change and keeping the tests fails exactly the two new ones:

```
* rejects an invalid account sync interval before installing a plist
* rejects an invalid bookmark sync interval before installing a plist
Tests  2 failed | 93 passed (95)
```


## Real behavior proof

Built the CLI with `npm run build:node` and ran the real binary against a temporary LaunchAgents directory, so nothing touches the real one.

Before, on `main`'s handler:

```
$ node bin/birdclaw.mjs jobs install-account-launchd \
    --interval-seconds abc --launch-agents-dir /tmp/bcla2 --no-load
  "ok": true,

$ grep -A1 StartInterval /tmp/bcla2/com.steipete.birdclaw.account-sync.plist
  <key>StartInterval</key>
  <integer>NaN</integer>

$ plutil -lint /tmp/bcla2/com.steipete.birdclaw.account-sync.plist
  (Unknown character 'N' (0x4e) in <integer> on line 27)
```

The command reports success and writes a plist that macOS cannot parse.

After, on this branch:

```
$ node bin/birdclaw.mjs jobs install-account-launchd \
    --interval-seconds abc --launch-agents-dir /tmp/bcla --no-load
{"error":"--interval-seconds must be a non-negative integer"}

$ ls /tmp/bcla | wc -l
0
```

No plist is written. A valid value is unaffected:

```
$ node bin/birdclaw.mjs jobs install-account-launchd \
    --interval-seconds 1800 --launch-agents-dir /tmp/bcla --no-load
  "ok": true,
$ grep -A1 StartInterval /tmp/bcla/com.steipete.birdclaw.account-sync.plist
  <key>StartInterval</key>
  <integer>1800</integer>
```

`install-bookmarks-launchd` takes the same option through the same helper.
