### PR TITLE
perf: reuse bounded SQLite statement compilations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Reuse up to 128 recently prepared SQLite statements per connection while keeping streaming iterators on independent cursors.
+
 - Hydrate each DM sender once per thread instead of copying profile columns for every message, preserving complete history and independent message objects.
 
 - Limit Inbox score reads to the current candidate mentions and conversations instead of loading the entire scoring history.

--- a/src/lib/sqlite.test.ts
+++ b/src/lib/sqlite.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { NativeSqliteDatabase } from "./sqlite";
+
+describe("prepared statement reuse", () => {
+	it("reuses native compilation while clearing omitted parameter bindings", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+		try {
+			expect(db.prepare("select ? a, ? b").get(1, 2)).toEqual({ a: 1, b: 2 });
+			expect(db.prepare("select ? a, ? b").get(3)).toEqual({ a: 3, b: null });
+			expect(db.prepare("select $a a, $b b").get({ a: 1, b: 2 })).toEqual({
+				a: 1,
+				b: 2,
+			});
+			expect(db.prepare("select $a a, $b b").get({ a: 3 })).toEqual({
+				a: 3,
+				b: null,
+			});
+			expect(prepare).toHaveBeenCalledTimes(2);
+		} finally {
+			prepare.mockRestore();
+			db.close();
+		}
+	});
+
+	it("keeps interleaved iterators and point reads independent", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const sql = "select 1 n union all select 2 union all select 3";
+		try {
+			const first = db.prepare(sql).iterate();
+			const second = db.prepare(sql).iterate();
+			expect(first.next().value).toEqual({ n: 1 });
+			expect(db.prepare(sql).all()).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+			expect(second.next().value).toEqual({ n: 1 });
+			expect(first.next().value).toEqual({ n: 2 });
+			first.return?.();
+			expect([...second]).toEqual([{ n: 2 }, { n: 3 }]);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("bounds the cache without invalidating retained wrappers and recompiles schema changes", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const retained = db.prepare("select 999 n");
+		const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+		try {
+			for (let i = 0; i < 128; i++) db.prepare(`select ${i} n`).get();
+			expect(retained.get()).toEqual({ n: 999 });
+			expect(db.prepare("select 999 n").get()).toEqual({ n: 999 });
+			expect(prepare).toHaveBeenCalledTimes(129);
+			// The most recently used statement remains cached.
+			const calls = prepare.mock.calls.length;
+			db.prepare("select 999 n").get();
+			expect(prepare).toHaveBeenCalledTimes(calls);
+			db.exec("create table sample (a integer); insert into sample values (1)");
+			expect(db.prepare("select * from sample").get()).toEqual({ a: 1 });
+			db.exec("alter table sample add column b integer default 2");
+			expect(db.prepare("select * from sample").get()).toEqual({ a: 1, b: 2 });
+		} finally {
+			prepare.mockRestore();
+			db.close();
+		}
+		expect(() => db.prepare("select 999 n")).toThrow(
+			/closed|not open|finalized|database/iu,
+		);
+		expect(() => retained.get()).toThrow(
+			/closed|not open|finalized|database/iu,
+		);
+	});
+});

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -19,6 +19,7 @@ type RunResult = {
 };
 
 export const SQLITE_BUSY_TIMEOUT_MS = 30_000;
+const STATEMENT_CACHE_LIMIT = 128;
 
 function bindArgs(parameters: unknown[]) {
 	if (parameters.length === 1 && Array.isArray(parameters[0])) {
@@ -57,6 +58,7 @@ class NativeSqliteStatement {
 	constructor(
 		private readonly statement: StatementSync,
 		private readonly sql: string,
+		private readonly prepareIterator: () => StatementSync,
 		private readonly onStatement?: (sql: string, durationMs: number) => void,
 	) {}
 
@@ -92,7 +94,8 @@ class NativeSqliteStatement {
 	}
 
 	iterate(...parameters: unknown[]): IterableIterator<unknown> {
-		const rows = this.statement.iterate(...bindArgs(parameters));
+		// Iterators own their native cursor so nested reads cannot reset it.
+		const rows = this.prepareIterator().iterate(...bindArgs(parameters));
 		const startedAt = performance.now();
 		const onStatement = this.onStatement;
 		const sql = this.sql;
@@ -112,6 +115,7 @@ export class NativeSqliteDatabase {
 	readonly writeIdentity: string | object;
 	private transactionDepth = 0;
 	private readonly db: DatabaseSync;
+	private readonly statements = new Map<string, StatementSync>();
 
 	constructor(
 		path: string,
@@ -128,6 +132,7 @@ export class NativeSqliteDatabase {
 		if (!this.db.isOpen) {
 			return;
 		}
+		this.statements.clear();
 		this.db.close();
 	}
 
@@ -147,9 +152,20 @@ export class NativeSqliteDatabase {
 	}
 
 	prepare(sql: string): NativeSqliteStatement {
+		let statement = this.statements.get(sql);
+		if (statement) {
+			this.statements.delete(sql);
+		} else {
+			statement = this.db.prepare(sql);
+			if (this.statements.size >= STATEMENT_CACHE_LIMIT) {
+				this.statements.delete(this.statements.keys().next().value!);
+			}
+		}
+		this.statements.set(sql, statement);
 		return new NativeSqliteStatement(
-			this.db.prepare(sql),
+			statement,
 			sql,
+			() => this.db.prepare(sql),
 			this.options.onStatement,
 		);
 	}


### PR DESCRIPTION
Repeated database reads recompiled identical SQL on every call. Keep a connection-local LRU of at most 128 native statements while returning fresh wrapper objects. Streaming iterators compile independent cursors so nested iteration and point reads cannot reset each other's progress; connection closure drops the cache.

Validation: format/lint/types; 101 database and query tests on Bun and Node. New cases cover native compilation reuse, omitted positional/named bindings, interleaved iterators, cache eviction with retained wrappers, schema changes, and closed connections. A 10,000-operation synthetic point-read benchmark preserves the checksum and improves paired Node median time from 20.608 to 5.908 ms. Independent P2 review passed.
