### PR TITLE
perf: hydrate DM senders once per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Limit Inbox score reads to the current candidate mentions and conversations instead of loading the entire scoring history.
+
 - Batch referenced-retweet hydration and enrichment per account, preserving collection state and missing/deleted-post fallbacks.
 
 - Batch mention-profile enrichment across timeline pages and cited tweets while preserving inline profiles and missing-handle fallbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Hydrate each DM sender once per thread instead of copying profile columns for every message, preserving complete history and independent message objects.
+
 - Limit Inbox score reads to the current candidate mentions and conversations instead of loading the entire scoring history.
 
 - Batch referenced-retweet hydration and enrichment per account, preserving collection state and missing/deleted-post fallbacks.

--- a/src/lib/dm-read-model.ts
+++ b/src/lib/dm-read-model.ts
@@ -320,57 +320,47 @@ export function getConversationThread(
 	}
 
 	const db = getReadDb();
-	const rows = db
-		.prepare(
-			`
-      select
-        m.id,
-        m.conversation_id,
-        m.text,
-        m.created_at,
-        m.direction,
-        m.is_replied,
-        m.media_count,
-        p.id as profile_id,
-        p.handle,
-        p.display_name,
-        p.bio,
-        p.followers_count,
-        p.following_count,
-        p.avatar_hue,
-        p.avatar_url,
-        p.created_at as profile_created_at
-      from dm_messages m
-      join profiles p on p.id = m.sender_profile_id
-      where m.conversation_id = ?
-      order by m.created_at asc
-      `,
-		)
-		.all(conversationId) as Array<Record<string, unknown>>;
-
-	return {
-		conversation,
-		messages: rows.map((row) => ({
-			id: String(row.id),
-			conversationId: String(row.conversation_id),
-			text: String(row.text),
-			createdAt: String(row.created_at),
-			direction: row.direction as DmMessageItem["direction"],
-			isReplied: Boolean(row.is_replied),
-			mediaCount: Number(row.media_count),
-			sender: profileFromDbRow({
-				id: row.profile_id,
-				handle: row.handle,
-				display_name: row.display_name,
-				bio: row.bio,
-				followers_count: row.followers_count,
-				following_count: row.following_count,
-				avatar_hue: row.avatar_hue,
-				avatar_url: row.avatar_url,
-				created_at: row.profile_created_at,
-			}),
-		})),
-	};
+	return db.readTransaction(() => {
+		const rows = db
+			.prepare(`
+			select m.id, m.conversation_id, m.text, m.created_at, m.direction,
+			  m.is_replied, m.media_count, m.sender_profile_id
+			from dm_messages m
+			join profiles p on p.id = m.sender_profile_id
+			where m.conversation_id = ?
+			order by m.created_at asc
+		`)
+			.all(conversationId) as Record<string, unknown>[];
+		const senderIds = [
+			...new Set(rows.map((row) => String(row.sender_profile_id))),
+		];
+		const senderRows =
+			senderIds.length === 0
+				? []
+				: (db
+						.prepare(`
+			select id, handle, display_name, bio, followers_count, following_count,
+			  avatar_hue, avatar_url, created_at
+			from profiles where id in (select value from json_each(?))
+		`)
+						.all(JSON.stringify(senderIds)) as Record<string, unknown>[]);
+		const senders = new Map(
+			senderRows.map((row) => [String(row.id), profileFromDbRow(row)]),
+		);
+		return {
+			conversation,
+			messages: rows.map((row) => ({
+				id: String(row.id),
+				conversationId: String(row.conversation_id),
+				text: String(row.text),
+				createdAt: String(row.created_at),
+				direction: row.direction as DmMessageItem["direction"],
+				isReplied: Boolean(row.is_replied),
+				mediaCount: Number(row.media_count),
+				sender: { ...senders.get(String(row.sender_profile_id))! },
+			})),
+		};
+	})();
 }
 
 function normalizeDmContext(value: number | undefined) {

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -38,16 +38,25 @@ function getHeuristicScoreForDm(
 	);
 }
 
-function readStoredScores() {
+function readStoredScores(mentions: string[], conversations: string[]) {
 	const db = getNativeDb();
+	const candidates = [
+		...mentions.map((id) => ["mention", id]),
+		...conversations.map((id) => ["dm", id]),
+	];
+	if (candidates.length === 0) return new Map();
 	const rows = db
 		.prepare(
 			`
       select entity_kind, entity_id, model, score, summary, reasoning, updated_at
       from ai_scores
+      where (entity_kind, entity_id) in (
+        select json_extract(value, '$[0]'), json_extract(value, '$[1]')
+        from json_each(?)
+      )
       `,
 		)
-		.all() as Array<Record<string, unknown>>;
+		.all(JSON.stringify(candidates)) as Array<Record<string, unknown>>;
 
 	return new Map(
 		rows.map((row) => [
@@ -70,16 +79,32 @@ export function listInboxItems({
 	hideLowSignal = false,
 	limit = 20,
 }: InboxQuery = {}): InboxResponse {
-	const storedScores = readStoredScores();
+	const mentions =
+		kind === "mixed" || kind === "mentions"
+			? listTimelineItems({
+					resource: "mentions",
+					account,
+					replyFilter: "unreplied",
+					limit: 50,
+				})
+			: [];
+	const conversations =
+		kind === "mixed" || kind === "dms"
+			? listDmConversations({
+					account,
+					replyFilter: "unreplied",
+					sort: "followers",
+					limit: 50,
+				})
+			: [];
+	const storedScores = readStoredScores(
+		mentions.map((item) => item.id),
+		conversations.map((item) => item.id),
+	);
 	const items: InboxItem[] = [];
 
 	if (kind === "mixed" || kind === "mentions") {
-		for (const mention of listTimelineItems({
-			resource: "mentions",
-			account,
-			replyFilter: "unreplied",
-			limit: 50,
-		})) {
+		for (const mention of mentions) {
 			const scoreKey = `mention:${mention.id}`;
 			const stored = storedScores.get(scoreKey);
 			items.push({
@@ -107,12 +132,7 @@ export function listInboxItems({
 	}
 
 	if (kind === "mixed" || kind === "dms") {
-		for (const dm of listDmConversations({
-			account,
-			replyFilter: "unreplied",
-			sort: "followers",
-			limit: 50,
-		})) {
+		for (const dm of conversations) {
 			const scoreKey = `dm:${dm.id}`;
 			const stored = storedScores.get(scoreKey);
 			items.push({

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -2300,6 +2300,35 @@ describe("query models", () => {
 		expect(conversation?.truncated).toBe(true);
 	});
 
+	it("keeps complete DM histories and independently mutable sender objects", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const baseline = getConversationThread("dm_001")!;
+		const insert = db.prepare(
+			"insert into dm_messages(id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count) values (?, 'dm_001', 'profile_me', 'Long thread', '2030-01-01', 'outbound', 0, 0)",
+		);
+		db.transaction(() => {
+			for (let i = 0; i < 1200; i++) insert.run(`long_dm_${i}`);
+		})();
+		const thread = getConversationThread("dm_001")!;
+		expect(thread.messages).toHaveLength(baseline.messages.length + 1200);
+		expect(thread.messages.slice(0, baseline.messages.length)).toEqual(
+			baseline.messages,
+		);
+		const first = thread.messages[baseline.messages.length]!;
+		const second = thread.messages[baseline.messages.length + 1]!;
+		expect(first.sender).toEqual(second.sender);
+		expect(first.sender).not.toBe(second.sender);
+		first.sender.displayName = "Changed locally";
+		expect(second.sender.displayName).not.toBe("Changed locally");
+		db.prepare(
+			"update profiles set display_name = 'Fresh sender' where id = 'profile_me'",
+		).run();
+		expect(
+			getConversationThread("dm_001")?.messages.at(-1)?.sender.displayName,
+		).toBe("Fresh sender");
+	});
+
 	it("reads stored Inbox scores only for current candidates", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -2300,6 +2300,51 @@ describe("query models", () => {
 		expect(conversation?.truncated).toBe(true);
 	});
 
+	it("reads stored Inbox scores only for current candidates", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const original = listInboxItems();
+		const candidate = original.items[0]!;
+		const insert = db.prepare(
+			"insert or replace into ai_scores values (?, ?, 'test', 99, 'Stored score', 'Reason', '2026-01-01')",
+		);
+		db.transaction(() => {
+			for (let i = 0; i < 1000; i++) insert.run("mention", `unrelated_${i}`);
+			insert.run(candidate.entityKind, candidate.entityId);
+		})();
+		const nativePrepare = NativeSqliteDatabase.prototype.prepare;
+		let scoreRows = 0;
+		const prepare = vi
+			.spyOn(NativeSqliteDatabase.prototype, "prepare")
+			.mockImplementation(function (this: NativeSqliteDatabase, sql: string) {
+				const statement = nativePrepare.call(this, sql);
+				if (sql.includes("from ai_scores")) {
+					const all = statement.all.bind(statement);
+					statement.all = (...params: unknown[]) => {
+						const rows = all(...params);
+						scoreRows += rows.length;
+						return rows;
+					};
+				}
+				return statement;
+			});
+		try {
+			const inbox = listInboxItems();
+			expect(inbox.items[0]).toMatchObject({
+				entityId: candidate.entityId,
+				source: "openai",
+				score: 99,
+				summary: "Stored score",
+			});
+			expect(scoreRows).toBeLessThanOrEqual(original.items.length);
+			expect(inbox.items.map((item) => item.entityId).sort()).toEqual(
+				original.items.map((item) => item.entityId).sort(),
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("builds a mixed inbox with ranked mentions and dms", () => {
 		setupTempHome();
 


### PR DESCRIPTION
Long DM threads repeated the sender's profile columns and profile conversion for every message. Read message rows narrowly, hydrate distinct senders once in the same SQLite snapshot, and create an independent sender object for each returned message. Complete history, ordering, and the public response shape are preserved.

Validation: format/lint/types; 77 query-model tests on Bun and Node; independent P2 review. A 10,000-message synthetic thread returns identical JSON and improves paired Node median latency from 32.971 to 18.026 ms. The regression checks untruncated history, unchanged older messages, object independence, and refreshed profile values on later reads.
