### PR TITLE
perf: defer linked account metadata projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Defer loading the HTTP/MCP server until `serve` runs, reducing startup work for CLI help and local commands.
+
 - Rank DM search matches using narrow message identifiers before loading the three selected messages and their sender profiles.
 
 - Normalize each distinct link URL once per insight query and reuse the result across ranking and hydration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.12.6 - Unreleased
 
+- Defer linked-account metadata lookup until link-search results are selected, preserving substring matching and account fallback precedence.
+
 - Defer loading the HTTP/MCP server until `serve` runs, reducing startup work for CLI help and local commands.
 
 - Rank DM search matches using narrow message identifiers before loading the three selected messages and their sender profiles.

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,13 +1,18 @@
+import { rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
+await rm(path.join(root, "dist/cli"), { recursive: true, force: true });
+
 await build({
 	absWorkingDir: root,
-	entryPoints: ["src/cli.ts"],
-	outfile: "dist/cli/birdclaw.js",
+	entryPoints: { birdclaw: "src/cli.ts" },
+	outdir: "dist/cli",
+	splitting: true,
+	chunkNames: "chunks/[name]-[hash]",
 	bundle: true,
 	platform: "node",
 	format: "esm",

--- a/src/cli/register-serve.ts
+++ b/src/cli/register-serve.ts
@@ -1,5 +1,4 @@
 import { requestBackupAutoUpdate } from "#/lib/backup";
-import { runProductionServer } from "#/lib/production-server";
 import { printError, type CliCommandContext } from "./command-context";
 
 export function registerServeCommand(
@@ -29,6 +28,7 @@ export function registerServeCommand(
 			}
 			const port = parseNonNegativeIntegerOption(options.port, "--port");
 			if (port === undefined) return;
+			const { runProductionServer } = await import("#/lib/production-server");
 			await runProductionServer({
 				packageRoot,
 				host,

--- a/src/lib/link-index.test.ts
+++ b/src/lib/link-index.test.ts
@@ -684,5 +684,38 @@ describe("link index", () => {
 				}),
 			}),
 		]);
+		db.prepare(
+			"update tweet_account_edges set account_id = 'acct_primary' where tweet_id = '777'",
+		).run();
+		expect(searchLinks("linked fallback")[0]?.linkedTweet).toMatchObject({
+			accountId: "acct_primary",
+			accountHandle: "steipete",
+		});
+		db.prepare(
+			"insert into accounts(id, name, handle, transport, is_default, created_at) values ('acct_alt', 'Alt', 'alternate', 'bird', 0, '2026-04-01')",
+		).run();
+		db.prepare(
+			"insert into tweet_collections(account_id, tweet_id, kind, collected_at, source, raw_json, updated_at) values ('acct_alt', '777', 'likes', '2026-04-01', 'test', '{}', '2026-04-01')",
+		).run();
+		expect(searchLinks("linked fallback")[0]?.linkedTweet?.accountHandle).toBe(
+			"steipete",
+		);
+		db.prepare("delete from tweet_account_edges where tweet_id = '777'").run();
+		expect(searchLinks("linked fallback")[0]?.linkedTweet).toMatchObject({
+			accountId: "acct_alt",
+			accountHandle: "alternate",
+		});
+		db.prepare(
+			"update link_occurrences set account_id = 'acct_primary' where short_url = 'https://t.co/manual'",
+		).run();
+		expect(searchLinks("linked fallback")[0]?.linkedTweet?.accountHandle).toBe(
+			"steipete",
+		);
+		db.prepare(
+			"update accounts set handle = 'refreshed' where id = 'acct_primary'",
+		).run();
+		expect(searchLinks("linked fallback")[0]?.linkedTweet?.accountHandle).toBe(
+			"refreshed",
+		);
 	});
 });

--- a/src/lib/link-index.ts
+++ b/src/lib/link-index.ts
@@ -575,7 +575,11 @@ export function searchLinks(query: string, options: LinkSearchOptions = {}) {
 				(select edge.account_id from tweet_account_edges edge where edge.tweet_id = linked.id order by edge.last_seen_at desc limit 1),
 				(select collection.account_id from tweet_collections collection where collection.tweet_id = linked.id order by collection.updated_at desc limit 1)
 			) as linked_account_id,
-			linked_account.handle as linked_account_handle,
+			(select linked_account.handle from accounts linked_account where linked_account.id = coalesce(
+				o.account_id,
+				(select edge.account_id from tweet_account_edges edge where edge.tweet_id = linked.id order by edge.last_seen_at desc limit 1),
+				(select collection.account_id from tweet_collections collection where collection.tweet_id = linked.id order by collection.updated_at desc limit 1)
+			)) as linked_account_handle,
 			coalesce(
 				(select edge.kind from tweet_account_edges edge where edge.tweet_id = linked.id order by edge.last_seen_at desc limit 1),
 				'thread'
@@ -617,12 +621,6 @@ export function searchLinks(query: string, options: LinkSearchOptions = {}) {
       on source_author.id = source_tweet.author_profile_id
     left join tweets linked
       on linked.id = e.expanded_tweet_id
-		left join accounts linked_account
-			on linked_account.id = coalesce(
-				o.account_id,
-				(select edge.account_id from tweet_account_edges edge where edge.tweet_id = linked.id order by edge.last_seen_at desc limit 1),
-				(select collection.account_id from tweet_collections collection where collection.tweet_id = linked.id order by collection.updated_at desc limit 1)
-			)
     left join profiles linked_author
       on linked_author.id = linked.author_profile_id
     ${conditions.length > 0 ? `where ${conditions.join(" and ")}` : ""}


### PR DESCRIPTION
Link search resolved linked-account metadata during candidate joins, including rows later rejected by the text filter. Move the handle lookup into the selected-row projection. Substring, punctuation, domain, and multi-field matching remain unchanged, as do occurrence-account, tweet-edge, and collection fallback precedence.

Validation: format/lint/types; 10 link-index tests on Bun and Node; independent P2 review. The expanded regression covers missing accounts, edge-versus-collection precedence, occurrence overrides, and refreshed handles. A selective search over 10,000 synthetic occurrences returns identical JSON and improves paired Node median latency from 32.493 to 26.907 ms.
