### PR TITLE
perf: reuse link URL normalization within reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Batch URL and mention-profile enrichment for conversation descendants while retaining traversal limits and truncation reporting.
+
 - Reuse up to 128 recently prepared SQLite statements per connection while keeping streaming iterators on independent cursors.
 
 - Hydrate each DM sender once per thread instead of copying profile columns for every message, preserving complete history and independent message objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Normalize each distinct link URL once per insight query and reuse the result across ranking and hydration.
+
 - Batch URL and mention-profile enrichment for conversation descendants while retaining traversal limits and truncation reporting.
 
 - Reuse up to 128 recently prepared SQLite statements per connection while keeping streaming iterators on independent cursors.

--- a/src/lib/link-insights.test.ts
+++ b/src/lib/link-insights.test.ts
@@ -234,6 +234,45 @@ describe("link insights", () => {
 		rmSync(homeDir, { recursive: true, force: true });
 	});
 
+	it("normalizes repeated URLs once per read and observes later expansion changes", () => {
+		const db = insertAccountFixture();
+		const shortUrl = "https://t.co/repeated";
+		insertExpansion(db, {
+			shortUrl,
+			finalUrl: "https://example.com/shared?utm_source=test",
+		});
+		for (let i = 0; i < 20; i++) {
+			insertTweet(db, {
+				id: `repeated_${i}`,
+				authorProfileId: "profile_a",
+				text: "Shared link",
+				createdAt: localIso(),
+			});
+			insertOccurrence(db, {
+				sourceKind: "tweet",
+				sourceId: `repeated_${i}`,
+				shortUrl,
+				createdAt: localIso(),
+			});
+		}
+		const normalizations = vi.spyOn(URLSearchParams.prototype, "sort");
+		try {
+			const result = getLinkInsights({ range: "all" });
+			expect(result.items).toHaveLength(1);
+			expect(result.items[0]?.shareCount).toBe(20);
+			expect(normalizations).toHaveBeenCalledTimes(1);
+			db.prepare(
+				"update url_expansions set final_url = 'https://example.com/refreshed?utm_source=test' where short_url = ?",
+			).run(shortUrl);
+			expect(getLinkInsights({ range: "all" }).items[0]?.url).toBe(
+				"https://example.com/refreshed",
+			);
+			expect(normalizations).toHaveBeenCalledTimes(2);
+		} finally {
+			normalizations.mockRestore();
+		}
+	});
+
 	it("groups top links, strips shared URLs from comments, and splits videos", () => {
 		const db = insertAccountFixture();
 		insertTweet(db, {

--- a/src/lib/link-insights.ts
+++ b/src/lib/link-insights.ts
@@ -663,6 +663,14 @@ function selectHydrationCandidates(
 export function getLinkInsights(
 	query: LinkInsightQuery = {},
 ): LinkInsightResponse {
+	const normalizedUrls = new Map<string, NormalizedUrl | null>();
+	const normalize = (url: string) => {
+		const cached = normalizedUrls.get(url);
+		if (cached !== undefined) return cached;
+		const normalized = normalizeUrl(url);
+		normalizedUrls.set(url, normalized);
+		return normalized;
+	};
 	const kind = query.kind ?? "links";
 	const range = query.range ?? "week";
 	const sort = query.sort ?? "rank";
@@ -756,7 +764,7 @@ export function getLinkInsights(
 	const rankedGroups = new Map<string, RankedInsightGroup>();
 	let occurrences = 0;
 	for (const row of rankRows) {
-		const normalized = normalizeUrl(
+		const normalized = normalize(
 			row.final_url || row.expanded_url || row.short_url,
 		);
 		if (!normalized) continue;
@@ -946,7 +954,7 @@ export function getLinkInsights(
 		) as LinkInsightRow[];
 
 	for (const row of needsRankingPass ? [] : rows) {
-		const normalized = normalizeUrl(
+		const normalized = normalize(
 			row.final_url || row.expanded_url || row.short_url,
 		);
 		if (!normalized) continue;
@@ -963,7 +971,7 @@ export function getLinkInsights(
 	const groups = new Map<string, InsightGroup>();
 	for (const row of rows) {
 		const rawUrl = row.final_url || row.expanded_url || row.short_url;
-		const normalized = normalizeUrl(rawUrl);
+		const normalized = normalize(rawUrl);
 		if (!normalized) {
 			continue;
 		}

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -928,6 +928,55 @@ describe("query models", () => {
 		}
 	});
 
+	it("batches descendant URL and mention enrichment without changing thread limits", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const stamp = "2030-01-01T00:00:00Z";
+		insertTestTweet(db, { id: "batch_root", text: "Root", createdAt: stamp });
+		for (let i = 0; i < 79; i++) {
+			insertTestTweet(db, {
+				id: `batch_child_${i}`,
+				text: `Reply @missing${i} https://t.co/child${i}`,
+				createdAt: stamp,
+				replyToId: "batch_root",
+			});
+		}
+		const prepare = vi.spyOn(NativeSqliteDatabase.prototype, "prepare");
+		try {
+			const thread = getTweetConversation("batch_root", 80, db)!;
+			expect(thread.items).toHaveLength(80);
+			expect(thread.truncated).toBe(false);
+			const children = thread.items.filter((item) => item.id !== "batch_root");
+			expect(
+				children.every(
+					(item) =>
+						item.entities.mentions?.length === 1 &&
+						item.entities.urls?.length === 1,
+				),
+			).toBe(true);
+			expect(
+				prepare.mock.calls.filter(([sql]) =>
+					sql.includes("from url_expansions"),
+				),
+			).toHaveLength(1);
+			expect(
+				prepare.mock.calls.filter(
+					([sql]) =>
+						sql.includes("from profiles") && sql.includes("lower(handle)"),
+				),
+			).toHaveLength(1);
+			expect(getTweetConversation("batch_root", 10, db)).toMatchObject({
+				truncated: true,
+				items: expect.any(Array),
+			});
+			expect(getTweetConversation("batch_root", 10, db)?.items).toHaveLength(
+				10,
+			);
+		} finally {
+			prepare.mockRestore();
+		}
+	});
+
 	it("batches cited tweets without changing order, visibility, or collection state", () => {
 		setupTempHome();
 		const db = getNativeDb();

--- a/src/lib/timeline-read-model.ts
+++ b/src/lib/timeline-read-model.ts
@@ -1509,9 +1509,9 @@ export function getTweetsByIds(
 function listTweetDescendants(
 	db: Database,
 	urlExpansionCache: UrlExpansionCache,
+	profileByHandleCache: ProfileByHandleCache,
 	rootId: string,
 	limit: number,
-	resolveProfileByHandle?: (handle: string) => ProfileRecord,
 	accountId?: string,
 ) {
 	const visibleLimit = Number.isFinite(limit)
@@ -1629,8 +1629,12 @@ function listTweetDescendants(
 		) as Array<Record<string, unknown>>;
 
 	const visibleRows = rows.filter((row) => typeof row.id === "string");
-	const items = visibleRows
-		.slice(0, visibleLimit)
+	const selectedRows = visibleRows.slice(0, visibleLimit);
+	preloadUrlExpansions(db, urlExpansionCache, selectedRows);
+	preloadMentionProfiles(db, profileByHandleCache, selectedRows);
+	const resolveProfileByHandle = (handle: string) =>
+		getProfileByHandle(db, profileByHandleCache, handle);
+	const items = selectedRows
 		.map((row) =>
 			buildEmbeddedTweet(
 				db,
@@ -1750,9 +1754,9 @@ export function getTweetConversation(
 	const focusedDescendants = listTweetDescendants(
 		db,
 		urlExpansionCache,
+		profileByHandleCache,
 		anchor.id,
 		remainingAfterRequired,
-		resolveProfileByHandle,
 		scopedAccountId,
 	);
 	const focusedDescendantsDropped = appendConversationTweets(
@@ -1768,9 +1772,9 @@ export function getTweetConversation(
 		const ambientDescendants = listTweetDescendants(
 			db,
 			urlExpansionCache,
+			profileByHandleCache,
 			root.id,
 			limit,
-			resolveProfileByHandle,
 			scopedAccountId,
 		);
 		const ambientDescendantsDropped = appendConversationTweets(


### PR DESCRIPTION
Link feeds normalized the same raw URL repeatedly during ranking and detail hydration. Reuse each result, including rejected URLs, within one insight query. The cache is discarded after each read so updated expansions remain visible.

Validation: format/lint/types; 10 link-insight tests on Bun and Node; independent P2 review. A synthetic feed with 10,000 occurrences of 100 URLs returns identical JSON and improves paired Node median time from 127.643 to 97.616 ms. The regression checks one canonicalization per distinct URL and a fresh result after an expansion update.
