### PR TITLE
perf: batch mention profile enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.
+
 - Return standalone CLI version checks directly from package metadata without loading every command and its dependencies.
 
 - Reposition hover previews on layout/content changes instead of every frame, and keep them outside contained feed rows so they remain correctly positioned and unclipped.

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -829,6 +829,50 @@ describe("query models", () => {
 		}
 	});
 
+	it("batches case-insensitive mention hits and misses and refreshes between reads", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2026-01-01T00:00:00Z";
+		for (let i = 0; i < 40; i++) {
+			const id = `mention_batch_${i}`;
+			const text = `bulkmention @Missing${i} @sam`;
+			insertTestTweet(db, { id, text, createdAt: stamp });
+			db.prepare("insert into tweets_fts(tweet_id, text) values (?, ?)").run(
+				id,
+				text,
+			);
+			insertTestEdge(db, id, stamp);
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const read = () =>
+				listTimelineItems({
+					resource: "home",
+					search: "bulkmention",
+					limit: 40,
+				});
+			const items = read();
+			expect(items).toHaveLength(40);
+			expect(items[0]?.entities.mentions?.[0]?.profile?.handle).toMatch(
+				/^missing/,
+			);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes("from profiles") && sql.includes("lower(handle)"),
+				),
+			).toHaveLength(1);
+			db.prepare(
+				"update profiles set display_name = 'Fresh Sam' where lower(handle) = 'sam'",
+			).run();
+			expect(read()[0]?.entities.mentions?.[1]?.profile?.displayName).toBe(
+				"Fresh Sam",
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -75,6 +75,48 @@ function getProfileByHandle(
 	return profile ?? fallbackProfileForHandle(normalized);
 }
 
+function preloadMentionProfiles(
+	db: Database,
+	cache: ProfileByHandleCache,
+	rows: Record<string, unknown>[],
+) {
+	const handles = new Set<string>();
+	for (const row of rows) {
+		for (const prefix of ["", "reply_", "quoted_"]) {
+			if (!row[`${prefix}id`]) continue;
+			const entities = parseJsonField<TweetEntities>(
+				row[`${prefix}entities_json`],
+				{},
+			);
+			for (const mention of entities.mentions ?? []) {
+				handles.add(profileHandleKey(mention.username));
+			}
+			for (const match of String(row[`${prefix}text`] ?? "").matchAll(
+				/(^|[^\w@])@([A-Za-z0-9_]{1,15})/g,
+			)) {
+				handles.add(profileHandleKey(match[2]!));
+			}
+		}
+	}
+	const missing = [...handles].filter((handle) => !cache.has(handle));
+	if (missing.length === 0) return;
+	// Keep the same first match as individual lookups when archived handles collide.
+	const profiles = db
+		.prepare(`
+		select id, handle, display_name, bio, followers_count, following_count,
+		  avatar_hue, avatar_url, location, url, verified_type, entities_json, created_at
+		from profiles
+		where rowid in (
+		  select (select rowid from profiles where lower(handle) = value limit 1)
+		  from json_each(?)
+		)
+	`)
+		.all(JSON.stringify(missing)) as Record<string, unknown>[];
+	for (const handle of missing) cache.set(handle, null);
+	for (const row of profiles)
+		cache.set(profileHandleKey(String(row.handle)), profileFromDbRow(row));
+}
+
 function spansOverlap(
 	leftStart: number,
 	leftEnd: number,
@@ -1075,6 +1117,7 @@ export function listTimelineItems(
 	const urlExpansionCache: UrlExpansionCache = new Map();
 	preloadUrlExpansions(db, urlExpansionCache, rows);
 	const profileByHandleCache: ProfileByHandleCache = new Map();
+	preloadMentionProfiles(db, profileByHandleCache, rows);
 	const items = rows.map((row) => {
 		const author = {
 			id: String(row.profile_id),
@@ -1400,6 +1443,7 @@ export function getTweetsByIds(
 		>[];
 		const byId = new Map(rows.map((row) => [String(row.id), row]));
 		preloadUrlExpansions(db, urlExpansionCache, rows);
+		preloadMentionProfiles(db, profileByHandleCache, rows);
 		for (const id of batch) {
 			const row = byId.get(id);
 			if (!row) continue;


### PR DESCRIPTION
Timeline and cited-tweet reads previously prepared one profile lookup for every distinct mentioned handle. Preload profile hits and misses in one indexed query per page/batch, preserving the first matching archived profile and inline-profile precedence. The cache remains scoped to one read so subsequent profile updates stay visible.

Validation: format/lint/type checks; 74 query-model tests on Bun and Node, including a 40-post regression that reduces mention queries to one and verifies refresh behavior. Paired Node measurements on a fixed local fixture preserve all seven output hashes: 50 cited tweets 1.877 → 0.942 ms; 500 cited tweets 17.038 → 7.899 ms. Home and Mentions improved in this sample; search timings were mixed. Independent P2 review passed.
