### PR TITLE
perf: scope inbox score reads to visible candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch referenced-retweet hydration and enrichment per account, preserving collection state and missing/deleted-post fallbacks.
+
 - Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.
 
 - Return standalone CLI version checks directly from package metadata without loading every command and its dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Limit Inbox score reads to the current candidate mentions and conversations instead of loading the entire scoring history.
+
 - Batch referenced-retweet hydration and enrichment per account, preserving collection state and missing/deleted-post fallbacks.
 
 - Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -38,16 +38,25 @@ function getHeuristicScoreForDm(
 	);
 }
 
-function readStoredScores() {
+function readStoredScores(mentions: string[], conversations: string[]) {
 	const db = getNativeDb();
+	const candidates = [
+		...mentions.map((id) => ["mention", id]),
+		...conversations.map((id) => ["dm", id]),
+	];
+	if (candidates.length === 0) return new Map();
 	const rows = db
 		.prepare(
 			`
       select entity_kind, entity_id, model, score, summary, reasoning, updated_at
       from ai_scores
+      where (entity_kind, entity_id) in (
+        select json_extract(value, '$[0]'), json_extract(value, '$[1]')
+        from json_each(?)
+      )
       `,
 		)
-		.all() as Array<Record<string, unknown>>;
+		.all(JSON.stringify(candidates)) as Array<Record<string, unknown>>;
 
 	return new Map(
 		rows.map((row) => [
@@ -70,16 +79,32 @@ export function listInboxItems({
 	hideLowSignal = false,
 	limit = 20,
 }: InboxQuery = {}): InboxResponse {
-	const storedScores = readStoredScores();
+	const mentions =
+		kind === "mixed" || kind === "mentions"
+			? listTimelineItems({
+					resource: "mentions",
+					account,
+					replyFilter: "unreplied",
+					limit: 50,
+				})
+			: [];
+	const conversations =
+		kind === "mixed" || kind === "dms"
+			? listDmConversations({
+					account,
+					replyFilter: "unreplied",
+					sort: "followers",
+					limit: 50,
+				})
+			: [];
+	const storedScores = readStoredScores(
+		mentions.map((item) => item.id),
+		conversations.map((item) => item.id),
+	);
 	const items: InboxItem[] = [];
 
 	if (kind === "mixed" || kind === "mentions") {
-		for (const mention of listTimelineItems({
-			resource: "mentions",
-			account,
-			replyFilter: "unreplied",
-			limit: 50,
-		})) {
+		for (const mention of mentions) {
 			const scoreKey = `mention:${mention.id}`;
 			const stored = storedScores.get(scoreKey);
 			items.push({
@@ -107,12 +132,7 @@ export function listInboxItems({
 	}
 
 	if (kind === "mixed" || kind === "dms") {
-		for (const dm of listDmConversations({
-			account,
-			replyFilter: "unreplied",
-			sort: "followers",
-			limit: 50,
-		})) {
+		for (const dm of conversations) {
 			const scoreKey = `dm:${dm.id}`;
 			const stored = storedScores.get(scoreKey);
 			items.push({

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -2300,6 +2300,51 @@ describe("query models", () => {
 		expect(conversation?.truncated).toBe(true);
 	});
 
+	it("reads stored Inbox scores only for current candidates", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const original = listInboxItems();
+		const candidate = original.items[0]!;
+		const insert = db.prepare(
+			"insert or replace into ai_scores values (?, ?, 'test', 99, 'Stored score', 'Reason', '2026-01-01')",
+		);
+		db.transaction(() => {
+			for (let i = 0; i < 1000; i++) insert.run("mention", `unrelated_${i}`);
+			insert.run(candidate.entityKind, candidate.entityId);
+		})();
+		const nativePrepare = NativeSqliteDatabase.prototype.prepare;
+		let scoreRows = 0;
+		const prepare = vi
+			.spyOn(NativeSqliteDatabase.prototype, "prepare")
+			.mockImplementation(function (this: NativeSqliteDatabase, sql: string) {
+				const statement = nativePrepare.call(this, sql);
+				if (sql.includes("from ai_scores")) {
+					const all = statement.all.bind(statement);
+					statement.all = (...params: unknown[]) => {
+						const rows = all(...params);
+						scoreRows += rows.length;
+						return rows;
+					};
+				}
+				return statement;
+			});
+		try {
+			const inbox = listInboxItems();
+			expect(inbox.items[0]).toMatchObject({
+				entityId: candidate.entityId,
+				source: "openai",
+				score: 99,
+				summary: "Stored score",
+			});
+			expect(scoreRows).toBeLessThanOrEqual(original.items.length);
+			expect(inbox.items.map((item) => item.entityId).sort()).toEqual(
+				original.items.map((item) => item.entityId).sort(),
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("builds a mixed inbox with ranked mentions and dms", () => {
 		setupTempHome();
 

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -873,6 +873,61 @@ describe("query models", () => {
 		}
 	});
 
+	it("hydrates repeated referenced retweets once per account", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2026-01-01T00:00:00Z";
+		insertTestTweet(db, {
+			id: "shared_retweet",
+			text: "Original @sam",
+			createdAt: stamp,
+		});
+		for (let i = 0; i < 40; i++) {
+			const id = `retweet_batch_${i}`;
+			insertTestTweet(db, { id, text: "bulkretweet", createdAt: stamp });
+			db.prepare("insert into tweets_fts(tweet_id, text) values (?, ?)").run(
+				id,
+				"bulkretweet",
+			);
+			insertTestEdge(db, id, stamp);
+			db.prepare(
+				"update tweet_account_edges set raw_json = ? where tweet_id = ?",
+			).run(JSON.stringify({ retweeted_tweet_id: "shared_retweet" }), id);
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const items = listTimelineItems({
+				resource: "home",
+				search: "bulkretweet",
+				limit: 40,
+			});
+			expect(items).toHaveLength(40);
+			expect(
+				items.every((item) => item.retweetedTweet?.text === "Original @sam"),
+			).toBe(true);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes(
+							"from tweets t indexed by sqlite_autoindex_tweets_1",
+						) && sql.includes("json_each"),
+				),
+			).toHaveLength(1);
+			db.prepare(
+				"update tweets set deleted_at = ? where id = 'shared_retweet'",
+			).run(stamp);
+			expect(
+				listTimelineItems({
+					resource: "home",
+					search: "bulkretweet",
+					limit: 40,
+				}).every((item) => item.retweetedTweet === null),
+			).toBe(true);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -420,8 +420,48 @@ function parseManualRetweet(text: string) {
 	};
 }
 
+type RetweetRows = Map<string, Map<string, Record<string, unknown>>>;
+
+function preloadRetweetedTweets(
+	db: Database,
+	rows: Record<string, unknown>[],
+): RetweetRows {
+	const idsByAccount = new Map<string, Set<string>>();
+	for (const row of rows) {
+		const id = getRetweetedTweetIdFromRaw(row.edge_raw_json);
+		if (!id) continue;
+		const account = String(row.account_id);
+		const ids = idsByAccount.get(account) ?? new Set<string>();
+		ids.add(id);
+		idsByAccount.set(account, ids);
+	}
+	const result: RetweetRows = new Map();
+	for (const [account, ids] of idsByAccount) {
+		const referenced = db
+			.prepare(`${conversationTweetSelect(
+				account,
+				"",
+				`from tweets t indexed by sqlite_autoindex_tweets_1
+		join profiles p on p.id = t.author_profile_id`,
+			)}
+		where t.id in (select value from json_each(?))
+		and t.deleted_at is null and t.superseded_at is null
+		`)
+			.all(account, account, JSON.stringify([...ids])) as Record<
+			string,
+			unknown
+		>[];
+		result.set(
+			account,
+			new Map(referenced.map((row) => [String(row.id), row])),
+		);
+	}
+	return result;
+}
+
 function buildRetweetedTweet(
 	db: Database,
+	retweetRows: RetweetRows,
 	urlExpansionCache: UrlExpansionCache,
 	row: Record<string, unknown>,
 	resolveProfileByHandle: (handle: string) => ProfileRecord,
@@ -429,17 +469,16 @@ function buildRetweetedTweet(
 	const retweetedId = getRetweetedTweetIdFromRaw(row.edge_raw_json);
 	const accountId = String(row.account_id);
 	if (retweetedId) {
-		// The visible retweet edge is the account-scoped evidence for its referenced
-		// tweet. Project this account's state without requiring a second membership row.
-		const tweet = getTweetById(
-			db,
-			urlExpansionCache,
-			retweetedId,
-			resolveProfileByHandle,
-			{ stateAccountId: accountId },
-		);
-		if (tweet) {
-			return tweet;
+		// The visible retweet edge supplies membership; project only its account's state.
+		const referenced = retweetRows.get(accountId)?.get(retweetedId);
+		if (referenced) {
+			return buildEmbeddedTweet(
+				db,
+				urlExpansionCache,
+				referenced,
+				"",
+				resolveProfileByHandle,
+			);
 		}
 	}
 
@@ -1114,10 +1153,15 @@ export function listTimelineItems(
 		}
 	}
 
+	const retweetRows = preloadRetweetedTweets(db, rows);
+	const enrichmentRows = [
+		...rows,
+		...[...retweetRows.values()].flatMap((byId) => [...byId.values()]),
+	];
 	const urlExpansionCache: UrlExpansionCache = new Map();
-	preloadUrlExpansions(db, urlExpansionCache, rows);
+	preloadUrlExpansions(db, urlExpansionCache, enrichmentRows);
 	const profileByHandleCache: ProfileByHandleCache = new Map();
-	preloadMentionProfiles(db, profileByHandleCache, rows);
+	preloadMentionProfiles(db, profileByHandleCache, enrichmentRows);
 	const items = rows.map((row) => {
 		const author = {
 			id: String(row.profile_id),
@@ -1211,6 +1255,7 @@ export function listTimelineItems(
 			),
 			retweetedTweet: buildRetweetedTweet(
 				db,
+				retweetRows,
 				urlExpansionCache,
 				row,
 				resolveProfileByHandle,


### PR DESCRIPTION
Opening Inbox loaded every stored AI score, even though only up to 50 mentions and 50 DM conversations can become candidates. Collect those candidates first and fetch their scores through the existing composite primary key. Empty candidate sets skip the score query, and ranking, score precedence, filters, and response shape stay unchanged.

Validation: format/lint/types; 76 query-model tests on Bun and Node; independent P2 review. A synthetic archive with 50,000 unrelated scores returns identical Inbox JSON while reducing paired Node median latency from 88.459 to 0.228 ms. A regression verifies that unrelated scores are never hydrated.
