### PR TITLE
fix(search): retain successful pages after live search failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Preserve completed Xurl search pages when a later request fails, keeping fetched tweets locally searchable without treating an interrupted discussion as complete. (#138 — thanks @sid-ravikumar)
+
 - Reject invalid account and bookmark LaunchAgent intervals before writing a plist while preserving existing numeric spellings. (#137 — thanks @devYRPauli)
 - Reject non-finite DM follower filters and inbox scores before reading or scoring, and validate inbox limits while preserving existing numeric spellings and fractional thresholds. (#133 — thanks @devYRPauli)
 - Reject invalid local tweet-search, DM-search, and `whois` limits before reading the archive while preserving zero, legacy numeric spellings, and link-search coercion. (#132 — thanks @devYRPauli)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -492,6 +492,11 @@ Fetch live keyword matches through `bird` or `xurl`, store them as local
 `search` tweets, then stream an OpenAI Markdown summary and discussion. DMs stay
 out unless explicitly requested.
 
+Xurl search stores each successful page before requesting the next. If a later
+request fails, earlier pages remain locally searchable, but the command still
+fails without caching a complete search or producing a partial AI summary.
+Use `--limit` and `--max-pages` to bound paid API reads; neither is a dollar budget.
+
 Flags:
 
 - `--account <account-id>`

--- a/src/lib/tweet-search-live.test.ts
+++ b/src/lib/tweet-search-live.test.ts
@@ -214,6 +214,57 @@ describe("live tweet search sync", () => {
 		).toEqual({ count: 2 });
 	});
 
+	it("retains each xurl page before a later failure without caching an incomplete search", async () => {
+		const db = getNativeDb();
+		mocks.searchRecentTweets
+			.mockResolvedValueOnce(payload(["retained"], "next"))
+			.mockImplementationOnce(() => {
+				expect(
+					db.prepare("select text from tweets where id = ?").get("retained"),
+				).toEqual({ text: "Search result retained about local-first systems" });
+				throw new Error("402 credits depleted");
+			});
+		const { syncTweetSearch } = await import("./tweet-search-live");
+		const options = {
+			query: "retained",
+			mode: "xurl" as const,
+			limit: 150,
+			maxPages: 2,
+		};
+		const result = await syncTweetSearch(options);
+		expect(result).toMatchObject({ ok: false, error: "402 credits depleted" });
+		expect(
+			db
+				.prepare(
+					"select kind, source from tweet_account_edges where tweet_id = ?",
+				)
+				.get("retained"),
+		).toEqual({ kind: "search", source: "xurl" });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from tweets_fts where tweets_fts match 'retained'",
+				)
+				.get(),
+		).toEqual({ count: 1 });
+		expect(
+			db
+				.prepare(
+					"select count(*) as count from sync_cache where cache_key like 'tweet-search:%'",
+				)
+				.get(),
+		).toEqual({ count: 0 });
+		mocks.searchRecentTweets.mockResolvedValueOnce(
+			payload(["retained", "resumed"]),
+		);
+		expect(await syncTweetSearch(options)).toMatchObject({
+			ok: true,
+			source: "xurl",
+			count: 2,
+		});
+		expect(mocks.searchRecentTweets).toHaveBeenCalledTimes(3);
+	});
+
 	it("combines bird and xurl results for auto searches", async () => {
 		mocks.searchTweetsViaBird.mockResolvedValue(
 			payload(["tweet_bird_1", "tweet_shared", "tweet_bird_2"]),

--- a/src/lib/tweet-search-live.ts
+++ b/src/lib/tweet-search-live.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import type { Database } from "./sqlite";
 import { searchTweetsViaBirdEffect } from "./bird";
 import { getNativeDb } from "./db";
+import { databaseWriteEffect } from "./database-writer";
 import { runEffectPromise, toError, trySync } from "./effect-runtime";
 import {
 	resolveLiveSyncAccount,
@@ -145,6 +146,7 @@ function fetchBirdSearchEffect({
 }
 
 function fetchXurlSearchEffect({
+	accountId,
 	query,
 	limit,
 	maxPages,
@@ -152,6 +154,7 @@ function fetchXurlSearchEffect({
 	since,
 	until,
 }: {
+	accountId: string;
 	query: string;
 	limit: number;
 	maxPages: number;
@@ -171,6 +174,18 @@ function fetchXurlSearchEffect({
 					timeoutMs,
 				});
 			},
+			persistPage: ({ page, fetched }) =>
+				databaseWriteEffect((db) =>
+					mergeTweetSearchIntoLocalStore(
+						db,
+						accountId,
+						limitResponse(
+							page,
+							Math.max(0, limit - fetched + page.data.length),
+						),
+						"xurl",
+					),
+				).pipe(Effect.asVoid),
 			getItemCount: (page) => page.data.length,
 			getNextCursor: (page) =>
 				typeof page.meta?.next_token === "string"


### PR DESCRIPTION
## Problem and change

A later Xurl search request could fail after earlier pages had already been fetched, leaving none of those results in the local archive. Persist each successful page through the existing database writer before requesting the next page, while respecting the requested result limit.

Interrupted searches still fail, do not populate a successful search cache, and do not produce a partial AI summary. This addresses the data-retention portion of #138; spend budgets, resumable searches, and partial-summary policy remain separate decisions. Please keep #138 open for those decisions.

## Verification

- Format, lint, and type checks passed.
- Added a regression covering persistence before the next request, FTS and search edges, failed-search cache isolation, and a subsequent retry.
- Built the actual CLI under Node 26.5.1 and ran `discuss retentionproof --mode xurl --limit 150 --max-pages 2 --refresh --json` against an isolated synthetic Xurl executable: page one succeeds and page two exits with a 402 response. Main retained 0 tweets; this branch retains 1 tweet and 1 FTS row, leaves 0 complete-search cache rows, and exits 1 with the original failure.
- Independent autoreview at P0–P2 is clean.

Thanks @sid-ravikumar for the report.
