### PR TITLE
perf: batch referenced retweet hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch referenced-retweet hydration and enrichment per account, preserving collection state and missing/deleted-post fallbacks.
+
 - Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.
 
 - Return standalone CLI version checks directly from package metadata without loading every command and its dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.
+
 - Return standalone CLI version checks directly from package metadata without loading every command and its dependencies.
 
 - Reposition hover previews on layout/content changes instead of every frame, and keep them outside contained feed rows so they remain correctly positioned and unclipped.

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -829,6 +829,50 @@ describe("query models", () => {
 		}
 	});
 
+	it("batches case-insensitive mention hits and misses and refreshes between reads", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2026-01-01T00:00:00Z";
+		for (let i = 0; i < 40; i++) {
+			const id = `mention_batch_${i}`;
+			const text = `bulkmention @Missing${i} @sam`;
+			insertTestTweet(db, { id, text, createdAt: stamp });
+			db.prepare("insert into tweets_fts(tweet_id, text) values (?, ?)").run(
+				id,
+				text,
+			);
+			insertTestEdge(db, id, stamp);
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const read = () =>
+				listTimelineItems({
+					resource: "home",
+					search: "bulkmention",
+					limit: 40,
+				});
+			const items = read();
+			expect(items).toHaveLength(40);
+			expect(items[0]?.entities.mentions?.[0]?.profile?.handle).toMatch(
+				/^missing/,
+			);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes("from profiles") && sql.includes("lower(handle)"),
+				),
+			).toHaveLength(1);
+			db.prepare(
+				"update profiles set display_name = 'Fresh Sam' where lower(handle) = 'sam'",
+			).run();
+			expect(read()[0]?.entities.mentions?.[1]?.profile?.displayName).toBe(
+				"Fresh Sam",
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -873,6 +873,61 @@ describe("query models", () => {
 		}
 	});
 
+	it("hydrates repeated referenced retweets once per account", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2026-01-01T00:00:00Z";
+		insertTestTweet(db, {
+			id: "shared_retweet",
+			text: "Original @sam",
+			createdAt: stamp,
+		});
+		for (let i = 0; i < 40; i++) {
+			const id = `retweet_batch_${i}`;
+			insertTestTweet(db, { id, text: "bulkretweet", createdAt: stamp });
+			db.prepare("insert into tweets_fts(tweet_id, text) values (?, ?)").run(
+				id,
+				"bulkretweet",
+			);
+			insertTestEdge(db, id, stamp);
+			db.prepare(
+				"update tweet_account_edges set raw_json = ? where tweet_id = ?",
+			).run(JSON.stringify({ retweeted_tweet_id: "shared_retweet" }), id);
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const items = listTimelineItems({
+				resource: "home",
+				search: "bulkretweet",
+				limit: 40,
+			});
+			expect(items).toHaveLength(40);
+			expect(
+				items.every((item) => item.retweetedTweet?.text === "Original @sam"),
+			).toBe(true);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes(
+							"from tweets t indexed by sqlite_autoindex_tweets_1",
+						) && sql.includes("json_each"),
+				),
+			).toHaveLength(1);
+			db.prepare(
+				"update tweets set deleted_at = ? where id = 'shared_retweet'",
+			).run(stamp);
+			expect(
+				listTimelineItems({
+					resource: "home",
+					search: "bulkretweet",
+					limit: 40,
+				}).every((item) => item.retweetedTweet === null),
+			).toBe(true);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -75,6 +75,48 @@ function getProfileByHandle(
 	return profile ?? fallbackProfileForHandle(normalized);
 }
 
+function preloadMentionProfiles(
+	db: Database,
+	cache: ProfileByHandleCache,
+	rows: Record<string, unknown>[],
+) {
+	const handles = new Set<string>();
+	for (const row of rows) {
+		for (const prefix of ["", "reply_", "quoted_"]) {
+			if (!row[`${prefix}id`]) continue;
+			const entities = parseJsonField<TweetEntities>(
+				row[`${prefix}entities_json`],
+				{},
+			);
+			for (const mention of entities.mentions ?? []) {
+				handles.add(profileHandleKey(mention.username));
+			}
+			for (const match of String(row[`${prefix}text`] ?? "").matchAll(
+				/(^|[^\w@])@([A-Za-z0-9_]{1,15})/g,
+			)) {
+				handles.add(profileHandleKey(match[2]!));
+			}
+		}
+	}
+	const missing = [...handles].filter((handle) => !cache.has(handle));
+	if (missing.length === 0) return;
+	// Keep the same first match as individual lookups when archived handles collide.
+	const profiles = db
+		.prepare(`
+		select id, handle, display_name, bio, followers_count, following_count,
+		  avatar_hue, avatar_url, location, url, verified_type, entities_json, created_at
+		from profiles
+		where rowid in (
+		  select (select rowid from profiles where lower(handle) = value limit 1)
+		  from json_each(?)
+		)
+	`)
+		.all(JSON.stringify(missing)) as Record<string, unknown>[];
+	for (const handle of missing) cache.set(handle, null);
+	for (const row of profiles)
+		cache.set(profileHandleKey(String(row.handle)), profileFromDbRow(row));
+}
+
 function spansOverlap(
 	leftStart: number,
 	leftEnd: number,
@@ -1075,6 +1117,7 @@ export function listTimelineItems(
 	const urlExpansionCache: UrlExpansionCache = new Map();
 	preloadUrlExpansions(db, urlExpansionCache, rows);
 	const profileByHandleCache: ProfileByHandleCache = new Map();
+	preloadMentionProfiles(db, profileByHandleCache, rows);
 	const items = rows.map((row) => {
 		const author = {
 			id: String(row.profile_id),
@@ -1400,6 +1443,7 @@ export function getTweetsByIds(
 		>[];
 		const byId = new Map(rows.map((row) => [String(row.id), row]));
 		preloadUrlExpansions(db, urlExpansionCache, rows);
+		preloadMentionProfiles(db, profileByHandleCache, rows);
 		for (const id of batch) {
 			const row = byId.get(id);
 			if (!row) continue;

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -420,8 +420,48 @@ function parseManualRetweet(text: string) {
 	};
 }
 
+type RetweetRows = Map<string, Map<string, Record<string, unknown>>>;
+
+function preloadRetweetedTweets(
+	db: Database,
+	rows: Record<string, unknown>[],
+): RetweetRows {
+	const idsByAccount = new Map<string, Set<string>>();
+	for (const row of rows) {
+		const id = getRetweetedTweetIdFromRaw(row.edge_raw_json);
+		if (!id) continue;
+		const account = String(row.account_id);
+		const ids = idsByAccount.get(account) ?? new Set<string>();
+		ids.add(id);
+		idsByAccount.set(account, ids);
+	}
+	const result: RetweetRows = new Map();
+	for (const [account, ids] of idsByAccount) {
+		const referenced = db
+			.prepare(`${conversationTweetSelect(
+				account,
+				"",
+				`from tweets t indexed by sqlite_autoindex_tweets_1
+		join profiles p on p.id = t.author_profile_id`,
+			)}
+		where t.id in (select value from json_each(?))
+		and t.deleted_at is null and t.superseded_at is null
+		`)
+			.all(account, account, JSON.stringify([...ids])) as Record<
+			string,
+			unknown
+		>[];
+		result.set(
+			account,
+			new Map(referenced.map((row) => [String(row.id), row])),
+		);
+	}
+	return result;
+}
+
 function buildRetweetedTweet(
 	db: Database,
+	retweetRows: RetweetRows,
 	urlExpansionCache: UrlExpansionCache,
 	row: Record<string, unknown>,
 	resolveProfileByHandle: (handle: string) => ProfileRecord,
@@ -429,17 +469,16 @@ function buildRetweetedTweet(
 	const retweetedId = getRetweetedTweetIdFromRaw(row.edge_raw_json);
 	const accountId = String(row.account_id);
 	if (retweetedId) {
-		// The visible retweet edge is the account-scoped evidence for its referenced
-		// tweet. Project this account's state without requiring a second membership row.
-		const tweet = getTweetById(
-			db,
-			urlExpansionCache,
-			retweetedId,
-			resolveProfileByHandle,
-			{ stateAccountId: accountId },
-		);
-		if (tweet) {
-			return tweet;
+		// The visible retweet edge supplies membership; project only its account's state.
+		const referenced = retweetRows.get(accountId)?.get(retweetedId);
+		if (referenced) {
+			return buildEmbeddedTweet(
+				db,
+				urlExpansionCache,
+				referenced,
+				"",
+				resolveProfileByHandle,
+			);
 		}
 	}
 
@@ -1114,10 +1153,15 @@ export function listTimelineItems(
 		}
 	}
 
+	const retweetRows = preloadRetweetedTweets(db, rows);
+	const enrichmentRows = [
+		...rows,
+		...[...retweetRows.values()].flatMap((byId) => [...byId.values()]),
+	];
 	const urlExpansionCache: UrlExpansionCache = new Map();
-	preloadUrlExpansions(db, urlExpansionCache, rows);
+	preloadUrlExpansions(db, urlExpansionCache, enrichmentRows);
 	const profileByHandleCache: ProfileByHandleCache = new Map();
-	preloadMentionProfiles(db, profileByHandleCache, rows);
+	preloadMentionProfiles(db, profileByHandleCache, enrichmentRows);
 	const items = rows.map((row) => {
 		const author = {
 			id: String(row.profile_id),
@@ -1211,6 +1255,7 @@ export function listTimelineItems(
 			),
 			retweetedTweet: buildRetweetedTweet(
 				db,
+				retweetRows,
 				urlExpansionCache,
 				row,
 				resolveProfileByHandle,


### PR DESCRIPTION
Retweet-heavy timelines loaded the same referenced posts repeatedly. Hydrate referenced tweets in one indexed batch per account, then share the page's URL and mention enrichment caches. Each row still uses its own inline profiles, and collection state remains scoped to the retweet's account. Missing, deleted, or superseded references retain the existing manual-retweet fallback.

Validation: format/lint/types; 75 query-model tests on Bun and Node; independent P2 review. A synthetic 50-retweet page produces identical JSON while reducing SQL statements from 52 to 3 and paired Node median latency from 2.772 to 0.964 ms.
