### PR TITLE
perf: defer CLI server dependency loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Defer loading the HTTP/MCP server until `serve` runs, reducing startup work for CLI help and local commands.
+
 - Rank DM search matches using narrow message identifiers before loading the three selected messages and their sender profiles.
 
 - Normalize each distinct link URL once per insight query and reuse the result across ranking and hydration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Rank DM search matches using narrow message identifiers before loading the three selected messages and their sender profiles.
+
 - Normalize each distinct link URL once per insight query and reuse the result across ranking and hydration.
 
 - Batch URL and mention-profile enrichment for conversation descendants while retaining traversal limits and truncation reporting.

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,13 +1,18 @@
+import { rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
+await rm(path.join(root, "dist/cli"), { recursive: true, force: true });
+
 await build({
 	absWorkingDir: root,
-	entryPoints: ["src/cli.ts"],
-	outfile: "dist/cli/birdclaw.js",
+	entryPoints: { birdclaw: "src/cli.ts" },
+	outdir: "dist/cli",
+	splitting: true,
+	chunkNames: "chunks/[name]-[hash]",
 	bundle: true,
 	platform: "node",
 	format: "esm",

--- a/src/cli/register-serve.ts
+++ b/src/cli/register-serve.ts
@@ -1,5 +1,4 @@
 import { requestBackupAutoUpdate } from "#/lib/backup";
-import { runProductionServer } from "#/lib/production-server";
 import { printError, type CliCommandContext } from "./command-context";
 
 export function registerServeCommand(
@@ -29,6 +28,7 @@ export function registerServeCommand(
 			}
 			const port = parseNonNegativeIntegerOption(options.port, "--port");
 			if (port === undefined) return;
+			const { runProductionServer } = await import("#/lib/production-server");
 			await runProductionServer({
 				packageRoot,
 				host,

--- a/src/lib/dm-read-model.ts
+++ b/src/lib/dm-read-model.ts
@@ -393,7 +393,7 @@ function mapDmMessageRow(row: Record<string, unknown>): DmMessageItem {
 	};
 }
 
-function selectDmMessageSql(where: string, orderBy: string) {
+function selectDmMessageSql(where: string, orderBy: string, join = "") {
 	return `
     select
       m.id,
@@ -414,6 +414,7 @@ function selectDmMessageSql(where: string, orderBy: string) {
       p.created_at as profile_created_at
     from dm_messages m
     join profiles p on p.id = m.sender_profile_id
+    ${join}
     ${where}
     ${orderBy}
   `;
@@ -436,24 +437,8 @@ function getDmSearchMatches({
 	const matchRows = db
 		.prepare(
 			`
-      with ranked_matches as (
-        select
-          m.id,
-          m.conversation_id,
-          m.text,
-          m.created_at,
-          m.direction,
-          m.is_replied,
-          m.media_count,
-          p.id as profile_id,
-          p.handle,
-          p.display_name,
-          p.bio,
-          p.followers_count,
-          p.following_count,
-          p.avatar_hue,
-          p.avatar_url,
-          p.created_at as profile_created_at,
+      with ranked_matches as materialized (
+        select m.id,
           row_number() over (
             partition by m.conversation_id
             order by m.created_at desc, m.id desc
@@ -464,10 +449,11 @@ function getDmSearchMatches({
         where dm_fts.text match ?
           and m.conversation_id in (${conversationPlaceholders})
       )
-      select *
-      from ranked_matches
-      where match_rank <= 3
-      order by created_at desc, id desc
+      ${selectDmMessageSql(
+				"where ranked_matches.match_rank <= 3",
+				"order by m.created_at desc, m.id desc",
+				"join ranked_matches on ranked_matches.id = m.id",
+			)}
       `,
 		)
 		.all(search, ...conversationIds) as Array<Record<string, unknown>>;

--- a/src/lib/query-models.test.ts
+++ b/src/lib/query-models.test.ts
@@ -428,6 +428,33 @@ describe("query models", () => {
 		);
 	});
 
+	it("keeps the latest three DM matches when ranking a large matching thread", () => {
+		setupTempHome();
+		const db = getNativeDb();
+		const insert = db.prepare(
+			"insert into dm_messages(id, conversation_id, sender_profile_id, text, created_at, direction, is_replied, media_count) values (?, 'dm_001', 'profile_me', 'rankneedle', '2030-01-01', 'outbound', 0, 0)",
+		);
+		db.transaction(() => {
+			for (let i = 0; i < 1000; i++) {
+				const id = `rank_${String(i).padStart(4, "0")}`;
+				insert.run(id);
+				db.prepare(
+					"insert into dm_fts(message_id, text) values (?, 'rankneedle')",
+				).run(id);
+			}
+		})();
+		const result = listDmConversations({ search: "rankneedle", context: 1 });
+		expect(result).toHaveLength(1);
+		expect(result[0]?.matches?.map((match) => match.message.id)).toEqual([
+			"rank_0999",
+			"rank_0998",
+			"rank_0997",
+		]);
+		expect(result[0]?.matches?.[0]?.before[0]?.id).toBe("rank_0998");
+		expect(result[0]?.matches?.[0]?.after).toEqual([]);
+		expect(result[0]?.matches?.[2]?.message.sender.id).toBe("profile_me");
+	});
+
 	it("returns nearby DM context when requested for search results", () => {
 		setupTempHome();
 		const db = getNativeDb();


### PR DESCRIPTION
Every CLI invocation eagerly loaded the HTTP/MCP server. Import it only when a validated `serve` action runs, and emit an ESM split build so the compiled package preserves that boundary. The launcher stays at the same path; builds clear old CLI chunks before emitting new ones.

Validation: format/lint/types; 106 CLI/package tests on Bun and Node; Node production build; installed-package smoke on both runtimes, including HTTP and MCP startup; independent P2 review. Paired fresh-process Node medians preserve exact output: top-level help 269.893 → 237.159 ms; tweet-search help 272.524 → 238.301 ms. The existing standalone version shortcut is unchanged.
