### PR TITLE
perf: batch conversation descendant enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch URL and mention-profile enrichment for conversation descendants while retaining traversal limits and truncation reporting.
+
 - Reuse up to 128 recently prepared SQLite statements per connection while keeping streaming iterators on independent cursors.
 
 - Hydrate each DM sender once per thread instead of copying profile columns for every message, preserving complete history and independent message objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Reuse up to 128 recently prepared SQLite statements per connection while keeping streaming iterators on independent cursors.
+
 - Hydrate each DM sender once per thread instead of copying profile columns for every message, preserving complete history and independent message objects.
 
 - Limit Inbox score reads to the current candidate mentions and conversations instead of loading the entire scoring history.

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -928,6 +928,55 @@ describe("query models", () => {
 		}
 	});
 
+	it("batches descendant URL and mention enrichment without changing thread limits", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2030-01-01T00:00:00Z";
+		insertTestTweet(db, { id: "batch_root", text: "Root", createdAt: stamp });
+		for (let i = 0; i < 79; i++) {
+			insertTestTweet(db, {
+				id: `batch_child_${i}`,
+				text: `Reply @missing${i} https://t.co/child${i}`,
+				createdAt: stamp,
+				replyToId: "batch_root",
+			});
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const thread = getTweetConversation("batch_root", 80, db)!;
+			expect(thread.items).toHaveLength(80);
+			expect(thread.truncated).toBe(false);
+			const children = thread.items.filter((item) => item.id !== "batch_root");
+			expect(
+				children.every(
+					(item) =>
+						item.entities.mentions?.length === 1 &&
+						item.entities.urls?.length === 1,
+				),
+			).toBe(true);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					sql.includes("from url_expansions"),
+				),
+			).toHaveLength(1);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes("from profiles") && sql.includes("lower(handle)"),
+				),
+			).toHaveLength(1);
+			expect(getTweetConversation("batch_root", 10, db)).toMatchObject({
+				truncated: true,
+				items: expect.any(Array),
+			});
+			expect(getTweetConversation("batch_root", 10, db)?.items).toHaveLength(
+				10,
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/sqlite.test.ts
+++ b/src/lib/sqlite.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { NativeSqliteDatabase } from "./sqlite";
+
+describe("prepared statement reuse", () => {
+	it("reuses native compilation while clearing omitted parameter bindings", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+		try {
+			expect(db.prepare("select ? a, ? b").get(1, 2)).toEqual({ a: 1, b: 2 });
+			expect(db.prepare("select ? a, ? b").get(3)).toEqual({ a: 3, b: null });
+			expect(db.prepare("select $a a, $b b").get({ a: 1, b: 2 })).toEqual({
+				a: 1,
+				b: 2,
+			});
+			expect(db.prepare("select $a a, $b b").get({ a: 3 })).toEqual({
+				a: 3,
+				b: null,
+			});
+			expect(prepare).toHaveBeenCalledTimes(2);
+		} finally {
+			prepare.mockRestore();
+			db.close();
+		}
+	});
+
+	it("keeps interleaved iterators and point reads independent", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const sql = "select 1 n union all select 2 union all select 3";
+		try {
+			const first = db.prepare(sql).iterate();
+			const second = db.prepare(sql).iterate();
+			expect(first.next().value).toEqual({ n: 1 });
+			expect(db.prepare(sql).all()).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+			expect(second.next().value).toEqual({ n: 1 });
+			expect(first.next().value).toEqual({ n: 2 });
+			first.return?.();
+			expect([...second]).toEqual([{ n: 2 }, { n: 3 }]);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("bounds the cache without invalidating retained wrappers and recompiles schema changes", () => {
+		const db = new NativeSqliteDatabase(":memory:");
+		const retained = db.prepare("select 999 n");
+		const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+		try {
+			for (let i = 0; i < 128; i++) db.prepare(`select ${i} n`).get();
+			expect(retained.get()).toEqual({ n: 999 });
+			expect(db.prepare("select 999 n").get()).toEqual({ n: 999 });
+			expect(prepare).toHaveBeenCalledTimes(129);
+			// The most recently used statement remains cached.
+			const calls = prepare.mock.calls.length;
+			db.prepare("select 999 n").get();
+			expect(prepare).toHaveBeenCalledTimes(calls);
+			db.exec("create table sample (a integer); insert into sample values (1)");
+			expect(db.prepare("select * from sample").get()).toEqual({ a: 1 });
+			db.exec("alter table sample add column b integer default 2");
+			expect(db.prepare("select * from sample").get()).toEqual({ a: 1, b: 2 });
+		} finally {
+			prepare.mockRestore();
+			db.close();
+		}
+		expect(() => db.prepare("select 999 n")).toThrow(
+			/closed|not open|finalized|database/iu,
+		);
+		expect(() => retained.get()).toThrow(
+			/closed|not open|finalized|database/iu,
+		);
+	});
+});

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -19,6 +19,7 @@ type RunResult = {
 };
 
 export const SQLITE_BUSY_TIMEOUT_MS = 30_000;
+const STATEMENT_CACHE_LIMIT = 128;
 
 function bindArgs(parameters: unknown[]) {
 	if (parameters.length === 1 && Array.isArray(parameters[0])) {
@@ -57,6 +58,7 @@ class NativeSqliteStatement {
 	constructor(
 		private readonly statement: StatementSync,
 		private readonly sql: string,
+		private readonly prepareIterator: () => StatementSync,
 		private readonly onStatement?: (sql: string, durationMs: number) => void,
 	) {}
 
@@ -92,7 +94,8 @@ class NativeSqliteStatement {
 	}
 
 	iterate(...parameters: unknown[]): IterableIterator<unknown> {
-		const rows = this.statement.iterate(...bindArgs(parameters));
+		// Iterators own their native cursor so nested reads cannot reset it.
+		const rows = this.prepareIterator().iterate(...bindArgs(parameters));
 		const startedAt = performance.now();
 		const onStatement = this.onStatement;
 		const sql = this.sql;
@@ -112,6 +115,7 @@ export class NativeSqliteDatabase {
 	readonly writeIdentity: string | object;
 	private transactionDepth = 0;
 	private readonly db: DatabaseSync;
+	private readonly statements = new Map<string, StatementSync>();
 
 	constructor(
 		path: string,
@@ -128,6 +132,7 @@ export class NativeSqliteDatabase {
 		if (!this.db.isOpen) {
 			return;
 		}
+		this.statements.clear();
 		this.db.close();
 	}
 
@@ -147,9 +152,20 @@ export class NativeSqliteDatabase {
 	}
 
 	prepare(sql: string): NativeSqliteStatement {
+		let statement = this.statements.get(sql);
+		if (statement) {
+			this.statements.delete(sql);
+		} else {
+			statement = this.db.prepare(sql);
+			if (this.statements.size >= STATEMENT_CACHE_LIMIT) {
+				this.statements.delete(this.statements.keys().next().value!);
+			}
+		}
+		this.statements.set(sql, statement);
 		return new NativeSqliteStatement(
-			this.db.prepare(sql),
+			statement,
 			sql,
+			() => this.db.prepare(sql),
 			this.options.onStatement,
 		);
 	}

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -1509,9 +1509,9 @@ export function getTweetsByIds(
 function listTweetDescendants(
 	db: Database,
 	urlExpansionCache: UrlExpansionCache,
+	profileByHandleCache: ProfileByHandleCache,
 	rootId: string,
 	limit: number,
-	resolveProfileByHandle?: (handle: string) => ProfileRecord,
 	accountId?: string,
 ) {
 	const visibleLimit = Number.isFinite(limit)
@@ -1629,8 +1629,12 @@ function listTweetDescendants(
 		) as Array<Record<string, unknown>>;
 
 	const visibleRows = rows.filter((row) => typeof row.id === "string");
-	const items = visibleRows
-		.slice(0, visibleLimit)
+	const selectedRows = visibleRows.slice(0, visibleLimit);
+	preloadUrlExpansions(db, urlExpansionCache, selectedRows);
+	preloadMentionProfiles(db, profileByHandleCache, selectedRows);
+	const resolveProfileByHandle = (handle: string) =>
+		getProfileByHandle(db, profileByHandleCache, handle);
+	const items = selectedRows
 		.map((row) =>
 			buildEmbeddedTweet(
 				db,
@@ -1750,9 +1754,9 @@ export function getTweetConversation(
 	const focusedDescendants = listTweetDescendants(
 		db,
 		urlExpansionCache,
+		profileByHandleCache,
 		anchor.id,
 		remainingAfterRequired,
-		resolveProfileByHandle,
 		scopedAccountId,
 	);
 	const focusedDescendantsDropped = appendConversationTweets(
@@ -1768,9 +1772,9 @@ export function getTweetConversation(
 		const ambientDescendants = listTweetDescendants(
 			db,
 			urlExpansionCache,
+			profileByHandleCache,
 			root.id,
 			limit,
-			resolveProfileByHandle,
 			scopedAccountId,
 		);
 		const ambientDescendantsDropped = appendConversationTweets(


### PR DESCRIPTION
Conversation descendants performed individual URL and mention-profile lookups for each displayed post. Preload enrichment for the selected visible descendants and share the existing conversation-scoped caches across focused and ambient branches. Traversal safety caps, visible limits, account visibility, and truncation reporting remain intact.

Validation: format/lint/types; 78 query-model tests on Bun and Node; independent P2 review. An 80-post synthetic conversation returns identical JSON while reducing SQL statements from 160 to 4 and paired Node median time from 1.212 to 0.980 ms. The regression also verifies a smaller result limit still reports truncation.
